### PR TITLE
Reparse 2016 from sources-ks

### DIFF
--- a/2016/20161108__ks__general__allen__precinct.csv
+++ b/2016/20161108__ks__general__allen__precinct.csv
@@ -1,396 +1,1005 @@
-county,precinct,office,district,party,candidate,votes
-Allen,0001 Carlyle Twp,President,,DEM,Clinton/Kaine,35
-Allen,0001 Carlyle Twp,President,,LIB,Johnson/Weld,4
-Allen,0001 Carlyle Twp,President,,IND,Stein/Baraka,3
-Allen,0001 Carlyle Twp,President,,REP,Trump/Pence,112
-Allen,0001 Carlyle Twp,President,,,WRITE-IN,3
-Allen,0001 Carlyle Twp,U.S. Senate,,LIB,Robert D. Garrard,5
-Allen,0001 Carlyle Twp,U.S. Senate,,REP,Jerry Moran,128
-Allen,0001 Carlyle Twp,U.S. Senate,,DEM,Patrick Wiesner,25
-Allen,0001 Carlyle Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0001 Carlyle Twp,U.S. House,2,LIB,James Houston Bales,5
-Allen,0001 Carlyle Twp,U.S. House,2,REP,Lynn Jenkins,125
-Allen,0001 Carlyle Twp,U.S. House,2,DEM,Britani Potter,27
-Allen,0001 Carlyle Twp,U.S. House,2,,WRITE-IN,0
-Allen,0001 Carlyle Twp,State Senate,12,DEM,Christopher B. Johnston,20
-Allen,0001 Carlyle Twp,State Senate,12,REP,Caryn Tyson,108
-Allen,0001 Carlyle Twp,State Senate,12,,WRITE-IN,25
-Allen,0001 Carlyle Twp,State House,9,LIB,Patrick McMurray,21
-Allen,0001 Carlyle Twp,State House,9,REP,Kent L. Thompson,133
-Allen,0001 Carlyle Twp,State House,9,,WRITE-IN,1
-Allen,0002 Cottage Grove Twp,President,,DEM,Clinton/Kaine,19
-Allen,0002 Cottage Grove Twp,President,,LIB,Johnson/Weld,0
-Allen,0002 Cottage Grove Twp,President,,IND,Stein/Baraka,0
-Allen,0002 Cottage Grove Twp,President,,REP,Trump/Pence,110
-Allen,0002 Cottage Grove Twp,President,,,WRITE-IN,1
-Allen,0002 Cottage Grove Twp,U.S. Senate,,LIB,Robert D. Garrard,4
-Allen,0002 Cottage Grove Twp,U.S. Senate,,REP,Jerry Moran,110
-Allen,0002 Cottage Grove Twp,U.S. Senate,,DEM,Patrick Wiesner,14
-Allen,0002 Cottage Grove Twp,U.S. Senate,,,WRITE-IN,1
-Allen,0002 Cottage Grove Twp,U.S. House,2,LIB,James Houston Bales,8
-Allen,0002 Cottage Grove Twp,U.S. House,2,REP,Lynn Jenkins,107
-Allen,0002 Cottage Grove Twp,U.S. House,2,DEM,Britani Potter,14
-Allen,0002 Cottage Grove Twp,U.S. House,2,,WRITE-IN,0
-Allen,0002 Cottage Grove Twp,State Senate,12,DEM,Christopher B. Johnston,21
-Allen,0002 Cottage Grove Twp,State Senate,12,REP,Caryn Tyson,104
-Allen,0002 Cottage Grove Twp,State Senate,12,,WRITE-IN,2
-Allen,0002 Cottage Grove Twp,State House,9,LIB,Patrick McMurray,17
-Allen,0002 Cottage Grove Twp,State House,9,REP,Kent L. Thompson,111
-Allen,0002 Cottage Grove Twp,State House,9,,WRITE-IN,0
-Allen,0003 Deer Creek Twp,President,,DEM,Clinton/Kaine,9
-Allen,0003 Deer Creek Twp,President,,LIB,Johnson/Weld,1
-Allen,0003 Deer Creek Twp,President,,IND,Stein/Baraka,1
-Allen,0003 Deer Creek Twp,President,,REP,Trump/Pence,46
-Allen,0003 Deer Creek Twp,President,,,WRITE-IN,1
-Allen,0003 Deer Creek Twp,U.S. Senate,,LIB,Robert D. Garrard,8
-Allen,0003 Deer Creek Twp,U.S. Senate,,REP,Jerry Moran,46
-Allen,0003 Deer Creek Twp,U.S. Senate,,DEM,Patrick Wiesner,8
-Allen,0003 Deer Creek Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0003 Deer Creek Twp,U.S. House,2,LIB,James Houston Bales,3
-Allen,0003 Deer Creek Twp,U.S. House,2,REP,Lynn Jenkins,45
-Allen,0003 Deer Creek Twp,U.S. House,2,DEM,Britani Potter,11
-Allen,0003 Deer Creek Twp,U.S. House,2,,WRITE-IN,2
-Allen,0003 Deer Creek Twp,State Senate,12,DEM,Christopher B. Johnston,9
-Allen,0003 Deer Creek Twp,State Senate,12,REP,Caryn Tyson,38
-Allen,0003 Deer Creek Twp,State Senate,12,,WRITE-IN,12
-Allen,0003 Deer Creek Twp,State House,9,LIB,Patrick McMurray,13
-Allen,0003 Deer Creek Twp,State House,9,REP,Kent L. Thompson,49
-Allen,0003 Deer Creek Twp,State House,9,,WRITE-IN,1
-Allen,0004 E Elm Twp,President,,DEM,Clinton/Kaine,58
-Allen,0004 E Elm Twp,President,,LIB,Johnson/Weld,13
-Allen,0004 E Elm Twp,President,,IND,Stein/Baraka,4
-Allen,0004 E Elm Twp,President,,REP,Trump/Pence,197
-Allen,0004 E Elm Twp,President,,,WRITE-IN,5
-Allen,0004 E Elm Twp,U.S. Senate,,LIB,Robert D. Garrard,13
-Allen,0004 E Elm Twp,U.S. Senate,,REP,Jerry Moran,199
-Allen,0004 E Elm Twp,U.S. Senate,,DEM,Patrick Wiesner,54
-Allen,0004 E Elm Twp,U.S. Senate,,,WRITE-IN,2
-Allen,0004 E Elm Twp,U.S. House,2,LIB,James Houston Bales,15
-Allen,0004 E Elm Twp,U.S. House,2,REP,Lynn Jenkins,196
-Allen,0004 E Elm Twp,U.S. House,2,DEM,Britani Potter,57
-Allen,0004 E Elm Twp,U.S. House,2,,WRITE-IN,3
-Allen,0004 E Elm Twp,State Senate,12,DEM,Christopher B. Johnston,54
-Allen,0004 E Elm Twp,State Senate,12,REP,Caryn Tyson,174
-Allen,0004 E Elm Twp,State Senate,12,,WRITE-IN,33
-Allen,0004 E Elm Twp,State House,9,LIB,Patrick McMurray,46
-Allen,0004 E Elm Twp,State House,9,REP,Kent L. Thompson,225
-Allen,0004 E Elm Twp,State House,9,,WRITE-IN,0
-Allen,0005 W Elm Twp,President,,DEM,Clinton/Kaine,124
-Allen,0005 W Elm Twp,President,,LIB,Johnson/Weld,22
-Allen,0005 W Elm Twp,President,,IND,Stein/Baraka,8
-Allen,0005 W Elm Twp,President,,REP,Trump/Pence,351
-Allen,0005 W Elm Twp,President,,,WRITE-IN,4
-Allen,0005 W Elm Twp,U.S. Senate,,LIB,Robert D. Garrard,31
-Allen,0005 W Elm Twp,U.S. Senate,,REP,Jerry Moran,367
-Allen,0005 W Elm Twp,U.S. Senate,,DEM,Patrick Wiesner,98
-Allen,0005 W Elm Twp,U.S. Senate,,,WRITE-IN,2
-Allen,0005 W Elm Twp,U.S. House,2,LIB,James Houston Bales,21
-Allen,0005 W Elm Twp,U.S. House,2,REP,Lynn Jenkins,359
-Allen,0005 W Elm Twp,U.S. House,2,DEM,Britani Potter,116
-Allen,0005 W Elm Twp,U.S. House,2,,WRITE-IN,3
-Allen,0005 W Elm Twp,State Senate,12,DEM,Christopher B. Johnston,86
-Allen,0005 W Elm Twp,State Senate,12,REP,Caryn Tyson,304
-Allen,0005 W Elm Twp,State Senate,12,,WRITE-IN,97
-Allen,0005 W Elm Twp,State House,9,LIB,Patrick McMurray,102
-Allen,0005 W Elm Twp,State House,9,REP,Kent L. Thompson,397
-Allen,0005 W Elm Twp,State House,9,,WRITE-IN,0
-Allen,0006 N Elsmore Twp,President,,DEM,Clinton/Kaine,23
-Allen,0006 N Elsmore Twp,President,,LIB,Johnson/Weld,6
-Allen,0006 N Elsmore Twp,President,,IND,Stein/Baraka,0
-Allen,0006 N Elsmore Twp,President,,REP,Trump/Pence,63
-Allen,0006 N Elsmore Twp,President,,,WRITE-IN,1
-Allen,0006 N Elsmore Twp,U.S. Senate,,LIB,Robert D. Garrard,7
-Allen,0006 N Elsmore Twp,U.S. Senate,,REP,Jerry Moran,77
-Allen,0006 N Elsmore Twp,U.S. Senate,,DEM,Patrick Wiesner,10
-Allen,0006 N Elsmore Twp,U.S. Senate,,,WRITE-IN,1
-Allen,0006 N Elsmore Twp,U.S. House,2,LIB,James Houston Bales,4
-Allen,0006 N Elsmore Twp,U.S. House,2,REP,Lynn Jenkins,73
-Allen,0006 N Elsmore Twp,U.S. House,2,DEM,Britani Potter,15
-Allen,0006 N Elsmore Twp,U.S. House,2,,WRITE-IN,1
-Allen,0006 N Elsmore Twp,State Senate,12,DEM,Christopher B. Johnston,14
-Allen,0006 N Elsmore Twp,State Senate,12,REP,Caryn Tyson,75
-Allen,0006 N Elsmore Twp,State Senate,12,,WRITE-IN,5
-Allen,0006 N Elsmore Twp,State House,2,DEM,Adam J. Lusker Sr,52
-Allen,0006 N Elsmore Twp,State House,2,,WRITE-IN,3
-Allen,0007 S Elsmore Twp,President,,DEM,Clinton/Kaine,19
-Allen,0007 S Elsmore Twp,President,,LIB,Johnson/Weld,0
-Allen,0007 S Elsmore Twp,President,,IND,Stein/Baraka,1
-Allen,0007 S Elsmore Twp,President,,REP,Trump/Pence,47
-Allen,0007 S Elsmore Twp,President,,,WRITE-IN,5
-Allen,0007 S Elsmore Twp,U.S. Senate,,LIB,Robert D. Garrard,1
-Allen,0007 S Elsmore Twp,U.S. Senate,,REP,Jerry Moran,56
-Allen,0007 S Elsmore Twp,U.S. Senate,,DEM,Patrick Wiesner,13
-Allen,0007 S Elsmore Twp,U.S. Senate,,,WRITE-IN,2
-Allen,0007 S Elsmore Twp,U.S. House,2,LIB,James Houston Bales,2
-Allen,0007 S Elsmore Twp,U.S. House,2,REP,Lynn Jenkins,51
-Allen,0007 S Elsmore Twp,U.S. House,2,DEM,Britani Potter,18
-Allen,0007 S Elsmore Twp,U.S. House,2,,WRITE-IN,0
-Allen,0007 S Elsmore Twp,State Senate,12,DEM,Christopher B. Johnston,16
-Allen,0007 S Elsmore Twp,State Senate,12,REP,Caryn Tyson,48
-Allen,0007 S Elsmore Twp,State Senate,12,,WRITE-IN,6
-Allen,0007 S Elsmore Twp,State House,2,DEM,Adam J. Lusker Sr,42
-Allen,0007 S Elsmore Twp,State House,2,,WRITE-IN,2
-Allen,0008 Geneva Twp,President,,DEM,Clinton/Kaine,10
-Allen,0008 Geneva Twp,President,,LIB,Johnson/Weld,2
-Allen,0008 Geneva Twp,President,,IND,Stein/Baraka,2
-Allen,0008 Geneva Twp,President,,REP,Trump/Pence,44
-Allen,0008 Geneva Twp,President,,,WRITE-IN,0
-Allen,0008 Geneva Twp,U.S. Senate,,LIB,Robert D. Garrard,5
-Allen,0008 Geneva Twp,U.S. Senate,,REP,Jerry Moran,43
-Allen,0008 Geneva Twp,U.S. Senate,,DEM,Patrick Wiesner,10
-Allen,0008 Geneva Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0008 Geneva Twp,U.S. House,2,LIB,James Houston Bales,4
-Allen,0008 Geneva Twp,U.S. House,2,REP,Lynn Jenkins,45
-Allen,0008 Geneva Twp,U.S. House,2,DEM,Britani Potter,8
-Allen,0008 Geneva Twp,U.S. House,2,,WRITE-IN,1
-Allen,0008 Geneva Twp,State Senate,12,DEM,Christopher B. Johnston,9
-Allen,0008 Geneva Twp,State Senate,12,REP,Caryn Tyson,40
-Allen,0008 Geneva Twp,State Senate,12,,WRITE-IN,8
-Allen,0008 Geneva Twp,State House,9,LIB,Patrick McMurray,13
-Allen,0008 Geneva Twp,State House,9,REP,Kent L. Thompson,44
-Allen,0008 Geneva Twp,State House,9,,WRITE-IN,0
-Allen,0009 Humboldt Twp,President,,DEM,Clinton/Kaine,27
-Allen,0009 Humboldt Twp,President,,LIB,Johnson/Weld,3
-Allen,0009 Humboldt Twp,President,,IND,Stein/Baraka,3
-Allen,0009 Humboldt Twp,President,,REP,Trump/Pence,106
-Allen,0009 Humboldt Twp,President,,,WRITE-IN,0
-Allen,0009 Humboldt Twp,U.S. Senate,,LIB,Robert D. Garrard,5
-Allen,0009 Humboldt Twp,U.S. Senate,,REP,Jerry Moran,112
-Allen,0009 Humboldt Twp,U.S. Senate,,DEM,Patrick Wiesner,19
-Allen,0009 Humboldt Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0009 Humboldt Twp,U.S. House,2,LIB,James Houston Bales,8
-Allen,0009 Humboldt Twp,U.S. House,2,REP,Lynn Jenkins,107
-Allen,0009 Humboldt Twp,U.S. House,2,DEM,Britani Potter,21
-Allen,0009 Humboldt Twp,U.S. House,2,,WRITE-IN,0
-Allen,0009 Humboldt Twp,State Senate,12,DEM,Christopher B. Johnston,23
-Allen,0009 Humboldt Twp,State Senate,12,REP,Caryn Tyson,97
-Allen,0009 Humboldt Twp,State Senate,12,,WRITE-IN,10
-Allen,0009 Humboldt Twp,State House,9,LIB,Patrick McMurray,19
-Allen,0009 Humboldt Twp,State House,9,REP,Kent L. Thompson,113
-Allen,0009 Humboldt Twp,State House,9,,WRITE-IN,0
-Allen,0010 N Iola Twp,President,,DEM,Clinton/Kaine,24
-Allen,0010 N Iola Twp,President,,LIB,Johnson/Weld,7
-Allen,0010 N Iola Twp,President,,IND,Stein/Baraka,3
-Allen,0010 N Iola Twp,President,,REP,Trump/Pence,101
-Allen,0010 N Iola Twp,President,,,WRITE-IN,3
-Allen,0010 N Iola Twp,U.S. Senate,,LIB,Robert D. Garrard,12
-Allen,0010 N Iola Twp,U.S. Senate,,REP,Jerry Moran,96
-Allen,0010 N Iola Twp,U.S. Senate,,DEM,Patrick Wiesner,28
-Allen,0010 N Iola Twp,U.S. Senate,,,WRITE-IN,1
-Allen,0010 N Iola Twp,U.S. House,2,LIB,James Houston Bales,13
-Allen,0010 N Iola Twp,U.S. House,2,REP,Lynn Jenkins,102
-Allen,0010 N Iola Twp,U.S. House,2,DEM,Britani Potter,20
-Allen,0010 N Iola Twp,U.S. House,2,,WRITE-IN,1
-Allen,0010 N Iola Twp,State Senate,12,DEM,Christopher B. Johnston,24
-Allen,0010 N Iola Twp,State Senate,12,REP,Caryn Tyson,93
-Allen,0010 N Iola Twp,State Senate,12,,WRITE-IN,18
-Allen,0010 N Iola Twp,State House,9,LIB,Patrick McMurray,25
-Allen,0010 N Iola Twp,State House,9,REP,Kent L. Thompson,110
-Allen,0010 N Iola Twp,State House,9,,WRITE-IN,1
-Allen,0011 S Iola Twp,President,,DEM,Clinton/Kaine,67
-Allen,0011 S Iola Twp,President,,LIB,Johnson/Weld,5
-Allen,0011 S Iola Twp,President,,IND,Stein/Baraka,7
-Allen,0011 S Iola Twp,President,,REP,Trump/Pence,197
-Allen,0011 S Iola Twp,President,,,WRITE-IN,3
-Allen,0011 S Iola Twp,U.S. Senate,,LIB,Robert D. Garrard,9
-Allen,0011 S Iola Twp,U.S. Senate,,REP,Jerry Moran,207
-Allen,0011 S Iola Twp,U.S. Senate,,DEM,Patrick Wiesner,54
-Allen,0011 S Iola Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0011 S Iola Twp,U.S. House,2,LIB,James Houston Bales,7
-Allen,0011 S Iola Twp,U.S. House,2,REP,Lynn Jenkins,200
-Allen,0011 S Iola Twp,U.S. House,2,DEM,Britani Potter,60
-Allen,0011 S Iola Twp,U.S. House,2,,WRITE-IN,3
-Allen,0011 S Iola Twp,State Senate,12,DEM,Christopher B. Johnston,47
-Allen,0011 S Iola Twp,State Senate,12,REP,Caryn Tyson,171
-Allen,0011 S Iola Twp,State Senate,12,,WRITE-IN,47
-Allen,0011 S Iola Twp,State House,9,LIB,Patrick McMurray,40
-Allen,0011 S Iola Twp,State House,9,REP,Kent L. Thompson,232
-Allen,0011 S Iola Twp,State House,9,,WRITE-IN,0
-Allen,0012 Logan Twp,President,,DEM,Clinton/Kaine,29
-Allen,0012 Logan Twp,President,,LIB,Johnson/Weld,5
-Allen,0012 Logan Twp,President,,IND,Stein/Baraka,0
-Allen,0012 Logan Twp,President,,REP,Trump/Pence,81
-Allen,0012 Logan Twp,President,,,WRITE-IN,1
-Allen,0012 Logan Twp,U.S. Senate,,LIB,Robert D. Garrard,8
-Allen,0012 Logan Twp,U.S. Senate,,REP,Jerry Moran,85
-Allen,0012 Logan Twp,U.S. Senate,,DEM,Patrick Wiesner,17
-Allen,0012 Logan Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0012 Logan Twp,U.S. House,2,LIB,James Houston Bales,7
-Allen,0012 Logan Twp,U.S. House,2,REP,Lynn Jenkins,88
-Allen,0012 Logan Twp,U.S. House,2,DEM,Britani Potter,18
-Allen,0012 Logan Twp,U.S. House,2,,WRITE-IN,0
-Allen,0012 Logan Twp,State Senate,12,DEM,Christopher B. Johnston,18
-Allen,0012 Logan Twp,State Senate,12,REP,Caryn Tyson,86
-Allen,0012 Logan Twp,State Senate,12,,WRITE-IN,6
-Allen,0012 Logan Twp,State House,9,LIB,Patrick McMurray,33
-Allen,0012 Logan Twp,State House,9,REP,Kent L. Thompson,75
-Allen,0012 Logan Twp,State House,9,,WRITE-IN,0
-Allen,0013 Marmaton Twp,President,,DEM,Clinton/Kaine,82
-Allen,0013 Marmaton Twp,President,,LIB,Johnson/Weld,11
-Allen,0013 Marmaton Twp,President,,IND,Stein/Baraka,5
-Allen,0013 Marmaton Twp,President,,REP,Trump/Pence,265
-Allen,0013 Marmaton Twp,President,,,WRITE-IN,3
-Allen,0013 Marmaton Twp,U.S. Senate,,LIB,Robert D. Garrard,22
-Allen,0013 Marmaton Twp,U.S. Senate,,REP,Jerry Moran,270
-Allen,0013 Marmaton Twp,U.S. Senate,,DEM,Patrick Wiesner,70
-Allen,0013 Marmaton Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0013 Marmaton Twp,U.S. House,2,LIB,James Houston Bales,30
-Allen,0013 Marmaton Twp,U.S. House,2,REP,Lynn Jenkins,253
-Allen,0013 Marmaton Twp,U.S. House,2,DEM,Britani Potter,73
-Allen,0013 Marmaton Twp,U.S. House,2,,WRITE-IN,2
-Allen,0013 Marmaton Twp,State Senate,12,DEM,Christopher B. Johnston,48
-Allen,0013 Marmaton Twp,State Senate,12,REP,Caryn Tyson,198
-Allen,0013 Marmaton Twp,State Senate,12,,WRITE-IN,98
-Allen,0013 Marmaton Twp,State House,2,DEM,Adam J. Lusker Sr,253
-Allen,0013 Marmaton Twp,State House,2,,WRITE-IN,10
-Allen,0014 Osage Twp,President,,DEM,Clinton/Kaine,27
-Allen,0014 Osage Twp,President,,LIB,Johnson/Weld,7
-Allen,0014 Osage Twp,President,,IND,Stein/Baraka,1
-Allen,0014 Osage Twp,President,,REP,Trump/Pence,91
-Allen,0014 Osage Twp,President,,,WRITE-IN,0
-Allen,0014 Osage Twp,U.S. Senate,,LIB,Robert D. Garrard,3
-Allen,0014 Osage Twp,U.S. Senate,,REP,Jerry Moran,96
-Allen,0014 Osage Twp,U.S. Senate,,DEM,Patrick Wiesner,24
-Allen,0014 Osage Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0014 Osage Twp,U.S. House,2,LIB,James Houston Bales,2
-Allen,0014 Osage Twp,U.S. House,2,REP,Lynn Jenkins,90
-Allen,0014 Osage Twp,U.S. House,2,DEM,Britani Potter,29
-Allen,0014 Osage Twp,U.S. House,2,,WRITE-IN,3
-Allen,0014 Osage Twp,State Senate,12,DEM,Christopher B. Johnston,21
-Allen,0014 Osage Twp,State Senate,12,REP,Caryn Tyson,82
-Allen,0014 Osage Twp,State Senate,12,,WRITE-IN,18
-Allen,0014 Osage Twp,State House,2,DEM,Adam J. Lusker Sr,81
-Allen,0014 Osage Twp,State House,2,,WRITE-IN,5
-Allen,0015 Salem Twp,President,,DEM,Clinton/Kaine,28
-Allen,0015 Salem Twp,President,,LIB,Johnson/Weld,8
-Allen,0015 Salem Twp,President,,IND,Stein/Baraka,5
-Allen,0015 Salem Twp,President,,REP,Trump/Pence,87
-Allen,0015 Salem Twp,President,,,WRITE-IN,1
-Allen,0015 Salem Twp,U.S. Senate,,LIB,Robert D. Garrard,7
-Allen,0015 Salem Twp,U.S. Senate,,REP,Jerry Moran,89
-Allen,0015 Salem Twp,U.S. Senate,,DEM,Patrick Wiesner,35
-Allen,0015 Salem Twp,U.S. Senate,,,WRITE-IN,0
-Allen,0015 Salem Twp,U.S. House,2,LIB,James Houston Bales,8
-Allen,0015 Salem Twp,U.S. House,2,REP,Lynn Jenkins,94
-Allen,0015 Salem Twp,U.S. House,2,DEM,Britani Potter,31
-Allen,0015 Salem Twp,U.S. House,2,,WRITE-IN,0
-Allen,0015 Salem Twp,State Senate,12,DEM,Christopher B. Johnston,32
-Allen,0015 Salem Twp,State Senate,12,REP,Caryn Tyson,86
-Allen,0015 Salem Twp,State Senate,12,,WRITE-IN,10
-Allen,0015 Salem Twp,State House,9,LIB,Patrick McMurray,21
-Allen,0015 Salem Twp,State House,9,REP,Kent L. Thompson,106
-Allen,0015 Salem Twp,State House,9,,WRITE-IN,0
-Allen,0016 Humboldt Wd 1,President,,DEM,Clinton/Kaine,114
-Allen,0016 Humboldt Wd 1,President,,LIB,Johnson/Weld,19
-Allen,0016 Humboldt Wd 1,President,,IND,Stein/Baraka,13
-Allen,0016 Humboldt Wd 1,President,,REP,Trump/Pence,212
-Allen,0016 Humboldt Wd 1,President,,,WRITE-IN,5
-Allen,0016 Humboldt Wd 1,U.S. Senate,,LIB,Robert D. Garrard,30
-Allen,0016 Humboldt Wd 1,U.S. Senate,,REP,Jerry Moran,226
-Allen,0016 Humboldt Wd 1,U.S. Senate,,DEM,Patrick Wiesner,102
-Allen,0016 Humboldt Wd 1,U.S. Senate,,,WRITE-IN,0
-Allen,0016 Humboldt Wd 1,U.S. House,2,LIB,James Houston Bales,20
-Allen,0016 Humboldt Wd 1,U.S. House,2,REP,Lynn Jenkins,230
-Allen,0016 Humboldt Wd 1,U.S. House,2,DEM,Britani Potter,106
-Allen,0016 Humboldt Wd 1,U.S. House,2,,WRITE-IN,0
-Allen,0016 Humboldt Wd 1,State Senate,12,DEM,Christopher B. Johnston,119
-Allen,0016 Humboldt Wd 1,State Senate,12,REP,Caryn Tyson,204
-Allen,0016 Humboldt Wd 1,State Senate,12,,WRITE-IN,25
-Allen,0016 Humboldt Wd 1,State House,9,LIB,Patrick McMurray,90
-Allen,0016 Humboldt Wd 1,State House,9,REP,Kent L. Thompson,256
-Allen,0016 Humboldt Wd 1,State House,9,,WRITE-IN,1
-Allen,0017 Humboldt Wd 2,President,,DEM,Clinton/Kaine,122
-Allen,0017 Humboldt Wd 2,President,,LIB,Johnson/Weld,17
-Allen,0017 Humboldt Wd 2,President,,IND,Stein/Baraka,13
-Allen,0017 Humboldt Wd 2,President,,REP,Trump/Pence,253
-Allen,0017 Humboldt Wd 2,President,,,WRITE-IN,4
-Allen,0017 Humboldt Wd 2,U.S. Senate,,LIB,Robert D. Garrard,22
-Allen,0017 Humboldt Wd 2,U.S. Senate,,REP,Jerry Moran,294
-Allen,0017 Humboldt Wd 2,U.S. Senate,,DEM,Patrick Wiesner,93
-Allen,0017 Humboldt Wd 2,U.S. Senate,,,WRITE-IN,0
-Allen,0017 Humboldt Wd 2,U.S. House,2,LIB,James Houston Bales,21
-Allen,0017 Humboldt Wd 2,U.S. House,2,REP,Lynn Jenkins,295
-Allen,0017 Humboldt Wd 2,U.S. House,2,DEM,Britani Potter,90
-Allen,0017 Humboldt Wd 2,U.S. House,2,,WRITE-IN,1
-Allen,0017 Humboldt Wd 2,State Senate,12,DEM,Christopher B. Johnston,104
-Allen,0017 Humboldt Wd 2,State Senate,12,REP,Caryn Tyson,258
-Allen,0017 Humboldt Wd 2,State Senate,12,,WRITE-IN,43
-Allen,0017 Humboldt Wd 2,State House,9,LIB,Patrick McMurray,77
-Allen,0017 Humboldt Wd 2,State House,9,REP,Kent L. Thompson,327
-Allen,0017 Humboldt Wd 2,State House,9,,WRITE-IN,1
-Allen,0018 Iola Wd 1,President,,DEM,Clinton/Kaine,145
-Allen,0018 Iola Wd 1,President,,LIB,Johnson/Weld,34
-Allen,0018 Iola Wd 1,President,,IND,Stein/Baraka,10
-Allen,0018 Iola Wd 1,President,,REP,Trump/Pence,282
-Allen,0018 Iola Wd 1,President,,,WRITE-IN,5
-Allen,0018 Iola Wd 1,U.S. Senate,,LIB,Robert D. Garrard,28
-Allen,0018 Iola Wd 1,U.S. Senate,,REP,Jerry Moran,328
-Allen,0018 Iola Wd 1,U.S. Senate,,DEM,Patrick Wiesner,111
-Allen,0018 Iola Wd 1,U.S. Senate,,,WRITE-IN,0
-Allen,0018 Iola Wd 1,U.S. House,2,LIB,James Houston Bales,26
-Allen,0018 Iola Wd 1,U.S. House,2,REP,Lynn Jenkins,323
-Allen,0018 Iola Wd 1,U.S. House,2,DEM,Britani Potter,112
-Allen,0018 Iola Wd 1,U.S. House,2,,WRITE-IN,3
-Allen,0018 Iola Wd 1,State Senate,12,DEM,Christopher B. Johnston,92
-Allen,0018 Iola Wd 1,State Senate,12,REP,Caryn Tyson,282
-Allen,0018 Iola Wd 1,State Senate,12,,WRITE-IN,82
-Allen,0018 Iola Wd 1,State House,9,LIB,Patrick McMurray,89
-Allen,0018 Iola Wd 1,State House,9,REP,Kent L. Thompson,368
-Allen,0018 Iola Wd 1,State House,9,,WRITE-IN,1
-Allen,0019 Iola Wd 2,President,,DEM,Clinton/Kaine,153
-Allen,0019 Iola Wd 2,President,,LIB,Johnson/Weld,20
-Allen,0019 Iola Wd 2,President,,IND,Stein/Baraka,13
-Allen,0019 Iola Wd 2,President,,REP,Trump/Pence,379
-Allen,0019 Iola Wd 2,President,,,WRITE-IN,10
-Allen,0019 Iola Wd 2,U.S. Senate,,LIB,Robert D. Garrard,28
-Allen,0019 Iola Wd 2,U.S. Senate,,REP,Jerry Moran,418
-Allen,0019 Iola Wd 2,U.S. Senate,,DEM,Patrick Wiesner,119
-Allen,0019 Iola Wd 2,U.S. Senate,,,WRITE-IN,1
-Allen,0019 Iola Wd 2,U.S. House,2,LIB,James Houston Bales,23
-Allen,0019 Iola Wd 2,U.S. House,2,REP,Lynn Jenkins,417
-Allen,0019 Iola Wd 2,U.S. House,2,DEM,Britani Potter,131
-Allen,0019 Iola Wd 2,U.S. House,2,,WRITE-IN,1
-Allen,0019 Iola Wd 2,State Senate,12,DEM,Christopher B. Johnston,98
-Allen,0019 Iola Wd 2,State Senate,12,REP,Caryn Tyson,356
-Allen,0019 Iola Wd 2,State Senate,12,,WRITE-IN,103
-Allen,0019 Iola Wd 2,State House,9,LIB,Patrick McMurray,90
-Allen,0019 Iola Wd 2,State House,9,REP,Kent L. Thompson,471
-Allen,0019 Iola Wd 2,State House,9,,WRITE-IN,3
-Allen,0020 Iola Wd 3,President,,DEM,Clinton/Kaine,169
-Allen,0020 Iola Wd 3,President,,LIB,Johnson/Weld,23
-Allen,0020 Iola Wd 3,President,,IND,Stein/Baraka,15
-Allen,0020 Iola Wd 3,President,,REP,Trump/Pence,293
-Allen,0020 Iola Wd 3,President,,,WRITE-IN,12
-Allen,0020 Iola Wd 3,U.S. Senate,,LIB,Robert D. Garrard,37
-Allen,0020 Iola Wd 3,U.S. Senate,,REP,Jerry Moran,307
-Allen,0020 Iola Wd 3,U.S. Senate,,DEM,Patrick Wiesner,147
-Allen,0020 Iola Wd 3,U.S. Senate,,,WRITE-IN,6
-Allen,0020 Iola Wd 3,U.S. House,2,LIB,James Houston Bales,35
-Allen,0020 Iola Wd 3,U.S. House,2,REP,Lynn Jenkins,317
-Allen,0020 Iola Wd 3,U.S. House,2,DEM,Britani Potter,150
-Allen,0020 Iola Wd 3,U.S. House,2,,WRITE-IN,3
-Allen,0020 Iola Wd 3,State Senate,12,DEM,Christopher B. Johnston,118
-Allen,0020 Iola Wd 3,State Senate,12,REP,Caryn Tyson,271
-Allen,0020 Iola Wd 3,State Senate,12,,WRITE-IN,100
-Allen,0020 Iola Wd 3,State House,9,LIB,Patrick McMurray,121
-Allen,0020 Iola Wd 3,State House,9,REP,Kent L. Thompson,381
-Allen,0020 Iola Wd 3,State House,9,,WRITE-IN,1
-Allen,0021 Iola Wd 4,President,,DEM,Clinton/Kaine,149
-Allen,0021 Iola Wd 4,President,,LIB,Johnson/Weld,22
-Allen,0021 Iola Wd 4,President,,IND,Stein/Baraka,14
-Allen,0021 Iola Wd 4,President,,REP,Trump/Pence,334
-Allen,0021 Iola Wd 4,President,,,WRITE-IN,8
-Allen,0021 Iola Wd 4,U.S. Senate,,LIB,Robert D. Garrard,36
-Allen,0021 Iola Wd 4,U.S. Senate,,REP,Jerry Moran,335
-Allen,0021 Iola Wd 4,U.S. Senate,,DEM,Patrick Wiesner,141
-Allen,0021 Iola Wd 4,U.S. Senate,,,WRITE-IN,3
-Allen,0021 Iola Wd 4,U.S. House,2,LIB,James Houston Bales,36
-Allen,0021 Iola Wd 4,U.S. House,2,REP,Lynn Jenkins,347
-Allen,0021 Iola Wd 4,U.S. House,2,DEM,Britani Potter,132
-Allen,0021 Iola Wd 4,U.S. House,2,,WRITE-IN,4
-Allen,0021 Iola Wd 4,State Senate,12,DEM,Christopher B. Johnston,106
-Allen,0021 Iola Wd 4,State Senate,12,REP,Caryn Tyson,298
-Allen,0021 Iola Wd 4,State Senate,12,,WRITE-IN,93
-Allen,0021 Iola Wd 4,State House,9,LIB,Patrick McMurray,117
-Allen,0021 Iola Wd 4,State House,9,REP,Kent L. Thompson,396
-Allen,0021 Iola Wd 4,State House,9,,WRITE-IN,1
+county,precinct,office,district,party,candidate,votes,vtd
+ALLEN,Carlyle Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",21,000010
+ALLEN,Carlyle Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",133,000010
+ALLEN,Cottage Grove Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",17,000020
+ALLEN,Cottage Grove Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",111,000020
+ALLEN,Deer Creek Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",13,000030
+ALLEN,Deer Creek Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",49,000030
+ALLEN,East Elm,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",46,000040
+ALLEN,East Elm,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",225,000040
+ALLEN,Geneva Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",13,000050
+ALLEN,Geneva Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",44,000050
+ALLEN,Humboldt Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",19,00006A
+ALLEN,Humboldt Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",113,00006A
+ALLEN,Humboldt Township Rural Enclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00006B
+ALLEN,Humboldt Township Split,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00006C
+ALLEN,Humboldt Township Split,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00006C
+ALLEN,Humboldt Ward 1,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",90,000070
+ALLEN,Humboldt Ward 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",256,000070
+ALLEN,Humboldt Ward 2,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",77,000080
+ALLEN,Humboldt Ward 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",327,000080
+ALLEN,Iola Ward 1,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",89,000090
+ALLEN,Iola Ward 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",368,000090
+ALLEN,Iola Ward 2,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",90,00010A
+ALLEN,Iola Ward 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",471,00010A
+ALLEN,Iola Ward 2 Exclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00010B
+ALLEN,Iola Ward 2 Exclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00010B
+ALLEN,Iola Ward 3,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",121,000110
+ALLEN,Iola Ward 3,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",381,000110
+ALLEN,Iola Ward 4,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",117,000120
+ALLEN,Iola Ward 4,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",396,000120
+ALLEN,Marmaton Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",253,000140
+ALLEN,North Elsmore,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",52,000150
+ALLEN,North Iola Part A,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",25,00016A
+ALLEN,North Iola Part A,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",110,00016A
+ALLEN,North Iola Part A Rural Enclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00016B
+ALLEN,North Iola Part B,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00016C
+ALLEN,North Iola Part B,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00016C
+ALLEN,Osage Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",81,000170
+ALLEN,Salem Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",21,000180
+ALLEN,Salem Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",106,000180
+ALLEN,South Elsmore,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",42,000190
+ALLEN,South Iola,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",40,00020A
+ALLEN,South Iola,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",232,00020A
+ALLEN,South Iola Enclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00020B
+ALLEN,South Iola Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00020B
+ALLEN,West Elm,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",102,000210
+ALLEN,West Elm,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",397,000210
+ALLEN,Logan Township S12,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",33,120020
+ALLEN,Logan Township S12,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",75,120020
+ALLEN,Logan Township S15,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,120030
+ALLEN,Logan Township S15,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,120030
+ALLEN,Carlyle Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",20,000010
+ALLEN,Carlyle Township,Kansas Senate,12,Republican,"Tyson, Caryn",108,000010
+ALLEN,Cottage Grove Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",21,000020
+ALLEN,Cottage Grove Township,Kansas Senate,12,Republican,"Tyson, Caryn",104,000020
+ALLEN,Deer Creek Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",9,000030
+ALLEN,Deer Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",38,000030
+ALLEN,East Elm,Kansas Senate,12,Democratic,"Johnston, Christopher B.",54,000040
+ALLEN,East Elm,Kansas Senate,12,Republican,"Tyson, Caryn",174,000040
+ALLEN,Geneva Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",9,000050
+ALLEN,Geneva Township,Kansas Senate,12,Republican,"Tyson, Caryn",40,000050
+ALLEN,Humboldt Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",23,00006A
+ALLEN,Humboldt Township,Kansas Senate,12,Republican,"Tyson, Caryn",97,00006A
+ALLEN,Humboldt Township Rural Enclave,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00006B
+ALLEN,Humboldt Township Split,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00006C
+ALLEN,Humboldt Township Split,Kansas Senate,12,Republican,"Tyson, Caryn",0,00006C
+ALLEN,Humboldt Ward 1,Kansas Senate,12,Democratic,"Johnston, Christopher B.",119,000070
+ALLEN,Humboldt Ward 1,Kansas Senate,12,Republican,"Tyson, Caryn",204,000070
+ALLEN,Humboldt Ward 2,Kansas Senate,12,Democratic,"Johnston, Christopher B.",104,000080
+ALLEN,Humboldt Ward 2,Kansas Senate,12,Republican,"Tyson, Caryn",258,000080
+ALLEN,Iola Ward 1,Kansas Senate,12,Democratic,"Johnston, Christopher B.",92,000090
+ALLEN,Iola Ward 1,Kansas Senate,12,Republican,"Tyson, Caryn",282,000090
+ALLEN,Iola Ward 2,Kansas Senate,12,Democratic,"Johnston, Christopher B.",98,00010A
+ALLEN,Iola Ward 2,Kansas Senate,12,Republican,"Tyson, Caryn",356,00010A
+ALLEN,Iola Ward 2 Exclave,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00010B
+ALLEN,Iola Ward 2 Exclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00010B
+ALLEN,Iola Ward 3,Kansas Senate,12,Democratic,"Johnston, Christopher B.",118,000110
+ALLEN,Iola Ward 3,Kansas Senate,12,Republican,"Tyson, Caryn",271,000110
+ALLEN,Iola Ward 4,Kansas Senate,12,Democratic,"Johnston, Christopher B.",106,000120
+ALLEN,Iola Ward 4,Kansas Senate,12,Republican,"Tyson, Caryn",298,000120
+ALLEN,Marmaton Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",48,000140
+ALLEN,Marmaton Township,Kansas Senate,12,Republican,"Tyson, Caryn",198,000140
+ALLEN,North Elsmore,Kansas Senate,12,Democratic,"Johnston, Christopher B.",14,000150
+ALLEN,North Elsmore,Kansas Senate,12,Republican,"Tyson, Caryn",75,000150
+ALLEN,North Iola Part A,Kansas Senate,12,Democratic,"Johnston, Christopher B.",24,00016A
+ALLEN,North Iola Part A,Kansas Senate,12,Republican,"Tyson, Caryn",93,00016A
+ALLEN,North Iola Part A Rural Enclave,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00016B
+ALLEN,North Iola Part B,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00016C
+ALLEN,North Iola Part B,Kansas Senate,12,Republican,"Tyson, Caryn",0,00016C
+ALLEN,Osage Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",21,000170
+ALLEN,Osage Township,Kansas Senate,12,Republican,"Tyson, Caryn",82,000170
+ALLEN,Salem Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",32,000180
+ALLEN,Salem Township,Kansas Senate,12,Republican,"Tyson, Caryn",86,000180
+ALLEN,South Elsmore,Kansas Senate,12,Democratic,"Johnston, Christopher B.",16,000190
+ALLEN,South Elsmore,Kansas Senate,12,Republican,"Tyson, Caryn",48,000190
+ALLEN,South Iola,Kansas Senate,12,Democratic,"Johnston, Christopher B.",47,00020A
+ALLEN,South Iola,Kansas Senate,12,Republican,"Tyson, Caryn",171,00020A
+ALLEN,South Iola Enclave,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00020B
+ALLEN,South Iola Enclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00020B
+ALLEN,West Elm,Kansas Senate,12,Democratic,"Johnston, Christopher B.",86,000210
+ALLEN,West Elm,Kansas Senate,12,Republican,"Tyson, Caryn",304,000210
+ALLEN,Logan Township S12,Kansas Senate,12,Democratic,"Johnston, Christopher B.",18,120020
+ALLEN,Logan Township S12,Kansas Senate,12,Republican,"Tyson, Caryn",86,120020
+ALLEN,Logan Township S15,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,120030
+ALLEN,Logan Township S15,Kansas Senate,15,Republican,"Goddard, Dan",0,120030
+ALLEN,Carlyle Township,President / Vice President,,independent,"Stein, Jill",3,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+ALLEN,Carlyle Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+ALLEN,Carlyle Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000010
+ALLEN,Carlyle Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000010
+ALLEN,Carlyle Township,President / Vice President,,Republican,"Trump, Donald J.",112,000010
+ALLEN,Cottage Grove Township,President / Vice President,,independent,"Stein, Jill",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"McMullin, Evan",1,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+ALLEN,Cottage Grove Township,President / Vice President,,Republican,"Trump, Donald J.",110,000020
+ALLEN,Deer Creek Township,President / Vice President,,independent,"Stein, Jill",1,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ALLEN,Deer Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000030
+ALLEN,Deer Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+ALLEN,Deer Creek Township,President / Vice President,,Republican,"Trump, Donald J.",46,000030
+ALLEN,East Elm,President / Vice President,,independent,"Stein, Jill",4,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Hedges, James A",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"McMullin, Evan",2,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Smith, Mike",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ALLEN,East Elm,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ALLEN,East Elm,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,000040
+ALLEN,East Elm,President / Vice President,,Libertarian,"Johnson, Gary",13,000040
+ALLEN,East Elm,President / Vice President,,Republican,"Trump, Donald J.",197,000040
+ALLEN,Geneva Township,President / Vice President,,independent,"Stein, Jill",2,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+ALLEN,Geneva Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+ALLEN,Geneva Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000050
+ALLEN,Geneva Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+ALLEN,Geneva Township,President / Vice President,,Republican,"Trump, Donald J.",44,000050
+ALLEN,Humboldt Township,President / Vice President,,independent,"Stein, Jill",3,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Hedges, James A",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"McMullin, Evan",2,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Smith, Mike",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+ALLEN,Humboldt Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,00006A
+ALLEN,Humboldt Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00006A
+ALLEN,Humboldt Township,President / Vice President,,Republican,"Trump, Donald J.",106,00006A
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,independent,"Stein, Jill",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Hedges, James A",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Smith, Mike",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+ALLEN,Humboldt Township Rural Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+ALLEN,Humboldt Township Split,President / Vice President,,independent,"Stein, Jill",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Castle, Darrell L",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Giordani, Rocky",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Hedges, James A",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Kahn, Lynn",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"La Riva, Gloria",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Levinson, Michael S.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Maturen, Michael A",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"McMullin, Evan",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Perry, Darryl",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Schriner, Joe C",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Smith, Mike",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Sood, Ajay",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Sterling, Shawna",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+ALLEN,Humboldt Township Split,President / Vice President,,Republican,"Trump, Donald J.",0,00006C
+ALLEN,Humboldt Ward 1,President / Vice President,,independent,"Stein, Jill",13,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"McMullin, Evan",3,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",114,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",19,000070
+ALLEN,Humboldt Ward 1,President / Vice President,,Republican,"Trump, Donald J.",212,000070
+ALLEN,Humboldt Ward 2,President / Vice President,,independent,"Stein, Jill",13,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",17,000080
+ALLEN,Humboldt Ward 2,President / Vice President,,Republican,"Trump, Donald J.",253,000080
+ALLEN,Iola Ward 1,President / Vice President,,independent,"Stein, Jill",10,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Castle, Darrell L",1,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+ALLEN,Iola Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",145,000090
+ALLEN,Iola Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",34,000090
+ALLEN,Iola Ward 1,President / Vice President,,Republican,"Trump, Donald J.",282,000090
+ALLEN,Iola Ward 2,President / Vice President,,independent,"Stein, Jill",13,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",153,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",20,00010A
+ALLEN,Iola Ward 2,President / Vice President,,Republican,"Trump, Donald J.",379,00010A
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+ALLEN,Iola Ward 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00010B
+ALLEN,Iola Ward 3,President / Vice President,,independent,"Stein, Jill",15,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"McMullin, Evan",3,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+ALLEN,Iola Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",169,000110
+ALLEN,Iola Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",23,000110
+ALLEN,Iola Ward 3,President / Vice President,,Republican,"Trump, Donald J.",293,000110
+ALLEN,Iola Ward 4,President / Vice President,,independent,"Stein, Jill",14,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+ALLEN,Iola Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",149,000120
+ALLEN,Iola Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",22,000120
+ALLEN,Iola Ward 4,President / Vice President,,Republican,"Trump, Donald J.",334,000120
+ALLEN,Marmaton Township,President / Vice President,,independent,"Stein, Jill",5,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+ALLEN,Marmaton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+ALLEN,Marmaton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,000140
+ALLEN,Marmaton Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000140
+ALLEN,Marmaton Township,President / Vice President,,Republican,"Trump, Donald J.",265,000140
+ALLEN,North Elsmore,President / Vice President,,independent,"Stein, Jill",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Hedges, James A",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"McMullin, Evan",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Perry, Darryl",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Smith, Mike",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Sood, Ajay",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+ALLEN,North Elsmore,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+ALLEN,North Elsmore,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000150
+ALLEN,North Elsmore,President / Vice President,,Libertarian,"Johnson, Gary",6,000150
+ALLEN,North Elsmore,President / Vice President,,Republican,"Trump, Donald J.",63,000150
+ALLEN,North Iola Part A,President / Vice President,,independent,"Stein, Jill",3,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Hedges, James A",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"McMullin, Evan",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Smith, Mike",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+ALLEN,North Iola Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,00016A
+ALLEN,North Iola Part A,President / Vice President,,Libertarian,"Johnson, Gary",7,00016A
+ALLEN,North Iola Part A,President / Vice President,,Republican,"Trump, Donald J.",101,00016A
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,independent,"Stein, Jill",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Hedges, James A",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Smith, Mike",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+ALLEN,North Iola Part A Rural Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00016B
+ALLEN,North Iola Part B,President / Vice President,,independent,"Stein, Jill",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Hedges, James A",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"McMullin, Evan",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Perry, Darryl",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Smith, Mike",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Sood, Ajay",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00016C
+ALLEN,North Iola Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00016C
+ALLEN,Osage Township,President / Vice President,,independent,"Stein, Jill",1,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+ALLEN,Osage Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+ALLEN,Osage Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000170
+ALLEN,Osage Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000170
+ALLEN,Osage Township,President / Vice President,,Republican,"Trump, Donald J.",91,000170
+ALLEN,Salem Township,President / Vice President,,independent,"Stein, Jill",5,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+ALLEN,Salem Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+ALLEN,Salem Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000180
+ALLEN,Salem Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000180
+ALLEN,Salem Township,President / Vice President,,Republican,"Trump, Donald J.",87,000180
+ALLEN,South Elsmore,President / Vice President,,independent,"Stein, Jill",1,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Hedges, James A",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"McMullin, Evan",2,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Perry, Darryl",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Smith, Mike",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Sood, Ajay",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+ALLEN,South Elsmore,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+ALLEN,South Elsmore,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000190
+ALLEN,South Elsmore,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+ALLEN,South Elsmore,President / Vice President,,Republican,"Trump, Donald J.",47,000190
+ALLEN,South Iola,President / Vice President,,independent,"Stein, Jill",7,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Castle, Darrell L",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Giordani, Rocky",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Hedges, James A",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Kahn, Lynn",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"La Riva, Gloria",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Levinson, Michael S.",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Maturen, Michael A",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"McMullin, Evan",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Perry, Darryl",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Schriner, Joe C",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Smith, Mike",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Sood, Ajay",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Sterling, Shawna",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020A
+ALLEN,South Iola,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020A
+ALLEN,South Iola,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,00020A
+ALLEN,South Iola,President / Vice President,,Libertarian,"Johnson, Gary",5,00020A
+ALLEN,South Iola,President / Vice President,,Republican,"Trump, Donald J.",197,00020A
+ALLEN,South Iola Enclave,President / Vice President,,independent,"Stein, Jill",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Hedges, James A",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Smith, Mike",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00020B
+ALLEN,South Iola Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00020B
+ALLEN,West Elm,President / Vice President,,independent,"Stein, Jill",8,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Hedges, James A",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"McMullin, Evan",2,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Perry, Darryl",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Smith, Mike",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Sood, Ajay",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+ALLEN,West Elm,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+ALLEN,West Elm,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,000210
+ALLEN,West Elm,President / Vice President,,Libertarian,"Johnson, Gary",22,000210
+ALLEN,West Elm,President / Vice President,,Republican,"Trump, Donald J.",351,000210
+ALLEN,Logan Township S12,President / Vice President,,independent,"Stein, Jill",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Hedges, James A",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"McMullin, Evan",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Perry, Darryl",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Smith, Mike",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Sood, Ajay",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+ALLEN,Logan Township S12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+ALLEN,Logan Township S12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,120020
+ALLEN,Logan Township S12,President / Vice President,,Libertarian,"Johnson, Gary",5,120020
+ALLEN,Logan Township S12,President / Vice President,,Republican,"Trump, Donald J.",81,120020
+ALLEN,Logan Township S15,President / Vice President,,independent,"Stein, Jill",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Hedges, James A",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"McMullin, Evan",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Perry, Darryl",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Smith, Mike",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Sood, Ajay",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+ALLEN,Logan Township S15,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+ALLEN,Logan Township S15,President / Vice President,,Republican,"Trump, Donald J.",0,120030
+ALLEN,Carlyle Township,United States House of Representatives,2,Democratic,"Potter, Britani",27,000010
+ALLEN,Carlyle Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000010
+ALLEN,Carlyle Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,000010
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000020
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000020
+ALLEN,Cottage Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,000020
+ALLEN,Deer Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",11,000030
+ALLEN,Deer Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000030
+ALLEN,Deer Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000030
+ALLEN,East Elm,United States House of Representatives,2,Democratic,"Potter, Britani",57,000040
+ALLEN,East Elm,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000040
+ALLEN,East Elm,United States House of Representatives,2,Republican,"Jenkins, Lynn",196,000040
+ALLEN,Geneva Township,United States House of Representatives,2,Democratic,"Potter, Britani",8,000050
+ALLEN,Geneva Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000050
+ALLEN,Geneva Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000050
+ALLEN,Humboldt Township,United States House of Representatives,2,Democratic,"Potter, Britani",21,00006A
+ALLEN,Humboldt Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,00006A
+ALLEN,Humboldt Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",107,00006A
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006B
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Democratic,"Potter, Britani",0,00006C
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00006C
+ALLEN,Humboldt Township Split,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006C
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",106,000070
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000070
+ALLEN,Humboldt Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,000070
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",90,000080
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000080
+ALLEN,Humboldt Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",295,000080
+ALLEN,Iola Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",112,000090
+ALLEN,Iola Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",26,000090
+ALLEN,Iola Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",323,000090
+ALLEN,Iola Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",131,00010A
+ALLEN,Iola Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,00010A
+ALLEN,Iola Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",417,00010A
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+ALLEN,Iola Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",150,000110
+ALLEN,Iola Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",35,000110
+ALLEN,Iola Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",317,000110
+ALLEN,Iola Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",132,000120
+ALLEN,Iola Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",36,000120
+ALLEN,Iola Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",347,000120
+ALLEN,Marmaton Township,United States House of Representatives,2,Democratic,"Potter, Britani",73,000140
+ALLEN,Marmaton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",30,000140
+ALLEN,Marmaton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",253,000140
+ALLEN,North Elsmore,United States House of Representatives,2,Democratic,"Potter, Britani",15,000150
+ALLEN,North Elsmore,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000150
+ALLEN,North Elsmore,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000150
+ALLEN,North Iola Part A,United States House of Representatives,2,Democratic,"Potter, Britani",20,00016A
+ALLEN,North Iola Part A,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,00016A
+ALLEN,North Iola Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,00016A
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+ALLEN,North Iola Part B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00016C
+ALLEN,North Iola Part B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00016C
+ALLEN,North Iola Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016C
+ALLEN,Osage Township,United States House of Representatives,2,Democratic,"Potter, Britani",29,000170
+ALLEN,Osage Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000170
+ALLEN,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,000170
+ALLEN,Salem Township,United States House of Representatives,2,Democratic,"Potter, Britani",31,000180
+ALLEN,Salem Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000180
+ALLEN,Salem Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000180
+ALLEN,South Elsmore,United States House of Representatives,2,Democratic,"Potter, Britani",18,000190
+ALLEN,South Elsmore,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000190
+ALLEN,South Elsmore,United States House of Representatives,2,Republican,"Jenkins, Lynn",51,000190
+ALLEN,South Iola,United States House of Representatives,2,Democratic,"Potter, Britani",60,00020A
+ALLEN,South Iola,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,00020A
+ALLEN,South Iola,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,00020A
+ALLEN,South Iola Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00020B
+ALLEN,South Iola Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00020B
+ALLEN,South Iola Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020B
+ALLEN,West Elm,United States House of Representatives,2,Democratic,"Potter, Britani",116,000210
+ALLEN,West Elm,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000210
+ALLEN,West Elm,United States House of Representatives,2,Republican,"Jenkins, Lynn",359,000210
+ALLEN,Logan Township S12,United States House of Representatives,2,Democratic,"Potter, Britani",18,120020
+ALLEN,Logan Township S12,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,120020
+ALLEN,Logan Township S12,United States House of Representatives,2,Republican,"Jenkins, Lynn",88,120020
+ALLEN,Logan Township S15,United States House of Representatives,2,Democratic,"Potter, Britani",0,120030
+ALLEN,Logan Township S15,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120030
+ALLEN,Logan Township S15,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+ALLEN,Carlyle Township,United States Senate,,write - in,"Smith, DJ",0,000010
+ALLEN,Carlyle Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000010
+ALLEN,Carlyle Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000010
+ALLEN,Carlyle Township,United States Senate,,Republican,"Moran, Jerry",128,000010
+ALLEN,Cottage Grove Township,United States Senate,,write - in,"Smith, DJ",0,000020
+ALLEN,Cottage Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000020
+ALLEN,Cottage Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+ALLEN,Cottage Grove Township,United States Senate,,Republican,"Moran, Jerry",110,000020
+ALLEN,Deer Creek Township,United States Senate,,write - in,"Smith, DJ",0,000030
+ALLEN,Deer Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000030
+ALLEN,Deer Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000030
+ALLEN,Deer Creek Township,United States Senate,,Republican,"Moran, Jerry",46,000030
+ALLEN,East Elm,United States Senate,,write - in,"Smith, DJ",0,000040
+ALLEN,East Elm,United States Senate,,Democratic,"Wiesner, Patrick",54,000040
+ALLEN,East Elm,United States Senate,,Libertarian,"Garrard, Robert D.",13,000040
+ALLEN,East Elm,United States Senate,,Republican,"Moran, Jerry",199,000040
+ALLEN,Geneva Township,United States Senate,,write - in,"Smith, DJ",0,000050
+ALLEN,Geneva Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000050
+ALLEN,Geneva Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000050
+ALLEN,Geneva Township,United States Senate,,Republican,"Moran, Jerry",43,000050
+ALLEN,Humboldt Township,United States Senate,,write - in,"Smith, DJ",0,00006A
+ALLEN,Humboldt Township,United States Senate,,Democratic,"Wiesner, Patrick",19,00006A
+ALLEN,Humboldt Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,00006A
+ALLEN,Humboldt Township,United States Senate,,Republican,"Moran, Jerry",112,00006A
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,write - in,"Smith, DJ",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+ALLEN,Humboldt Township Rural Enclave,United States Senate,,Republican,"Moran, Jerry",0,00006B
+ALLEN,Humboldt Township Split,United States Senate,,write - in,"Smith, DJ",0,00006C
+ALLEN,Humboldt Township Split,United States Senate,,Democratic,"Wiesner, Patrick",0,00006C
+ALLEN,Humboldt Township Split,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006C
+ALLEN,Humboldt Township Split,United States Senate,,Republican,"Moran, Jerry",0,00006C
+ALLEN,Humboldt Ward 1,United States Senate,,write - in,"Smith, DJ",0,000070
+ALLEN,Humboldt Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",102,000070
+ALLEN,Humboldt Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",30,000070
+ALLEN,Humboldt Ward 1,United States Senate,,Republican,"Moran, Jerry",226,000070
+ALLEN,Humboldt Ward 2,United States Senate,,write - in,"Smith, DJ",0,000080
+ALLEN,Humboldt Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",93,000080
+ALLEN,Humboldt Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,000080
+ALLEN,Humboldt Ward 2,United States Senate,,Republican,"Moran, Jerry",294,000080
+ALLEN,Iola Ward 1,United States Senate,,write - in,"Smith, DJ",0,000090
+ALLEN,Iola Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",111,000090
+ALLEN,Iola Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",28,000090
+ALLEN,Iola Ward 1,United States Senate,,Republican,"Moran, Jerry",328,000090
+ALLEN,Iola Ward 2,United States Senate,,write - in,"Smith, DJ",0,00010A
+ALLEN,Iola Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",119,00010A
+ALLEN,Iola Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",28,00010A
+ALLEN,Iola Ward 2,United States Senate,,Republican,"Moran, Jerry",418,00010A
+ALLEN,Iola Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00010B
+ALLEN,Iola Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00010B
+ALLEN,Iola Ward 3,United States Senate,,write - in,"Smith, DJ",0,000110
+ALLEN,Iola Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",147,000110
+ALLEN,Iola Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",37,000110
+ALLEN,Iola Ward 3,United States Senate,,Republican,"Moran, Jerry",307,000110
+ALLEN,Iola Ward 4,United States Senate,,write - in,"Smith, DJ",0,000120
+ALLEN,Iola Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",141,000120
+ALLEN,Iola Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",36,000120
+ALLEN,Iola Ward 4,United States Senate,,Republican,"Moran, Jerry",335,000120
+ALLEN,Marmaton Township,United States Senate,,write - in,"Smith, DJ",0,000140
+ALLEN,Marmaton Township,United States Senate,,Democratic,"Wiesner, Patrick",70,000140
+ALLEN,Marmaton Township,United States Senate,,Libertarian,"Garrard, Robert D.",22,000140
+ALLEN,Marmaton Township,United States Senate,,Republican,"Moran, Jerry",270,000140
+ALLEN,North Elsmore,United States Senate,,write - in,"Smith, DJ",0,000150
+ALLEN,North Elsmore,United States Senate,,Democratic,"Wiesner, Patrick",10,000150
+ALLEN,North Elsmore,United States Senate,,Libertarian,"Garrard, Robert D.",7,000150
+ALLEN,North Elsmore,United States Senate,,Republican,"Moran, Jerry",77,000150
+ALLEN,North Iola Part A,United States Senate,,write - in,"Smith, DJ",0,00016A
+ALLEN,North Iola Part A,United States Senate,,Democratic,"Wiesner, Patrick",28,00016A
+ALLEN,North Iola Part A,United States Senate,,Libertarian,"Garrard, Robert D.",12,00016A
+ALLEN,North Iola Part A,United States Senate,,Republican,"Moran, Jerry",96,00016A
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,write - in,"Smith, DJ",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016B
+ALLEN,North Iola Part A Rural Enclave,United States Senate,,Republican,"Moran, Jerry",0,00016B
+ALLEN,North Iola Part B,United States Senate,,write - in,"Smith, DJ",0,00016C
+ALLEN,North Iola Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00016C
+ALLEN,North Iola Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016C
+ALLEN,North Iola Part B,United States Senate,,Republican,"Moran, Jerry",0,00016C
+ALLEN,Osage Township,United States Senate,,write - in,"Smith, DJ",0,000170
+ALLEN,Osage Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000170
+ALLEN,Osage Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+ALLEN,Osage Township,United States Senate,,Republican,"Moran, Jerry",96,000170
+ALLEN,Salem Township,United States Senate,,write - in,"Smith, DJ",0,000180
+ALLEN,Salem Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000180
+ALLEN,Salem Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000180
+ALLEN,Salem Township,United States Senate,,Republican,"Moran, Jerry",89,000180
+ALLEN,South Elsmore,United States Senate,,write - in,"Smith, DJ",0,000190
+ALLEN,South Elsmore,United States Senate,,Democratic,"Wiesner, Patrick",13,000190
+ALLEN,South Elsmore,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+ALLEN,South Elsmore,United States Senate,,Republican,"Moran, Jerry",56,000190
+ALLEN,South Iola,United States Senate,,write - in,"Smith, DJ",0,00020A
+ALLEN,South Iola,United States Senate,,Democratic,"Wiesner, Patrick",54,00020A
+ALLEN,South Iola,United States Senate,,Libertarian,"Garrard, Robert D.",9,00020A
+ALLEN,South Iola,United States Senate,,Republican,"Moran, Jerry",207,00020A
+ALLEN,South Iola Enclave,United States Senate,,write - in,"Smith, DJ",0,00020B
+ALLEN,South Iola Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00020B
+ALLEN,South Iola Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00020B
+ALLEN,South Iola Enclave,United States Senate,,Republican,"Moran, Jerry",0,00020B
+ALLEN,West Elm,United States Senate,,write - in,"Smith, DJ",0,000210
+ALLEN,West Elm,United States Senate,,Democratic,"Wiesner, Patrick",98,000210
+ALLEN,West Elm,United States Senate,,Libertarian,"Garrard, Robert D.",31,000210
+ALLEN,West Elm,United States Senate,,Republican,"Moran, Jerry",367,000210
+ALLEN,Logan Township S12,United States Senate,,write - in,"Smith, DJ",0,120020
+ALLEN,Logan Township S12,United States Senate,,Democratic,"Wiesner, Patrick",17,120020
+ALLEN,Logan Township S12,United States Senate,,Libertarian,"Garrard, Robert D.",8,120020
+ALLEN,Logan Township S12,United States Senate,,Republican,"Moran, Jerry",85,120020
+ALLEN,Logan Township S15,United States Senate,,write - in,"Smith, DJ",0,120030
+ALLEN,Logan Township S15,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+ALLEN,Logan Township S15,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+ALLEN,Logan Township S15,United States Senate,,Republican,"Moran, Jerry",0,120030

--- a/2016/20161108__ks__general__anderson__precinct.csv
+++ b/2016/20161108__ks__general__anderson__precinct.csv
@@ -1,241 +1,647 @@
-county,precinct,office,district,party,candidate,votes
-Anderson,Garnett 1,President,,LBT,Gary Johnson,22
-Anderson,Garnett 2,President,,LBT,Gary Johnson,27
-Anderson,Garnett 3,President,,LBT,Gary Johnson,17
-Anderson,Garnett 4,President,,LBT,Gary Johnson,5
-Anderson,Indian Creek,President,,LBT,Gary Johnson,0
-Anderson,Jackson,President,,LBT,Gary Johnson,9
-Anderson,Lincoln,President,,LBT,Gary Johnson,3
-Anderson,Lone Elm,President,,LBT,Gary Johnson,2
-Anderson,Monroe,President,,LBT,Gary Johnson,7
-Anderson,Ozark,President,,LBT,Gary Johnson,8
-Anderson,Putnam,President,,LBT,Gary Johnson,9
-Anderson,Rich,President,,LBT,Gary Johnson,4
-Anderson,Reeder,President,,LBT,Gary Johnson,3
-Anderson,Walker,President,,LBT,Gary Johnson,18
-Anderson,Washington,President,,LBT,Gary Johnson,4
-Anderson,Welda,President,,LBT,Gary Johnson,2
-Anderson,Westphalia,President,,LBT,Gary Johnson,6
-Anderson,Garnett 1,President,,DEM,Hillary Clinton,99
-Anderson,Garnett 2,President,,DEM,Hillary Clinton,85
-Anderson,Garnett 3,President,,DEM,Hillary Clinton,73
-Anderson,Garnett 4,President,,DEM,Hillary Clinton,17
-Anderson,Indian Creek,President,,DEM,Hillary Clinton,10
-Anderson,Jackson,President,,DEM,Hillary Clinton,32
-Anderson,Lincoln,President,,DEM,Hillary Clinton,16
-Anderson,Lone Elm,President,,DEM,Hillary Clinton,17
-Anderson,Monroe,President,,DEM,Hillary Clinton,28
-Anderson,Ozark,President,,DEM,Hillary Clinton,36
-Anderson,Putnam,President,,DEM,Hillary Clinton,40
-Anderson,Rich,President,,DEM,Hillary Clinton,22
-Anderson,Reeder,President,,DEM,Hillary Clinton,17
-Anderson,Walker,President,,DEM,Hillary Clinton,84
-Anderson,Washington,President,,DEM,Hillary Clinton,29
-Anderson,Welda,President,,DEM,Hillary Clinton,33
-Anderson,Westphalia,President,,DEM,Hillary Clinton,27
-Anderson,Garnett 1,President,,GRE,Jill Stein,12
-Anderson,Garnett 2,President,,GRE,Jill Stein,15
-Anderson,Garnett 3,President,,GRE,Jill Stein,6
-Anderson,Garnett 4,President,,GRE,Jill Stein,2
-Anderson,Indian Creek,President,,GRE,Jill Stein,1
-Anderson,Jackson,President,,GRE,Jill Stein,3
-Anderson,Lincoln,President,,GRE,Jill Stein,1
-Anderson,Lone Elm,President,,GRE,Jill Stein,5
-Anderson,Monroe,President,,GRE,Jill Stein,3
-Anderson,Ozark,President,,GRE,Jill Stein,7
-Anderson,Putnam,President,,GRE,Jill Stein,0
-Anderson,Rich,President,,GRE,Jill Stein,2
-Anderson,Reeder,President,,GRE,Jill Stein,3
-Anderson,Walker,President,,GRE,Jill Stein,8
-Anderson,Washington,President,,GRE,Jill Stein,3
-Anderson,Welda,President,,GRE,Jill Stein,5
-Anderson,Westphalia,President,,GRE,Jill Stein,4
-Anderson,Garnett 1,President,,REP,Donald J Trump,324
-Anderson,Garnett 2,President,,REP,Donald J Trump,290
-Anderson,Garnett 3,President,,REP,Donald J Trump,231
-Anderson,Garnett 4,President,,REP,Donald J Trump,38
-Anderson,Indian Creek,President,,REP,Donald J Trump,52
-Anderson,Jackson,President,,REP,Donald J Trump,151
-Anderson,Lincoln,President,,REP,Donald J Trump,78
-Anderson,Lone Elm,President,,REP,Donald J Trump,88
-Anderson,Monroe,President,,REP,Donald J Trump,132
-Anderson,Ozark,President,,REP,Donald J Trump,208
-Anderson,Putnam,President,,REP,Donald J Trump,99
-Anderson,Rich,President,,REP,Donald J Trump,128
-Anderson,Reeder,President,,REP,Donald J Trump,76
-Anderson,Walker,President,,REP,Donald J Trump,197
-Anderson,Washington,President,,REP,Donald J Trump,94
-Anderson,Welda,President,,REP,Donald J Trump,96
-Anderson,Westphalia,President,,REP,Donald J Trump,104
-Anderson,Garnett 1,U.S. Senate,,,Robert D Garrard ,24
-Anderson,Garnett 2,U.S. Senate,,,Robert D Garrard ,16
-Anderson,Garnett 3,U.S. Senate,,,Robert D Garrard ,19
-Anderson,Garnett 4,U.S. Senate,,,Robert D Garrard ,4
-Anderson,Indian Creek,U.S. Senate,,,Robert D Garrard ,0
-Anderson,Jackson,U.S. Senate,,,Robert D Garrard ,3
-Anderson,Lincoln,U.S. Senate,,,Robert D Garrard ,8
-Anderson,Lone Elm,U.S. Senate,,,Robert D Garrard ,3
-Anderson,Monroe,U.S. Senate,,,Robert D Garrard ,6
-Anderson,Ozark,U.S. Senate,,,Robert D Garrard ,11
-Anderson,Putnam,U.S. Senate,,,Robert D Garrard ,8
-Anderson,Rich,U.S. Senate,,,Robert D Garrard ,7
-Anderson,Reeder,U.S. Senate,,,Robert D Garrard ,4
-Anderson,Walker,U.S. Senate,,,Robert D Garrard ,26
-Anderson,Washington,U.S. Senate,,,Robert D Garrard ,5
-Anderson,Welda,U.S. Senate,,,Robert D Garrard ,6
-Anderson,Westphalia,U.S. Senate,,,Robert D Garrard ,5
-Anderson,Garnett 1,U.S. Senate,,REP,Jerry Moran,334
-Anderson,Garnett 2,U.S. Senate,,REP,Jerry Moran,299
-Anderson,Garnett 3,U.S. Senate,,REP,Jerry Moran,225
-Anderson,Garnett 4,U.S. Senate,,REP,Jerry Moran,32
-Anderson,Indian Creek,U.S. Senate,,REP,Jerry Moran,50
-Anderson,Jackson,U.S. Senate,,REP,Jerry Moran,153
-Anderson,Lincoln,U.S. Senate,,REP,Jerry Moran,76
-Anderson,Lone Elm,U.S. Senate,,REP,Jerry Moran,89
-Anderson,Monroe,U.S. Senate,,REP,Jerry Moran,132
-Anderson,Ozark,U.S. Senate,,REP,Jerry Moran,198
-Anderson,Putnam,U.S. Senate,,REP,Jerry Moran,95
-Anderson,Rich,U.S. Senate,,REP,Jerry Moran,127
-Anderson,Reeder,U.S. Senate,,REP,Jerry Moran,74
-Anderson,Walker,U.S. Senate,,REP,Jerry Moran,199
-Anderson,Washington,U.S. Senate,,REP,Jerry Moran,97
-Anderson,Welda,U.S. Senate,,REP,Jerry Moran,97
-Anderson,Westphalia,U.S. Senate,,REP,Jerry Moran,104
-Anderson,Garnett 1,U.S. Senate,,,Patrick Wiesner ,101
-Anderson,Garnett 2,U.S. Senate,,,Patrick Wiesner ,98
-Anderson,Garnett 3,U.S. Senate,,,Patrick Wiesner ,77
-Anderson,Garnett 4,U.S. Senate,,,Patrick Wiesner ,24
-Anderson,Indian Creek,U.S. Senate,,,Patrick Wiesner ,11
-Anderson,Jackson,U.S. Senate,,,Patrick Wiesner ,37
-Anderson,Lincoln,U.S. Senate,,,Patrick Wiesner ,13
-Anderson,Lone Elm,U.S. Senate,,,Patrick Wiesner ,16
-Anderson,Monroe,U.S. Senate,,,Patrick Wiesner ,31
-Anderson,Ozark,U.S. Senate,,,Patrick Wiesner ,44
-Anderson,Putnam,U.S. Senate,,,Patrick Wiesner ,42
-Anderson,Rich,U.S. Senate,,,Patrick Wiesner ,25
-Anderson,Reeder,U.S. Senate,,,Patrick Wiesner ,20
-Anderson,Walker,U.S. Senate,,,Patrick Wiesner ,85
-Anderson,Washington,U.S. Senate,,,Patrick Wiesner ,24
-Anderson,Welda,U.S. Senate,,,Patrick Wiesner ,30
-Anderson,Westphalia,U.S. Senate,,,Patrick Wiesner ,28
-Anderson,Garnett 1,U.S. House,2,,James Houston Bales ,20
-Anderson,Garnett 2,U.S. House,2,,James Houston Bales ,7
-Anderson,Garnett 3,U.S. House,2,,James Houston Bales ,13
-Anderson,Garnett 4,U.S. House,2,,James Houston Bales ,2
-Anderson,Indian Creek,U.S. House,2,,James Houston Bales ,1
-Anderson,Jackson,U.S. House,2,,James Houston Bales ,1
-Anderson,Lincoln,U.S. House,2,,James Houston Bales ,9
-Anderson,Lone Elm,U.S. House,2,,James Houston Bales ,5
-Anderson,Monroe,U.S. House,2,,James Houston Bales ,3
-Anderson,Ozark,U.S. House,2,,James Houston Bales ,9
-Anderson,Putnam,U.S. House,2,,James Houston Bales ,5
-Anderson,Rich,U.S. House,2,,James Houston Bales ,6
-Anderson,Reeder,U.S. House,2,,James Houston Bales ,6
-Anderson,Walker,U.S. House,2,,James Houston Bales ,12
-Anderson,Washington,U.S. House,2,,James Houston Bales ,6
-Anderson,Welda,U.S. House,2,,James Houston Bales ,6
-Anderson,Westphalia,U.S. House,2,,James Houston Bales ,5
-Anderson,Garnett 1,U.S. House,2,REP,Lynn Jenkins ,333
-Anderson,Garnett 2,U.S. House,2,REP,Lynn Jenkins ,296
-Anderson,Garnett 3,U.S. House,2,REP,Lynn Jenkins ,227
-Anderson,Garnett 4,U.S. House,2,REP,Lynn Jenkins ,37
-Anderson,Indian Creek,U.S. House,2,REP,Lynn Jenkins ,50
-Anderson,Jackson,U.S. House,2,REP,Lynn Jenkins ,161
-Anderson,Lincoln,U.S. House,2,REP,Lynn Jenkins ,74
-Anderson,Lone Elm,U.S. House,2,REP,Lynn Jenkins ,86
-Anderson,Monroe,U.S. House,2,REP,Lynn Jenkins ,130
-Anderson,Ozark,U.S. House,2,REP,Lynn Jenkins ,189
-Anderson,Putnam,U.S. House,2,REP,Lynn Jenkins ,102
-Anderson,Rich,U.S. House,2,REP,Lynn Jenkins ,128
-Anderson,Reeder,U.S. House,2,REP,Lynn Jenkins ,71
-Anderson,Walker,U.S. House,2,REP,Lynn Jenkins ,221
-Anderson,Washington,U.S. House,2,REP,Lynn Jenkins ,99
-Anderson,Welda,U.S. House,2,REP,Lynn Jenkins ,94
-Anderson,Westphalia,U.S. House,2,REP,Lynn Jenkins ,100
-Anderson,Garnett 1,U.S. House,2,,Britani Potter ,105
-Anderson,Garnett 2,U.S. House,2,,Britani Potter ,109
-Anderson,Garnett 3,U.S. House,2,,Britani Potter ,85
-Anderson,Garnett 4,U.S. House,2,,Britani Potter ,23
-Anderson,Indian Creek,U.S. House,2,,Britani Potter ,9
-Anderson,Jackson,U.S. House,2,,Britani Potter ,33
-Anderson,Lincoln,U.S. House,2,,Britani Potter ,14
-Anderson,Lone Elm,U.S. House,2,,Britani Potter ,16
-Anderson,Monroe,U.S. House,2,,Britani Potter ,36
-Anderson,Ozark,U.S. House,2,,Britani Potter ,56
-Anderson,Putnam,U.S. House,2,,Britani Potter ,39
-Anderson,Rich,U.S. House,2,,Britani Potter ,24
-Anderson,Reeder,U.S. House,2,,Britani Potter ,22
-Anderson,Walker,U.S. House,2,,Britani Potter ,80
-Anderson,Washington,U.S. House,2,,Britani Potter ,24
-Anderson,Welda,U.S. House,2,,Britani Potter ,35
-Anderson,Westphalia,U.S. House,2,,Britani Potter ,32
-Anderson,Garnett 1,State Senate,12,,Christopher B Johnston ,111
-Anderson,Garnett 2,State Senate,12,,Christopher B Johnston ,99
-Anderson,Garnett 3,State Senate,12,,Christopher B Johnston ,73
-Anderson,Garnett 4,State Senate,12,,Christopher B Johnston ,19
-Anderson,Indian Creek,State Senate,12,,Christopher B Johnston ,12
-Anderson,Jackson,State Senate,12,,Christopher B Johnston ,31
-Anderson,Lincoln,State Senate,12,,Christopher B Johnston ,15
-Anderson,Lone Elm,State Senate,12,,Christopher B Johnston ,21
-Anderson,Monroe,State Senate,12,,Christopher B Johnston ,31
-Anderson,Ozark,State Senate,12,,Christopher B Johnston ,59
-Anderson,Putnam,State Senate,12,,Christopher B Johnston ,39
-Anderson,Rich,State Senate,12,,Christopher B Johnston ,26
-Anderson,Reeder,State Senate,12,,Christopher B Johnston ,26
-Anderson,Walker,State Senate,12,,Christopher B Johnston ,76
-Anderson,Washington,State Senate,12,,Christopher B Johnston ,23
-Anderson,Welda,State Senate,12,,Christopher B Johnston ,37
-Anderson,Westphalia,State Senate,12,,Christopher B Johnston ,31
-Anderson,Garnett 1,State Senate,12,,Caryn Tyson ,302
-Anderson,Garnett 2,State Senate,12,,Caryn Tyson ,266
-Anderson,Garnett 3,State Senate,12,,Caryn Tyson ,222
-Anderson,Garnett 4,State Senate,12,,Caryn Tyson ,36
-Anderson,Indian Creek,State Senate,12,,Caryn Tyson ,48
-Anderson,Jackson,State Senate,12,,Caryn Tyson ,151
-Anderson,Lincoln,State Senate,12,,Caryn Tyson ,80
-Anderson,Lone Elm,State Senate,12,,Caryn Tyson ,78
-Anderson,Monroe,State Senate,12,,Caryn Tyson ,117
-Anderson,Ozark,State Senate,12,,Caryn Tyson ,172
-Anderson,Putnam,State Senate,12,,Caryn Tyson ,93
-Anderson,Rich,State Senate,12,,Caryn Tyson ,114
-Anderson,Reeder,State Senate,12,,Caryn Tyson ,67
-Anderson,Walker,State Senate,12,,Caryn Tyson ,205
-Anderson,Washington,State Senate,12,,Caryn Tyson ,94
-Anderson,Welda,State Senate,12,,Caryn Tyson ,84
-Anderson,Westphalia,State Senate,12,,Caryn Tyson ,96
-Anderson,Garnett 1,State House,5,,Doug Walker ,167
-Anderson,Garnett 2,State House,5,,Doug Walker ,152
-Anderson,Garnett 3,State House,5,,Doug Walker ,122
-Anderson,Garnett 4,State House,5,,Doug Walker ,28
-Anderson,Indian Creek,State House,5,,Doug Walker ,16
-Anderson,Jackson,State House,5,,Doug Walker ,62
-Anderson,Lincoln,State House,5,,Doug Walker ,23
-Anderson,Lone Elm,State House,5,,Doug Walker ,0
-Anderson,Monroe,State House,5,,Doug Walker ,59
-Anderson,Ozark,State House,5,,Doug Walker ,83
-Anderson,Putnam,State House,5,,Doug Walker ,57
-Anderson,Rich,State House,5,,Doug Walker ,0
-Anderson,Reeder,State House,5,,Doug Walker ,30
-Anderson,Walker,State House,5,,Doug Walker ,171
-Anderson,Washington,State House,5,,Doug Walker ,46
-Anderson,Welda,State House,5,,Doug Walker ,47
-Anderson,Westphalia,State House,5,,Doug Walker ,49
-Anderson,Garnett 1,State House,5,,Kevin Jones,288
-Anderson,Garnett 2,State House,5,,Kevin Jones,259
-Anderson,Garnett 3,State House,5,,Kevin Jones,203
-Anderson,Garnett 4,State House,5,,Kevin Jones,34
-Anderson,Indian Creek,State House,5,,Kevin Jones,45
-Anderson,Jackson,State House,5,,Kevin Jones,133
-Anderson,Lincoln,State House,5,,Kevin Jones,73
-Anderson,Lone Elm,State House,5,,Kevin Jones,0
-Anderson,Monroe,State House,5,,Kevin Jones,111
-Anderson,Ozark,State House,5,,Kevin Jones,172
-Anderson,Putnam,State House,5,,Kevin Jones,86
-Anderson,Rich,State House,5,,Kevin Jones,0
-Anderson,Reeder,State House,5,,Kevin Jones,67
-Anderson,Walker,State House,5,,Kevin Jones,141
-Anderson,Washington,State House,5,,Kevin Jones,81
-Anderson,Welda,State House,5,,Kevin Jones,85
-Anderson,Westphalia,State House,5,,Kevin Jones,83
-Anderson,Lone Elm,State House,4,,Trevor Jacobs,91
-Anderson,Rich,State House,4,,Trevor Jacobs,132
+county,precinct,office,district,party,candidate,votes,vtd
+ANDERSON,Garnett Precinct 1,Kansas House of Representatives,5,Democratic,"Walker, Doug",168,00002A
+ANDERSON,Garnett Precinct 1,Kansas House of Representatives,5,Republican,"Jones, Kevin",299,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Kansas House of Representatives,5,Democratic,"Walker, Doug",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Kansas House of Representatives,5,Republican,"Jones, Kevin",0,00002B
+ANDERSON,Garnett Precinct 2,Kansas House of Representatives,5,Democratic,"Walker, Doug",158,000030
+ANDERSON,Garnett Precinct 2,Kansas House of Representatives,5,Republican,"Jones, Kevin",167,000030
+ANDERSON,Garnett Precinct 3,Kansas House of Representatives,5,Democratic,"Walker, Doug",124,000040
+ANDERSON,Garnett Precinct 3,Kansas House of Representatives,5,Republican,"Jones, Kevin",211,000040
+ANDERSON,Garnett Precinct 4,Kansas House of Representatives,5,Democratic,"Walker, Doug",28,000050
+ANDERSON,Garnett Precinct 4,Kansas House of Representatives,5,Republican,"Jones, Kevin",37,000050
+ANDERSON,Indian Creek Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",16,000080
+ANDERSON,Indian Creek Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",48,000080
+ANDERSON,Lincoln Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",23,000110
+ANDERSON,Lincoln Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",73,000110
+ANDERSON,Monroe Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",59,00014A
+ANDERSON,Monroe Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",113,00014A
+ANDERSON,Putnam Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",57,000170
+ANDERSON,Putnam Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",86,000170
+ANDERSON,Reeder Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",30,000180
+ANDERSON,Reeder Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",67,000180
+ANDERSON,Washington Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",46,000210
+ANDERSON,Washington Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",81,000210
+ANDERSON,Welda Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",47,000220
+ANDERSON,Welda Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",86,000220
+ANDERSON,Lone Elm Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",91,130010
+ANDERSON,Ozark Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",83,130020
+ANDERSON,Ozark Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",175,130020
+ANDERSON,Rich Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",134,130030
+ANDERSON,Walker Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",171,130040
+ANDERSON,Walker Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",143,130040
+ANDERSON,Westphalia Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",49,130050
+ANDERSON,Westphalia Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",85,130050
+ANDERSON,Jackson Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",63,140010
+ANDERSON,Jackson Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",133,140010
+ANDERSON,Garnett Precinct 1,Kansas Senate,12,Democratic,"Johnston, Christopher B.",113,00002A
+ANDERSON,Garnett Precinct 1,Kansas Senate,12,Republican,"Tyson, Caryn",312,00002A
+ANDERSON,Garnett Precinct 1 Exclave,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002B
+ANDERSON,Garnett Precinct 2,Kansas Senate,12,Democratic,"Johnston, Christopher B.",105,000030
+ANDERSON,Garnett Precinct 2,Kansas Senate,12,Republican,"Tyson, Caryn",275,000030
+ANDERSON,Garnett Precinct 3,Kansas Senate,12,Democratic,"Johnston, Christopher B.",77,000040
+ANDERSON,Garnett Precinct 3,Kansas Senate,12,Republican,"Tyson, Caryn",228,000040
+ANDERSON,Garnett Precinct 4,Kansas Senate,12,Democratic,"Johnston, Christopher B.",19,000050
+ANDERSON,Garnett Precinct 4,Kansas Senate,12,Republican,"Tyson, Caryn",40,000050
+ANDERSON,Indian Creek Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",12,000080
+ANDERSON,Indian Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",51,000080
+ANDERSON,Lincoln Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",15,000110
+ANDERSON,Lincoln Township,Kansas Senate,12,Republican,"Tyson, Caryn",80,000110
+ANDERSON,Monroe Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",31,00014A
+ANDERSON,Monroe Township,Kansas Senate,12,Republican,"Tyson, Caryn",119,00014A
+ANDERSON,Putnam Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",39,000170
+ANDERSON,Putnam Township,Kansas Senate,12,Republican,"Tyson, Caryn",93,000170
+ANDERSON,Reeder Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",26,000180
+ANDERSON,Reeder Township,Kansas Senate,12,Republican,"Tyson, Caryn",67,000180
+ANDERSON,Washington Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",23,000210
+ANDERSON,Washington Township,Kansas Senate,12,Republican,"Tyson, Caryn",94,000210
+ANDERSON,Welda Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",37,000220
+ANDERSON,Welda Township,Kansas Senate,12,Republican,"Tyson, Caryn",85,000220
+ANDERSON,Lone Elm Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",21,130010
+ANDERSON,Lone Elm Township,Kansas Senate,12,Republican,"Tyson, Caryn",78,130010
+ANDERSON,Ozark Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",60,130020
+ANDERSON,Ozark Township,Kansas Senate,12,Republican,"Tyson, Caryn",177,130020
+ANDERSON,Rich Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",26,130030
+ANDERSON,Rich Township,Kansas Senate,12,Republican,"Tyson, Caryn",118,130030
+ANDERSON,Walker Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",76,130040
+ANDERSON,Walker Township,Kansas Senate,12,Republican,"Tyson, Caryn",207,130040
+ANDERSON,Westphalia Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",31,130050
+ANDERSON,Westphalia Township,Kansas Senate,12,Republican,"Tyson, Caryn",98,130050
+ANDERSON,Jackson Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",31,140010
+ANDERSON,Jackson Township,Kansas Senate,12,Republican,"Tyson, Caryn",152,140010
+ANDERSON,Garnett Precinct 1,President / Vice President,,independent,"Stein, Jill",12,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",100,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",23,00002A
+ANDERSON,Garnett Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",334,00002A
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00002B
+ANDERSON,Garnett Precinct 2,President / Vice President,,independent,"Stein, Jill",16,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",27,000030
+ANDERSON,Garnett Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",300,000030
+ANDERSON,Garnett Precinct 3,President / Vice President,,independent,"Stein, Jill",6,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"McMullin, Evan",2,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",19,000040
+ANDERSON,Garnett Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",238,000040
+ANDERSON,Garnett Precinct 4,President / Vice President,,independent,"Stein, Jill",2,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"McMullin, Evan",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+ANDERSON,Garnett Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",42,000050
+ANDERSON,Indian Creek Township,President / Vice President,,independent,"Stein, Jill",1,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+ANDERSON,Indian Creek Township,President / Vice President,,Republican,"Trump, Donald J.",55,000080
+ANDERSON,Lincoln Township,President / Vice President,,independent,"Stein, Jill",1,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+ANDERSON,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000110
+ANDERSON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+ANDERSON,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",78,000110
+ANDERSON,Monroe Township,President / Vice President,,independent,"Stein, Jill",3,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Castle, Darrell L",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Giordani, Rocky",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Hedges, James A",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Kahn, Lynn",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"La Riva, Gloria",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Maturen, Michael A",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"McMullin, Evan",1,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Perry, Darryl",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Schriner, Joe C",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Smith, Mike",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Sood, Ajay",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Sterling, Shawna",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014A
+ANDERSON,Monroe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,00014A
+ANDERSON,Monroe Township,President / Vice President,,Libertarian,"Johnson, Gary",8,00014A
+ANDERSON,Monroe Township,President / Vice President,,Republican,"Trump, Donald J.",133,00014A
+ANDERSON,Putnam Township,President / Vice President,,independent,"Stein, Jill",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+ANDERSON,Putnam Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+ANDERSON,Putnam Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000170
+ANDERSON,Putnam Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+ANDERSON,Putnam Township,President / Vice President,,Republican,"Trump, Donald J.",99,000170
+ANDERSON,Reeder Township,President / Vice President,,independent,"Stein, Jill",3,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"McMullin, Evan",1,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+ANDERSON,Reeder Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+ANDERSON,Reeder Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000180
+ANDERSON,Reeder Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000180
+ANDERSON,Reeder Township,President / Vice President,,Republican,"Trump, Donald J.",76,000180
+ANDERSON,Washington Township,President / Vice President,,independent,"Stein, Jill",3,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+ANDERSON,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+ANDERSON,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000210
+ANDERSON,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000210
+ANDERSON,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",95,000210
+ANDERSON,Welda Township,President / Vice President,,independent,"Stein, Jill",5,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+ANDERSON,Welda Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+ANDERSON,Welda Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000220
+ANDERSON,Welda Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+ANDERSON,Welda Township,President / Vice President,,Republican,"Trump, Donald J.",97,000220
+ANDERSON,Lone Elm Township,President / Vice President,,independent,"Stein, Jill",5,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Castle, Darrell L",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Hedges, James A",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Maturen, Michael A",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"McMullin, Evan",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Perry, Darryl",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Smith, Mike",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Sood, Ajay",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+ANDERSON,Lone Elm Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,130010
+ANDERSON,Lone Elm Township,President / Vice President,,Libertarian,"Johnson, Gary",2,130010
+ANDERSON,Lone Elm Township,President / Vice President,,Republican,"Trump, Donald J.",88,130010
+ANDERSON,Ozark Township,President / Vice President,,independent,"Stein, Jill",7,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Castle, Darrell L",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Giordani, Rocky",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Hedges, James A",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Hoefling, Tom",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Kahn, Lynn",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"La Riva, Gloria",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Maturen, Michael A",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"McMullin, Evan",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Perry, Darryl",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Schriner, Joe C",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Smith, Mike",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Sood, Ajay",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Sterling, Shawna",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130020
+ANDERSON,Ozark Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130020
+ANDERSON,Ozark Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,130020
+ANDERSON,Ozark Township,President / Vice President,,Libertarian,"Johnson, Gary",8,130020
+ANDERSON,Ozark Township,President / Vice President,,Republican,"Trump, Donald J.",212,130020
+ANDERSON,Rich Township,President / Vice President,,independent,"Stein, Jill",2,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Castle, Darrell L",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Giordani, Rocky",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Hedges, James A",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Hoefling, Tom",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Kahn, Lynn",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"La Riva, Gloria",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Maturen, Michael A",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"McMullin, Evan",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Perry, Darryl",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Schriner, Joe C",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Smith, Mike",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Sood, Ajay",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Sterling, Shawna",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130030
+ANDERSON,Rich Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130030
+ANDERSON,Rich Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,130030
+ANDERSON,Rich Township,President / Vice President,,Libertarian,"Johnson, Gary",5,130030
+ANDERSON,Rich Township,President / Vice President,,Republican,"Trump, Donald J.",131,130030
+ANDERSON,Walker Township,President / Vice President,,independent,"Stein, Jill",8,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Castle, Darrell L",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Giordani, Rocky",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Hedges, James A",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Hoefling, Tom",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Kahn, Lynn",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"La Riva, Gloria",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Maturen, Michael A",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"McMullin, Evan",3,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Perry, Darryl",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Schriner, Joe C",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Smith, Mike",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Sood, Ajay",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Sterling, Shawna",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130040
+ANDERSON,Walker Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130040
+ANDERSON,Walker Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,130040
+ANDERSON,Walker Township,President / Vice President,,Libertarian,"Johnson, Gary",18,130040
+ANDERSON,Walker Township,President / Vice President,,Republican,"Trump, Donald J.",199,130040
+ANDERSON,Westphalia Township,President / Vice President,,independent,"Stein, Jill",4,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Castle, Darrell L",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Giordani, Rocky",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Hedges, James A",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Hoefling, Tom",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Kahn, Lynn",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"La Riva, Gloria",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Maturen, Michael A",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"McMullin, Evan",2,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Perry, Darryl",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Schriner, Joe C",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Smith, Mike",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Sood, Ajay",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Sterling, Shawna",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130050
+ANDERSON,Westphalia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,130050
+ANDERSON,Westphalia Township,President / Vice President,,Libertarian,"Johnson, Gary",6,130050
+ANDERSON,Westphalia Township,President / Vice President,,Republican,"Trump, Donald J.",106,130050
+ANDERSON,Jackson Township,President / Vice President,,independent,"Stein, Jill",3,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+ANDERSON,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+ANDERSON,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,140010
+ANDERSON,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",9,140010
+ANDERSON,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",152,140010
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",106,00002A
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,00002A
+ANDERSON,Garnett Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",342,00002A
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002B
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",115,000030
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000030
+ANDERSON,Garnett Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",303,000030
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",88,000040
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000040
+ANDERSON,Garnett Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,000040
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",23,000050
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000050
+ANDERSON,Garnett Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000050
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",9,000080
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000080
+ANDERSON,Indian Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000080
+ANDERSON,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000110
+ANDERSON,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000110
+ANDERSON,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,000110
+ANDERSON,Monroe Township,United States House of Representatives,2,Democratic,"Potter, Britani",36,00014A
+ANDERSON,Monroe Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,00014A
+ANDERSON,Monroe Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,00014A
+ANDERSON,Putnam Township,United States House of Representatives,2,Democratic,"Potter, Britani",39,000170
+ANDERSON,Putnam Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000170
+ANDERSON,Putnam Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000170
+ANDERSON,Reeder Township,United States House of Representatives,2,Democratic,"Potter, Britani",22,000180
+ANDERSON,Reeder Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000180
+ANDERSON,Reeder Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,000180
+ANDERSON,Washington Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000210
+ANDERSON,Washington Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000210
+ANDERSON,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000210
+ANDERSON,Welda Township,United States House of Representatives,2,Democratic,"Potter, Britani",35,000220
+ANDERSON,Welda Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000220
+ANDERSON,Welda Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000220
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Democratic,"Potter, Britani",16,130010
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,130010
+ANDERSON,Lone Elm Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,130010
+ANDERSON,Ozark Township,United States House of Representatives,2,Democratic,"Potter, Britani",58,130020
+ANDERSON,Ozark Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,130020
+ANDERSON,Ozark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,130020
+ANDERSON,Rich Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,130030
+ANDERSON,Rich Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,130030
+ANDERSON,Rich Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,130030
+ANDERSON,Walker Township,United States House of Representatives,2,Democratic,"Potter, Britani",80,130040
+ANDERSON,Walker Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,130040
+ANDERSON,Walker Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",223,130040
+ANDERSON,Westphalia Township,United States House of Representatives,2,Democratic,"Potter, Britani",32,130050
+ANDERSON,Westphalia Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,130050
+ANDERSON,Westphalia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,130050
+ANDERSON,Jackson Township,United States House of Representatives,2,Democratic,"Potter, Britani",34,140010
+ANDERSON,Jackson Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,140010
+ANDERSON,Jackson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,140010
+ANDERSON,Garnett Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00002A
+ANDERSON,Garnett Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",103,00002A
+ANDERSON,Garnett Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",26,00002A
+ANDERSON,Garnett Precinct 1,United States Senate,,Republican,"Moran, Jerry",343,00002A
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002B
+ANDERSON,Garnett Precinct 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00002B
+ANDERSON,Garnett Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000030
+ANDERSON,Garnett Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",101,000030
+ANDERSON,Garnett Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,000030
+ANDERSON,Garnett Precinct 2,United States Senate,,Republican,"Moran, Jerry",309,000030
+ANDERSON,Garnett Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000040
+ANDERSON,Garnett Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",81,000040
+ANDERSON,Garnett Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",19,000040
+ANDERSON,Garnett Precinct 3,United States Senate,,Republican,"Moran, Jerry",231,000040
+ANDERSON,Garnett Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000050
+ANDERSON,Garnett Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",24,000050
+ANDERSON,Garnett Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",4,000050
+ANDERSON,Garnett Precinct 4,United States Senate,,Republican,"Moran, Jerry",36,000050
+ANDERSON,Indian Creek Township,United States Senate,,write - in,"Smith, DJ",0,000080
+ANDERSON,Indian Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000080
+ANDERSON,Indian Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+ANDERSON,Indian Creek Township,United States Senate,,Republican,"Moran, Jerry",53,000080
+ANDERSON,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000110
+ANDERSON,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000110
+ANDERSON,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000110
+ANDERSON,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",76,000110
+ANDERSON,Monroe Township,United States Senate,,write - in,"Smith, DJ",0,00014A
+ANDERSON,Monroe Township,United States Senate,,Democratic,"Wiesner, Patrick",31,00014A
+ANDERSON,Monroe Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,00014A
+ANDERSON,Monroe Township,United States Senate,,Republican,"Moran, Jerry",134,00014A
+ANDERSON,Putnam Township,United States Senate,,write - in,"Smith, DJ",0,000170
+ANDERSON,Putnam Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000170
+ANDERSON,Putnam Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000170
+ANDERSON,Putnam Township,United States Senate,,Republican,"Moran, Jerry",95,000170
+ANDERSON,Reeder Township,United States Senate,,write - in,"Smith, DJ",0,000180
+ANDERSON,Reeder Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000180
+ANDERSON,Reeder Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000180
+ANDERSON,Reeder Township,United States Senate,,Republican,"Moran, Jerry",74,000180
+ANDERSON,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000210
+ANDERSON,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000210
+ANDERSON,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000210
+ANDERSON,Washington Township,United States Senate,,Republican,"Moran, Jerry",97,000210
+ANDERSON,Welda Township,United States Senate,,write - in,"Smith, DJ",0,000220
+ANDERSON,Welda Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000220
+ANDERSON,Welda Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000220
+ANDERSON,Welda Township,United States Senate,,Republican,"Moran, Jerry",97,000220
+ANDERSON,Lone Elm Township,United States Senate,,write - in,"Smith, DJ",0,130010
+ANDERSON,Lone Elm Township,United States Senate,,Democratic,"Wiesner, Patrick",16,130010
+ANDERSON,Lone Elm Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,130010
+ANDERSON,Lone Elm Township,United States Senate,,Republican,"Moran, Jerry",89,130010
+ANDERSON,Ozark Township,United States Senate,,write - in,"Smith, DJ",0,130020
+ANDERSON,Ozark Township,United States Senate,,Democratic,"Wiesner, Patrick",45,130020
+ANDERSON,Ozark Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,130020
+ANDERSON,Ozark Township,United States Senate,,Republican,"Moran, Jerry",202,130020
+ANDERSON,Rich Township,United States Senate,,write - in,"Smith, DJ",0,130030
+ANDERSON,Rich Township,United States Senate,,Democratic,"Wiesner, Patrick",25,130030
+ANDERSON,Rich Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,130030
+ANDERSON,Rich Township,United States Senate,,Republican,"Moran, Jerry",130,130030
+ANDERSON,Walker Township,United States Senate,,write - in,"Smith, DJ",0,130040
+ANDERSON,Walker Township,United States Senate,,Democratic,"Wiesner, Patrick",85,130040
+ANDERSON,Walker Township,United States Senate,,Libertarian,"Garrard, Robert D.",26,130040
+ANDERSON,Walker Township,United States Senate,,Republican,"Moran, Jerry",201,130040
+ANDERSON,Westphalia Township,United States Senate,,write - in,"Smith, DJ",0,130050
+ANDERSON,Westphalia Township,United States Senate,,Democratic,"Wiesner, Patrick",28,130050
+ANDERSON,Westphalia Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,130050
+ANDERSON,Westphalia Township,United States Senate,,Republican,"Moran, Jerry",106,130050
+ANDERSON,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,140010
+ANDERSON,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",38,140010
+ANDERSON,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,140010
+ANDERSON,Jackson Township,United States Senate,,Republican,"Moran, Jerry",153,140010

--- a/2016/20161108__ks__general__atchison__precinct.csv
+++ b/2016/20161108__ks__general__atchison__precinct.csv
@@ -1,309 +1,934 @@
-county,precinct,office,district,party,candidate,votes
-Atchison,Total,President,,DEM,Hillary Clinton,1989
-Atchison,Total,President,,LBT,Gary Johnson,316
-Atchison,Total,President,,IND,Jill Stein,163
-Atchison,Total,President,,REP,Donald J Trump,4049
-Atchison,Advance,President,,DEM,Hillary Clinton,676
-Atchison,Advance,President,,LBT,Gary Johnson,65
-Atchison,Advance,President,,IND,Jill Stein,40
-Atchison,Advance,President,,REP,Donald J Trump,942
-Atchison,Only 1st,President,,DEM,Hillary Clinton,58
-Atchison,Only 1st,President,,LBT,Gary Johnson,9
-Atchison,Only 1st,President,,IND,Jill Stein,7
-Atchison,Only 1st,President,,REP,Donald J Trump,122
-Atchison,East 2nd,President,,DEM,Hillary Clinton,56
-Atchison,East 2nd,President,,LBT,Gary Johnson,12
-Atchison,East 2nd,President,,IND,Jill Stein,5
-Atchison,East 2nd,President,,REP,Donald J Trump,90
-Atchison,West 2nd,President,,DEM,Hillary Clinton,61
-Atchison,West 2nd,President,,LBT,Gary Johnson,9
-Atchison,West 2nd,President,,IND,Jill Stein,7
-Atchison,West 2nd,President,,REP,Donald J Trump,121
-Atchison,East 3rd,President,,DEM,Hillary Clinton,125
-Atchison,East 3rd,President,,LBT,Gary Johnson,13
-Atchison,East 3rd,President,,IND,Jill Stein,12
-Atchison,East 3rd,President,,REP,Donald J Trump,183
-Atchison,West 3rd,President,,DEM,Hillary Clinton,169
-Atchison,West 3rd,President,,LBT,Gary Johnson,33
-Atchison,West 3rd,President,,IND,Jill Stein,9
-Atchison,West 3rd,President,,REP,Donald J Trump,283
-Atchison,Only 4th,President,,DEM,Hillary Clinton,127
-Atchison,Only 4th,President,,LBT,Gary Johnson,8
-Atchison,Only 4th,President,,IND,Jill Stein,4
-Atchison,Only 4th,President,,REP,Donald J Trump,168
-Atchison,North 5th,President,,DEM,Hillary Clinton,119
-Atchison,North 5th,President,,LBT,Gary Johnson,34
-Atchison,North 5th,President,,IND,Jill Stein,14
-Atchison,North 5th,President,,REP,Donald J Trump,223
-Atchison,South 5th,President,,DEM,Hillary Clinton,96
-Atchison,South 5th,President,,LBT,Gary Johnson,15
-Atchison,South 5th,President,,IND,Jill Stein,5
-Atchison,South 5th,President,,REP,Donald J Trump,127
-Atchison,Benton 62,President,,DEM,Hillary Clinton,63
-Atchison,Benton 62,President,,LBT,Gary Johnson,15
-Atchison,Benton 62,President,,IND,Jill Stein,12
-Atchison,Benton 62,President,,REP,Donald J Trump,218
-Atchison,Benton 63,President,,DEM,Hillary Clinton,26
-Atchison,Benton 63,President,,LBT,Gary Johnson,3
-Atchison,Benton 63,President,,IND,Jill Stein,1
-Atchison,Benton 63,President,,REP,Donald J Trump,67
-Atchison,Center,President,,DEM,Hillary Clinton,51
-Atchison,Center,President,,LBT,Gary Johnson,9
-Atchison,Center,President,,IND,Jill Stein,2
-Atchison,Center,President,,REP,Donald J Trump,200
-Atchison,Grasshopper,President,,DEM,Hillary Clinton,28
-Atchison,Grasshopper,President,,LBT,Gary Johnson,5
-Atchison,Grasshopper,President,,IND,Jill Stein,7
-Atchison,Grasshopper,President,,REP,Donald J Trump,208
-Atchison,Kapioma,President,,DEM,Hillary Clinton,24
-Atchison,Kapioma,President,,LBT,Gary Johnson,7
-Atchison,Kapioma,President,,IND,Jill Stein,2
-Atchison,Kapioma,President,,REP,Donald J Trump,101
-Atchison,Huron,President,,DEM,Hillary Clinton,13
-Atchison,Huron,President,,LBT,Gary Johnson,4
-Atchison,Huron,President,,IND,Jill Stein,2
-Atchison,Huron,President,,REP,Donald J Trump,59
-Atchison,Lancaster,President,,DEM,Hillary Clinton,47
-Atchison,Lancaster,President,,LBT,Gary Johnson,18
-Atchison,Lancaster,President,,IND,Jill Stein,11
-Atchison,Lancaster,President,,REP,Donald J Trump,178
-Atchison,Mt. Pleasant,President,,DEM,Hillary Clinton,57
-Atchison,Mt. Pleasant,President,,LBT,Gary Johnson,12
-Atchison,Mt. Pleasant,President,,IND,Jill Stein,7
-Atchison,Mt. Pleasant,President,,REP,Donald J Trump,257
-Atchison,Shannon,President,,DEM,Hillary Clinton,106
-Atchison,Shannon,President,,LBT,Gary Johnson,32
-Atchison,Shannon,President,,IND,Jill Stein,9
-Atchison,Shannon,President,,REP,Donald J Trump,319
-Atchison,Walnut,President,,DEM,Hillary Clinton,51
-Atchison,Walnut,President,,LBT,Gary Johnson,9
-Atchison,Walnut,President,,IND,Jill Stein,5
-Atchison,Walnut,President,,REP,Donald J Trump,119
-Atchison,Walnut*,President,,DEM,Hillary Clinton,0
-Atchison,Walnut*,President,,LBT,Gary Johnson,0
-Atchison,Walnut*,President,,IND,Jill Stein,0
-Atchison,Walnut*,President,,REP,Donald J Trump,2
-Atchison,Provisional,President,,DEM,Hillary Clinton,36
-Atchison,Provisional,President,,LBT,Gary Johnson,4
-Atchison,Provisional,President,,IND,Jill Stein,2
-Atchison,Provisional,President,,REP,Donald J Trump,62
-Atchison,Total,U.S. Senate,,LBT,Robert D. Garrard,301
-Atchison,Total,U.S. Senate,,REP,Jerry Moran,4295
-Atchison,Total,U.S. Senate,,DEM,Patrick Wiesner,1917
-Atchison,Advance,U.S. Senate,,LBT,Robert D. Garrard,65
-Atchison,Advance,U.S. Senate,,REP,Jerry Moran,1060
-Atchison,Advance,U.S. Senate,,DEM,Patrick Wiesner,595
-Atchison,Only 1st,U.S. Senate,,LBT,Robert D. Garrard,11
-Atchison,Only 1st,U.S. Senate,,REP,Jerry Moran,120
-Atchison,Only 1st,U.S. Senate,,DEM,Patrick Wiesner,71
-Atchison,East 2nd,U.S. Senate,,LBT,Robert D. Garrard,8
-Atchison,East 2nd,U.S. Senate,,REP,Jerry Moran,123
-Atchison,East 2nd,U.S. Senate,,DEM,Patrick Wiesner,47
-Atchison,West 2nd,U.S. Senate,,LBT,Robert D. Garrard,17
-Atchison,West 2nd,U.S. Senate,,REP,Jerry Moran,119
-Atchison,West 2nd,U.S. Senate,,DEM,Patrick Wiesner,60
-Atchison,East 3rd,U.S. Senate,,LBT,Robert D. Garrard,12
-Atchison,East 3rd,U.S. Senate,,REP,Jerry Moran,212
-Atchison,East 3rd,U.S. Senate,,DEM,Patrick Wiesner,110
-Atchison,West 3rd,U.S. Senate,,LBT,Robert D. Garrard,18
-Atchison,West 3rd,U.S. Senate,,REP,Jerry Moran,318
-Atchison,West 3rd,U.S. Senate,,DEM,Patrick Wiesner,156
-Atchison,Only 4th,U.S. Senate,,LBT,Robert D. Garrard,16
-Atchison,Only 4th,U.S. Senate,,REP,Jerry Moran,170
-Atchison,Only 4th,U.S. Senate,,DEM,Patrick Wiesner,118
-Atchison,North 5th,U.S. Senate,,LBT,Robert D. Garrard,26
-Atchison,North 5th,U.S. Senate,,REP,Jerry Moran,227
-Atchison,North 5th,U.S. Senate,,DEM,Patrick Wiesner,136
-Atchison,South 5th,U.S. Senate,,LBT,Robert D. Garrard,20
-Atchison,South 5th,U.S. Senate,,REP,Jerry Moran,124
-Atchison,South 5th,U.S. Senate,,DEM,Patrick Wiesner,96
-Atchison,Benton 62,U.S. Senate,,LBT,Robert D. Garrard,21
-Atchison,Benton 62,U.S. Senate,,REP,Jerry Moran,225
-Atchison,Benton 62,U.S. Senate,,DEM,Patrick Wiesner,53
-Atchison,Benton 63,U.S. Senate,,LBT,Robert D. Garrard,2
-Atchison,Benton 63,U.S. Senate,,REP,Jerry Moran,76
-Atchison,Benton 63,U.S. Senate,,DEM,Patrick Wiesner,19
-Atchison,Center,U.S. Senate,,LBT,Robert D. Garrard,10
-Atchison,Center,U.S. Senate,,REP,Jerry Moran,213
-Atchison,Center,U.S. Senate,,DEM,Patrick Wiesner,43
-Atchison,Grasshopper,U.S. Senate,,LBT,Robert D. Garrard,9
-Atchison,Grasshopper,U.S. Senate,,REP,Jerry Moran,206
-Atchison,Grasshopper,U.S. Senate,,DEM,Patrick Wiesner,31
-Atchison,Kapioma,U.S. Senate,,LBT,Robert D. Garrard,4
-Atchison,Kapioma,U.S. Senate,,REP,Jerry Moran,98
-Atchison,Kapioma,U.S. Senate,,DEM,Patrick Wiesner,26
-Atchison,Huron,U.S. Senate,,LBT,Robert D. Garrard,6
-Atchison,Huron,U.S. Senate,,REP,Jerry Moran,57
-Atchison,Huron,U.S. Senate,,DEM,Patrick Wiesner,17
-Atchison,Lancaster,U.S. Senate,,LBT,Robert D. Garrard,8
-Atchison,Lancaster,U.S. Senate,,REP,Jerry Moran,202
-Atchison,Lancaster,U.S. Senate,,DEM,Patrick Wiesner,43
-Atchison,Mt. Pleasant,U.S. Senate,,LBT,Robert D. Garrard,9
-Atchison,Mt. Pleasant,U.S. Senate,,REP,Jerry Moran,252
-Atchison,Mt. Pleasant,U.S. Senate,,DEM,Patrick Wiesner,73
-Atchison,Shannon,U.S. Senate,,LBT,Robert D. Garrard,24
-Atchison,Shannon,U.S. Senate,,REP,Jerry Moran,314
-Atchison,Shannon,U.S. Senate,,DEM,Patrick Wiesner,126
-Atchison,Walnut,U.S. Senate,,LBT,Robert D. Garrard,8
-Atchison,Walnut,U.S. Senate,,REP,Jerry Moran,114
-Atchison,Walnut,U.S. Senate,,DEM,Patrick Wiesner,62
-Atchison,Walnut*,U.S. Senate,,LBT,Robert D. Garrard,0
-Atchison,Walnut*,U.S. Senate,,REP,Jerry Moran,2
-Atchison,Walnut*,U.S. Senate,,DEM,Patrick Wiesner,0
-Atchison,Provisional,U.S. Senate,,LBT,Robert D. Garrard,7
-Atchison,Provisional,U.S. Senate,,REP,Jerry Moran,63
-Atchison,Provisional,U.S. Senate,,DEM,Patrick Wiesner,35
-Atchison,Total,U.S. House,2,LBT,James Houston Bales,336
-Atchison,Total,U.S. House,2,REP,Lynn Jenkins,4599
-Atchison,Total,U.S. House,2,DEM,Britani Potter,1614
-Atchison,Advance,U.S. House,2,LBT,James Houston Bales,91
-Atchison,Advance,U.S. House,2,REP,Lynn Jenkins,1122
-Atchison,Advance,U.S. House,2,DEM,Britani Potter,526
-Atchison,Only 1st,U.S. House,2,LBT,James Houston Bales,13
-Atchison,Only 1st,U.S. House,2,REP,Lynn Jenkins,135
-Atchison,Only 1st,U.S. House,2,DEM,Britani Potter,53
-Atchison,East 2nd,U.S. House,2,LBT,James Houston Bales,8
-Atchison,East 2nd,U.S. House,2,REP,Lynn Jenkins,127
-Atchison,East 2nd,U.S. House,2,DEM,Britani Potter,44
-Atchison,West 2nd,U.S. House,2,LBT,James Houston Bales,13
-Atchison,West 2nd,U.S. House,2,REP,Lynn Jenkins,137
-Atchison,West 2nd,U.S. House,2,DEM,Britani Potter,48
-Atchison,East 3rd,U.S. House,2,LBT,James Houston Bales,16
-Atchison,East 3rd,U.S. House,2,REP,Lynn Jenkins,219
-Atchison,East 3rd,U.S. House,2,DEM,Britani Potter,103
-Atchison,West 3rd,U.S. House,2,LBT,James Houston Bales,28
-Atchison,West 3rd,U.S. House,2,REP,Lynn Jenkins,336
-Atchison,West 3rd,U.S. House,2,DEM,Britani Potter,127
-Atchison,Only 4th,U.S. House,2,LBT,James Houston Bales,12
-Atchison,Only 4th,U.S. House,2,REP,Lynn Jenkins,194
-Atchison,Only 4th,U.S. House,2,DEM,Britani Potter,96
-Atchison,North 5th,U.S. House,2,LBT,James Houston Bales,25
-Atchison,North 5th,U.S. House,2,REP,Lynn Jenkins,256
-Atchison,North 5th,U.S. House,2,DEM,Britani Potter,110
-Atchison,South 5th,U.S. House,2,LBT,James Houston Bales,19
-Atchison,South 5th,U.S. House,2,REP,Lynn Jenkins,150
-Atchison,South 5th,U.S. House,2,DEM,Britani Potter,71
-Atchison,Benton 62,U.S. House,2,LBT,James Houston Bales,10
-Atchison,Benton 62,U.S. House,2,REP,Lynn Jenkins,239
-Atchison,Benton 62,U.S. House,2,DEM,Britani Potter,54
-Atchison,Benton 63,U.S. House,2,LBT,James Houston Bales,2
-Atchison,Benton 63,U.S. House,2,REP,Lynn Jenkins,80
-Atchison,Benton 63,U.S. House,2,DEM,Britani Potter,15
-Atchison,Center,U.S. House,2,LBT,James Houston Bales,13
-Atchison,Center,U.S. House,2,REP,Lynn Jenkins,217
-Atchison,Center,U.S. House,2,DEM,Britani Potter,37
-Atchison,Grasshopper,U.S. House,2,LBT,James Houston Bales,13
-Atchison,Grasshopper,U.S. House,2,REP,Lynn Jenkins,203
-Atchison,Grasshopper,U.S. House,2,DEM,Britani Potter,34
-Atchison,Kapioma,U.S. House,2,LBT,James Houston Bales,9
-Atchison,Kapioma,U.S. House,2,REP,Lynn Jenkins,94
-Atchison,Kapioma,U.S. House,2,DEM,Britani Potter,24
-Atchison,Huron,U.S. House,2,LBT,James Houston Bales,3
-Atchison,Huron,U.S. House,2,REP,Lynn Jenkins,60
-Atchison,Huron,U.S. House,2,DEM,Britani Potter,17
-Atchison,Lancaster,U.S. House,2,LBT,James Houston Bales,11
-Atchison,Lancaster,U.S. House,2,REP,Lynn Jenkins,206
-Atchison,Lancaster,U.S. House,2,DEM,Britani Potter,35
-Atchison,Mt. Pleasant,U.S. House,2,LBT,James Houston Bales,12
-Atchison,Mt. Pleasant,U.S. House,2,REP,Lynn Jenkins,272
-Atchison,Mt. Pleasant,U.S. House,2,DEM,Britani Potter,51
-Atchison,Shannon,U.S. House,2,LBT,James Houston Bales,24
-Atchison,Shannon,U.S. House,2,REP,Lynn Jenkins,347
-Atchison,Shannon,U.S. House,2,DEM,Britani Potter,94
-Atchison,Walnut,U.S. House,2,LBT,James Houston Bales,10
-Atchison,Walnut,U.S. House,2,REP,Lynn Jenkins,127
-Atchison,Walnut,U.S. House,2,DEM,Britani Potter,51
-Atchison,Walnut*,U.S. House,2,LBT,James Houston Bales,0
-Atchison,Walnut*,U.S. House,2,REP,Lynn Jenkins,2
-Atchison,Walnut*,U.S. House,2,DEM,Britani Potter,0
-Atchison,Provisional,U.S. House,2,LBT,James Houston Bales,4
-Atchison,Provisional,U.S. House,2,REP,Lynn Jenkins,76
-Atchison,Provisional,U.S. House,2,DEM,Britani Potter,24
-Atchison,Total,State Senate,1,DEM,Jerry Henry,3813
-Atchison,Total,State Senate,1,REP,Dennis D. Pyle,2816
-Atchison,Advance,State Senate,1,DEM,Jerry Henry,1131
-Atchison,Advance,State Senate,1,REP,Dennis D. Pyle,623
-Atchison,Only 1st,State Senate,1,DEM,Jerry Henry,113
-Atchison,Only 1st,State Senate,1,REP,Dennis D. Pyle,87
-Atchison,East 2nd,State Senate,1,DEM,Jerry Henry,118
-Atchison,East 2nd,State Senate,1,REP,Dennis D. Pyle,63
-Atchison,West 2nd,State Senate,1,DEM,Jerry Henry,113
-Atchison,West 2nd,State Senate,1,REP,Dennis D. Pyle,88
-Atchison,East 3rd,State Senate,1,DEM,Jerry Henry,199
-Atchison,East 3rd,State Senate,1,REP,Dennis D. Pyle,140
-Atchison,West 3rd,State Senate,1,DEM,Jerry Henry,328
-Atchison,West 3rd,State Senate,1,REP,Dennis D. Pyle,174
-Atchison,Only 4th,State Senate,1,DEM,Jerry Henry,203
-Atchison,Only 4th,State Senate,1,REP,Dennis D. Pyle,101
-Atchison,North 5th,State Senate,1,DEM,Jerry Henry,253
-Atchison,North 5th,State Senate,1,REP,Dennis D. Pyle,145
-Atchison,South 5th,State Senate,1,DEM,Jerry Henry,149
-Atchison,South 5th,State Senate,1,REP,Dennis D. Pyle,97
-Atchison,Benton 62,State Senate,1,DEM,Jerry Henry,147
-Atchison,Benton 62,State Senate,1,REP,Dennis D. Pyle,162
-Atchison,Benton 63,State Senate,1,DEM,Jerry Henry,51
-Atchison,Benton 63,State Senate,1,REP,Dennis D. Pyle,46
-Atchison,Center,State Senate,1,DEM,Jerry Henry,99
-Atchison,Center,State Senate,1,REP,Dennis D. Pyle,173
-Atchison,Grasshopper,State Senate,1,DEM,Jerry Henry,89
-Atchison,Grasshopper,State Senate,1,REP,Dennis D. Pyle,160
-Atchison,Kapioma,State Senate,1,DEM,Jerry Henry,41
-Atchison,Kapioma,State Senate,1,REP,Dennis D. Pyle,89
-Atchison,Huron,State Senate,1,DEM,Jerry Henry,38
-Atchison,Huron,State Senate,1,REP,Dennis D. Pyle,42
-Atchison,Lancaster,State Senate,1,DEM,Jerry Henry,130
-Atchison,Lancaster,State Senate,1,REP,Dennis D. Pyle,128
-Atchison,Mt. Pleasant,State Senate,1,DEM,Jerry Henry,156
-Atchison,Mt. Pleasant,State Senate,1,REP,Dennis D. Pyle,183
-Atchison,Shannon,State Senate,1,DEM,Jerry Henry,294
-Atchison,Shannon,State Senate,1,REP,Dennis D. Pyle,181
-Atchison,Walnut,State Senate,1,DEM,Jerry Henry,101
-Atchison,Walnut,State Senate,1,REP,Dennis D. Pyle,88
-Atchison,Walnut*,State Senate,1,DEM,Jerry Henry,2
-Atchison,Walnut*,State Senate,1,REP,Dennis D. Pyle,0
-Atchison,Provisional,State Senate,1,DEM,Jerry Henry,58
-Atchison,Provisional,State Senate,1,REP,Dennis D. Pyle,46
-Atchison,Total,State House,62,REP,Randy Garber,648
-Atchison,Advance,State House,62,REP,Randy Garber,70
-Atchison,Benton 62,State House,62,REP,Randy Garber,249
-Atchison,Grasshopper,State House,62,REP,Randy Garber,218
-Atchison,Kapioma,State House,62,REP,Randy Garber,110
-Atchison,Provisional,State House,62,REP,Randy Garber,1
-Atchison,Total,State House,63,REP,John R Eplee,4630
-Atchison,Total,State House,63,DEM,W. Brett Neibling,1232
-Atchison,Advance,State House,63,REP,John R Eplee,1248
-Atchison,Advance,State House,63,DEM,W. Brett Neibling,425
-Atchison,Only 1st,State House,63,REP,John R Eplee,161
-Atchison,Only 1st,State House,63,DEM,W. Brett Neibling,39
-Atchison,East 2nd,State House,63,REP,John R Eplee,145
-Atchison,East 2nd,State House,63,DEM,W. Brett Neibling,35
-Atchison,West 2nd,State House,63,REP,John R Eplee,154
-Atchison,West 2nd,State House,63,DEM,W. Brett Neibling,46
-Atchison,East 3rd,State House,63,REP,John R Eplee,264
-Atchison,East 3rd,State House,63,DEM,W. Brett Neibling,78
-Atchison,West 3rd,State House,63,REP,John R Eplee,418
-Atchison,West 3rd,State House,63,DEM,W. Brett Neibling,84
-Atchison,Only 4th,State House,63,REP,John R Eplee,235
-Atchison,Only 4th,State House,63,DEM,W. Brett Neibling,74
-Atchison,North 5th,State House,63,REP,John R Eplee,311
-Atchison,North 5th,State House,63,DEM,W. Brett Neibling,87
-Atchison,South 5th,State House,63,REP,John R Eplee,199
-Atchison,South 5th,State House,63,DEM,W. Brett Neibling,46
-Atchison,Benton 63,State House,63,REP,John R Eplee,78
-Atchison,Benton 63,State House,63,DEM,W. Brett Neibling,19
-Atchison,Center,State House,63,REP,John R Eplee,225
-Atchison,Center,State House,63,DEM,W. Brett Neibling,48
-Atchison,Huron,State House,63,REP,John R Eplee,67
-Atchison,Huron,State House,63,DEM,W. Brett Neibling,13
-Atchison,Lancaster,State House,63,REP,John R Eplee,209
-Atchison,Lancaster,State House,63,DEM,W. Brett Neibling,50
-Atchison,Mt. Pleasant,State House,63,REP,John R Eplee,281
-Atchison,Mt. Pleasant,State House,63,DEM,W. Brett Neibling,55
-Atchison,Shannon,State House,63,REP,John R Eplee,397
-Atchison,Shannon,State House,63,DEM,W. Brett Neibling,79
-Atchison,Walnut,State House,63,REP,John R Eplee,144
-Atchison,Walnut,State House,63,DEM,W. Brett Neibling,43
-Atchison,Walnut*,State House,63,REP,John R Eplee,2
-Atchison,Walnut*,State House,63,DEM,W. Brett Neibling,0
-Atchison,Provisional,State House,63,REP,John R Eplee,92
-Atchison,Provisional,State House,63,DEM,W. Brett Neibling,11
+county,precinct,office,district,party,candidate,votes,vtd
+ATCHISON,Atchison Precinct 1,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",50,000010
+ATCHISON,Atchison Precinct 1,Kansas House of Representatives,63,Republican,"Eplee, John R.",208,000010
+ATCHISON,Atchison Precinct 2 East,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",61,000020
+ATCHISON,Atchison Precinct 2 East,Kansas House of Representatives,63,Republican,"Eplee, John R.",235,000020
+ATCHISON,Atchison Precinct 2 West,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",75,000030
+ATCHISON,Atchison Precinct 2 West,Kansas House of Representatives,63,Republican,"Eplee, John R.",239,000030
+ATCHISON,Atchison Precinct 3 East,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",123,000040
+ATCHISON,Atchison Precinct 3 East,Kansas House of Representatives,63,Republican,"Eplee, John R.",403,000040
+ATCHISON,Atchison Precinct 3 West,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",170,00005A
+ATCHISON,Atchison Precinct 3 West,Kansas House of Representatives,63,Republican,"Eplee, John R.",651,00005A
+ATCHISON,Atchison Precinct 4,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",114,00006A
+ATCHISON,Atchison Precinct 4,Kansas House of Representatives,63,Republican,"Eplee, John R.",335,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00006C
+ATCHISON,Atchison Precinct 5 North,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",146,00007A
+ATCHISON,Atchison Precinct 5 North,Kansas House of Representatives,63,Republican,"Eplee, John R.",450,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00007C
+ATCHISON,Atchison Precinct 5 South,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",64,00008A
+ATCHISON,Atchison Precinct 5 South,Kansas House of Representatives,63,Republican,"Eplee, John R.",299,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas House of Representatives,63,Republican,"Eplee, John R.",0,00008D
+ATCHISON,Center Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",64,000100
+ATCHISON,Center Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",277,000100
+ATCHISON,Grasshopper Township,Kansas House of Representatives,62,Republican,"Garber, Randy",251,000110
+ATCHISON,Huron Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",15,000120
+ATCHISON,Huron Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",82,000120
+ATCHISON,Kapioma Township,Kansas House of Representatives,62,Republican,"Garber, Randy",116,000130
+ATCHISON,Lancaster Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",63,000140
+ATCHISON,Lancaster Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",246,000140
+ATCHISON,Shannon Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",118,00016A
+ATCHISON,Shannon Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",541,00016A
+ATCHISON,Walnut Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",57,00017A
+ATCHISON,Walnut Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",185,00017A
+ATCHISON,Walnut Township Enclave,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",1,00017B
+ATCHISON,Walnut Township Enclave,Kansas House of Representatives,63,Republican,"Eplee, John R.",2,00017B
+ATCHISON,Mount Pleasant Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",86,100050
+ATCHISON,Mount Pleasant Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",380,100050
+ATCHISON,Benton Township H62,Kansas House of Representatives,62,Republican,"Garber, Randy",281,120020
+ATCHISON,Benton Township H63,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",25,120030
+ATCHISON,Benton Township H63,Kansas House of Representatives,63,Republican,"Eplee, John R.",97,120030
+ATCHISON,Atchison Precinct 1,Kansas Senate,1,Democratic,"Henry, Jerry",143,000010
+ATCHISON,Atchison Precinct 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",114,000010
+ATCHISON,Atchison Precinct 2 East,Kansas Senate,1,Democratic,"Henry, Jerry",189,000020
+ATCHISON,Atchison Precinct 2 East,Kansas Senate,1,Republican,"Pyle, Dennis D.",111,000020
+ATCHISON,Atchison Precinct 2 West,Kansas Senate,1,Democratic,"Henry, Jerry",187,000030
+ATCHISON,Atchison Precinct 2 West,Kansas Senate,1,Republican,"Pyle, Dennis D.",126,000030
+ATCHISON,Atchison Precinct 3 East,Kansas Senate,1,Democratic,"Henry, Jerry",322,000040
+ATCHISON,Atchison Precinct 3 East,Kansas Senate,1,Republican,"Pyle, Dennis D.",207,000040
+ATCHISON,Atchison Precinct 3 West,Kansas Senate,1,Democratic,"Henry, Jerry",542,00005A
+ATCHISON,Atchison Precinct 3 West,Kansas Senate,1,Republican,"Pyle, Dennis D.",278,00005A
+ATCHISON,Atchison Precinct 4,Kansas Senate,1,Democratic,"Henry, Jerry",305,00006A
+ATCHISON,Atchison Precinct 4,Kansas Senate,1,Republican,"Pyle, Dennis D.",138,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00006C
+ATCHISON,Atchison Precinct 5 North,Kansas Senate,1,Democratic,"Henry, Jerry",391,00007A
+ATCHISON,Atchison Precinct 5 North,Kansas Senate,1,Republican,"Pyle, Dennis D.",206,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00007C
+ATCHISON,Atchison Precinct 5 South,Kansas Senate,1,Democratic,"Henry, Jerry",225,00008A
+ATCHISON,Atchison Precinct 5 South,Kansas Senate,1,Republican,"Pyle, Dennis D.",138,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas Senate,1,Democratic,"Henry, Jerry",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008D
+ATCHISON,Center Township,Kansas Senate,1,Democratic,"Henry, Jerry",129,000100
+ATCHISON,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",209,000100
+ATCHISON,Grasshopper Township,Kansas Senate,1,Democratic,"Henry, Jerry",101,000110
+ATCHISON,Grasshopper Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",186,000110
+ATCHISON,Huron Township,Kansas Senate,1,Democratic,"Henry, Jerry",47,000120
+ATCHISON,Huron Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",50,000120
+ATCHISON,Kapioma Township,Kansas Senate,1,Democratic,"Henry, Jerry",43,000130
+ATCHISON,Kapioma Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",94,000130
+ATCHISON,Lancaster Township,Kansas Senate,1,Democratic,"Henry, Jerry",165,000140
+ATCHISON,Lancaster Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",143,000140
+ATCHISON,Shannon Township,Kansas Senate,1,Democratic,"Henry, Jerry",411,00016A
+ATCHISON,Shannon Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",246,00016A
+ATCHISON,Walnut Township,Kansas Senate,1,Democratic,"Henry, Jerry",130,00017A
+ATCHISON,Walnut Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",111,00017A
+ATCHISON,Walnut Township Enclave,Kansas Senate,1,Democratic,"Henry, Jerry",3,00017B
+ATCHISON,Walnut Township Enclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00017B
+ATCHISON,Mount Pleasant Township,Kansas Senate,1,Democratic,"Henry, Jerry",242,100050
+ATCHISON,Mount Pleasant Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",226,100050
+ATCHISON,Benton Township H62,Kansas Senate,1,Democratic,"Henry, Jerry",172,120020
+ATCHISON,Benton Township H62,Kansas Senate,1,Republican,"Pyle, Dennis D.",177,120020
+ATCHISON,Benton Township H63,Kansas Senate,1,Democratic,"Henry, Jerry",66,120030
+ATCHISON,Benton Township H63,Kansas Senate,1,Republican,"Pyle, Dennis D.",56,120030
+ATCHISON,Atchison Precinct 1,President / Vice President,,independent,"Stein, Jill",8,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000010
+ATCHISON,Atchison Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",157,000010
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,independent,"Stein, Jill",8,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Hedges, James A",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Maturen, Michael A",3,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"McMullin, Evan",9,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Perry, Darryl",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Smith, Mike",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Sood, Ajay",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Libertarian,"Johnson, Gary",13,000020
+ATCHISON,Atchison Precinct 2 East,President / Vice President,,Republican,"Trump, Donald J.",160,000020
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,independent,"Stein, Jill",11,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Hedges, James A",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"McMullin, Evan",3,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Smith, Mike",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Libertarian,"Johnson, Gary",13,000030
+ATCHISON,Atchison Precinct 2 West,President / Vice President,,Republican,"Trump, Donald J.",174,000030
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,independent,"Stein, Jill",16,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Hedges, James A",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Maturen, Michael A",4,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"McMullin, Evan",8,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Smith, Mike",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",203,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Libertarian,"Johnson, Gary",19,000040
+ATCHISON,Atchison Precinct 3 East,President / Vice President,,Republican,"Trump, Donald J.",275,000040
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,independent,"Stein, Jill",14,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Hedges, James A",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Maturen, Michael A",6,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"McMullin, Evan",8,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Smith, Mike",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",311,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Libertarian,"Johnson, Gary",44,00005A
+ATCHISON,Atchison Precinct 3 West,President / Vice President,,Republican,"Trump, Donald J.",436,00005A
+ATCHISON,Atchison Precinct 4,President / Vice President,,independent,"Stein, Jill",7,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"McMullin, Evan",2,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",209,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",12,00006A
+ATCHISON,Atchison Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",221,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00006C
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,independent,"Stein, Jill",20,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Castle, Darrell L",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Giordani, Rocky",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Hedges, James A",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Kahn, Lynn",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"La Riva, Gloria",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Levinson, Michael S.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Maturen, Michael A",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"McMullin, Evan",1,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Perry, Darryl",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Schriner, Joe C",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Smith, Mike",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Sood, Ajay",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Sterling, Shawna",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Democratic,"Clinton, Hillary Rodham",204,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Libertarian,"Johnson, Gary",47,00007A
+ATCHISON,Atchison Precinct 5 North,President / Vice President,,Republican,"Trump, Donald J.",323,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,independent,"Stein, Jill",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,independent,"Stein, Jill",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00007C
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,independent,"Stein, Jill",9,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Castle, Darrell L",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Giordani, Rocky",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Hedges, James A",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Kahn, Lynn",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"La Riva, Gloria",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Levinson, Michael S.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Maturen, Michael A",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"McMullin, Evan",3,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Perry, Darryl",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Schriner, Joe C",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Smith, Mike",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Sood, Ajay",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Sterling, Shawna",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Democratic,"Clinton, Hillary Rodham",130,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Libertarian,"Johnson, Gary",20,00008A
+ATCHISON,Atchison Precinct 5 South,President / Vice President,,Republican,"Trump, Donald J.",197,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,independent,"Stein, Jill",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,independent,"Stein, Jill",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,independent,"Stein, Jill",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00008D
+ATCHISON,Center Township,President / Vice President,,independent,"Stein, Jill",2,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Maturen, Michael A",4,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"McMullin, Evan",1,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+ATCHISON,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+ATCHISON,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000100
+ATCHISON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000100
+ATCHISON,Center Township,President / Vice President,,Republican,"Trump, Donald J.",241,000100
+ATCHISON,Grasshopper Township,President / Vice President,,independent,"Stein, Jill",9,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+ATCHISON,Grasshopper Township,President / Vice President,,Republican,"Trump, Donald J.",239,000110
+ATCHISON,Huron Township,President / Vice President,,independent,"Stein, Jill",2,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+ATCHISON,Huron Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+ATCHISON,Huron Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000120
+ATCHISON,Huron Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+ATCHISON,Huron Township,President / Vice President,,Republican,"Trump, Donald J.",71,000120
+ATCHISON,Kapioma Township,President / Vice President,,independent,"Stein, Jill",2,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+ATCHISON,Kapioma Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000130
+ATCHISON,Kapioma Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000130
+ATCHISON,Kapioma Township,President / Vice President,,Republican,"Trump, Donald J.",106,000130
+ATCHISON,Lancaster Township,President / Vice President,,independent,"Stein, Jill",12,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+ATCHISON,Lancaster Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000140
+ATCHISON,Lancaster Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000140
+ATCHISON,Lancaster Township,President / Vice President,,Republican,"Trump, Donald J.",209,000140
+ATCHISON,Shannon Township,President / Vice President,,independent,"Stein, Jill",14,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Hedges, James A",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"McMullin, Evan",2,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Smith, Mike",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+ATCHISON,Shannon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",167,00016A
+ATCHISON,Shannon Township,President / Vice President,,Libertarian,"Johnson, Gary",35,00016A
+ATCHISON,Shannon Township,President / Vice President,,Republican,"Trump, Donald J.",432,00016A
+ATCHISON,Walnut Township,President / Vice President,,independent,"Stein, Jill",6,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",2,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+ATCHISON,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,00017A
+ATCHISON,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",12,00017A
+ATCHISON,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",152,00017A
+ATCHISON,Walnut Township Enclave,President / Vice President,,independent,"Stein, Jill",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+ATCHISON,Walnut Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",2,00017B
+ATCHISON,Mount Pleasant Township,President / Vice President,,independent,"Stein, Jill",9,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",1,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",98,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",15,100050
+ATCHISON,Mount Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",334,100050
+ATCHISON,Benton Township H62,President / Vice President,,independent,"Stein, Jill",13,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Hedges, James A",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"McMullin, Evan",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Perry, Darryl",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Smith, Mike",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Sood, Ajay",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+ATCHISON,Benton Township H62,President / Vice President,,Democratic,"Clinton, Hillary Rodham",78,120020
+ATCHISON,Benton Township H62,President / Vice President,,Libertarian,"Johnson, Gary",16,120020
+ATCHISON,Benton Township H62,President / Vice President,,Republican,"Trump, Donald J.",240,120020
+ATCHISON,Benton Township H63,President / Vice President,,independent,"Stein, Jill",1,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Hedges, James A",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"McMullin, Evan",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Perry, Darryl",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Smith, Mike",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Sood, Ajay",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+ATCHISON,Benton Township H63,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,120030
+ATCHISON,Benton Township H63,President / Vice President,,Libertarian,"Johnson, Gary",6,120030
+ATCHISON,Benton Township H63,President / Vice President,,Republican,"Trump, Donald J.",80,120030
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",67,000010
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000010
+ATCHISON,Atchison Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000010
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Democratic,"Potter, Britani",80,000020
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000020
+ATCHISON,Atchison Precinct 2 East,United States House of Representatives,2,Republican,"Jenkins, Lynn",208,000020
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Democratic,"Potter, Britani",89,000030
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000030
+ATCHISON,Atchison Precinct 2 West,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,000030
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Democratic,"Potter, Britani",159,000040
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000040
+ATCHISON,Atchison Precinct 3 East,United States House of Representatives,2,Republican,"Jenkins, Lynn",340,000040
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Democratic,"Potter, Britani",227,00005A
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Libertarian,"Bales, James Houston",46,00005A
+ATCHISON,Atchison Precinct 3 West,United States House of Representatives,2,Republican,"Jenkins, Lynn",533,00005A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",161,00006A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,00006A
+ATCHISON,Atchison Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",259,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00006C
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Democratic,"Potter, Britani",178,00007A
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,00007A
+ATCHISON,Atchison Precinct 5 North,United States House of Representatives,2,Republican,"Jenkins, Lynn",380,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00007C
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Democratic,"Potter, Britani",94,00008A
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,00008A
+ATCHISON,Atchison Precinct 5 South,United States House of Representatives,2,Republican,"Jenkins, Lynn",234,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Democratic,"Potter, Britani",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008D
+ATCHISON,Center Township,United States House of Representatives,2,Democratic,"Potter, Britani",52,000100
+ATCHISON,Center Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000100
+ATCHISON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",268,000100
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Democratic,"Potter, Britani",42,000110
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000110
+ATCHISON,Grasshopper Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,000110
+ATCHISON,Huron Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,000120
+ATCHISON,Huron Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000120
+ATCHISON,Huron Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,000120
+ATCHISON,Kapioma Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000130
+ATCHISON,Kapioma Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000130
+ATCHISON,Kapioma Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000130
+ATCHISON,Lancaster Township,United States House of Representatives,2,Democratic,"Potter, Britani",52,000140
+ATCHISON,Lancaster Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000140
+ATCHISON,Lancaster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",235,000140
+ATCHISON,Shannon Township,United States House of Representatives,2,Democratic,"Potter, Britani",139,00016A
+ATCHISON,Shannon Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",34,00016A
+ATCHISON,Shannon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",474,00016A
+ATCHISON,Walnut Township,United States House of Representatives,2,Democratic,"Potter, Britani",67,00017A
+ATCHISON,Walnut Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,00017A
+ATCHISON,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",161,00017A
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",1,00017B
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00017B
+ATCHISON,Walnut Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",2,00017B
+ATCHISON,Mount Pleasant Township,United States House of Representatives,2,Democratic,"Potter, Britani",78,100050
+ATCHISON,Mount Pleasant Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,100050
+ATCHISON,Mount Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",368,100050
+ATCHISON,Benton Township H62,United States House of Representatives,2,Democratic,"Potter, Britani",64,120020
+ATCHISON,Benton Township H62,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,120020
+ATCHISON,Benton Township H62,United States House of Representatives,2,Republican,"Jenkins, Lynn",266,120020
+ATCHISON,Benton Township H63,United States House of Representatives,2,Democratic,"Potter, Britani",21,120030
+ATCHISON,Benton Township H63,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,120030
+ATCHISON,Benton Township H63,United States House of Representatives,2,Republican,"Jenkins, Lynn",95,120030
+ATCHISON,Atchison Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000010
+ATCHISON,Atchison Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",88,000010
+ATCHISON,Atchison Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",13,000010
+ATCHISON,Atchison Precinct 1,United States Senate,,Republican,"Moran, Jerry",157,000010
+ATCHISON,Atchison Precinct 2 East,United States Senate,,write - in,"Smith, DJ",0,000020
+ATCHISON,Atchison Precinct 2 East,United States Senate,,Democratic,"Wiesner, Patrick",84,000020
+ATCHISON,Atchison Precinct 2 East,United States Senate,,Libertarian,"Garrard, Robert D.",14,000020
+ATCHISON,Atchison Precinct 2 East,United States Senate,,Republican,"Moran, Jerry",198,000020
+ATCHISON,Atchison Precinct 2 West,United States Senate,,write - in,"Smith, DJ",0,000030
+ATCHISON,Atchison Precinct 2 West,United States Senate,,Democratic,"Wiesner, Patrick",102,000030
+ATCHISON,Atchison Precinct 2 West,United States Senate,,Libertarian,"Garrard, Robert D.",23,000030
+ATCHISON,Atchison Precinct 2 West,United States Senate,,Republican,"Moran, Jerry",179,000030
+ATCHISON,Atchison Precinct 3 East,United States Senate,,write - in,"Smith, DJ",0,000040
+ATCHISON,Atchison Precinct 3 East,United States Senate,,Democratic,"Wiesner, Patrick",172,000040
+ATCHISON,Atchison Precinct 3 East,United States Senate,,Libertarian,"Garrard, Robert D.",17,000040
+ATCHISON,Atchison Precinct 3 East,United States Senate,,Republican,"Moran, Jerry",330,000040
+ATCHISON,Atchison Precinct 3 West,United States Senate,,write - in,"Smith, DJ",0,00005A
+ATCHISON,Atchison Precinct 3 West,United States Senate,,Democratic,"Wiesner, Patrick",273,00005A
+ATCHISON,Atchison Precinct 3 West,United States Senate,,Libertarian,"Garrard, Robert D.",35,00005A
+ATCHISON,Atchison Precinct 3 West,United States Senate,,Republican,"Moran, Jerry",497,00005A
+ATCHISON,Atchison Precinct 4,United States Senate,,write - in,"Smith, DJ",0,00006A
+ATCHISON,Atchison Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",188,00006A
+ATCHISON,Atchison Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",21,00006A
+ATCHISON,Atchison Precinct 4,United States Senate,,Republican,"Moran, Jerry",233,00006A
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00006B
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006C
+ATCHISON,Atchison Precinct 4 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00006C
+ATCHISON,Atchison Precinct 5 North,United States Senate,,write - in,"Smith, DJ",0,00007A
+ATCHISON,Atchison Precinct 5 North,United States Senate,,Democratic,"Wiesner, Patrick",214,00007A
+ATCHISON,Atchison Precinct 5 North,United States Senate,,Libertarian,"Garrard, Robert D.",32,00007A
+ATCHISON,Atchison Precinct 5 North,United States Senate,,Republican,"Moran, Jerry",337,00007A
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,write - in,"Smith, DJ",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00007B
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,write - in,"Smith, DJ",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00007C
+ATCHISON,Atchison Precinct 5 North Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00007C
+ATCHISON,Atchison Precinct 5 South,United States Senate,,write - in,"Smith, DJ",0,00008A
+ATCHISON,Atchison Precinct 5 South,United States Senate,,Democratic,"Wiesner, Patrick",132,00008A
+ATCHISON,Atchison Precinct 5 South,United States Senate,,Libertarian,"Garrard, Robert D.",23,00008A
+ATCHISON,Atchison Precinct 5 South,United States Senate,,Republican,"Moran, Jerry",199,00008A
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,write - in,"Smith, DJ",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00008B
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,write - in,"Smith, DJ",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00008C
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,write - in,"Smith, DJ",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008D
+ATCHISON,Atchison Precinct 5 South Exclave C,United States Senate,,Republican,"Moran, Jerry",0,00008D
+ATCHISON,Center Township,United States Senate,,write - in,"Smith, DJ",0,000100
+ATCHISON,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",60,000100
+ATCHISON,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000100
+ATCHISON,Center Township,United States Senate,,Republican,"Moran, Jerry",260,000100
+ATCHISON,Grasshopper Township,United States Senate,,write - in,"Smith, DJ",0,000110
+ATCHISON,Grasshopper Township,United States Senate,,Democratic,"Wiesner, Patrick",40,000110
+ATCHISON,Grasshopper Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000110
+ATCHISON,Grasshopper Township,United States Senate,,Republican,"Moran, Jerry",235,000110
+ATCHISON,Huron Township,United States Senate,,write - in,"Smith, DJ",0,000120
+ATCHISON,Huron Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000120
+ATCHISON,Huron Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000120
+ATCHISON,Huron Township,United States Senate,,Republican,"Moran, Jerry",71,000120
+ATCHISON,Kapioma Township,United States Senate,,write - in,"Smith, DJ",0,000130
+ATCHISON,Kapioma Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000130
+ATCHISON,Kapioma Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+ATCHISON,Kapioma Township,United States Senate,,Republican,"Moran, Jerry",105,000130
+ATCHISON,Lancaster Township,United States Senate,,write - in,"Smith, DJ",0,000140
+ATCHISON,Lancaster Township,United States Senate,,Democratic,"Wiesner, Patrick",61,000140
+ATCHISON,Lancaster Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000140
+ATCHISON,Lancaster Township,United States Senate,,Republican,"Moran, Jerry",231,000140
+ATCHISON,Shannon Township,United States Senate,,write - in,"Smith, DJ",0,00016A
+ATCHISON,Shannon Township,United States Senate,,Democratic,"Wiesner, Patrick",180,00016A
+ATCHISON,Shannon Township,United States Senate,,Libertarian,"Garrard, Robert D.",31,00016A
+ATCHISON,Shannon Township,United States Senate,,Republican,"Moran, Jerry",429,00016A
+ATCHISON,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,00017A
+ATCHISON,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",78,00017A
+ATCHISON,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,00017A
+ATCHISON,Walnut Township,United States Senate,,Republican,"Moran, Jerry",150,00017A
+ATCHISON,Walnut Township Enclave,United States Senate,,write - in,"Smith, DJ",0,00017B
+ATCHISON,Walnut Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",1,00017B
+ATCHISON,Walnut Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017B
+ATCHISON,Walnut Township Enclave,United States Senate,,Republican,"Moran, Jerry",2,00017B
+ATCHISON,Mount Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,100050
+ATCHISON,Mount Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",106,100050
+ATCHISON,Mount Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,100050
+ATCHISON,Mount Pleasant Township,United States Senate,,Republican,"Moran, Jerry",342,100050
+ATCHISON,Benton Township H62,United States Senate,,write - in,"Smith, DJ",0,120020
+ATCHISON,Benton Township H62,United States Senate,,Democratic,"Wiesner, Patrick",66,120020
+ATCHISON,Benton Township H62,United States Senate,,Libertarian,"Garrard, Robert D.",23,120020
+ATCHISON,Benton Township H62,United States Senate,,Republican,"Moran, Jerry",249,120020
+ATCHISON,Benton Township H63,United States Senate,,write - in,"Smith, DJ",0,120030
+ATCHISON,Benton Township H63,United States Senate,,Democratic,"Wiesner, Patrick",26,120030
+ATCHISON,Benton Township H63,United States Senate,,Libertarian,"Garrard, Robert D.",4,120030
+ATCHISON,Benton Township H63,United States Senate,,Republican,"Moran, Jerry",91,120030

--- a/2016/20161108__ks__general__barber__precinct.csv
+++ b/2016/20161108__ks__general__barber__precinct.csv
@@ -1,349 +1,852 @@
-county,precinct,office,district,party,candidate,votes
-Barber,Aetna,President,,D,Hillary Clinton,1
-Barber,Aetna,President,,LBT,Gary Johnson,1
-Barber,Aetna,President,,GRN,Jill Stein,0
-Barber,Aetna,President,,R,Donald Trump,5
-Barber,Deerhead,President,,D,Hillary Clinton,0
-Barber,Deerhead,President,,LBT,Gary Johnson,0
-Barber,Deerhead,President,,GRN,Jill Stein,0
-Barber,Deerhead,President,,R,Donald Trump,7
-Barber,Eagle,President,,D,Hillary Clinton,0
-Barber,Eagle,President,,LBT,Gary Johnson,0
-Barber,Eagle,President,,GRN,Jill Stein,0
-Barber,Eagle,President,,R,Donald Trump,22
-Barber,Elm Mills,President,,D,Hillary Clinton,10
-Barber,Elm Mills,President,,LBT,Gary Johnson,4
-Barber,Elm Mills,President,,GRN,Jill Stein,3
-Barber,Elm Mills,President,,R,Donald Trump,59
-Barber,Elwood,President,,D,Hillary Clinton,17
-Barber,Elwood,President,,LBT,Gary Johnson,3
-Barber,Elwood,President,,GRN,Jill Stein,1
-Barber,Elwood,President,,R,Donald Trump,72
-Barber,Hazelton,President,,D,Hillary Clinton,15
-Barber,Hazelton,President,,LBT,Gary Johnson,4
-Barber,Hazelton,President,,GRN,Jill Stein,1
-Barber,Hazelton,President,,R,Donald Trump,59
-Barber,Kiowa East,President,,D,Hillary Clinton,41
-Barber,Kiowa East,President,,LBT,Gary Johnson,12
-Barber,Kiowa East,President,,GRN,Jill Stein,6
-Barber,Kiowa East,President,,R,Donald Trump,266
-Barber,Kiowa West,President,,D,Hillary Clinton,29
-Barber,Kiowa West,President,,LBT,Gary Johnson,4
-Barber,Kiowa West,President,,GRN,Jill Stein,1
-Barber,Kiowa West,President,,R,Donald Trump,164
-Barber,Lake City,President,,D,Hillary Clinton,5
-Barber,Lake City,President,,LBT,Gary Johnson,1
-Barber,Lake City,President,,GRN,Jill Stein,4
-Barber,Lake City,President,,R,Donald Trump,30
-Barber,McAdoo,President,,D,Hillary Clinton,0
-Barber,McAdoo,President,,LBT,Gary Johnson,0
-Barber,McAdoo,President,,GRN,Jill Stein,0
-Barber,McAdoo,President,,R,Donald Trump,16
-Barber,Med Lodge 1,President,,D,Hillary Clinton,54
-Barber,Med Lodge 1,President,,LBT,Gary Johnson,15
-Barber,Med Lodge 1,President,,GRN,Jill Stein,5
-Barber,Med Lodge 1,President,,R,Donald Trump,266
-Barber,Med Lodge 2,President,,D,Hillary Clinton,39
-Barber,Med Lodge 2,President,,LBT,Gary Johnson,14
-Barber,Med Lodge 2,President,,GRN,Jill Stein,1
-Barber,Med Lodge 2,President,,R,Donald Trump,214
-Barber,Med Lodge 3,President,,D,Hillary Clinton,28
-Barber,Med Lodge 3,President,,LBT,Gary Johnson,6
-Barber,Med Lodge 3,President,,GRN,Jill Stein,2
-Barber,Med Lodge 3,President,,R,Donald Trump,161
-Barber,Med Lodge 4,President,,D,Hillary Clinton,11
-Barber,Med Lodge 4,President,,LBT,Gary Johnson,0
-Barber,Med Lodge 4,President,,GRN,Jill Stein,1
-Barber,Med Lodge 4,President,,R,Donald Trump,128
-Barber,Med Lodge 5,President,,D,Hillary Clinton,1
-Barber,Med Lodge 5,President,,LBT,Gary Johnson,0
-Barber,Med Lodge 5,President,,GRN,Jill Stein,1
-Barber,Med Lodge 5,President,,R,Donald Trump,29
-Barber,Mingona,President,,D,Hillary Clinton,4
-Barber,Mingona,President,,LBT,Gary Johnson,3
-Barber,Mingona,President,,GRN,Jill Stein,0
-Barber,Mingona,President,,R,Donald Trump,42
-Barber,Moore,President,,D,Hillary Clinton,5
-Barber,Moore,President,,LBT,Gary Johnson,0
-Barber,Moore,President,,GRN,Jill Stein,0
-Barber,Moore,President,,R,Donald Trump,16
-Barber,Nippawalla,President,,D,Hillary Clinton,0
-Barber,Nippawalla,President,,LBT,Gary Johnson,2
-Barber,Nippawalla,President,,GRN,Jill Stein,0
-Barber,Nippawalla,President,,R,Donald Trump,18
-Barber,Sharon,President,,D,Hillary Clinton,17
-Barber,Sharon,President,,LBT,Gary Johnson,5
-Barber,Sharon,President,,GRN,Jill Stein,2
-Barber,Sharon,President,,R,Donald Trump,174
-Barber,Sun City,President,,D,Hillary Clinton,0
-Barber,Sun City,President,,LBT,Gary Johnson,2
-Barber,Sun City,President,,GRN,Jill Stein,0
-Barber,Sun City,President,,R,Donald Trump,27
-Barber,Turkey Creek,President,,D,Hillary Clinton,4
-Barber,Turkey Creek,President,,LBT,Gary Johnson,1
-Barber,Turkey Creek,President,,GRN,Jill Stein,0
-Barber,Turkey Creek,President,,R,Donald Trump,9
-Barber,Valley,President,,D,Hillary Clinton,5
-Barber,Valley,President,,LBT,Gary Johnson,1
-Barber,Valley,President,,GRN,Jill Stein,0
-Barber,Valley,President,,R,Donald Trump,66
-Barber,Med Lodge 1,President,,,John McCain,1
-Barber,Med Lodge 1,President,,,Darrell Castle,1
-Barber,Med Lodge 1,President,,,Ted Cruz,1
-Barber,Med Lodge 1,President,,,Constitution,1
-Barber,Med Lodge 1,President,,,Paul Ryan,1
-Barber,Med Lodge 2,President,,,Kanye West,1
-Barber,Med Lodge 2,President,,,Evan McMullin,2
-Barber,Med Lodge 3,President,,,Evan McMullin,1
-Barber,Med Lodge 4,President,,,Evan McMullin,1
-Barber,Sharon,President,,,Evan McMullin,2
-Barber,Elm Mills,President,,,Evan McMullin,1
-Barber,Kiowa East,President,,,Ben Carson,1
-Barber,Kiowa West,President,,,Darrell Castle,1
-Barber,Sun City,President,,,Tom Hoefling,1
-Barber,Sharon,President,,,Marco Rubio,1
-Barber,Sharon,President,,,Bernie Sanders,1
-Barber,Med Lodge 4,President,,,Bernie Sanders,1
-Barber,Aetna,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Aetna,U.S. Senate,,R,Jerry Moran,6
-Barber,Aetna,U.S. Senate,,D,Patrick Weissner,0
-Barber,Deerhead,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Deerhead,U.S. Senate,,R,Jerry Moran,6
-Barber,Deerhead,U.S. Senate,,D,Patrick Weissner,0
-Barber,Eagle,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Eagle,U.S. Senate,,R,Jerry Moran,21
-Barber,Eagle,U.S. Senate,,D,Patrick Weissner,0
-Barber,Elm Mills,U.S. Senate,,LBT,Robert Garrard,5
-Barber,Elm Mills,U.S. Senate,,R,Jerry Moran,60
-Barber,Elm Mills,U.S. Senate,,D,Patrick Weissner,11
-Barber,Elwood,U.S. Senate,,LBT,Robert Garrard,5
-Barber,Elwood,U.S. Senate,,R,Jerry Moran,72
-Barber,Elwood,U.S. Senate,,D,Patrick Weissner,16
-Barber,Hazelton,U.S. Senate,,LBT,Robert Garrard,2
-Barber,Hazelton,U.S. Senate,,R,Jerry Moran,60
-Barber,Hazelton,U.S. Senate,,D,Patrick Weissner,15
-Barber,Kiowa East,U.S. Senate,,LBT,Robert Garrard,17
-Barber,Kiowa East,U.S. Senate,,R,Jerry Moran,273
-Barber,Kiowa East,U.S. Senate,,D,Patrick Weissner,32
-Barber,Kiowa West,U.S. Senate,,LBT,Robert Garrard,10
-Barber,Kiowa West,U.S. Senate,,R,Jerry Moran,162
-Barber,Kiowa West,U.S. Senate,,D,Patrick Weissner,28
-Barber,Lake City,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Lake City,U.S. Senate,,R,Jerry Moran,32
-Barber,Lake City,U.S. Senate,,D,Patrick Weissner,3
-Barber,McAdoo,U.S. Senate,,LBT,Robert Garrard,0
-Barber,McAdoo,U.S. Senate,,R,Jerry Moran,16
-Barber,McAdoo,U.S. Senate,,D,Patrick Weissner,0
-Barber,Med Lodge 1,U.S. Senate,,LBT,Robert Garrard,14
-Barber,Med Lodge 1,U.S. Senate,,R,Jerry Moran,278
-Barber,Med Lodge 1,U.S. Senate,,D,Patrick Weissner,50
-Barber,Med Lodge 2,U.S. Senate,,LBT,Robert Garrard,17
-Barber,Med Lodge 2,U.S. Senate,,R,Jerry Moran,206
-Barber,Med Lodge 2,U.S. Senate,,D,Patrick Weissner,40
-Barber,Med Lodge 3,U.S. Senate,,LBT,Robert Garrard,12
-Barber,Med Lodge 3,U.S. Senate,,R,Jerry Moran,157
-Barber,Med Lodge 3,U.S. Senate,,D,Patrick Weissner,23
-Barber,Med Lodge 4,U.S. Senate,,LBT,Robert Garrard,9
-Barber,Med Lodge 4,U.S. Senate,,R,Jerry Moran,119
-Barber,Med Lodge 4,U.S. Senate,,D,Patrick Weissner,10
-Barber,Med Lodge 5,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Med Lodge 5,U.S. Senate,,R,Jerry Moran,29
-Barber,Med Lodge 5,U.S. Senate,,D,Patrick Weissner,2
-Barber,Mingona,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Mingona,U.S. Senate,,R,Jerry Moran,42
-Barber,Mingona,U.S. Senate,,D,Patrick Weissner,4
-Barber,Moore,U.S. Senate,,LBT,Robert Garrard,0
-Barber,Moore,U.S. Senate,,R,Jerry Moran,15
-Barber,Moore,U.S. Senate,,D,Patrick Weissner,6
-Barber,Nippawalla,U.S. Senate,,LBT,Robert Garrard,2
-Barber,Nippawalla,U.S. Senate,,R,Jerry Moran,18
-Barber,Nippawalla,U.S. Senate,,D,Patrick Weissner,0
-Barber,Sharon,U.S. Senate,,LBT,Robert Garrard,7
-Barber,Sharon,U.S. Senate,,R,Jerry Moran,165
-Barber,Sharon,U.S. Senate,,D,Patrick Weissner,26
-Barber,Sun City,U.S. Senate,,LBT,Robert Garrard,4
-Barber,Sun City,U.S. Senate,,R,Jerry Moran,24
-Barber,Sun City,U.S. Senate,,D,Patrick Weissner,2
-Barber,Turkey Creek,U.S. Senate,,LBT,Robert Garrard,1
-Barber,Turkey Creek,U.S. Senate,,R,Jerry Moran,10
-Barber,Turkey Creek,U.S. Senate,,D,Patrick Weissner,3
-Barber,Valley,U.S. Senate,,LBT,Robert Garrard,3
-Barber,Valley,U.S. Senate,,R,Jerry Moran,65
-Barber,Valley,U.S. Senate,,D,Patrick Weissner,4
-Barber,Aetna,U.S. House,4,IND,Miranda Allen,2
-Barber,Aetna,U.S. House,4,LBT,Gordon Bakken,1
-Barber,Aetna,U.S. House,4,D,Daniel Giroux,0
-Barber,Aetna,U.S. House,4,R,Mike Pompeo,4
-Barber,Deerhead,U.S. House,4,IND,Miranda Allen,1
-Barber,Deerhead,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Deerhead,U.S. House,4,D,Daniel Giroux,0
-Barber,Deerhead,U.S. House,4,R,Mike Pompeo,6
-Barber,Eagle,U.S. House,4,IND,Miranda Allen,3
-Barber,Eagle,U.S. House,4,LBT,Gordon Bakken,2
-Barber,Eagle,U.S. House,4,D,Daniel Giroux,0
-Barber,Eagle,U.S. House,4,R,Mike Pompeo,17
-Barber,Elm Mills,U.S. House,4,IND,Miranda Allen,12
-Barber,Elm Mills,U.S. House,4,LBT,Gordon Bakken,1
-Barber,Elm Mills,U.S. House,4,D,Daniel Giroux,8
-Barber,Elm Mills,U.S. House,4,R,Mike Pompeo,54
-Barber,Elwood,U.S. House,4,IND,Miranda Allen,27
-Barber,Elwood,U.S. House,4,LBT,Gordon Bakken,3
-Barber,Elwood,U.S. House,4,D,Daniel Giroux,11
-Barber,Elwood,U.S. House,4,R,Mike Pompeo,53
-Barber,Hazelton,U.S. House,4,IND,Miranda Allen,32
-Barber,Hazelton,U.S. House,4,LBT,Gordon Bakken,3
-Barber,Hazelton,U.S. House,4,D,Daniel Giroux,4
-Barber,Hazelton,U.S. House,4,R,Mike Pompeo,40
-Barber,Kiowa East,U.S. House,4,IND,Miranda Allen,112
-Barber,Kiowa East,U.S. House,4,LBT,Gordon Bakken,2
-Barber,Kiowa East,U.S. House,4,D,Daniel Giroux,19
-Barber,Kiowa East,U.S. House,4,R,Mike Pompeo,193
-Barber,Kiowa West,U.S. House,4,IND,Miranda Allen,83
-Barber,Kiowa West,U.S. House,4,LBT,Gordon Bakken,3
-Barber,Kiowa West,U.S. House,4,D,Daniel Giroux,7
-Barber,Kiowa West,U.S. House,4,R,Mike Pompeo,107
-Barber,Lake City,U.S. House,4,IND,Miranda Allen,6
-Barber,Lake City,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Lake City,U.S. House,4,D,Daniel Giroux,5
-Barber,Lake City,U.S. House,4,R,Mike Pompeo,26
-Barber,McAdoo,U.S. House,4,IND,Miranda Allen,2
-Barber,McAdoo,U.S. House,4,LBT,Gordon Bakken,0
-Barber,McAdoo,U.S. House,4,D,Daniel Giroux,0
-Barber,McAdoo,U.S. House,4,R,Mike Pompeo,15
-Barber,Med Lodge 1,U.S. House,4,IND,Miranda Allen,74
-Barber,Med Lodge 1,U.S. House,4,LBT,Gordon Bakken,6
-Barber,Med Lodge 1,U.S. House,4,D,Daniel Giroux,39
-Barber,Med Lodge 1,U.S. House,4,R,Mike Pompeo,225
-Barber,Med Lodge 2,U.S. House,4,IND,Miranda Allen,41
-Barber,Med Lodge 2,U.S. House,4,LBT,Gordon Bakken,3
-Barber,Med Lodge 2,U.S. House,4,D,Daniel Giroux,32
-Barber,Med Lodge 2,U.S. House,4,R,Mike Pompeo,183
-Barber,Med Lodge 3,U.S. House,4,IND,Miranda Allen,45
-Barber,Med Lodge 3,U.S. House,4,LBT,Gordon Bakken,4
-Barber,Med Lodge 3,U.S. House,4,D,Daniel Giroux,17
-Barber,Med Lodge 3,U.S. House,4,R,Mike Pompeo,129
-Barber,Med Lodge 4,U.S. House,4,IND,Miranda Allen,28
-Barber,Med Lodge 4,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Med Lodge 4,U.S. House,4,D,Daniel Giroux,6
-Barber,Med Lodge 4,U.S. House,4,R,Mike Pompeo,105
-Barber,Med Lodge 5,U.S. House,4,IND,Miranda Allen,4
-Barber,Med Lodge 5,U.S. House,4,LBT,Gordon Bakken,1
-Barber,Med Lodge 5,U.S. House,4,D,Daniel Giroux,1
-Barber,Med Lodge 5,U.S. House,4,R,Mike Pompeo,26
-Barber,Mingona,U.S. House,4,IND,Miranda Allen,12
-Barber,Mingona,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Mingona,U.S. House,4,D,Daniel Giroux,3
-Barber,Mingona,U.S. House,4,R,Mike Pompeo,33
-Barber,Moore,U.S. House,4,IND,Miranda Allen,6
-Barber,Moore,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Moore,U.S. House,4,D,Daniel Giroux,5
-Barber,Moore,U.S. House,4,R,Mike Pompeo,10
-Barber,Nippawalla,U.S. House,4,IND,Miranda Allen,5
-Barber,Nippawalla,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Nippawalla,U.S. House,4,D,Daniel Giroux,0
-Barber,Nippawalla,U.S. House,4,R,Mike Pompeo,15
-Barber,Sharon,U.S. House,4,IND,Miranda Allen,43
-Barber,Sharon,U.S. House,4,LBT,Gordon Bakken,2
-Barber,Sharon,U.S. House,4,D,Daniel Giroux,14
-Barber,Sharon,U.S. House,4,R,Mike Pompeo,139
-Barber,Sun City,U.S. House,4,IND,Miranda Allen,10
-Barber,Sun City,U.S. House,4,LBT,Gordon Bakken,2
-Barber,Sun City,U.S. House,4,D,Daniel Giroux,0
-Barber,Sun City,U.S. House,4,R,Mike Pompeo,17
-Barber,Turkey Creek,U.S. House,4,IND,Miranda Allen,4
-Barber,Turkey Creek,U.S. House,4,LBT,Gordon Bakken,1
-Barber,Turkey Creek,U.S. House,4,D,Daniel Giroux,1
-Barber,Turkey Creek,U.S. House,4,R,Mike Pompeo,8
-Barber,Valley,U.S. House,4,IND,Miranda Allen,15
-Barber,Valley,U.S. House,4,LBT,Gordon Bakken,0
-Barber,Valley,U.S. House,4,D,Daniel Giroux,3
-Barber,Valley,U.S. House,4,R,Mike Pompeo,51
-Barber,Aetna,State Senate,32,R,Larry Alley,5
-Barber,Aetna,State Senate,32,D,Don Shimkus,1
-Barber,Aetna,State House,116,R,Kyle Hoffman,6
-Barber,Aetna,State House,116,D,Jolene Roitman,1
-Barber,Deerhead,State Senate,32,R,Larry Alley,6
-Barber,Deerhead,State Senate,32,D,Don Shimkus,0
-Barber,Deerhead,State House,116,R,Kyle Hoffman,6
-Barber,Deerhead,State House,116,D,Jolene Roitman,1
-Barber,Eagle,State Senate,32,R,Larry Alley,16
-Barber,Eagle,State Senate,32,D,Don Shimkus,4
-Barber,Eagle,State House,116,R,Kyle Hoffman,19
-Barber,Eagle,State House,116,D,Jolene Roitman,1
-Barber,Elm Mills,State Senate,32,R,Larry Alley,58
-Barber,Elm Mills,State Senate,32,D,Don Shimkus,14
-Barber,Elm Mills,State House,116,R,Kyle Hoffman,53
-Barber,Elm Mills,State House,116,D,Jolene Roitman,21
-Barber,Elwood,State Senate,32,R,Larry Alley,73
-Barber,Elwood,State Senate,32,D,Don Shimkus,21
-Barber,Elwood,State House,116,R,Kyle Hoffman,75
-Barber,Elwood,State House,116,D,Jolene Roitman,17
-Barber,Hazelton,State Senate,32,R,Larry Alley,51
-Barber,Hazelton,State Senate,32,D,Don Shimkus,24
-Barber,Hazelton,State House,116,R,Kyle Hoffman,56
-Barber,Hazelton,State House,116,D,Jolene Roitman,23
-Barber,Kiowa East,State Senate,32,R,Larry Alley,251
-Barber,Kiowa East,State Senate,32,D,Don Shimkus,59
-Barber,Kiowa East,State House,116,R,Kyle Hoffman,221
-Barber,Kiowa East,State House,116,D,Jolene Roitman,95
-Barber,Kiowa West,State Senate,32,R,Larry Alley,146
-Barber,Kiowa West,State Senate,32,D,Don Shimkus,45
-Barber,Kiowa West,State House,116,R,Kyle Hoffman,141
-Barber,Kiowa West,State House,116,D,Jolene Roitman,57
-Barber,Lake City,State Senate,32,R,Larry Alley,24
-Barber,Lake City,State Senate,32,D,Don Shimkus,9
-Barber,Lake City,State House,116,R,Kyle Hoffman,24
-Barber,Lake City,State House,116,D,Jolene Roitman,11
-Barber,McAdoo,State Senate,32,R,Larry Alley,16
-Barber,McAdoo,State Senate,32,D,Don Shimkus,0
-Barber,McAdoo,State House,116,R,Kyle Hoffman,16
-Barber,McAdoo,State House,116,D,Jolene Roitman,0
-Barber,Med Lodge 1,State Senate,32,R,Larry Alley,244
-Barber,Med Lodge 1,State Senate,32,D,Don Shimkus,86
-Barber,Med Lodge 1,State House,116,R,Kyle Hoffman,243
-Barber,Med Lodge 1,State House,116,D,Jolene Roitman,96
-Barber,Med Lodge 2,State Senate,32,R,Larry Alley,187
-Barber,Med Lodge 2,State Senate,32,D,Don Shimkus,67
-Barber,Med Lodge 2,State House,116,R,Kyle Hoffman,184
-Barber,Med Lodge 2,State House,116,D,Jolene Roitman,73
-Barber,Med Lodge 3,State Senate,32,R,Larry Alley,140
-Barber,Med Lodge 3,State Senate,32,D,Don Shimkus,43
-Barber,Med Lodge 3,State House,116,R,Kyle Hoffman,137
-Barber,Med Lodge 3,State House,116,D,Jolene Roitman,53
-Barber,Med Lodge 4,State Senate,32,R,Larry Alley,118
-Barber,Med Lodge 4,State Senate,32,D,Don Shimkus,17
-Barber,Med Lodge 4,State House,116,R,Kyle Hoffman,115
-Barber,Med Lodge 4,State House,116,D,Jolene Roitman,25
-Barber,Med Lodge 5,State Senate,32,R,Larry Alley,30
-Barber,Med Lodge 5,State Senate,32,D,Don Shimkus,1
-Barber,Med Lodge 5,State House,116,R,Kyle Hoffman,27
-Barber,Med Lodge 5,State House,116,D,Jolene Roitman,4
-Barber,Mingona,State Senate,32,R,Larry Alley,36
-Barber,Mingona,State Senate,32,D,Don Shimkus,7
-Barber,Mingona,State House,116,R,Kyle Hoffman,34
-Barber,Mingona,State House,116,D,Jolene Roitman,10
-Barber,Moore,State Senate,32,R,Larry Alley,14
-Barber,Moore,State Senate,32,D,Don Shimkus,7
-Barber,Moore,State House,116,R,Kyle Hoffman,13
-Barber,Moore,State House,116,D,Jolene Roitman,8
-Barber,Nippawalla,State Senate,32,R,Larry Alley,17
-Barber,Nippawalla,State Senate,32,D,Don Shimkus,1
-Barber,Nippawalla,State House,116,R,Kyle Hoffman,18
-Barber,Nippawalla,State House,116,D,Jolene Roitman,1
-Barber,Sharon,State Senate,32,R,Larry Alley,160
-Barber,Sharon,State Senate,32,D,Don Shimkus,30
-Barber,Sharon,State House,116,R,Kyle Hoffman,147
-Barber,Sharon,State House,116,D,Jolene Roitman,45
-Barber,Sun City,State Senate,32,R,Larry Alley,29
-Barber,Sun City,State Senate,32,D,Don Shimkus,0
-Barber,Sun City,State House,116,R,Kyle Hoffman,28
-Barber,Sun City,State House,116,D,Jolene Roitman,1
-Barber,Turkey Creek,State Senate,32,R,Larry Alley,9
-Barber,Turkey Creek,State Senate,32,D,Don Shimkus,4
-Barber,Turkey Creek,State House,116,R,Kyle Hoffman,9
-Barber,Turkey Creek,State House,116,D,Jolene Roitman,5
-Barber,Valley,State Senate,32,R,Larry Alley,56
-Barber,Valley,State Senate,32,D,Don Shimkus,5
-Barber,Valley,State House,116,R,Kyle Hoffman,54
-Barber,Valley,State House,116,D,Jolene Roitman,9
-Barber,Med Lodge 3,State Senate,,,Ken Freeman,1
+county,precinct,office,district,party,candidate,votes,vtd
+BARBER,Aetna Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",1,000010
+BARBER,Aetna Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",6,000010
+BARBER,Deerhead Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",1,000020
+BARBER,Deerhead Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",6,000020
+BARBER,Eagle Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",1,000030
+BARBER,Eagle Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",19,000030
+BARBER,Elm Mills Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",21,000040
+BARBER,Elm Mills Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",53,000040
+BARBER,Elwood Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",17,000050
+BARBER,Elwood Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",75,000050
+BARBER,Hazelton Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",23,000060
+BARBER,Hazelton Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",56,000060
+BARBER,Kiowa East Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",95,000070
+BARBER,Kiowa East Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",221,000070
+BARBER,Kiowa West Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",57,000080
+BARBER,Kiowa West Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",141,000080
+BARBER,Lake City Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",11,000090
+BARBER,Lake City Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",24,000090
+BARBER,McAdoo Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",0,000100
+BARBER,McAdoo Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",16,000100
+BARBER,Medicine Lodge Precinct 1,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",96,000110
+BARBER,Medicine Lodge Precinct 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",243,000110
+BARBER,Medicine Lodge Precinct 2,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",73,00012A
+BARBER,Medicine Lodge Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",184,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,00012B
+BARBER,Medicine Lodge Precinct 3,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",53,000130
+BARBER,Medicine Lodge Precinct 3,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",137,000130
+BARBER,Medicine Lodge Precinct 4,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",25,000140
+BARBER,Medicine Lodge Precinct 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",115,000140
+BARBER,Medicine Lodge Precinct 5,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",4,000150
+BARBER,Medicine Lodge Precinct 5,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",27,000150
+BARBER,Mingona Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",10,000160
+BARBER,Mingona Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",34,000160
+BARBER,Moore Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",8,000170
+BARBER,Moore Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",13,000170
+BARBER,Nippawalla Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",1,000180
+BARBER,Nippawalla Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",18,000180
+BARBER,Sun City Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",1,000210
+BARBER,Sun City Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",28,000210
+BARBER,Turkey Creek Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",5,000220
+BARBER,Turkey Creek Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",9,000220
+BARBER,Valley Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",9,000230
+BARBER,Valley Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",54,000230
+BARBER,Sharon Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",45,130010
+BARBER,Sharon Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",147,130010
+BARBER,Aetna Township,Kansas Senate,32,Democratic,"Shimkus, Don",1,000010
+BARBER,Aetna Township,Kansas Senate,32,Republican,"Alley, Larry W.",5,000010
+BARBER,Deerhead Township,Kansas Senate,32,Democratic,"Shimkus, Don",0,000020
+BARBER,Deerhead Township,Kansas Senate,32,Republican,"Alley, Larry W.",6,000020
+BARBER,Eagle Township,Kansas Senate,32,Democratic,"Shimkus, Don",4,000030
+BARBER,Eagle Township,Kansas Senate,32,Republican,"Alley, Larry W.",16,000030
+BARBER,Elm Mills Township,Kansas Senate,32,Democratic,"Shimkus, Don",14,000040
+BARBER,Elm Mills Township,Kansas Senate,32,Republican,"Alley, Larry W.",58,000040
+BARBER,Elwood Township,Kansas Senate,32,Democratic,"Shimkus, Don",21,000050
+BARBER,Elwood Township,Kansas Senate,32,Republican,"Alley, Larry W.",73,000050
+BARBER,Hazelton Township,Kansas Senate,32,Democratic,"Shimkus, Don",24,000060
+BARBER,Hazelton Township,Kansas Senate,32,Republican,"Alley, Larry W.",51,000060
+BARBER,Kiowa East Township,Kansas Senate,32,Democratic,"Shimkus, Don",59,000070
+BARBER,Kiowa East Township,Kansas Senate,32,Republican,"Alley, Larry W.",251,000070
+BARBER,Kiowa West Township,Kansas Senate,32,Democratic,"Shimkus, Don",45,000080
+BARBER,Kiowa West Township,Kansas Senate,32,Republican,"Alley, Larry W.",146,000080
+BARBER,Lake City Township,Kansas Senate,32,Democratic,"Shimkus, Don",9,000090
+BARBER,Lake City Township,Kansas Senate,32,Republican,"Alley, Larry W.",24,000090
+BARBER,McAdoo Township,Kansas Senate,32,Democratic,"Shimkus, Don",0,000100
+BARBER,McAdoo Township,Kansas Senate,32,Republican,"Alley, Larry W.",16,000100
+BARBER,Medicine Lodge Precinct 1,Kansas Senate,32,Democratic,"Shimkus, Don",86,000110
+BARBER,Medicine Lodge Precinct 1,Kansas Senate,32,Republican,"Alley, Larry W.",244,000110
+BARBER,Medicine Lodge Precinct 2,Kansas Senate,32,Democratic,"Shimkus, Don",67,00012A
+BARBER,Medicine Lodge Precinct 2,Kansas Senate,32,Republican,"Alley, Larry W.",187,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas Senate,32,Democratic,"Shimkus, Don",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,Kansas Senate,32,Republican,"Alley, Larry W.",0,00012B
+BARBER,Medicine Lodge Precinct 3,Kansas Senate,32,Democratic,"Shimkus, Don",43,000130
+BARBER,Medicine Lodge Precinct 3,Kansas Senate,32,Republican,"Alley, Larry W.",140,000130
+BARBER,Medicine Lodge Precinct 4,Kansas Senate,32,Democratic,"Shimkus, Don",17,000140
+BARBER,Medicine Lodge Precinct 4,Kansas Senate,32,Republican,"Alley, Larry W.",118,000140
+BARBER,Medicine Lodge Precinct 5,Kansas Senate,32,Democratic,"Shimkus, Don",1,000150
+BARBER,Medicine Lodge Precinct 5,Kansas Senate,32,Republican,"Alley, Larry W.",30,000150
+BARBER,Mingona Township,Kansas Senate,32,Democratic,"Shimkus, Don",7,000160
+BARBER,Mingona Township,Kansas Senate,32,Republican,"Alley, Larry W.",36,000160
+BARBER,Moore Township,Kansas Senate,32,Democratic,"Shimkus, Don",7,000170
+BARBER,Moore Township,Kansas Senate,32,Republican,"Alley, Larry W.",14,000170
+BARBER,Nippawalla Township,Kansas Senate,32,Democratic,"Shimkus, Don",1,000180
+BARBER,Nippawalla Township,Kansas Senate,32,Republican,"Alley, Larry W.",17,000180
+BARBER,Sun City Township,Kansas Senate,32,Democratic,"Shimkus, Don",0,000210
+BARBER,Sun City Township,Kansas Senate,32,Republican,"Alley, Larry W.",29,000210
+BARBER,Turkey Creek Township,Kansas Senate,32,Democratic,"Shimkus, Don",4,000220
+BARBER,Turkey Creek Township,Kansas Senate,32,Republican,"Alley, Larry W.",9,000220
+BARBER,Valley Township,Kansas Senate,32,Democratic,"Shimkus, Don",5,000230
+BARBER,Valley Township,Kansas Senate,32,Republican,"Alley, Larry W.",56,000230
+BARBER,Sharon Township,Kansas Senate,32,Democratic,"Shimkus, Don",30,130010
+BARBER,Sharon Township,Kansas Senate,32,Republican,"Alley, Larry W.",160,130010
+BARBER,Aetna Township,President / Vice President,,independent,"Stein, Jill",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+BARBER,Aetna Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+BARBER,Aetna Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000010
+BARBER,Aetna Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+BARBER,Aetna Township,President / Vice President,,Republican,"Trump, Donald J.",5,000010
+BARBER,Deerhead Township,President / Vice President,,independent,"Stein, Jill",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+BARBER,Deerhead Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+BARBER,Deerhead Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+BARBER,Deerhead Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+BARBER,Deerhead Township,President / Vice President,,Republican,"Trump, Donald J.",7,000020
+BARBER,Eagle Township,President / Vice President,,independent,"Stein, Jill",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+BARBER,Eagle Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+BARBER,Eagle Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+BARBER,Eagle Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+BARBER,Eagle Township,President / Vice President,,Republican,"Trump, Donald J.",22,000030
+BARBER,Elm Mills Township,President / Vice President,,independent,"Stein, Jill",3,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"McMullin, Evan",1,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+BARBER,Elm Mills Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+BARBER,Elm Mills Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000040
+BARBER,Elm Mills Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+BARBER,Elm Mills Township,President / Vice President,,Republican,"Trump, Donald J.",59,000040
+BARBER,Elwood Township,President / Vice President,,independent,"Stein, Jill",1,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+BARBER,Elwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+BARBER,Elwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000050
+BARBER,Elwood Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+BARBER,Elwood Township,President / Vice President,,Republican,"Trump, Donald J.",72,000050
+BARBER,Hazelton Township,President / Vice President,,independent,"Stein, Jill",1,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+BARBER,Hazelton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+BARBER,Hazelton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000060
+BARBER,Hazelton Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000060
+BARBER,Hazelton Township,President / Vice President,,Republican,"Trump, Donald J.",59,000060
+BARBER,Kiowa East Township,President / Vice President,,independent,"Stein, Jill",6,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+BARBER,Kiowa East Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+BARBER,Kiowa East Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000070
+BARBER,Kiowa East Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000070
+BARBER,Kiowa East Township,President / Vice President,,Republican,"Trump, Donald J.",266,000070
+BARBER,Kiowa West Township,President / Vice President,,independent,"Stein, Jill",1,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Castle, Darrell L",1,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+BARBER,Kiowa West Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+BARBER,Kiowa West Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000080
+BARBER,Kiowa West Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+BARBER,Kiowa West Township,President / Vice President,,Republican,"Trump, Donald J.",164,000080
+BARBER,Lake City Township,President / Vice President,,independent,"Stein, Jill",4,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+BARBER,Lake City Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+BARBER,Lake City Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000090
+BARBER,Lake City Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+BARBER,Lake City Township,President / Vice President,,Republican,"Trump, Donald J.",30,000090
+BARBER,McAdoo Township,President / Vice President,,independent,"Stein, Jill",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+BARBER,McAdoo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+BARBER,McAdoo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000100
+BARBER,McAdoo Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+BARBER,McAdoo Township,President / Vice President,,Republican,"Trump, Donald J.",16,000100
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000110
+BARBER,Medicine Lodge Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",266,000110
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,independent,"Stein, Jill",1,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,00012A
+BARBER,Medicine Lodge Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",214,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00012B
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,independent,"Stein, Jill",2,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"McMullin, Evan",1,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+BARBER,Medicine Lodge Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",161,000130
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,independent,"Stein, Jill",1,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"McMullin, Evan",1,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+BARBER,Medicine Lodge Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",128,000140
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,independent,"Stein, Jill",1,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"McMullin, Evan",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+BARBER,Medicine Lodge Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",29,000150
+BARBER,Mingona Township,President / Vice President,,independent,"Stein, Jill",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+BARBER,Mingona Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+BARBER,Mingona Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000160
+BARBER,Mingona Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+BARBER,Mingona Township,President / Vice President,,Republican,"Trump, Donald J.",42,000160
+BARBER,Moore Township,President / Vice President,,independent,"Stein, Jill",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+BARBER,Moore Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+BARBER,Moore Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000170
+BARBER,Moore Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+BARBER,Moore Township,President / Vice President,,Republican,"Trump, Donald J.",16,000170
+BARBER,Nippawalla Township,President / Vice President,,independent,"Stein, Jill",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+BARBER,Nippawalla Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+BARBER,Nippawalla Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000180
+BARBER,Nippawalla Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+BARBER,Nippawalla Township,President / Vice President,,Republican,"Trump, Donald J.",18,000180
+BARBER,Sun City Township,President / Vice President,,independent,"Stein, Jill",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Hoefling, Tom",1,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+BARBER,Sun City Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+BARBER,Sun City Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000210
+BARBER,Sun City Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+BARBER,Sun City Township,President / Vice President,,Republican,"Trump, Donald J.",27,000210
+BARBER,Turkey Creek Township,President / Vice President,,independent,"Stein, Jill",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+BARBER,Turkey Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000220
+BARBER,Turkey Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+BARBER,Turkey Creek Township,President / Vice President,,Republican,"Trump, Donald J.",9,000220
+BARBER,Valley Township,President / Vice President,,independent,"Stein, Jill",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+BARBER,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+BARBER,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000230
+BARBER,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+BARBER,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",66,000230
+BARBER,Sharon Township,President / Vice President,,independent,"Stein, Jill",2,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Castle, Darrell L",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Hedges, James A",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Maturen, Michael A",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"McMullin, Evan",2,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Perry, Darryl",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Smith, Mike",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Sood, Ajay",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+BARBER,Sharon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+BARBER,Sharon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,130010
+BARBER,Sharon Township,President / Vice President,,Libertarian,"Johnson, Gary",5,130010
+BARBER,Sharon Township,President / Vice President,,Republican,"Trump, Donald J.",174,130010
+BARBER,Aetna Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000010
+BARBER,Aetna Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000010
+BARBER,Aetna Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000010
+BARBER,Aetna Township,United States House of Representatives,4,Republican,"Pompeo, Michael",4,000010
+BARBER,Deerhead Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000020
+BARBER,Deerhead Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000020
+BARBER,Deerhead Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000020
+BARBER,Deerhead Township,United States House of Representatives,4,Republican,"Pompeo, Michael",6,000020
+BARBER,Eagle Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000030
+BARBER,Eagle Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000030
+BARBER,Eagle Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000030
+BARBER,Eagle Township,United States House of Representatives,4,Republican,"Pompeo, Michael",17,000030
+BARBER,Elm Mills Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000040
+BARBER,Elm Mills Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000040
+BARBER,Elm Mills Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000040
+BARBER,Elm Mills Township,United States House of Representatives,4,Republican,"Pompeo, Michael",54,000040
+BARBER,Elwood Township,United States House of Representatives,4,independent,"Allen, Miranda",27,000050
+BARBER,Elwood Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000050
+BARBER,Elwood Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000050
+BARBER,Elwood Township,United States House of Representatives,4,Republican,"Pompeo, Michael",53,000050
+BARBER,Hazelton Township,United States House of Representatives,4,independent,"Allen, Miranda",32,000060
+BARBER,Hazelton Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000060
+BARBER,Hazelton Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000060
+BARBER,Hazelton Township,United States House of Representatives,4,Republican,"Pompeo, Michael",40,000060
+BARBER,Kiowa East Township,United States House of Representatives,4,independent,"Allen, Miranda",112,000070
+BARBER,Kiowa East Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,000070
+BARBER,Kiowa East Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000070
+BARBER,Kiowa East Township,United States House of Representatives,4,Republican,"Pompeo, Michael",193,000070
+BARBER,Kiowa West Township,United States House of Representatives,4,independent,"Allen, Miranda",83,000080
+BARBER,Kiowa West Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,000080
+BARBER,Kiowa West Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000080
+BARBER,Kiowa West Township,United States House of Representatives,4,Republican,"Pompeo, Michael",107,000080
+BARBER,Lake City Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000090
+BARBER,Lake City Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000090
+BARBER,Lake City Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000090
+BARBER,Lake City Township,United States House of Representatives,4,Republican,"Pompeo, Michael",26,000090
+BARBER,McAdoo Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000100
+BARBER,McAdoo Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000100
+BARBER,McAdoo Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000100
+BARBER,McAdoo Township,United States House of Representatives,4,Republican,"Pompeo, Michael",15,000100
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",74,000110
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",39,000110
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000110
+BARBER,Medicine Lodge Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",225,000110
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",41,00012A
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",32,00012A
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,00012A
+BARBER,Medicine Lodge Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",183,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00012B
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,independent,"Allen, Miranda",45,000130
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",17,000130
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000130
+BARBER,Medicine Lodge Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Michael",129,000130
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,independent,"Allen, Miranda",28,000140
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000140
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000140
+BARBER,Medicine Lodge Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Michael",105,000140
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,independent,"Allen, Miranda",4,000150
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000150
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000150
+BARBER,Medicine Lodge Precinct 5,United States House of Representatives,4,Republican,"Pompeo, Michael",26,000150
+BARBER,Mingona Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000160
+BARBER,Mingona Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000160
+BARBER,Mingona Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000160
+BARBER,Mingona Township,United States House of Representatives,4,Republican,"Pompeo, Michael",33,000160
+BARBER,Moore Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000170
+BARBER,Moore Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000170
+BARBER,Moore Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000170
+BARBER,Moore Township,United States House of Representatives,4,Republican,"Pompeo, Michael",10,000170
+BARBER,Nippawalla Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000180
+BARBER,Nippawalla Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000180
+BARBER,Nippawalla Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000180
+BARBER,Nippawalla Township,United States House of Representatives,4,Republican,"Pompeo, Michael",15,000180
+BARBER,Sun City Township,United States House of Representatives,4,independent,"Allen, Miranda",10,000210
+BARBER,Sun City Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000210
+BARBER,Sun City Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000210
+BARBER,Sun City Township,United States House of Representatives,4,Republican,"Pompeo, Michael",17,000210
+BARBER,Turkey Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",4,000220
+BARBER,Turkey Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000220
+BARBER,Turkey Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000220
+BARBER,Turkey Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",8,000220
+BARBER,Valley Township,United States House of Representatives,4,independent,"Allen, Miranda",15,000230
+BARBER,Valley Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000230
+BARBER,Valley Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000230
+BARBER,Valley Township,United States House of Representatives,4,Republican,"Pompeo, Michael",51,000230
+BARBER,Sharon Township,United States House of Representatives,4,independent,"Allen, Miranda",43,130010
+BARBER,Sharon Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",14,130010
+BARBER,Sharon Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,130010
+BARBER,Sharon Township,United States House of Representatives,4,Republican,"Pompeo, Michael",139,130010
+BARBER,Aetna Township,United States Senate,,write - in,"Smith, DJ",0,000010
+BARBER,Aetna Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+BARBER,Aetna Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+BARBER,Aetna Township,United States Senate,,Republican,"Moran, Jerry",6,000010
+BARBER,Deerhead Township,United States Senate,,write - in,"Smith, DJ",0,000020
+BARBER,Deerhead Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+BARBER,Deerhead Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+BARBER,Deerhead Township,United States Senate,,Republican,"Moran, Jerry",6,000020
+BARBER,Eagle Township,United States Senate,,write - in,"Smith, DJ",0,000030
+BARBER,Eagle Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000030
+BARBER,Eagle Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+BARBER,Eagle Township,United States Senate,,Republican,"Moran, Jerry",21,000030
+BARBER,Elm Mills Township,United States Senate,,write - in,"Smith, DJ",0,000040
+BARBER,Elm Mills Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000040
+BARBER,Elm Mills Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000040
+BARBER,Elm Mills Township,United States Senate,,Republican,"Moran, Jerry",60,000040
+BARBER,Elwood Township,United States Senate,,write - in,"Smith, DJ",0,000050
+BARBER,Elwood Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000050
+BARBER,Elwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000050
+BARBER,Elwood Township,United States Senate,,Republican,"Moran, Jerry",72,000050
+BARBER,Hazelton Township,United States Senate,,write - in,"Smith, DJ",0,000060
+BARBER,Hazelton Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000060
+BARBER,Hazelton Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000060
+BARBER,Hazelton Township,United States Senate,,Republican,"Moran, Jerry",60,000060
+BARBER,Kiowa East Township,United States Senate,,write - in,"Smith, DJ",0,000070
+BARBER,Kiowa East Township,United States Senate,,Democratic,"Wiesner, Patrick",32,000070
+BARBER,Kiowa East Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000070
+BARBER,Kiowa East Township,United States Senate,,Republican,"Moran, Jerry",273,000070
+BARBER,Kiowa West Township,United States Senate,,write - in,"Smith, DJ",0,000080
+BARBER,Kiowa West Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000080
+BARBER,Kiowa West Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000080
+BARBER,Kiowa West Township,United States Senate,,Republican,"Moran, Jerry",162,000080
+BARBER,Lake City Township,United States Senate,,write - in,"Smith, DJ",0,000090
+BARBER,Lake City Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000090
+BARBER,Lake City Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000090
+BARBER,Lake City Township,United States Senate,,Republican,"Moran, Jerry",32,000090
+BARBER,McAdoo Township,United States Senate,,write - in,"Smith, DJ",0,000100
+BARBER,McAdoo Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000100
+BARBER,McAdoo Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+BARBER,McAdoo Township,United States Senate,,Republican,"Moran, Jerry",16,000100
+BARBER,Medicine Lodge Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000110
+BARBER,Medicine Lodge Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",50,000110
+BARBER,Medicine Lodge Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000110
+BARBER,Medicine Lodge Precinct 1,United States Senate,,Republican,"Moran, Jerry",278,000110
+BARBER,Medicine Lodge Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00012A
+BARBER,Medicine Lodge Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",40,00012A
+BARBER,Medicine Lodge Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,00012A
+BARBER,Medicine Lodge Precinct 2,United States Senate,,Republican,"Moran, Jerry",206,00012A
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00012B
+BARBER,Medicine Lodge Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00012B
+BARBER,Medicine Lodge Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000130
+BARBER,Medicine Lodge Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",23,000130
+BARBER,Medicine Lodge Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",12,000130
+BARBER,Medicine Lodge Precinct 3,United States Senate,,Republican,"Moran, Jerry",157,000130
+BARBER,Medicine Lodge Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000140
+BARBER,Medicine Lodge Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",10,000140
+BARBER,Medicine Lodge Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",9,000140
+BARBER,Medicine Lodge Precinct 4,United States Senate,,Republican,"Moran, Jerry",119,000140
+BARBER,Medicine Lodge Precinct 5,United States Senate,,write - in,"Smith, DJ",0,000150
+BARBER,Medicine Lodge Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",2,000150
+BARBER,Medicine Lodge Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",1,000150
+BARBER,Medicine Lodge Precinct 5,United States Senate,,Republican,"Moran, Jerry",29,000150
+BARBER,Mingona Township,United States Senate,,write - in,"Smith, DJ",0,000160
+BARBER,Mingona Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000160
+BARBER,Mingona Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+BARBER,Mingona Township,United States Senate,,Republican,"Moran, Jerry",42,000160
+BARBER,Moore Township,United States Senate,,write - in,"Smith, DJ",0,000170
+BARBER,Moore Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000170
+BARBER,Moore Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000170
+BARBER,Moore Township,United States Senate,,Republican,"Moran, Jerry",15,000170
+BARBER,Nippawalla Township,United States Senate,,write - in,"Smith, DJ",0,000180
+BARBER,Nippawalla Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+BARBER,Nippawalla Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000180
+BARBER,Nippawalla Township,United States Senate,,Republican,"Moran, Jerry",18,000180
+BARBER,Sun City Township,United States Senate,,write - in,"Smith, DJ",0,000210
+BARBER,Sun City Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000210
+BARBER,Sun City Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000210
+BARBER,Sun City Township,United States Senate,,Republican,"Moran, Jerry",24,000210
+BARBER,Turkey Creek Township,United States Senate,,write - in,"Smith, DJ",0,000220
+BARBER,Turkey Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000220
+BARBER,Turkey Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000220
+BARBER,Turkey Creek Township,United States Senate,,Republican,"Moran, Jerry",10,000220
+BARBER,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000230
+BARBER,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000230
+BARBER,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000230
+BARBER,Valley Township,United States Senate,,Republican,"Moran, Jerry",65,000230
+BARBER,Sharon Township,United States Senate,,write - in,"Smith, DJ",0,130010
+BARBER,Sharon Township,United States Senate,,Democratic,"Wiesner, Patrick",26,130010
+BARBER,Sharon Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,130010
+BARBER,Sharon Township,United States Senate,,Republican,"Moran, Jerry",165,130010

--- a/2016/20161108__ks__general__barton__precinct.csv
+++ b/2016/20161108__ks__general__barton__precinct.csv
@@ -1,801 +1,1801 @@
-county,precinct,office,district,candidate,party,votes
-Barton,001 GBC W1P1,,,Registered Voters,,721
-Barton,001 GBC W1P1,,,Ballots Cast,,339
-Barton,001 GBC W1P1,President,,Hillary Clinton,DEM,105
-Barton,001 GBC W1P1,President,,Gary Johnson,LBT,20
-Barton,001 GBC W1P1,President,,Jill Stein,IND,11
-Barton,001 GBC W1P1,President,,Donald Trump,REP,200
-Barton,001 GBC W1P1,President,,Write-ins,,1
-Barton,001 GBC W1P1,U.S. Senate,,Robert Garrard,LBT,25
-Barton,001 GBC W1P1,U.S. Senate,,Jerry Moran,REP,227
-Barton,001 GBC W1P1,U.S. Senate,,Patrick Wiesner,DEM,74
-Barton,001 GBC W1P1,U.S. Senate,,Write-ins,,0
-Barton,001 GBC W1P1,U.S. House,1,Kerry Burt,LBT,18
-Barton,001 GBC W1P1,U.S. House,1,Alan LaPolice,IND,99
-Barton,001 GBC W1P1,U.S. House,1,Roger Marshall,REP,212
-Barton,001 GBC W1P1,U.S. House,1,Write-ins,,0
-Barton,001 GBC W1P1,State Senate,33,Matt Bristow,DEM,126
-Barton,001 GBC W1P1,State Senate,33,Mary Jo Taylor,REP,196
-Barton,001 GBC W1P1,State Senate,33,Write-ins,,0
-Barton,001 GBC W1P1,State House,112,Tory Arnberger,REP,294
-Barton,001 GBC W1P1,State House,112,Write-ins,,1
-Barton,002 GBC W1P2,,,Registered Voters,,867
-Barton,002 GBC W1P2,,,Ballots Cast,,496
-Barton,002 GBC W1P2,President,,Hillary Clinton,DEM,101
-Barton,002 GBC W1P2,President,,Gary Johnson,LBT,13
-Barton,002 GBC W1P2,President,,Jill Stein,IND,11
-Barton,002 GBC W1P2,President,,Donald Trump,REP,363
-Barton,002 GBC W1P2,President,,Write-ins,,4
-Barton,002 GBC W1P2,U.S. Senate,,Robert Garrard,LBT,21
-Barton,002 GBC W1P2,U.S. Senate,,Jerry Moran,REP,384
-Barton,002 GBC W1P2,U.S. Senate,,Patrick Wiesner,DEM,81
-Barton,002 GBC W1P2,U.S. Senate,,Write-ins,,0
-Barton,002 GBC W1P2,U.S. House,1,Kerry Burt,LBT,30
-Barton,002 GBC W1P2,U.S. House,1,Alan LaPolice,IND,113
-Barton,002 GBC W1P2,U.S. House,1,Roger Marshall,REP,334
-Barton,002 GBC W1P2,U.S. House,1,Write-ins,,1
-Barton,002 GBC W1P2,State Senate,33,Matt Bristow,DEM,141
-Barton,002 GBC W1P2,State Senate,33,Mary Jo Taylor,REP,329
-Barton,002 GBC W1P2,State Senate,33,Write-ins,,0
-Barton,002 GBC W1P2,State House,112,Tory Arnberger,REP,437
-Barton,002 GBC W1P2,State House,112,Write-ins,,3
-Barton,003 GBC W1P3,,,Registered Voters,,656
-Barton,003 GBC W1P3,,,Ballots Cast,,394
-Barton,003 GBC W1P3,President,,Hillary Clinton,DEM,83
-Barton,003 GBC W1P3,President,,Gary Johnson,LBT,21
-Barton,003 GBC W1P3,President,,Jill Stein,IND,9
-Barton,003 GBC W1P3,President,,Donald Trump,REP,273
-Barton,003 GBC W1P3,President,,Write-ins,,6
-Barton,003 GBC W1P3,U.S. Senate,,Robert Garrard,LBT,29
-Barton,003 GBC W1P3,U.S. Senate,,Jerry Moran,REP,295
-Barton,003 GBC W1P3,U.S. Senate,,Patrick Wiesner,DEM,64
-Barton,003 GBC W1P3,U.S. Senate,,Write-ins,,0
-Barton,003 GBC W1P3,U.S. House,1,Kerry Burt,LBT,20
-Barton,003 GBC W1P3,U.S. House,1,Alan LaPolice,IND,127
-Barton,003 GBC W1P3,U.S. House,1,Roger Marshall,REP,241
-Barton,003 GBC W1P3,U.S. House,1,Write-ins,,0
-Barton,003 GBC W1P3,State Senate,33,Matt Bristow,DEM,143
-Barton,003 GBC W1P3,State Senate,33,Mary Jo Taylor,REP,239
-Barton,003 GBC W1P3,State Senate,33,Write-ins,,1
-Barton,003 GBC W1P3,State House,112,Tory Arnberger,REP,351
-Barton,003 GBC W1P3,State House,112,Write-ins,,11
-Barton,004 GBC W2P1,,,Registered Voters,,969
-Barton,004 GBC W2P1,,,Ballots Cast,,638
-Barton,004 GBC W2P1,President,,Hillary Clinton,DEM,114
-Barton,004 GBC W2P1,President,,Gary Johnson,LBT,24
-Barton,004 GBC W2P1,President,,Jill Stein,IND,16
-Barton,004 GBC W2P1,President,,Donald Trump,REP,470
-Barton,004 GBC W2P1,President,,Write-ins,,9
-Barton,004 GBC W2P1,U.S. Senate,,Robert Garrard,LBT,25
-Barton,004 GBC W2P1,U.S. Senate,,Jerry Moran,REP,517
-Barton,004 GBC W2P1,U.S. Senate,,Patrick Wiesner,DEM,87
-Barton,004 GBC W2P1,U.S. Senate,,Write-ins,,0
-Barton,004 GBC W2P1,U.S. House,1,Kerry Burt,LBT,34
-Barton,004 GBC W2P1,U.S. House,1,Alan LaPolice,IND,179
-Barton,004 GBC W2P1,U.S. House,1,Roger Marshall,REP,411
-Barton,004 GBC W2P1,U.S. House,1,Write-ins,,3
-Barton,004 GBC W2P1,State Senate,33,Matt Bristow,DEM,182
-Barton,004 GBC W2P1,State Senate,33,Mary Jo Taylor,REP,424
-Barton,004 GBC W2P1,State Senate,33,Write-ins,,0
-Barton,004 GBC W2P1,State House,112,Tory Arnberger,REP,562
-Barton,004 GBC W2P1,State House,112,Write-ins,,10
-Barton,005 GBC W2P2,,,Registered Voters,,860
-Barton,005 GBC W2P2,,,Ballots Cast,,592
-Barton,005 GBC W2P2,President,,Hillary Clinton,DEM,113
-Barton,005 GBC W2P2,President,,Gary Johnson,LBT,12
-Barton,005 GBC W2P2,President,,Jill Stein,IND,8
-Barton,005 GBC W2P2,President,,Donald Trump,REP,442
-Barton,005 GBC W2P2,President,,Write-ins,,11
-Barton,005 GBC W2P2,U.S. Senate,,Robert Garrard,LBT,19
-Barton,005 GBC W2P2,U.S. Senate,,Jerry Moran,REP,485
-Barton,005 GBC W2P2,U.S. Senate,,Patrick Wiesner,DEM,80
-Barton,005 GBC W2P2,U.S. Senate,,Write-ins,,1
-Barton,005 GBC W2P2,U.S. House,1,Kerry Burt,LBT,27
-Barton,005 GBC W2P2,U.S. House,1,Alan LaPolice,IND,148
-Barton,005 GBC W2P2,U.S. House,1,Roger Marshall,REP,408
-Barton,005 GBC W2P2,U.S. House,1,Write-ins,,1
-Barton,005 GBC W2P2,State Senate,33,Matt Bristow,DEM,166
-Barton,005 GBC W2P2,State Senate,33,Mary Jo Taylor,REP,407
-Barton,005 GBC W2P2,State Senate,33,Write-ins,,0
-Barton,005 GBC W2P2,State House,112,Tory Arnberger,REP,535
-Barton,005 GBC W2P2,State House,112,Write-ins,,7
-Barton,006 GBC W2P3,,,Registered Voters,,951
-Barton,006 GBC W2P3,,,Ballots Cast,,721
-Barton,006 GBC W2P3,President,,Hillary Clinton,DEM,122
-Barton,006 GBC W2P3,President,,Gary Johnson,LBT,13
-Barton,006 GBC W2P3,President,,Jill Stein,IND,9
-Barton,006 GBC W2P3,President,,Donald Trump,REP,563
-Barton,006 GBC W2P3,President,,Write-ins,,3
-Barton,006 GBC W2P3,U.S. Senate,,Robert Garrard,LBT,21
-Barton,006 GBC W2P3,U.S. Senate,,Jerry Moran,REP,617
-Barton,006 GBC W2P3,U.S. Senate,,Patrick Wiesner,DEM,66
-Barton,006 GBC W2P3,U.S. Senate,,Write-ins,,1
-Barton,006 GBC W2P3,U.S. House,1,Kerry Burt,LBT,27
-Barton,006 GBC W2P3,U.S. House,1,Alan LaPolice,IND,140
-Barton,006 GBC W2P3,U.S. House,1,Roger Marshall,REP,541
-Barton,006 GBC W2P3,U.S. House,1,Write-ins,,2
-Barton,006 GBC W2P3,State Senate,33,Matt Bristow,DEM,165
-Barton,006 GBC W2P3,State Senate,33,Mary Jo Taylor,REP,535
-Barton,006 GBC W2P3,State Senate,33,Write-ins,,1
-Barton,006 GBC W2P3,State House,112,Tory Arnberger,REP,656
-Barton,006 GBC W2P3,State House,112,Write-ins,,4
-Barton,007 GBC W3P1,,,Registered Voters,,721
-Barton,007 GBC W3P1,,,Ballots Cast,,419
-Barton,007 GBC W3P1,President,,Hillary Clinton,DEM,84
-Barton,007 GBC W3P1,President,,Gary Johnson,LBT,16
-Barton,007 GBC W3P1,President,,Jill Stein,IND,5
-Barton,007 GBC W3P1,President,,Donald Trump,REP,303
-Barton,007 GBC W3P1,President,,Write-ins,,8
-Barton,007 GBC W3P1,U.S. Senate,,Robert Garrard,LBT,16
-Barton,007 GBC W3P1,U.S. Senate,,Jerry Moran,REP,335
-Barton,007 GBC W3P1,U.S. Senate,,Patrick Wiesner,DEM,54
-Barton,007 GBC W3P1,U.S. Senate,,Write-ins,,0
-Barton,007 GBC W3P1,U.S. House,1,Kerry Burt,LBT,22
-Barton,007 GBC W3P1,U.S. House,1,Alan LaPolice,IND,120
-Barton,007 GBC W3P1,U.S. House,1,Roger Marshall,REP,267
-Barton,007 GBC W3P1,U.S. House,1,Write-ins,,0
-Barton,007 GBC W3P1,State Senate,33,Matt Bristow,DEM,129
-Barton,007 GBC W3P1,State Senate,33,Mary Jo Taylor,REP,267
-Barton,007 GBC W3P1,State Senate,33,Write-ins,,1
-Barton,007 GBC W3P1,State House,112,Tory Arnberger,REP,361
-Barton,007 GBC W3P1,State House,112,Write-ins,,3
-Barton,008 GBC W3P2,,,Registered Voters,,852
-Barton,008 GBC W3P2,,,Ballots Cast,,467
-Barton,008 GBC W3P2,President,,Hillary Clinton,DEM,105
-Barton,008 GBC W3P2,President,,Gary Johnson,LBT,18
-Barton,008 GBC W3P2,President,,Jill Stein,IND,8
-Barton,008 GBC W3P2,President,,Donald Trump,REP,329
-Barton,008 GBC W3P2,President,,Write-ins,,4
-Barton,008 GBC W3P2,U.S. Senate,,Robert Garrard,LBT,31
-Barton,008 GBC W3P2,U.S. Senate,,Jerry Moran,REP,355
-Barton,008 GBC W3P2,U.S. Senate,,Patrick Wiesner,DEM,72
-Barton,008 GBC W3P2,U.S. Senate,,Write-ins,,0
-Barton,008 GBC W3P2,U.S. House,1,Kerry Burt,LBT,22
-Barton,008 GBC W3P2,U.S. House,1,Alan LaPolice,IND,124
-Barton,008 GBC W3P2,U.S. House,1,Roger Marshall,REP,315
-Barton,008 GBC W3P2,U.S. House,1,Write-ins,,1
-Barton,008 GBC W3P2,State Senate,33,Matt Bristow,DEM,153
-Barton,008 GBC W3P2,State Senate,33,Mary Jo Taylor,REP,301
-Barton,008 GBC W3P2,State Senate,33,Write-ins,,2
-Barton,008 GBC W3P2,State House,112,Tory Arnberger,REP,429
-Barton,008 GBC W3P2,State House,112,Write-ins,,6
-Barton,009 GBC W3P3,,,Registered Voters,,836
-Barton,009 GBC W3P3,,,Ballots Cast,,516
-Barton,009 GBC W3P3,President,,Hillary Clinton,DEM,99
-Barton,009 GBC W3P3,President,,Gary Johnson,LBT,16
-Barton,009 GBC W3P3,President,,Jill Stein,IND,11
-Barton,009 GBC W3P3,President,,Donald Trump,REP,385
-Barton,009 GBC W3P3,President,,Write-ins,,4
-Barton,009 GBC W3P3,U.S. Senate,,Robert Garrard,LBT,19
-Barton,009 GBC W3P3,U.S. Senate,,Jerry Moran,REP,421
-Barton,009 GBC W3P3,U.S. Senate,,Patrick Wiesner,DEM,63
-Barton,009 GBC W3P3,U.S. Senate,,Write-ins,,1
-Barton,009 GBC W3P3,U.S. House,1,Kerry Burt,LBT,17
-Barton,009 GBC W3P3,U.S. House,1,Alan LaPolice,IND,146
-Barton,009 GBC W3P3,U.S. House,1,Roger Marshall,REP,341
-Barton,009 GBC W3P3,U.S. House,1,Write-ins,,0
-Barton,009 GBC W3P3,State Senate,33,Matt Bristow,DEM,149
-Barton,009 GBC W3P3,State Senate,33,Mary Jo Taylor,REP,345
-Barton,009 GBC W3P3,State Senate,33,Write-ins,,0
-Barton,009 GBC W3P3,State House,112,Tory Arnberger,REP,469
-Barton,009 GBC W3P3,State House,112,Write-ins,,7
-Barton,010 GBC W4P1,,,Registered Voters,,634
-Barton,010 GBC W4P1,,,Ballots Cast,,278
-Barton,010 GBC W4P1,President,,Hillary Clinton,DEM,76
-Barton,010 GBC W4P1,President,,Gary Johnson,LBT,11
-Barton,010 GBC W4P1,President,,Jill Stein,IND,5
-Barton,010 GBC W4P1,President,,Donald Trump,REP,181
-Barton,010 GBC W4P1,President,,Write-ins,,3
-Barton,010 GBC W4P1,U.S. Senate,,Robert Garrard,LBT,19
-Barton,010 GBC W4P1,U.S. Senate,,Jerry Moran,REP,196
-Barton,010 GBC W4P1,U.S. Senate,,Patrick Wiesner,DEM,55
-Barton,010 GBC W4P1,U.S. Senate,,Write-ins,,0
-Barton,010 GBC W4P1,U.S. House,1,Kerry Burt,LBT,17
-Barton,010 GBC W4P1,U.S. House,1,Alan LaPolice,IND,65
-Barton,010 GBC W4P1,U.S. House,1,Roger Marshall,REP,183
-Barton,010 GBC W4P1,U.S. House,1,Write-ins,,0
-Barton,010 GBC W4P1,State Senate,33,Matt Bristow,DEM,99
-Barton,010 GBC W4P1,State Senate,33,Mary Jo Taylor,REP,160
-Barton,010 GBC W4P1,State Senate,33,Write-ins,,0
-Barton,010 GBC W4P1,State House,112,Tory Arnberger,REP,238
-Barton,010 GBC W4P1,State House,112,Write-ins,,1
-Barton,011 GBC W4P2,,,Registered Voters,,571
-Barton,011 GBC W4P2,,,Ballots Cast,,228
-Barton,011 GBC W4P2,President,,Hillary Clinton,DEM,69
-Barton,011 GBC W4P2,President,,Gary Johnson,LBT,11
-Barton,011 GBC W4P2,President,,Jill Stein,IND,3
-Barton,011 GBC W4P2,President,,Donald Trump,REP,142
-Barton,011 GBC W4P2,President,,Write-ins,,3
-Barton,011 GBC W4P2,U.S. Senate,,Robert Garrard,LBT,18
-Barton,011 GBC W4P2,U.S. Senate,,Jerry Moran,REP,151
-Barton,011 GBC W4P2,U.S. Senate,,Patrick Wiesner,DEM,53
-Barton,011 GBC W4P2,U.S. Senate,,Write-ins,,0
-Barton,011 GBC W4P2,U.S. House,1,Kerry Burt,LBT,22
-Barton,011 GBC W4P2,U.S. House,1,Alan LaPolice,IND,55
-Barton,011 GBC W4P2,U.S. House,1,Roger Marshall,REP,139
-Barton,011 GBC W4P2,U.S. House,1,Write-ins,,1
-Barton,011 GBC W4P2,State Senate,33,Matt Bristow,DEM,88
-Barton,011 GBC W4P2,State Senate,33,Mary Jo Taylor,REP,120
-Barton,011 GBC W4P2,State Senate,33,Write-ins,,0
-Barton,011 GBC W4P2,State House,112,Tory Arnberger,REP,189
-Barton,011 GBC W4P2,State House,112,Write-ins,,5
-Barton,012 GBC W4P3,,,Registered Voters,,339
-Barton,012 GBC W4P3,,,Ballots Cast,,97
-Barton,012 GBC W4P3,President,,Hillary Clinton,DEM,37
-Barton,012 GBC W4P3,President,,Gary Johnson,LBT,4
-Barton,012 GBC W4P3,President,,Jill Stein,IND,1
-Barton,012 GBC W4P3,President,,Donald Trump,REP,53
-Barton,012 GBC W4P3,President,,Write-ins,,1
-Barton,012 GBC W4P3,U.S. Senate,,Robert Garrard,LBT,6
-Barton,012 GBC W4P3,U.S. Senate,,Jerry Moran,REP,58
-Barton,012 GBC W4P3,U.S. Senate,,Patrick Wiesner,DEM,23
-Barton,012 GBC W4P3,U.S. Senate,,Write-ins,,1
-Barton,012 GBC W4P3,U.S. House,1,Kerry Burt,LBT,15
-Barton,012 GBC W4P3,U.S. House,1,Alan LaPolice,IND,17
-Barton,012 GBC W4P3,U.S. House,1,Roger Marshall,REP,59
-Barton,012 GBC W4P3,U.S. House,1,Write-ins,,0
-Barton,012 GBC W4P3,State Senate,33,Matt Bristow,DEM,41
-Barton,012 GBC W4P3,State Senate,33,Mary Jo Taylor,REP,46
-Barton,012 GBC W4P3,State Senate,33,Write-ins,,0
-Barton,012 GBC W4P3,State House,112,Tory Arnberger,REP,81
-Barton,012 GBC W4P3,State House,112,Write-ins,,1
-Barton,013 HOIS W1,,,Registered Voters,,481
-Barton,013 HOIS W1,,,Ballots Cast,,275
-Barton,013 HOIS W1,President,,Hillary Clinton,DEM,45
-Barton,013 HOIS W1,President,,Gary Johnson,LBT,9
-Barton,013 HOIS W1,President,,Jill Stein,IND,7
-Barton,013 HOIS W1,President,,Donald Trump,REP,205
-Barton,013 HOIS W1,President,,Write-ins,,4
-Barton,013 HOIS W1,U.S. Senate,,Robert Garrard,LBT,17
-Barton,013 HOIS W1,U.S. Senate,,Jerry Moran,REP,213
-Barton,013 HOIS W1,U.S. Senate,,Patrick Wiesner,DEM,33
-Barton,013 HOIS W1,U.S. Senate,,Write-ins,,0
-Barton,013 HOIS W1,U.S. House,1,Kerry Burt,LBT,21
-Barton,013 HOIS W1,U.S. House,1,Alan LaPolice,IND,75
-Barton,013 HOIS W1,U.S. House,1,Roger Marshall,REP,171
-Barton,013 HOIS W1,U.S. House,1,Write-ins,,0
-Barton,013 HOIS W1,State Senate,33,Matt Bristow,DEM,102
-Barton,013 HOIS W1,State Senate,33,Mary Jo Taylor,REP,159
-Barton,013 HOIS W1,State Senate,33,Write-ins,,1
-Barton,013 HOIS W1,State House,112,Tory Arnberger,REP,236
-Barton,013 HOIS W1,State House,112,Write-ins,,1
-Barton,014 HOIS W2,,,Registered Voters,,455
-Barton,014 HOIS W2,,,Ballots Cast,,299
-Barton,014 HOIS W2,President,,Hillary Clinton,DEM,50
-Barton,014 HOIS W2,President,,Gary Johnson,LBT,10
-Barton,014 HOIS W2,President,,Jill Stein,IND,2
-Barton,014 HOIS W2,President,,Donald Trump,REP,233
-Barton,014 HOIS W2,President,,Write-ins,,0
-Barton,014 HOIS W2,U.S. Senate,,Robert Garrard,LBT,6
-Barton,014 HOIS W2,U.S. Senate,,Jerry Moran,REP,250
-Barton,014 HOIS W2,U.S. Senate,,Patrick Wiesner,DEM,35
-Barton,014 HOIS W2,U.S. Senate,,Write-ins,,0
-Barton,014 HOIS W2,U.S. House,1,Kerry Burt,LBT,20
-Barton,014 HOIS W2,U.S. House,1,Alan LaPolice,IND,106
-Barton,014 HOIS W2,U.S. House,1,Roger Marshall,REP,161
-Barton,014 HOIS W2,U.S. House,1,Write-ins,,0
-Barton,014 HOIS W2,State Senate,33,Matt Bristow,DEM,107
-Barton,014 HOIS W2,State Senate,33,Mary Jo Taylor,REP,176
-Barton,014 HOIS W2,State Senate,33,Write-ins,,1
-Barton,014 HOIS W2,State House,112,Tory Arnberger,REP,260
-Barton,014 HOIS W2,State House,112,Write-ins,,0
-Barton,015 HOIS W3 ,,,Registered Voters,,487
-Barton,015 HOIS W3 ,,,Ballots Cast,,273
-Barton,015 HOIS W3 ,President,,Hillary Clinton,DEM,45
-Barton,015 HOIS W3 ,President,,Gary Johnson,LBT,15
-Barton,015 HOIS W3 ,President,,Jill Stein,IND,3
-Barton,015 HOIS W3 ,President,,Donald Trump,REP,209
-Barton,015 HOIS W3 ,President,,Write-ins,,0
-Barton,015 HOIS W3 ,U.S. Senate,,Robert Garrard,LBT,16
-Barton,015 HOIS W3 ,U.S. Senate,,Jerry Moran,REP,221
-Barton,015 HOIS W3 ,U.S. Senate,,Patrick Wiesner,DEM,27
-Barton,015 HOIS W3 ,U.S. Senate,,Write-ins,,0
-Barton,015 HOIS W3 ,U.S. House,1,Kerry Burt,LBT,21
-Barton,015 HOIS W3 ,U.S. House,1,Alan LaPolice,IND,79
-Barton,015 HOIS W3 ,U.S. House,1,Roger Marshall,REP,162
-Barton,015 HOIS W3 ,U.S. House,1,Write-ins,,0
-Barton,015 HOIS W3 ,State Senate,33,Matt Bristow,DEM,75
-Barton,015 HOIS W3 ,State Senate,33,Mary Jo Taylor,REP,183
-Barton,015 HOIS W3 ,State Senate,33,Write-ins,,1
-Barton,015 HOIS W3 ,State House,112,Tory Arnberger,REP,243
-Barton,015 HOIS W3 ,State House,112,Write-ins,,1
-Barton,016 HOIS W4,,,Registered Voters,,438
-Barton,016 HOIS W4,,,Ballots Cast,,239
-Barton,016 HOIS W4,President,,Hillary Clinton,DEM,27
-Barton,016 HOIS W4,President,,Gary Johnson,LBT,13
-Barton,016 HOIS W4,President,,Jill Stein,IND,3
-Barton,016 HOIS W4,President,,Donald Trump,REP,192
-Barton,016 HOIS W4,President,,Write-ins,,4
-Barton,016 HOIS W4,U.S. Senate,,Robert Garrard,LBT,18
-Barton,016 HOIS W4,U.S. Senate,,Jerry Moran,REP,191
-Barton,016 HOIS W4,U.S. Senate,,Patrick Wiesner,DEM,26
-Barton,016 HOIS W4,U.S. Senate,,Write-ins,,0
-Barton,016 HOIS W4,U.S. House,1,Kerry Burt,LBT,20
-Barton,016 HOIS W4,U.S. House,1,Alan LaPolice,IND,69
-Barton,016 HOIS W4,U.S. House,1,Roger Marshall,REP,144
-Barton,016 HOIS W4,U.S. House,1,Write-ins,,1
-Barton,016 HOIS W4,State Senate,33,Matt Bristow,DEM,78
-Barton,016 HOIS W4,State Senate,33,Mary Jo Taylor,REP,150
-Barton,016 HOIS W4,State Senate,33,Write-ins,,0
-Barton,016 HOIS W4,State House,112,Tory Arnberger,REP,224
-Barton,016 HOIS W4,State House,112,Write-ins,,0
-Barton,017 Albion,,,Registered Voters,,37
-Barton,017 Albion,,,Ballots Cast,,28
-Barton,017 Albion,President,,Hillary Clinton,DEM,1
-Barton,017 Albion,President,,Gary Johnson,LBT,3
-Barton,017 Albion,President,,Jill Stein,IND,0
-Barton,017 Albion,President,,Donald Trump,REP,24
-Barton,017 Albion,President,,Write-ins,,0
-Barton,017 Albion,U.S. Senate,,Robert Garrard,LBT,0
-Barton,017 Albion,U.S. Senate,,Jerry Moran,REP,25
-Barton,017 Albion,U.S. Senate,,Patrick Wiesner,DEM,0
-Barton,017 Albion,U.S. Senate,,Write-ins,,0
-Barton,017 Albion,U.S. House,1,Kerry Burt,LBT,0
-Barton,017 Albion,U.S. House,1,Alan LaPolice,IND,9
-Barton,017 Albion,U.S. House,1,Roger Marshall,REP,18
-Barton,017 Albion,U.S. House,1,Write-ins,,0
-Barton,017 Albion,State Senate,33,Matt Bristow,DEM,7
-Barton,017 Albion,State Senate,33,Mary Jo Taylor,REP,19
-Barton,017 Albion,State Senate,33,Write-ins,,0
-Barton,017 Albion,State House,112,Tory Arnberger,REP,24
-Barton,017 Albion,State House,112,Write-ins,,0
-Barton,018 Beaver,,,Registered Voters,,74
-Barton,018 Beaver,,,Ballots Cast,,47
-Barton,018 Beaver,President,,Hillary Clinton,DEM,7
-Barton,018 Beaver,President,,Gary Johnson,LBT,0
-Barton,018 Beaver,President,,Jill Stein,IND,0
-Barton,018 Beaver,President,,Donald Trump,REP,38
-Barton,018 Beaver,President,,Write-ins,,1
-Barton,018 Beaver,U.S. Senate,,Robert Garrard,LBT,4
-Barton,018 Beaver,U.S. Senate,,Jerry Moran,REP,36
-Barton,018 Beaver,U.S. Senate,,Patrick Wiesner,DEM,4
-Barton,018 Beaver,U.S. Senate,,Write-ins,,0
-Barton,018 Beaver,U.S. House,1,Kerry Burt,LBT,4
-Barton,018 Beaver,U.S. House,1,Alan LaPolice,IND,12
-Barton,018 Beaver,U.S. House,1,Roger Marshall,REP,27
-Barton,018 Beaver,U.S. House,1,Write-ins,,1
-Barton,018 Beaver,State Senate,33,Matt Bristow,DEM,14
-Barton,018 Beaver,State Senate,33,Mary Jo Taylor,REP,29
-Barton,018 Beaver,State Senate,33,Write-ins,,0
-Barton,018 Beaver,State House,112,Tory Arnberger,REP,44
-Barton,018 Beaver,State House,112,Write-ins,,0
-Barton,019 Buffalo,,,Registered Voters,,312
-Barton,019 Buffalo,,,Ballots Cast,,230
-Barton,019 Buffalo,President,,Hillary Clinton,DEM,28
-Barton,019 Buffalo,President,,Gary Johnson,LBT,5
-Barton,019 Buffalo,President,,Jill Stein,IND,0
-Barton,019 Buffalo,President,,Donald Trump,REP,197
-Barton,019 Buffalo,President,,Write-ins,,0
-Barton,019 Buffalo,U.S. Senate,,Robert Garrard,LBT,11
-Barton,019 Buffalo,U.S. Senate,,Jerry Moran,REP,197
-Barton,019 Buffalo,U.S. Senate,,Patrick Wiesner,DEM,19
-Barton,019 Buffalo,U.S. Senate,,Write-ins,,0
-Barton,019 Buffalo,U.S. House,1,Kerry Burt,LBT,8
-Barton,019 Buffalo,U.S. House,1,Alan LaPolice,IND,54
-Barton,019 Buffalo,U.S. House,1,Roger Marshall,REP,165
-Barton,019 Buffalo,U.S. House,1,Write-ins,,0
-Barton,019 Buffalo,State Senate,33,Matt Bristow,DEM,40
-Barton,019 Buffalo,State Senate,33,Mary Jo Taylor,REP,174
-Barton,019 Buffalo,State Senate,33,Write-ins,,3
-Barton,019 Buffalo,State House,112,Tory Arnberger,REP,209
-Barton,019 Buffalo,State House,112,Write-ins,,0
-Barton,020 Cheyenne,,,Registered Voters,,160
-Barton,020 Cheyenne,,,Ballots Cast,,108
-Barton,020 Cheyenne,President,,Hillary Clinton,DEM,13
-Barton,020 Cheyenne,President,,Gary Johnson,LBT,2
-Barton,020 Cheyenne,President,,Jill Stein,IND,1
-Barton,020 Cheyenne,President,,Donald Trump,REP,91
-Barton,020 Cheyenne,President,,Write-ins,,1
-Barton,020 Cheyenne,U.S. Senate,,Robert Garrard,LBT,7
-Barton,020 Cheyenne,U.S. Senate,,Jerry Moran,REP,89
-Barton,020 Cheyenne,U.S. Senate,,Patrick Wiesner,DEM,10
-Barton,020 Cheyenne,U.S. Senate,,Write-ins,,0
-Barton,020 Cheyenne,U.S. House,1,Kerry Burt,LBT,5
-Barton,020 Cheyenne,U.S. House,1,Alan LaPolice,IND,37
-Barton,020 Cheyenne,U.S. House,1,Roger Marshall,REP,61
-Barton,020 Cheyenne,U.S. House,1,Write-ins,,0
-Barton,020 Cheyenne,State Senate,33,Matt Bristow,DEM,28
-Barton,020 Cheyenne,State Senate,33,Mary Jo Taylor,REP,74
-Barton,020 Cheyenne,State Senate,33,Write-ins,,0
-Barton,020 Cheyenne,State House,109,Troy Waymaster,REP,99
-Barton,020 Cheyenne,State House,109,Write-ins,,0
-Barton,021 Clarence,,,Registered Voters,,87
-Barton,021 Clarence,,,Ballots Cast,,56
-Barton,021 Clarence,President,,Hillary Clinton,DEM,8
-Barton,021 Clarence,President,,Gary Johnson,LBT,4
-Barton,021 Clarence,President,,Jill Stein,IND,1
-Barton,021 Clarence,President,,Donald Trump,REP,43
-Barton,021 Clarence,President,,Write-ins,,0
-Barton,021 Clarence,U.S. Senate,,Robert Garrard,LBT,2
-Barton,021 Clarence,U.S. Senate,,Jerry Moran,REP,47
-Barton,021 Clarence,U.S. Senate,,Patrick Wiesner,DEM,7
-Barton,021 Clarence,U.S. Senate,,Write-ins,,0
-Barton,021 Clarence,U.S. House,1,Kerry Burt,LBT,3
-Barton,021 Clarence,U.S. House,1,Alan LaPolice,IND,16
-Barton,021 Clarence,U.S. House,1,Roger Marshall,REP,35
-Barton,021 Clarence,U.S. House,1,Write-ins,,0
-Barton,021 Clarence,State Senate,33,Matt Bristow,DEM,12
-Barton,021 Clarence,State Senate,33,Mary Jo Taylor,REP,43
-Barton,021 Clarence,State Senate,33,Write-ins,,0
-Barton,021 Clarence,State House,109,Troy Waymaster,REP,50
-Barton,021 Clarence,State House,109,Write-ins,,1
-Barton,022 Cleveland,,,Registered Voters,,33
-Barton,022 Cleveland,,,Ballots Cast,,18
-Barton,022 Cleveland,President,,Hillary Clinton,DEM,1
-Barton,022 Cleveland,President,,Gary Johnson,LBT,0
-Barton,022 Cleveland,President,,Jill Stein,IND,0
-Barton,022 Cleveland,President,,Donald Trump,REP,17
-Barton,022 Cleveland,President,,Write-ins,,0
-Barton,022 Cleveland,U.S. Senate,,Robert Garrard,LBT,1
-Barton,022 Cleveland,U.S. Senate,,Jerry Moran,REP,17
-Barton,022 Cleveland,U.S. Senate,,Patrick Wiesner,DEM,0
-Barton,022 Cleveland,U.S. Senate,,Write-ins,,0
-Barton,022 Cleveland,U.S. House,1,Kerry Burt,LBT,0
-Barton,022 Cleveland,U.S. House,1,Alan LaPolice,IND,3
-Barton,022 Cleveland,U.S. House,1,Roger Marshall,REP,15
-Barton,022 Cleveland,U.S. House,1,Write-ins,,0
-Barton,022 Cleveland,State Senate,33,Matt Bristow,DEM,6
-Barton,022 Cleveland,State Senate,33,Mary Jo Taylor,REP,12
-Barton,022 Cleveland,State Senate,33,Write-ins,,0
-Barton,022 Cleveland,State House,109,Troy Waymaster,REP,18
-Barton,022 Cleveland,State House,109,Write-ins,,0
-Barton,023 Comanche,,,Registered Voters,,299
-Barton,023 Comanche,,,Ballots Cast,,209
-Barton,023 Comanche,President,,Hillary Clinton,DEM,22
-Barton,023 Comanche,President,,Gary Johnson,LBT,3
-Barton,023 Comanche,President,,Jill Stein,IND,2
-Barton,023 Comanche,President,,Donald Trump,REP,176
-Barton,023 Comanche,President,,Write-ins,,2
-Barton,023 Comanche,U.S. Senate,,Robert Garrard,LBT,11
-Barton,023 Comanche,U.S. Senate,,Jerry Moran,REP,178
-Barton,023 Comanche,U.S. Senate,,Patrick Wiesner,DEM,15
-Barton,023 Comanche,U.S. Senate,,Write-ins,,0
-Barton,023 Comanche,U.S. House,1,Kerry Burt,LBT,18
-Barton,023 Comanche,U.S. House,1,Alan LaPolice,IND,54
-Barton,023 Comanche,U.S. House,1,Roger Marshall,REP,133
-Barton,023 Comanche,U.S. House,1,Write-ins,,1
-Barton,023 Comanche,State Senate,33,Matt Bristow,DEM,66
-Barton,023 Comanche,State Senate,33,Mary Jo Taylor,REP,131
-Barton,023 Comanche,State Senate,33,Write-ins,,1
-Barton,023 Comanche,State House,113,Greg Lewis,REP,181
-Barton,023 Comanche,State House,113,Write-ins,,4
-Barton,024 Eureka,,,Registered Voters,,74
-Barton,024 Eureka,,,Ballots Cast,,47
-Barton,024 Eureka,President,,Hillary Clinton,DEM,0
-Barton,024 Eureka,President,,Gary Johnson,LBT,0
-Barton,024 Eureka,President,,Jill Stein,IND,0
-Barton,024 Eureka,President,,Donald Trump,REP,46
-Barton,024 Eureka,President,,Write-ins,,1
-Barton,024 Eureka,U.S. Senate,,Robert Garrard,LBT,3
-Barton,024 Eureka,U.S. Senate,,Jerry Moran,REP,43
-Barton,024 Eureka,U.S. Senate,,Patrick Wiesner,DEM,1
-Barton,024 Eureka,U.S. Senate,,Write-ins,,0
-Barton,024 Eureka,U.S. House,1,Kerry Burt,LBT,0
-Barton,024 Eureka,U.S. House,1,Alan LaPolice,IND,18
-Barton,024 Eureka,U.S. House,1,Roger Marshall,REP,28
-Barton,024 Eureka,U.S. House,1,Write-ins,,0
-Barton,024 Eureka,State Senate,33,Matt Bristow,DEM,13
-Barton,024 Eureka,State Senate,33,Mary Jo Taylor,REP,29
-Barton,024 Eureka,State Senate,33,Write-ins,,0
-Barton,024 Eureka,State House,112,Tory Arnberger,REP,40
-Barton,024 Eureka,State House,112,Write-ins,,0
-Barton,025 Fairview,,,Registered Voters,,80
-Barton,025 Fairview,,,Ballots Cast,,51
-Barton,025 Fairview,President,,Hillary Clinton,DEM,9
-Barton,025 Fairview,President,,Gary Johnson,LBT,2
-Barton,025 Fairview,President,,Jill Stein,IND,1
-Barton,025 Fairview,President,,Donald Trump,REP,35
-Barton,025 Fairview,President,,Write-ins,,2
-Barton,025 Fairview,U.S. Senate,,Robert Garrard,LBT,3
-Barton,025 Fairview,U.S. Senate,,Jerry Moran,REP,43
-Barton,025 Fairview,U.S. Senate,,Patrick Wiesner,DEM,4
-Barton,025 Fairview,U.S. Senate,,Write-ins,,0
-Barton,025 Fairview,U.S. House,1,Kerry Burt,LBT,1
-Barton,025 Fairview,U.S. House,1,Alan LaPolice,IND,16
-Barton,025 Fairview,U.S. House,1,Roger Marshall,REP,32
-Barton,025 Fairview,U.S. House,1,Write-ins,,0
-Barton,025 Fairview,State Senate,33,Matt Bristow,DEM,10
-Barton,025 Fairview,State Senate,33,Mary Jo Taylor,REP,37
-Barton,025 Fairview,State Senate,33,Write-ins,,0
-Barton,025 Fairview,State House,109,Troy Waymaster,REP,42
-Barton,025 Fairview,State House,109,Write-ins,,1
-Barton,026 Grant,,,Registered Voters,,43
-Barton,026 Grant,,,Ballots Cast,,27
-Barton,026 Grant,President,,Hillary Clinton,DEM,5
-Barton,026 Grant,President,,Gary Johnson,LBT,2
-Barton,026 Grant,President,,Jill Stein,IND,0
-Barton,026 Grant,President,,Donald Trump,REP,17
-Barton,026 Grant,President,,Write-ins,,2
-Barton,026 Grant,U.S. Senate,,Robert Garrard,LBT,1
-Barton,026 Grant,U.S. Senate,,Jerry Moran,REP,23
-Barton,026 Grant,U.S. Senate,,Patrick Wiesner,DEM,2
-Barton,026 Grant,U.S. Senate,,Write-ins,,0
-Barton,026 Grant,U.S. House,1,Kerry Burt,LBT,1
-Barton,026 Grant,U.S. House,1,Alan LaPolice,IND,10
-Barton,026 Grant,U.S. House,1,Roger Marshall,REP,15
-Barton,026 Grant,U.S. House,1,Write-ins,,0
-Barton,026 Grant,State Senate,33,Matt Bristow,DEM,6
-Barton,026 Grant,State Senate,33,Mary Jo Taylor,REP,21
-Barton,026 Grant,State Senate,33,Write-ins,,0
-Barton,026 Grant,State House,109,Troy Waymaster,REP,25
-Barton,026 Grant,State House,109,Write-ins,,0
-Barton,027 GB twp A,,,Registered Voters,,1357
-Barton,027 GB twp A,,,Ballots Cast,,625
-Barton,027 GB twp A,President,,Hillary Clinton,DEM,95
-Barton,027 GB twp A,President,,Gary Johnson,LBT,12
-Barton,027 GB twp A,President,,Jill Stein,IND,4
-Barton,027 GB twp A,President,,Donald Trump,REP,507
-Barton,027 GB twp A,President,,Write-ins,,3
-Barton,027 GB twp A,U.S. Senate,,Robert Garrard,LBT,36
-Barton,027 GB twp A,U.S. Senate,,Jerry Moran,REP,506
-Barton,027 GB twp A,U.S. Senate,,Patrick Wiesner,DEM,66
-Barton,027 GB twp A,U.S. Senate,,Write-ins,,0
-Barton,027 GB twp A,U.S. House,1,Kerry Burt,LBT,30
-Barton,027 GB twp A,U.S. House,1,Alan LaPolice,IND,137
-Barton,027 GB twp A,U.S. House,1,Roger Marshall,REP,446
-Barton,027 GB twp A,U.S. House,1,Write-ins,,0
-Barton,027 GB twp A,State Senate,33,Matt Bristow,DEM,170
-Barton,027 GB twp A,State Senate,33,Mary Jo Taylor,REP,429
-Barton,027 GB twp A,State Senate,33,Write-ins,,2
-Barton,027 GB twp A,State House,112,Tory Arnberger,REP,554
-Barton,027 GB twp A,State House,112,Write-ins,,3
-Barton,028 GB twp B,,,Registered Voters,,157
-Barton,028 GB twp B,,,Ballots Cast,,112
-Barton,028 GB twp B,President,,Hillary Clinton,DEM,12
-Barton,028 GB twp B,President,,Gary Johnson,LBT,4
-Barton,028 GB twp B,President,,Jill Stein,IND,0
-Barton,028 GB twp B,President,,Donald Trump,REP,95
-Barton,028 GB twp B,President,,Write-ins,,1
-Barton,028 GB twp B,U.S. Senate,,Robert Garrard,LBT,7
-Barton,028 GB twp B,U.S. Senate,,Jerry Moran,REP,92
-Barton,028 GB twp B,U.S. Senate,,Patrick Wiesner,DEM,10
-Barton,028 GB twp B,U.S. Senate,,Write-ins,,0
-Barton,028 GB twp B,U.S. House,1,Kerry Burt,LBT,2
-Barton,028 GB twp B,U.S. House,1,Alan LaPolice,IND,41
-Barton,028 GB twp B,U.S. House,1,Roger Marshall,REP,68
-Barton,028 GB twp B,U.S. House,1,Write-ins,,0
-Barton,028 GB twp B,State Senate,33,Matt Bristow,DEM,29
-Barton,028 GB twp B,State Senate,33,Mary Jo Taylor,REP,78
-Barton,028 GB twp B,State Senate,33,Write-ins,,0
-Barton,028 GB twp B,State House,109,Troy Waymaster,REP,105
-Barton,028 GB twp B,State House,109,Write-ins,,0
-Barton,029 North Home,,,Registered Voters,,93
-Barton,029 North Home,,,Ballots Cast,,72
-Barton,029 North Home,President,,Hillary Clinton,DEM,9
-Barton,029 North Home,President,,Gary Johnson,LBT,7
-Barton,029 North Home,President,,Jill Stein,IND,1
-Barton,029 North Home,President,,Donald Trump,REP,53
-Barton,029 North Home,President,,Write-ins,,1
-Barton,029 North Home,U.S. Senate,,Robert Garrard,LBT,2
-Barton,029 North Home,U.S. Senate,,Jerry Moran,REP,58
-Barton,029 North Home,U.S. Senate,,Patrick Wiesner,DEM,12
-Barton,029 North Home,U.S. Senate,,Write-ins,,0
-Barton,029 North Home,U.S. House,1,Kerry Burt,LBT,3
-Barton,029 North Home,U.S. House,1,Alan LaPolice,IND,22
-Barton,029 North Home,U.S. House,1,Roger Marshall,REP,44
-Barton,029 North Home,U.S. House,1,Write-ins,,0
-Barton,029 North Home,State Senate,33,Matt Bristow,DEM,22
-Barton,029 North Home,State Senate,33,Mary Jo Taylor,REP,47
-Barton,029 North Home,State Senate,33,Write-ins,,0
-Barton,029 North Home,State House,112,Tory Arnberger,REP,64
-Barton,029 North Home,State House,112,Write-ins,,3
-Barton,030 South Home,,,Registered Voters,,253
-Barton,030 South Home,,,Ballots Cast,,164
-Barton,030 South Home,President,,Hillary Clinton,DEM,13
-Barton,030 South Home,President,,Gary Johnson,LBT,6
-Barton,030 South Home,President,,Jill Stein,IND,1
-Barton,030 South Home,President,,Donald Trump,REP,137
-Barton,030 South Home,President,,Write-ins,,2
-Barton,030 South Home,U.S. Senate,,Robert Garrard,LBT,11
-Barton,030 South Home,U.S. Senate,,Jerry Moran,REP,131
-Barton,030 South Home,U.S. Senate,,Patrick Wiesner,DEM,17
-Barton,030 South Home,U.S. Senate,,Write-ins,,0
-Barton,030 South Home,U.S. House,1,Kerry Burt,LBT,10
-Barton,030 South Home,U.S. House,1,Alan LaPolice,IND,45
-Barton,030 South Home,U.S. House,1,Roger Marshall,REP,107
-Barton,030 South Home,U.S. House,1,Write-ins,,0
-Barton,030 South Home,State Senate,33,Matt Bristow,DEM,35
-Barton,030 South Home,State Senate,33,Mary Jo Taylor,REP,123
-Barton,030 South Home,State Senate,33,Write-ins,,0
-Barton,030 South Home,State House,112,Tory Arnberger,REP,149
-Barton,030 South Home,State House,112,Write-ins,,1
-Barton,031 Independent,,,Registered Voters,,530
-Barton,031 Independent,,,Ballots Cast,,376
-Barton,031 Independent,President,,Hillary Clinton,DEM,41
-Barton,031 Independent,President,,Gary Johnson,LBT,14
-Barton,031 Independent,President,,Jill Stein,IND,9
-Barton,031 Independent,President,,Donald Trump,REP,305
-Barton,031 Independent,President,,Write-ins,,2
-Barton,031 Independent,U.S. Senate,,Robert Garrard,LBT,13
-Barton,031 Independent,U.S. Senate,,Jerry Moran,REP,334
-Barton,031 Independent,U.S. Senate,,Patrick Wiesner,DEM,23
-Barton,031 Independent,U.S. Senate,,Write-ins,,0
-Barton,031 Independent,U.S. House,1,Kerry Burt,LBT,15
-Barton,031 Independent,U.S. House,1,Alan LaPolice,IND,101
-Barton,031 Independent,U.S. House,1,Roger Marshall,REP,252
-Barton,031 Independent,U.S. House,1,Write-ins,,3
-Barton,031 Independent,State Senate,33,Matt Bristow,DEM,102
-Barton,031 Independent,State Senate,33,Mary Jo Taylor,REP,263
-Barton,031 Independent,State Senate,33,Write-ins,,0
-Barton,031 Independent,State House,109,Troy Waymaster,REP,340
-Barton,031 Independent,State House,109,Write-ins,,1
-Barton,032 Lakin,,,Registered Voters,,1581
-Barton,032 Lakin,,,Ballots Cast,,1047
-Barton,032 Lakin,President,,Hillary Clinton,DEM,164
-Barton,032 Lakin,President,,Gary Johnson,LBT,30
-Barton,032 Lakin,President,,Jill Stein,IND,11
-Barton,032 Lakin,President,,Donald Trump,REP,818
-Barton,032 Lakin,President,,Write-ins,,13
-Barton,032 Lakin,U.S. Senate,,Robert Garrard,LBT,65
-Barton,032 Lakin,U.S. Senate,,Jerry Moran,REP,839
-Barton,032 Lakin,U.S. Senate,,Patrick Wiesner,DEM,121
-Barton,032 Lakin,U.S. Senate,,Write-ins,,0
-Barton,032 Lakin,U.S. House,1,Kerry Burt,LBT,51
-Barton,032 Lakin,U.S. House,1,Alan LaPolice,IND,313
-Barton,032 Lakin,U.S. House,1,Roger Marshall,REP,653
-Barton,032 Lakin,U.S. House,1,Write-ins,,8
-Barton,032 Lakin,State Senate,33,Matt Bristow,DEM,440
-Barton,032 Lakin,State Senate,33,Mary Jo Taylor,REP,569
-Barton,032 Lakin,State Senate,33,Write-ins,,0
-Barton,032 Lakin,State House,113,Greg Lewis,REP,939
-Barton,032 Lakin,State House,113,Write-ins,,12
-Barton,033 Liberty,,,Registered Voters,,184
-Barton,033 Liberty,,,Ballots Cast,,113
-Barton,033 Liberty,President,,Hillary Clinton,DEM,12
-Barton,033 Liberty,President,,Gary Johnson,LBT,2
-Barton,033 Liberty,President,,Jill Stein,IND,1
-Barton,033 Liberty,President,,Donald Trump,REP,98
-Barton,033 Liberty,President,,Write-ins,,0
-Barton,033 Liberty,U.S. Senate,,Robert Garrard,LBT,4
-Barton,033 Liberty,U.S. Senate,,Jerry Moran,REP,99
-Barton,033 Liberty,U.S. Senate,,Patrick Wiesner,DEM,8
-Barton,033 Liberty,U.S. Senate,,Write-ins,,0
-Barton,033 Liberty,U.S. House,1,Kerry Burt,LBT,3
-Barton,033 Liberty,U.S. House,1,Alan LaPolice,IND,41
-Barton,033 Liberty,U.S. House,1,Roger Marshall,REP,68
-Barton,033 Liberty,U.S. House,1,Write-ins,,0
-Barton,033 Liberty,State Senate,33,Matt Bristow,DEM,23
-Barton,033 Liberty,State Senate,33,Mary Jo Taylor,REP,83
-Barton,033 Liberty,State Senate,33,Write-ins,,0
-Barton,033 Liberty,State House,112,Tory Arnberger,REP,101
-Barton,033 Liberty,State House,112,Write-ins,,0
-Barton,034 Logan,,,Registered Voters,,118
-Barton,034 Logan,,,Ballots Cast,,84
-Barton,034 Logan,President,,Hillary Clinton,DEM,10
-Barton,034 Logan,President,,Gary Johnson,LBT,2
-Barton,034 Logan,President,,Jill Stein,IND,1
-Barton,034 Logan,President,,Donald Trump,REP,68
-Barton,034 Logan,President,,Write-ins,,3
-Barton,034 Logan,U.S. Senate,,Robert Garrard,LBT,4
-Barton,034 Logan,U.S. Senate,,Jerry Moran,REP,75
-Barton,034 Logan,U.S. Senate,,Patrick Wiesner,DEM,4
-Barton,034 Logan,U.S. Senate,,Write-ins,,0
-Barton,034 Logan,U.S. House,1,Kerry Burt,LBT,1
-Barton,034 Logan,U.S. House,1,Alan LaPolice,IND,23
-Barton,034 Logan,U.S. House,1,Roger Marshall,REP,60
-Barton,034 Logan,U.S. House,1,Write-ins,,0
-Barton,034 Logan,State Senate,33,Matt Bristow,DEM,30
-Barton,034 Logan,State Senate,33,Mary Jo Taylor,REP,48
-Barton,034 Logan,State Senate,33,Write-ins,,0
-Barton,034 Logan,State House,109,Troy Waymaster,REP,72
-Barton,034 Logan,State House,109,Write-ins,,0
-Barton,035 Pawnee Rock twp,,,Registered Voters,,276
-Barton,035 Pawnee Rock twp,,,Ballots Cast,,177
-Barton,035 Pawnee Rock twp,President,,Hillary Clinton,DEM,34
-Barton,035 Pawnee Rock twp,President,,Gary Johnson,LBT,4
-Barton,035 Pawnee Rock twp,President,,Jill Stein,IND,3
-Barton,035 Pawnee Rock twp,President,,Donald Trump,REP,131
-Barton,035 Pawnee Rock twp,President,,Write-ins,,5
-Barton,035 Pawnee Rock twp,U.S. Senate,,Robert Garrard,LBT,14
-Barton,035 Pawnee Rock twp,U.S. Senate,,Jerry Moran,REP,134
-Barton,035 Pawnee Rock twp,U.S. Senate,,Patrick Wiesner,DEM,23
-Barton,035 Pawnee Rock twp,U.S. Senate,,Write-ins,,0
-Barton,035 Pawnee Rock twp,U.S. House,1,Kerry Burt,LBT,14
-Barton,035 Pawnee Rock twp,U.S. House,1,Alan LaPolice,IND,56
-Barton,035 Pawnee Rock twp,U.S. House,1,Roger Marshall,REP,103
-Barton,035 Pawnee Rock twp,U.S. House,1,Write-ins,,0
-Barton,035 Pawnee Rock twp,State Senate,33,Matt Bristow,DEM,51
-Barton,035 Pawnee Rock twp,State Senate,33,Mary Jo Taylor,REP,113
-Barton,035 Pawnee Rock twp,State Senate,33,Write-ins,,3
-Barton,035 Pawnee Rock twp,State House,113,Greg Lewis,REP,153
-Barton,035 Pawnee Rock twp,State House,113,Write-ins,,1
-Barton,036 South Bend,,,Registered Voters,,436
-Barton,036 South Bend,,,Ballots Cast,,287
-Barton,036 South Bend,President,,Hillary Clinton,DEM,47
-Barton,036 South Bend,President,,Gary Johnson,LBT,8
-Barton,036 South Bend,President,,Jill Stein,IND,3
-Barton,036 South Bend,President,,Donald Trump,REP,228
-Barton,036 South Bend,President,,Write-ins,,1
-Barton,036 South Bend,U.S. Senate,,Robert Garrard,LBT,17
-Barton,036 South Bend,U.S. Senate,,Jerry Moran,REP,228
-Barton,036 South Bend,U.S. Senate,,Patrick Wiesner,DEM,35
-Barton,036 South Bend,U.S. Senate,,Write-ins,,1
-Barton,036 South Bend,U.S. House,1,Kerry Burt,LBT,10
-Barton,036 South Bend,U.S. House,1,Alan LaPolice,IND,86
-Barton,036 South Bend,U.S. House,1,Roger Marshall,REP,184
-Barton,036 South Bend,U.S. House,1,Write-ins,,1
-Barton,036 South Bend,State Senate,33,Matt Bristow,DEM,78
-Barton,036 South Bend,State Senate,33,Mary Jo Taylor,REP,192
-Barton,036 South Bend,State Senate,33,Write-ins,,1
-Barton,036 South Bend,State House,112,Tory Arnberger,REP,251
-Barton,036 South Bend,State House,112,Write-ins,,1
-Barton,037 Union,,,Registered Voters,,81
-Barton,037 Union,,,Ballots Cast,,57
-Barton,037 Union,President,,Hillary Clinton,DEM,8
-Barton,037 Union,President,,Gary Johnson,LBT,4
-Barton,037 Union,President,,Jill Stein,IND,0
-Barton,037 Union,President,,Donald Trump,REP,44
-Barton,037 Union,President,,Write-ins,,0
-Barton,037 Union,U.S. Senate,,Robert Garrard,LBT,7
-Barton,037 Union,U.S. Senate,,Jerry Moran,REP,40
-Barton,037 Union,U.S. Senate,,Patrick Wiesner,DEM,8
-Barton,037 Union,U.S. Senate,,Write-ins,,0
-Barton,037 Union,U.S. House,1,Kerry Burt,LBT,4
-Barton,037 Union,U.S. House,1,Alan LaPolice,IND,23
-Barton,037 Union,U.S. House,1,Roger Marshall,REP,30
-Barton,037 Union,U.S. House,1,Write-ins,,0
-Barton,037 Union,State Senate,33,Matt Bristow,DEM,22
-Barton,037 Union,State Senate,33,Mary Jo Taylor,REP,33
-Barton,037 Union,State Senate,33,Write-ins,,0
-Barton,037 Union,State House,109,Troy Waymaster,REP,52
-Barton,037 Union,State House,109,Write-ins,,1
-Barton,038 Walnut-Albert,,,Registered Voters,,152
-Barton,038 Walnut-Albert,,,Ballots Cast,,101
-Barton,038 Walnut-Albert,President,,Hillary Clinton,DEM,10
-Barton,038 Walnut-Albert,President,,Gary Johnson,LBT,3
-Barton,038 Walnut-Albert,President,,Jill Stein,IND,3
-Barton,038 Walnut-Albert,President,,Donald Trump,REP,84
-Barton,038 Walnut-Albert,President,,Write-ins,,1
-Barton,038 Walnut-Albert,U.S. Senate,,Robert Garrard,LBT,5
-Barton,038 Walnut-Albert,U.S. Senate,,Jerry Moran,REP,83
-Barton,038 Walnut-Albert,U.S. Senate,,Patrick Wiesner,DEM,10
-Barton,038 Walnut-Albert,U.S. Senate,,Write-ins,,0
-Barton,038 Walnut-Albert,U.S. House,1,Kerry Burt,LBT,10
-Barton,038 Walnut-Albert,U.S. House,1,Alan LaPolice,IND,20
-Barton,038 Walnut-Albert,U.S. House,1,Roger Marshall,REP,67
-Barton,038 Walnut-Albert,U.S. House,1,Write-ins,,0
-Barton,038 Walnut-Albert,State Senate,33,Matt Bristow,DEM,29
-Barton,038 Walnut-Albert,State Senate,33,Mary Jo Taylor,REP,67
-Barton,038 Walnut-Albert,State Senate,33,Write-ins,,0
-Barton,038 Walnut-Albert,State House,109,Troy Waymaster,REP,84
-Barton,038 Walnut-Albert,State House,109,Write-ins,,0
-Barton,039 Walnut-Olmita,,,Registered Voters,,126
-Barton,039 Walnut-Olmita,,,Ballots Cast,,88
-Barton,039 Walnut-Olmita,President,,Hillary Clinton,DEM,14
-Barton,039 Walnut-Olmita,President,,Gary Johnson,LBT,2
-Barton,039 Walnut-Olmita,President,,Jill Stein,IND,3
-Barton,039 Walnut-Olmita,President,,Donald Trump,REP,67
-Barton,039 Walnut-Olmita,President,,Write-ins,,1
-Barton,039 Walnut-Olmita,U.S. Senate,,Robert Garrard,LBT,5
-Barton,039 Walnut-Olmita,U.S. Senate,,Jerry Moran,REP,64
-Barton,039 Walnut-Olmita,U.S. Senate,,Patrick Wiesner,DEM,14
-Barton,039 Walnut-Olmita,U.S. Senate,,Write-ins,,0
-Barton,039 Walnut-Olmita,U.S. House,1,Kerry Burt,LBT,6
-Barton,039 Walnut-Olmita,U.S. House,1,Alan LaPolice,IND,23
-Barton,039 Walnut-Olmita,U.S. House,1,Roger Marshall,REP,53
-Barton,039 Walnut-Olmita,U.S. House,1,Write-ins,,0
-Barton,039 Walnut-Olmita,State Senate,33,Matt Bristow,DEM,30
-Barton,039 Walnut-Olmita,State Senate,33,Mary Jo Taylor,REP,48
-Barton,039 Walnut-Olmita,State Senate,33,Write-ins,,0
-Barton,039 Walnut-Olmita,State House,109,Troy Waymaster,REP,68
-Barton,039 Walnut-Olmita,State House,109,Write-ins,,0
-Barton,040 Wheatland,,,Registered Voters,,46
-Barton,040 Wheatland,,,Ballots Cast,,30
-Barton,040 Wheatland,President,,Hillary Clinton,DEM,1
-Barton,040 Wheatland,President,,Gary Johnson,LBT,2
-Barton,040 Wheatland,President,,Jill Stein,IND,0
-Barton,040 Wheatland,President,,Donald Trump,REP,26
-Barton,040 Wheatland,President,,Write-ins,,1
-Barton,040 Wheatland,U.S. Senate,,Robert Garrard,LBT,4
-Barton,040 Wheatland,U.S. Senate,,Jerry Moran,REP,24
-Barton,040 Wheatland,U.S. Senate,,Patrick Wiesner,DEM,2
-Barton,040 Wheatland,U.S. Senate,,Write-ins,,0
-Barton,040 Wheatland,U.S. House,1,Kerry Burt,LBT,0
-Barton,040 Wheatland,U.S. House,1,Alan LaPolice,IND,8
-Barton,040 Wheatland,U.S. House,1,Roger Marshall,REP,21
-Barton,040 Wheatland,U.S. House,1,Write-ins,,0
-Barton,040 Wheatland,State Senate,33,Matt Bristow,DEM,2
-Barton,040 Wheatland,State Senate,33,Mary Jo Taylor,REP,26
-Barton,040 Wheatland,State Senate,33,Write-ins,,0
-Barton,040 Wheatland,State House,109,Troy Waymaster,REP,27
-Barton,040 Wheatland,State House,109,Write-ins,,0
+county,precinct,office,district,party,candidate,votes,vtd
+BARTON,Albion Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",24,000010
+BARTON,Beaver Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",44,000020
+BARTON,Buffalo Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",209,000030
+BARTON,Cheyenne Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",99,000040
+BARTON,Clarence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",50,000050
+BARTON,Cleveland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",18,000060
+BARTON,Comanche Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",181,000070
+BARTON,Eureka Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",40,000080
+BARTON,Fairview Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",42,000090
+BARTON,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",294,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",437,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",351,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",562,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",535,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",656,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",361,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",429,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",469,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",238,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",189,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",81,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00022F
+BARTON,Great Bend Township Part A,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",554,00023A
+BARTON,Great Bend Township Part B,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",105,00023B
+BARTON,Great Bend Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00023C
+BARTON,Hoisington Ward 1,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",236,000240
+BARTON,Hoisington Ward 2,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",260,000250
+BARTON,Hoisington Ward 3,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",243,000260
+BARTON,Hoisington Ward 4,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",224,00027A
+BARTON,Hoisington Ward 4 Exclave,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,00027B
+BARTON,Independent Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",340,000280
+BARTON,Lakin Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",939,000290
+BARTON,Liberty Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",101,000300
+BARTON,Logan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",72,000310
+BARTON,North Homestead Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",64,000320
+BARTON,Pawnee Rock Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",153,000330
+BARTON,South Bend Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",251,000340
+BARTON,South Homestead Township,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",149,000350
+BARTON,Union Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000360
+BARTON,Walnut Township Albert,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",84,000370
+BARTON,Walnut Township Olmitz,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",68,000380
+BARTON,Wheatland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",27,000390
+BARTON,Hoisington Landfill,Kansas House of Representatives,112,Republican,"Arnberger, Tory M.",0,900010
+BARTON,Albion Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000010
+BARTON,Albion Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",19,000010
+BARTON,Beaver Township,Kansas Senate,33,Democratic,"Bristow, Matt",14,000020
+BARTON,Beaver Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",29,000020
+BARTON,Buffalo Township,Kansas Senate,33,Democratic,"Bristow, Matt",40,000030
+BARTON,Buffalo Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",174,000030
+BARTON,Cheyenne Township,Kansas Senate,33,Democratic,"Bristow, Matt",28,000040
+BARTON,Cheyenne Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",74,000040
+BARTON,Clarence Township,Kansas Senate,33,Democratic,"Bristow, Matt",12,000050
+BARTON,Clarence Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",43,000050
+BARTON,Cleveland Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000060
+BARTON,Cleveland Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",12,000060
+BARTON,Comanche Township,Kansas Senate,33,Democratic,"Bristow, Matt",66,000070
+BARTON,Comanche Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",131,000070
+BARTON,Eureka Township,Kansas Senate,33,Democratic,"Bristow, Matt",13,000080
+BARTON,Eureka Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",29,000080
+BARTON,Fairview Township,Kansas Senate,33,Democratic,"Bristow, Matt",10,000090
+BARTON,Fairview Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",37,000090
+BARTON,Grant Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000100
+BARTON,Grant Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",21,000100
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas Senate,33,Democratic,"Bristow, Matt",126,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",196,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas Senate,33,Democratic,"Bristow, Matt",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas Senate,33,Democratic,"Bristow, Matt",141,000120
+BARTON,Great Bend City Ward 1 Precinct 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",329,000120
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas Senate,33,Democratic,"Bristow, Matt",143,000130
+BARTON,Great Bend City Ward 1 Precinct 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",239,000130
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas Senate,33,Democratic,"Bristow, Matt",182,000140
+BARTON,Great Bend City Ward 2 Precinct 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",424,000140
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas Senate,33,Democratic,"Bristow, Matt",166,000150
+BARTON,Great Bend City Ward 2 Precinct 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",407,000150
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas Senate,33,Democratic,"Bristow, Matt",165,000160
+BARTON,Great Bend City Ward 2 Precinct 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",535,000160
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas Senate,33,Democratic,"Bristow, Matt",129,000170
+BARTON,Great Bend City Ward 3 Precinct 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",267,000170
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas Senate,33,Democratic,"Bristow, Matt",153,000180
+BARTON,Great Bend City Ward 3 Precinct 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",301,000180
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas Senate,33,Democratic,"Bristow, Matt",149,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",345,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas Senate,33,Democratic,"Bristow, Matt",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas Senate,33,Democratic,"Bristow, Matt",99,000200
+BARTON,Great Bend City Ward 4 Precinct 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",160,000200
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas Senate,33,Democratic,"Bristow, Matt",88,000210
+BARTON,Great Bend City Ward 4 Precinct 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",120,000210
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas Senate,33,Democratic,"Bristow, Matt",41,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",46,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas Senate,33,Democratic,"Bristow, Matt",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas Senate,33,Democratic,"Bristow, Matt",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas Senate,33,Democratic,"Bristow, Matt",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas Senate,33,Democratic,"Bristow, Matt",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas Senate,33,Democratic,"Bristow, Matt",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00022F
+BARTON,Great Bend Township Part A,Kansas Senate,33,Democratic,"Bristow, Matt",170,00023A
+BARTON,Great Bend Township Part A,Kansas Senate,33,Republican,"Taylor, Mary Jo",429,00023A
+BARTON,Great Bend Township Part B,Kansas Senate,33,Democratic,"Bristow, Matt",29,00023B
+BARTON,Great Bend Township Part B,Kansas Senate,33,Republican,"Taylor, Mary Jo",78,00023B
+BARTON,Great Bend Township,Kansas Senate,33,Democratic,"Bristow, Matt",0,00023C
+BARTON,Great Bend Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00023C
+BARTON,Hoisington Ward 1,Kansas Senate,33,Democratic,"Bristow, Matt",102,000240
+BARTON,Hoisington Ward 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",159,000240
+BARTON,Hoisington Ward 2,Kansas Senate,33,Democratic,"Bristow, Matt",107,000250
+BARTON,Hoisington Ward 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",176,000250
+BARTON,Hoisington Ward 3,Kansas Senate,33,Democratic,"Bristow, Matt",75,000260
+BARTON,Hoisington Ward 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",183,000260
+BARTON,Hoisington Ward 4,Kansas Senate,33,Democratic,"Bristow, Matt",78,00027A
+BARTON,Hoisington Ward 4,Kansas Senate,33,Republican,"Taylor, Mary Jo",150,00027A
+BARTON,Hoisington Ward 4 Exclave,Kansas Senate,33,Democratic,"Bristow, Matt",0,00027B
+BARTON,Hoisington Ward 4 Exclave,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00027B
+BARTON,Independent Township,Kansas Senate,33,Democratic,"Bristow, Matt",102,000280
+BARTON,Independent Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",263,000280
+BARTON,Lakin Township,Kansas Senate,33,Democratic,"Bristow, Matt",440,000290
+BARTON,Lakin Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",569,000290
+BARTON,Liberty Township,Kansas Senate,33,Democratic,"Bristow, Matt",23,000300
+BARTON,Liberty Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",83,000300
+BARTON,Logan Township,Kansas Senate,33,Democratic,"Bristow, Matt",30,000310
+BARTON,Logan Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",48,000310
+BARTON,North Homestead Township,Kansas Senate,33,Democratic,"Bristow, Matt",22,000320
+BARTON,North Homestead Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",47,000320
+BARTON,Pawnee Rock Township,Kansas Senate,33,Democratic,"Bristow, Matt",51,000330
+BARTON,Pawnee Rock Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",113,000330
+BARTON,South Bend Township,Kansas Senate,33,Democratic,"Bristow, Matt",78,000340
+BARTON,South Bend Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",192,000340
+BARTON,South Homestead Township,Kansas Senate,33,Democratic,"Bristow, Matt",35,000350
+BARTON,South Homestead Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",123,000350
+BARTON,Union Township,Kansas Senate,33,Democratic,"Bristow, Matt",22,000360
+BARTON,Union Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",33,000360
+BARTON,Walnut Township Albert,Kansas Senate,33,Democratic,"Bristow, Matt",29,000370
+BARTON,Walnut Township Albert,Kansas Senate,33,Republican,"Taylor, Mary Jo",67,000370
+BARTON,Walnut Township Olmitz,Kansas Senate,33,Democratic,"Bristow, Matt",30,000380
+BARTON,Walnut Township Olmitz,Kansas Senate,33,Republican,"Taylor, Mary Jo",48,000380
+BARTON,Wheatland Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000390
+BARTON,Wheatland Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",26,000390
+BARTON,Hoisington Landfill,Kansas Senate,33,Democratic,"Bristow, Matt",0,900010
+BARTON,Hoisington Landfill,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,900010
+BARTON,Albion Township,President / Vice President,,independent,"Stein, Jill",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+BARTON,Albion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+BARTON,Albion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000010
+BARTON,Albion Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+BARTON,Albion Township,President / Vice President,,Republican,"Trump, Donald J.",24,000010
+BARTON,Beaver Township,President / Vice President,,independent,"Stein, Jill",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+BARTON,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+BARTON,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000020
+BARTON,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+BARTON,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",38,000020
+BARTON,Buffalo Township,President / Vice President,,independent,"Stein, Jill",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+BARTON,Buffalo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+BARTON,Buffalo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000030
+BARTON,Buffalo Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000030
+BARTON,Buffalo Township,President / Vice President,,Republican,"Trump, Donald J.",197,000030
+BARTON,Cheyenne Township,President / Vice President,,independent,"Stein, Jill",1,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+BARTON,Cheyenne Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+BARTON,Cheyenne Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000040
+BARTON,Cheyenne Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+BARTON,Cheyenne Township,President / Vice President,,Republican,"Trump, Donald J.",91,000040
+BARTON,Clarence Township,President / Vice President,,independent,"Stein, Jill",1,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+BARTON,Clarence Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+BARTON,Clarence Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000050
+BARTON,Clarence Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+BARTON,Clarence Township,President / Vice President,,Republican,"Trump, Donald J.",43,000050
+BARTON,Cleveland Township,President / Vice President,,independent,"Stein, Jill",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+BARTON,Cleveland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+BARTON,Cleveland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000060
+BARTON,Cleveland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+BARTON,Cleveland Township,President / Vice President,,Republican,"Trump, Donald J.",17,000060
+BARTON,Comanche Township,President / Vice President,,independent,"Stein, Jill",2,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Castle, Darrell L",1,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+BARTON,Comanche Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+BARTON,Comanche Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000070
+BARTON,Comanche Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+BARTON,Comanche Township,President / Vice President,,Republican,"Trump, Donald J.",176,000070
+BARTON,Eureka Township,President / Vice President,,independent,"Stein, Jill",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+BARTON,Eureka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+BARTON,Eureka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+BARTON,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+BARTON,Eureka Township,President / Vice President,,Republican,"Trump, Donald J.",46,000080
+BARTON,Fairview Township,President / Vice President,,independent,"Stein, Jill",1,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+BARTON,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+BARTON,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000090
+BARTON,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+BARTON,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",35,000090
+BARTON,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+BARTON,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+BARTON,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000100
+BARTON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+BARTON,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",17,000100
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",11,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",105,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",20,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",200,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,independent,"Stein, Jill",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Castle, Darrell L",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Giordani, Rocky",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Hedges, James A",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Hoefling, Tom",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Kahn, Lynn",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"La Riva, Gloria",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Levinson, Michael S.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Maturen, Michael A",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"McMullin, Evan",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Perry, Darryl",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Schriner, Joe C",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Smith, Mike",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Sood, Ajay",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Sterling, Shawna",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,Libertarian,"Johnson, Gary",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,President / Vice President,,Republican,"Trump, Donald J.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",11,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000120
+BARTON,Great Bend City Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",363,000120
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,independent,"Stein, Jill",9,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",3,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",21,000130
+BARTON,Great Bend City Ward 1 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",273,000130
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",16,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",114,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",24,000140
+BARTON,Great Bend City Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",470,000140
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",7,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",113,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000150
+BARTON,Great Bend City Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",442,000150
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",9,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",13,000160
+BARTON,Great Bend City Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",563,000160
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",16,000170
+BARTON,Great Bend City Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",303,000170
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",1,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",105,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",18,000180
+BARTON,Great Bend City Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",329,000180
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,independent,"Stein, Jill",11,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",2,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",99,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",16,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",385,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",1,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",11,000200
+BARTON,Great Bend City Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",181,000200
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",3,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",11,000210
+BARTON,Great Bend City Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",142,000210
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",1,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",4,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",53,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,independent,"Stein, Jill",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,independent,"Stein, Jill",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Castle, Darrell L",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Giordani, Rocky",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Hedges, James A",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Hoefling, Tom",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Kahn, Lynn",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"La Riva, Gloria",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Levinson, Michael S.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Maturen, Michael A",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"McMullin, Evan",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Perry, Darryl",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Schriner, Joe C",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Smith, Mike",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Sood, Ajay",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Sterling, Shawna",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,Libertarian,"Johnson, Gary",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,President / Vice President,,Republican,"Trump, Donald J.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,independent,"Stein, Jill",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Castle, Darrell L",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Giordani, Rocky",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Hedges, James A",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Hoefling, Tom",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Kahn, Lynn",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"La Riva, Gloria",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Levinson, Michael S.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Maturen, Michael A",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"McMullin, Evan",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Perry, Darryl",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Schriner, Joe C",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Smith, Mike",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Sood, Ajay",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Sterling, Shawna",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,Libertarian,"Johnson, Gary",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,President / Vice President,,Republican,"Trump, Donald J.",0,00022F
+BARTON,Great Bend Township Part A,President / Vice President,,independent,"Stein, Jill",4,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Hedges, James A",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"McMullin, Evan",1,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Perry, Darryl",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Smith, Mike",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Sood, Ajay",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",12,00023A
+BARTON,Great Bend Township Part A,President / Vice President,,Republican,"Trump, Donald J.",507,00023A
+BARTON,Great Bend Township Part B,President / Vice President,,independent,"Stein, Jill",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Hedges, James A",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"McMullin, Evan",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Perry, Darryl",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Smith, Mike",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Sood, Ajay",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",4,00023B
+BARTON,Great Bend Township Part B,President / Vice President,,Republican,"Trump, Donald J.",95,00023B
+BARTON,Great Bend Township,President / Vice President,,independent,"Stein, Jill",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Castle, Darrell L",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Giordani, Rocky",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Hedges, James A",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Hoefling, Tom",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Kahn, Lynn",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"La Riva, Gloria",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Maturen, Michael A",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"McMullin, Evan",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Perry, Darryl",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Schriner, Joe C",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Smith, Mike",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Sood, Ajay",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Sterling, Shawna",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023C
+BARTON,Great Bend Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023C
+BARTON,Great Bend Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00023C
+BARTON,Great Bend Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00023C
+BARTON,Great Bend Township,President / Vice President,,Republican,"Trump, Donald J.",0,00023C
+BARTON,Hoisington Ward 1,President / Vice President,,independent,"Stein, Jill",7,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000240
+BARTON,Hoisington Ward 1,President / Vice President,,Republican,"Trump, Donald J.",205,000240
+BARTON,Hoisington Ward 2,President / Vice President,,independent,"Stein, Jill",2,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000250
+BARTON,Hoisington Ward 2,President / Vice President,,Republican,"Trump, Donald J.",233,000250
+BARTON,Hoisington Ward 3,President / Vice President,,independent,"Stein, Jill",3,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",15,000260
+BARTON,Hoisington Ward 3,President / Vice President,,Republican,"Trump, Donald J.",209,000260
+BARTON,Hoisington Ward 4,President / Vice President,,independent,"Stein, Jill",3,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",13,00027A
+BARTON,Hoisington Ward 4,President / Vice President,,Republican,"Trump, Donald J.",192,00027A
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027B
+BARTON,Hoisington Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00027B
+BARTON,Independent Township,President / Vice President,,independent,"Stein, Jill",9,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"McMullin, Evan",1,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+BARTON,Independent Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+BARTON,Independent Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000280
+BARTON,Independent Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000280
+BARTON,Independent Township,President / Vice President,,Republican,"Trump, Donald J.",305,000280
+BARTON,Lakin Township,President / Vice President,,independent,"Stein, Jill",11,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"McMullin, Evan",3,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+BARTON,Lakin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+BARTON,Lakin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",164,000290
+BARTON,Lakin Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000290
+BARTON,Lakin Township,President / Vice President,,Republican,"Trump, Donald J.",818,000290
+BARTON,Liberty Township,President / Vice President,,independent,"Stein, Jill",1,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+BARTON,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+BARTON,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000300
+BARTON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000300
+BARTON,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",98,000300
+BARTON,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"McMullin, Evan",1,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+BARTON,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+BARTON,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000310
+BARTON,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000310
+BARTON,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",68,000310
+BARTON,North Homestead Township,President / Vice President,,independent,"Stein, Jill",1,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"McMullin, Evan",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+BARTON,North Homestead Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+BARTON,North Homestead Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000320
+BARTON,North Homestead Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000320
+BARTON,North Homestead Township,President / Vice President,,Republican,"Trump, Donald J.",53,000320
+BARTON,Pawnee Rock Township,President / Vice President,,independent,"Stein, Jill",3,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Castle, Darrell L",2,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000330
+BARTON,Pawnee Rock Township,President / Vice President,,Republican,"Trump, Donald J.",131,000330
+BARTON,South Bend Township,President / Vice President,,independent,"Stein, Jill",3,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Hedges, James A",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"McMullin, Evan",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Perry, Darryl",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Smith, Mike",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Sood, Ajay",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+BARTON,South Bend Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+BARTON,South Bend Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,000340
+BARTON,South Bend Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000340
+BARTON,South Bend Township,President / Vice President,,Republican,"Trump, Donald J.",228,000340
+BARTON,South Homestead Township,President / Vice President,,independent,"Stein, Jill",1,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Hedges, James A",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"McMullin, Evan",1,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Perry, Darryl",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Smith, Mike",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Sood, Ajay",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+BARTON,South Homestead Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+BARTON,South Homestead Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000350
+BARTON,South Homestead Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000350
+BARTON,South Homestead Township,President / Vice President,,Republican,"Trump, Donald J.",137,000350
+BARTON,Union Township,President / Vice President,,independent,"Stein, Jill",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+BARTON,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+BARTON,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000360
+BARTON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000360
+BARTON,Union Township,President / Vice President,,Republican,"Trump, Donald J.",44,000360
+BARTON,Walnut Township Albert,President / Vice President,,independent,"Stein, Jill",3,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Hedges, James A",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"McMullin, Evan",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Perry, Darryl",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Smith, Mike",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Sood, Ajay",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+BARTON,Walnut Township Albert,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000370
+BARTON,Walnut Township Albert,President / Vice President,,Libertarian,"Johnson, Gary",3,000370
+BARTON,Walnut Township Albert,President / Vice President,,Republican,"Trump, Donald J.",84,000370
+BARTON,Walnut Township Olmitz,President / Vice President,,independent,"Stein, Jill",3,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Hedges, James A",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"McMullin, Evan",1,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Perry, Darryl",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Smith, Mike",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Sood, Ajay",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Libertarian,"Johnson, Gary",2,000380
+BARTON,Walnut Township Olmitz,President / Vice President,,Republican,"Trump, Donald J.",67,000380
+BARTON,Wheatland Township,President / Vice President,,independent,"Stein, Jill",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Hedges, James A",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"McMullin, Evan",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Perry, Darryl",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Smith, Mike",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Sood, Ajay",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000390
+BARTON,Wheatland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000390
+BARTON,Wheatland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000390
+BARTON,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000390
+BARTON,Wheatland Township,President / Vice President,,Republican,"Trump, Donald J.",26,000390
+BARTON,Hoisington Landfill,President / Vice President,,independent,"Stein, Jill",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Hedges, James A",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"McMullin, Evan",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Perry, Darryl",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Smith, Mike",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Sood, Ajay",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+BARTON,Hoisington Landfill,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+BARTON,Albion Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000010
+BARTON,Albion Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+BARTON,Albion Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+BARTON,Albion Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000010
+BARTON,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000020
+BARTON,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+BARTON,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000020
+BARTON,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000020
+BARTON,Buffalo Township,United States House of Representatives,1,independent,"LaPolice, Alan",54,000030
+BARTON,Buffalo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+BARTON,Buffalo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000030
+BARTON,Buffalo Township,United States House of Representatives,1,Republican,"Marshall, Roger",165,000030
+BARTON,Cheyenne Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000040
+BARTON,Cheyenne Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+BARTON,Cheyenne Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000040
+BARTON,Cheyenne Township,United States House of Representatives,1,Republican,"Marshall, Roger",61,000040
+BARTON,Clarence Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000050
+BARTON,Clarence Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+BARTON,Clarence Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000050
+BARTON,Clarence Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000050
+BARTON,Cleveland Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000060
+BARTON,Cleveland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+BARTON,Cleveland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+BARTON,Cleveland Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000060
+BARTON,Comanche Township,United States House of Representatives,1,independent,"LaPolice, Alan",54,000070
+BARTON,Comanche Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+BARTON,Comanche Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000070
+BARTON,Comanche Township,United States House of Representatives,1,Republican,"Marshall, Roger",133,000070
+BARTON,Eureka Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000080
+BARTON,Eureka Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+BARTON,Eureka Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+BARTON,Eureka Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000080
+BARTON,Fairview Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000090
+BARTON,Fairview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+BARTON,Fairview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000090
+BARTON,Fairview Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000090
+BARTON,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000100
+BARTON,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+BARTON,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+BARTON,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000100
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",99,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",212,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,independent,"LaPolice, Alan",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States House of Representatives,1,Republican,"Marshall, Roger",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",113,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",334,000120
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",127,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",241,000130
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",179,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",411,000140
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",148,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",408,000150
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",140,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",541,000160
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",120,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",267,000170
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",124,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",315,000180
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",146,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",341,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",65,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",183,000200
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",55,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",139,000210
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",17,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",59,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022F
+BARTON,Great Bend Township Part A,United States House of Representatives,1,independent,"LaPolice, Alan",137,00023A
+BARTON,Great Bend Township Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00023A
+BARTON,Great Bend Township Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,00023A
+BARTON,Great Bend Township Part A,United States House of Representatives,1,Republican,"Marshall, Roger",446,00023A
+BARTON,Great Bend Township Part B,United States House of Representatives,1,independent,"LaPolice, Alan",41,00023B
+BARTON,Great Bend Township Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00023B
+BARTON,Great Bend Township Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,00023B
+BARTON,Great Bend Township Part B,United States House of Representatives,1,Republican,"Marshall, Roger",68,00023B
+BARTON,Great Bend Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,00023C
+BARTON,Great Bend Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00023C
+BARTON,Great Bend Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00023C
+BARTON,Great Bend Township,United States House of Representatives,1,Republican,"Marshall, Roger",0,00023C
+BARTON,Hoisington Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",75,000240
+BARTON,Hoisington Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+BARTON,Hoisington Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,000240
+BARTON,Hoisington Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",171,000240
+BARTON,Hoisington Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",106,000250
+BARTON,Hoisington Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+BARTON,Hoisington Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000250
+BARTON,Hoisington Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",161,000250
+BARTON,Hoisington Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",79,000260
+BARTON,Hoisington Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+BARTON,Hoisington Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,000260
+BARTON,Hoisington Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",162,000260
+BARTON,Hoisington Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",69,00027A
+BARTON,Hoisington Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00027A
+BARTON,Hoisington Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,00027A
+BARTON,Hoisington Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",144,00027A
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00027B
+BARTON,Independent Township,United States House of Representatives,1,independent,"LaPolice, Alan",101,000280
+BARTON,Independent Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+BARTON,Independent Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000280
+BARTON,Independent Township,United States House of Representatives,1,Republican,"Marshall, Roger",252,000280
+BARTON,Lakin Township,United States House of Representatives,1,independent,"LaPolice, Alan",313,000290
+BARTON,Lakin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+BARTON,Lakin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,000290
+BARTON,Lakin Township,United States House of Representatives,1,Republican,"Marshall, Roger",653,000290
+BARTON,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",41,000300
+BARTON,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000300
+BARTON,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000300
+BARTON,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",68,000300
+BARTON,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000310
+BARTON,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+BARTON,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000310
+BARTON,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",60,000310
+BARTON,North Homestead Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000320
+BARTON,North Homestead Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000320
+BARTON,North Homestead Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000320
+BARTON,North Homestead Township,United States House of Representatives,1,Republican,"Marshall, Roger",44,000320
+BARTON,Pawnee Rock Township,United States House of Representatives,1,independent,"LaPolice, Alan",56,000330
+BARTON,Pawnee Rock Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000330
+BARTON,Pawnee Rock Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000330
+BARTON,Pawnee Rock Township,United States House of Representatives,1,Republican,"Marshall, Roger",103,000330
+BARTON,South Bend Township,United States House of Representatives,1,independent,"LaPolice, Alan",86,000340
+BARTON,South Bend Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000340
+BARTON,South Bend Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000340
+BARTON,South Bend Township,United States House of Representatives,1,Republican,"Marshall, Roger",184,000340
+BARTON,South Homestead Township,United States House of Representatives,1,independent,"LaPolice, Alan",45,000350
+BARTON,South Homestead Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000350
+BARTON,South Homestead Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000350
+BARTON,South Homestead Township,United States House of Representatives,1,Republican,"Marshall, Roger",107,000350
+BARTON,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000360
+BARTON,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000360
+BARTON,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000360
+BARTON,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000360
+BARTON,Walnut Township Albert,United States House of Representatives,1,independent,"LaPolice, Alan",20,000370
+BARTON,Walnut Township Albert,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000370
+BARTON,Walnut Township Albert,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000370
+BARTON,Walnut Township Albert,United States House of Representatives,1,Republican,"Marshall, Roger",67,000370
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,independent,"LaPolice, Alan",23,000380
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000380
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000380
+BARTON,Walnut Township Olmitz,United States House of Representatives,1,Republican,"Marshall, Roger",53,000380
+BARTON,Wheatland Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000390
+BARTON,Wheatland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000390
+BARTON,Wheatland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000390
+BARTON,Wheatland Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000390
+BARTON,Hoisington Landfill,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+BARTON,Hoisington Landfill,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+BARTON,Hoisington Landfill,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+BARTON,Hoisington Landfill,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+BARTON,Albion Township,United States Senate,,write - in,"Smith, DJ",0,000010
+BARTON,Albion Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+BARTON,Albion Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+BARTON,Albion Township,United States Senate,,Republican,"Moran, Jerry",25,000010
+BARTON,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000020
+BARTON,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000020
+BARTON,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+BARTON,Beaver Township,United States Senate,,Republican,"Moran, Jerry",36,000020
+BARTON,Buffalo Township,United States Senate,,write - in,"Smith, DJ",0,000030
+BARTON,Buffalo Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000030
+BARTON,Buffalo Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000030
+BARTON,Buffalo Township,United States Senate,,Republican,"Moran, Jerry",197,000030
+BARTON,Cheyenne Township,United States Senate,,write - in,"Smith, DJ",0,000040
+BARTON,Cheyenne Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000040
+BARTON,Cheyenne Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000040
+BARTON,Cheyenne Township,United States Senate,,Republican,"Moran, Jerry",89,000040
+BARTON,Clarence Township,United States Senate,,write - in,"Smith, DJ",0,000050
+BARTON,Clarence Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000050
+BARTON,Clarence Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+BARTON,Clarence Township,United States Senate,,Republican,"Moran, Jerry",47,000050
+BARTON,Cleveland Township,United States Senate,,write - in,"Smith, DJ",0,000060
+BARTON,Cleveland Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+BARTON,Cleveland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+BARTON,Cleveland Township,United States Senate,,Republican,"Moran, Jerry",17,000060
+BARTON,Comanche Township,United States Senate,,write - in,"Smith, DJ",0,000070
+BARTON,Comanche Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000070
+BARTON,Comanche Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000070
+BARTON,Comanche Township,United States Senate,,Republican,"Moran, Jerry",178,000070
+BARTON,Eureka Township,United States Senate,,write - in,"Smith, DJ",0,000080
+BARTON,Eureka Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000080
+BARTON,Eureka Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000080
+BARTON,Eureka Township,United States Senate,,Republican,"Moran, Jerry",43,000080
+BARTON,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000090
+BARTON,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000090
+BARTON,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+BARTON,Fairview Township,United States Senate,,Republican,"Moran, Jerry",43,000090
+BARTON,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000100
+BARTON,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+BARTON,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+BARTON,Grant Township,United States Senate,,Republican,"Moran, Jerry",23,000100
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",74,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",25,00011A
+BARTON,Great Bend City Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",227,00011A
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,write - in,"Smith, DJ",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,Democratic,"Wiesner, Patrick",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,Libertarian,"Garrard, Robert D.",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 1 Courthouse,United States Senate,,Republican,"Moran, Jerry",0,00011B
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",81,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",21,000120
+BARTON,Great Bend City Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",384,000120
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",64,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",29,000130
+BARTON,Great Bend City Ward 1 Precinct 3,United States Senate,,Republican,"Moran, Jerry",295,000130
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",87,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",25,000140
+BARTON,Great Bend City Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",517,000140
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",80,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,000150
+BARTON,Great Bend City Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",485,000150
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",66,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",21,000160
+BARTON,Great Bend City Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",617,000160
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",54,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,000170
+BARTON,Great Bend City Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",335,000170
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",72,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",31,000180
+BARTON,Great Bend City Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",355,000180
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",63,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",19,00019A
+BARTON,Great Bend City Ward 3 Precinct 3,United States Senate,,Republican,"Moran, Jerry",421,00019A
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00019B
+BARTON,Great Bend City Ward 3 Precinct 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00019B
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",55,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000200
+BARTON,Great Bend City Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",196,000200
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",53,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,000210
+BARTON,Great Bend City Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",151,000210
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",23,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",6,00022A
+BARTON,Great Bend City Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",58,00022A
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00022B
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00022C
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,write - in,"Smith, DJ",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,00022D
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,write - in,"Smith, DJ",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,Democratic,"Wiesner, Patrick",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D1,United States Senate,,Republican,"Moran, Jerry",0,00022E
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,write - in,"Smith, DJ",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,Democratic,"Wiesner, Patrick",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022F
+BARTON,Great Bend City Ward 4 Precinct 3 Exclave D2,United States Senate,,Republican,"Moran, Jerry",0,00022F
+BARTON,Great Bend Township Part A,United States Senate,,write - in,"Smith, DJ",0,00023A
+BARTON,Great Bend Township Part A,United States Senate,,Democratic,"Wiesner, Patrick",66,00023A
+BARTON,Great Bend Township Part A,United States Senate,,Libertarian,"Garrard, Robert D.",36,00023A
+BARTON,Great Bend Township Part A,United States Senate,,Republican,"Moran, Jerry",506,00023A
+BARTON,Great Bend Township Part B,United States Senate,,write - in,"Smith, DJ",0,00023B
+BARTON,Great Bend Township Part B,United States Senate,,Democratic,"Wiesner, Patrick",10,00023B
+BARTON,Great Bend Township Part B,United States Senate,,Libertarian,"Garrard, Robert D.",7,00023B
+BARTON,Great Bend Township Part B,United States Senate,,Republican,"Moran, Jerry",92,00023B
+BARTON,Great Bend Township,United States Senate,,write - in,"Smith, DJ",0,00023C
+BARTON,Great Bend Township,United States Senate,,Democratic,"Wiesner, Patrick",0,00023C
+BARTON,Great Bend Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,00023C
+BARTON,Great Bend Township,United States Senate,,Republican,"Moran, Jerry",0,00023C
+BARTON,Hoisington Ward 1,United States Senate,,write - in,"Smith, DJ",0,000240
+BARTON,Hoisington Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",33,000240
+BARTON,Hoisington Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000240
+BARTON,Hoisington Ward 1,United States Senate,,Republican,"Moran, Jerry",213,000240
+BARTON,Hoisington Ward 2,United States Senate,,write - in,"Smith, DJ",0,000250
+BARTON,Hoisington Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",35,000250
+BARTON,Hoisington Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",6,000250
+BARTON,Hoisington Ward 2,United States Senate,,Republican,"Moran, Jerry",250,000250
+BARTON,Hoisington Ward 3,United States Senate,,write - in,"Smith, DJ",0,000260
+BARTON,Hoisington Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",27,000260
+BARTON,Hoisington Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",16,000260
+BARTON,Hoisington Ward 3,United States Senate,,Republican,"Moran, Jerry",221,000260
+BARTON,Hoisington Ward 4,United States Senate,,write - in,"Smith, DJ",0,00027A
+BARTON,Hoisington Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",26,00027A
+BARTON,Hoisington Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",18,00027A
+BARTON,Hoisington Ward 4,United States Senate,,Republican,"Moran, Jerry",191,00027A
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00027B
+BARTON,Hoisington Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00027B
+BARTON,Independent Township,United States Senate,,write - in,"Smith, DJ",0,000280
+BARTON,Independent Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000280
+BARTON,Independent Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000280
+BARTON,Independent Township,United States Senate,,Republican,"Moran, Jerry",334,000280
+BARTON,Lakin Township,United States Senate,,write - in,"Smith, DJ",0,000290
+BARTON,Lakin Township,United States Senate,,Democratic,"Wiesner, Patrick",121,000290
+BARTON,Lakin Township,United States Senate,,Libertarian,"Garrard, Robert D.",65,000290
+BARTON,Lakin Township,United States Senate,,Republican,"Moran, Jerry",839,000290
+BARTON,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000300
+BARTON,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000300
+BARTON,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000300
+BARTON,Liberty Township,United States Senate,,Republican,"Moran, Jerry",99,000300
+BARTON,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000310
+BARTON,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000310
+BARTON,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000310
+BARTON,Logan Township,United States Senate,,Republican,"Moran, Jerry",75,000310
+BARTON,North Homestead Township,United States Senate,,write - in,"Smith, DJ",0,000320
+BARTON,North Homestead Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000320
+BARTON,North Homestead Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000320
+BARTON,North Homestead Township,United States Senate,,Republican,"Moran, Jerry",58,000320
+BARTON,Pawnee Rock Township,United States Senate,,write - in,"Smith, DJ",0,000330
+BARTON,Pawnee Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000330
+BARTON,Pawnee Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000330
+BARTON,Pawnee Rock Township,United States Senate,,Republican,"Moran, Jerry",134,000330
+BARTON,South Bend Township,United States Senate,,write - in,"Smith, DJ",0,000340
+BARTON,South Bend Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000340
+BARTON,South Bend Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000340
+BARTON,South Bend Township,United States Senate,,Republican,"Moran, Jerry",228,000340
+BARTON,South Homestead Township,United States Senate,,write - in,"Smith, DJ",0,000350
+BARTON,South Homestead Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000350
+BARTON,South Homestead Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000350
+BARTON,South Homestead Township,United States Senate,,Republican,"Moran, Jerry",131,000350
+BARTON,Union Township,United States Senate,,write - in,"Smith, DJ",0,000360
+BARTON,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000360
+BARTON,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000360
+BARTON,Union Township,United States Senate,,Republican,"Moran, Jerry",40,000360
+BARTON,Walnut Township Albert,United States Senate,,write - in,"Smith, DJ",0,000370
+BARTON,Walnut Township Albert,United States Senate,,Democratic,"Wiesner, Patrick",10,000370
+BARTON,Walnut Township Albert,United States Senate,,Libertarian,"Garrard, Robert D.",5,000370
+BARTON,Walnut Township Albert,United States Senate,,Republican,"Moran, Jerry",83,000370
+BARTON,Walnut Township Olmitz,United States Senate,,write - in,"Smith, DJ",0,000380
+BARTON,Walnut Township Olmitz,United States Senate,,Democratic,"Wiesner, Patrick",14,000380
+BARTON,Walnut Township Olmitz,United States Senate,,Libertarian,"Garrard, Robert D.",5,000380
+BARTON,Walnut Township Olmitz,United States Senate,,Republican,"Moran, Jerry",64,000380
+BARTON,Wheatland Township,United States Senate,,write - in,"Smith, DJ",0,000390
+BARTON,Wheatland Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000390
+BARTON,Wheatland Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000390
+BARTON,Wheatland Township,United States Senate,,Republican,"Moran, Jerry",24,000390
+BARTON,Hoisington Landfill,United States Senate,,write - in,"Smith, DJ",0,900010
+BARTON,Hoisington Landfill,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+BARTON,Hoisington Landfill,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+BARTON,Hoisington Landfill,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__bourbon__precinct.csv
+++ b/2016/20161108__ks__general__bourbon__precinct.csv
@@ -1,260 +1,1051 @@
-county,precinct,office,district,party,candidate,votes
-Bourbon,Drywood twp,President,,D,Clinton / Kaine,29
-Bourbon,Drywood twp,President,,R,Trump / Pence,165
-Bourbon,Drywood twp,President,,LBT,Johnson / Weld,5
-Bourbon,Drywood twp,President,,IND,Stein / Baraka,3
-Bourbon,Fort Scott W1,President,,D,Clinton / Kaine,124
-Bourbon,Fort Scott W1,President,,R,Trump / Pence,215
-Bourbon,Fort Scott W1,President,,LBT,Johnson / Weld,12
-Bourbon,Fort Scott W1,President,,IND,Stein / Baraka,9
-Bourbon,Fort Scott W1,President,,wri,McMullen / Johnson,1
-Bourbon,Fort Scott W2,President,,D,Clinton / Kaine,123
-Bourbon,Fort Scott W2,President,,R,Trump / Pence,241
-Bourbon,Fort Scott W2,President,,LBT,Johnson / Weld,22
-Bourbon,Fort Scott W2,President,,IND,Stein / Baraka,6
-Bourbon,Fort Scott W2,President,,wri,McMullen / Johnson,2
-Bourbon,Fort Scott W3,President,,D,Clinton / Kaine,52
-Bourbon,Fort Scott W3,President,,R,Trump / Pence,105
-Bourbon,Fort Scott W3,President,,LBT,Johnson / Weld,5
-Bourbon,Fort Scott W3,President,,IND,Stein / Baraka,4
-Bourbon,Fort Scott W4,President,,D,Clinton / Kaine,95
-Bourbon,Fort Scott W4,President,,R,Trump / Pence,254
-Bourbon,Fort Scott W4,President,,LBT,Johnson / Weld,20
-Bourbon,Fort Scott W4,President,,IND,Stein / Baraka,15
-Bourbon,Fort Scott W4,President,,wri,Castle / Bradley,1
-Bourbon,Fort Scott W4,President,,wri,McMullen / Johnson,3
-Bourbon,Fort Scott W5,President,,D,Clinton / Kaine,106
-Bourbon,Fort Scott W5,President,,R,Trump / Pence,317
-Bourbon,Fort Scott W5,President,,LBT,Johnson / Weld,18
-Bourbon,Fort Scott W5,President,,IND,Stein / Baraka,7
-Bourbon,Fort Scott W5,President,,wri,McMullen / Johnson,2
-Bourbon,Fort Scott W6,President,,D,Clinton / Kaine,144
-Bourbon,Fort Scott W6,President,,R,Trump / Pence,373
-Bourbon,Fort Scott W6,President,,LBT,Johnson / Weld,23
-Bourbon,Fort Scott W6,President,,IND,Stein / Baraka,9
-Bourbon,Fort Scott W6,President,,wri,Castle / Bradley,1
-Bourbon,Fort Scott W6,President,,wri,McMullen / Johnson,2
-Bourbon,Fort Scott W7,President,,D,Clinton / Kaine,122
-Bourbon,Fort Scott W7,President,,R,Trump / Pence,376
-Bourbon,Fort Scott W7,President,,LBT,Johnson / Weld,13
-Bourbon,Fort Scott W7,President,,IND,Stein / Baraka,9
-Bourbon,Fort Scott W7,President,,wri,McMullen / Johnson,1
-Bourbon,Franklin twp,President,,D,Clinton / Kaine,24
-Bourbon,Franklin twp,President,,R,Trump / Pence,113
-Bourbon,Franklin twp,President,,LBT,Johnson / Weld,3
-Bourbon,Franklin twp,President,,IND,Stein / Baraka,0
-Bourbon,Freedom twp,President,,D,Clinton / Kaine,23
-Bourbon,Freedom twp,President,,R,Trump / Pence,151
-Bourbon,Freedom twp,President,,LBT,Johnson / Weld,8
-Bourbon,Freedom twp,President,,IND,Stein / Baraka,5
-Bourbon,Marion twp,President,,D,Clinton / Kaine,71
-Bourbon,Marion twp,President,,R,Trump / Pence,413
-Bourbon,Marion twp,President,,LBT,Johnson / Weld,8
-Bourbon,Marion twp,President,,IND,Stein / Baraka,4
-Bourbon,Marmaton twp,President,,wri,McMullen / Johnson,3
-Bourbon,Marmaton twp,President,,D,Clinton / Kaine,70
-Bourbon,Marmaton twp,President,,R,Trump / Pence,253
-Bourbon,Marmaton twp,President,,LBT,Johnson / Weld,9
-Bourbon,Marmaton twp,President,,IND,Stein / Baraka,5
-Bourbon,Mill Creek twp,President,,D,Clinton / Kaine,43
-Bourbon,Mill Creek twp,President,,R,Trump / Pence,179
-Bourbon,Mill Creek twp,President,,LBT,Johnson / Weld,13
-Bourbon,Mill Creek twp,President,,IND,Stein / Baraka,3
-Bourbon,N Scott twp,President,,D,Clinton / Kaine,79
-Bourbon,N Scott twp,President,,R,Trump / Pence,287
-Bourbon,N Scott twp,President,,LBT,Johnson / Weld,11
-Bourbon,N Scott twp,President,,IND,Stein / Baraka,8
-Bourbon,Osage twp,President,,D,Clinton / Kaine,34
-Bourbon,Osage twp,President,,R,Trump / Pence,163
-Bourbon,Osage twp,President,,LBT,Johnson / Weld,5
-Bourbon,Osage twp,President,,IND,Stein / Baraka,6
-Bourbon,Pawnee twp,President,,D,Clinton / Kaine,25
-Bourbon,Pawnee twp,President,,R,Trump / Pence,114
-Bourbon,Pawnee twp,President,,LBT,Johnson / Weld,2
-Bourbon,Pawnee twp,President,,IND,Stein / Baraka,3
-Bourbon,S Scott twp,President,,D,Clinton / Kaine,147
-Bourbon,S Scott twp,President,,R,Trump / Pence,581
-Bourbon,S Scott twp,President,,LBT,Johnson / Weld,23
-Bourbon,S Scott twp,President,,IND,Stein / Baraka,9
-Bourbon,S Scott twp,President,,wri,McMullen / Johnson,3
-Bourbon,Timberhill twp,President,,D,Clinton / Kaine,21
-Bourbon,Timberhill twp,President,,R,Trump / Pence,80
-Bourbon,Timberhill twp,President,,LBT,Johnson / Weld,4
-Bourbon,Timberhill twp,President,,IND,Stein / Baraka,2
-Bourbon,Walnut twp,President,,D,Clinton / Kaine,4
-Bourbon,Walnut twp,President,,R,Trump / Pence,47
-Bourbon,Walnut twp,President,,LBT,Johnson / Weld,1
-Bourbon,Walnut twp,President,,IND,Stein / Baraka,1
-Bourbon,Drywood twp,U.S. Senate,,D,Patrick Wiesner,33
-Bourbon,Drywood twp,U.S. Senate,,R,Jerry Moran,158
-Bourbon,Drywood twp,U.S. Senate,,LBT,Robert Garrard,13
-Bourbon,Fort Scott W1,U.S. Senate,,D,Patrick Wiesner,110
-Bourbon,Fort Scott W1,U.S. Senate,,R,Jerry Moran,223
-Bourbon,Fort Scott W1,U.S. Senate,,LBT,Robert Garrard,23
-Bourbon,Fort Scott W2,U.S. Senate,,D,Patrick Wiesner,115
-Bourbon,Fort Scott W2,U.S. Senate,,R,Jerry Moran,244
-Bourbon,Fort Scott W2,U.S. Senate,,LBT,Robert Garrard,29
-Bourbon,Fort Scott W3,U.S. Senate,,D,Patrick Wiesner,50
-Bourbon,Fort Scott W3,U.S. Senate,,R,Jerry Moran,101
-Bourbon,Fort Scott W3,U.S. Senate,,LBT,Robert Garrard,13
-Bourbon,Fort Scott W4,U.S. Senate,,D,Patrick Wiesner,94
-Bourbon,Fort Scott W4,U.S. Senate,,R,Jerry Moran,265
-Bourbon,Fort Scott W4,U.S. Senate,,LBT,Robert Garrard,27
-Bourbon,Fort Scott W5,U.S. Senate,,D,Patrick Wiesner,93
-Bourbon,Fort Scott W5,U.S. Senate,,R,Jerry Moran,331
-Bourbon,Fort Scott W5,U.S. Senate,,LBT,Robert Garrard,30
-Bourbon,Fort Scott W6,U.S. Senate,,D,Patrick Wiesner,131
-Bourbon,Fort Scott W6,U.S. Senate,,R,Jerry Moran,392
-Bourbon,Fort Scott W6,U.S. Senate,,LBT,Robert Garrard,29
-Bourbon,Fort Scott W7,U.S. Senate,,D,Patrick Wiesner,128
-Bourbon,Fort Scott W7,U.S. Senate,,R,Jerry Moran,359
-Bourbon,Fort Scott W7,U.S. Senate,,LBT,Robert Garrard,30
-Bourbon,Franklin twp,U.S. Senate,,D,Patrick Wiesner,22
-Bourbon,Franklin twp,U.S. Senate,,R,Jerry Moran,109
-Bourbon,Franklin twp,U.S. Senate,,LBT,Robert Garrard,9
-Bourbon,Freedom twp,U.S. Senate,,D,Patrick Wiesner,29
-Bourbon,Freedom twp,U.S. Senate,,R,Jerry Moran,143
-Bourbon,Freedom twp,U.S. Senate,,LBT,Robert Garrard,10
-Bourbon,Marion twp,U.S. Senate,,D,Patrick Wiesner,81
-Bourbon,Marion twp,U.S. Senate,,R,Jerry Moran,386
-Bourbon,Marion twp,U.S. Senate,,LBT,Robert Garrard,26
-Bourbon,Marmaton twp,U.S. Senate,,D,Patrick Wiesner,77
-Bourbon,Marmaton twp,U.S. Senate,,R,Jerry Moran,251
-Bourbon,Marmaton twp,U.S. Senate,,LBT,Robert Garrard,23
-Bourbon,Mill Creek twp,U.S. Senate,,D,Patrick Wiesner,42
-Bourbon,Mill Creek twp,U.S. Senate,,R,Jerry Moran,180
-Bourbon,Mill Creek twp,U.S. Senate,,LBT,Robert Garrard,13
-Bourbon,N Scott twp,U.S. Senate,,D,Patrick Wiesner,79
-Bourbon,N Scott twp,U.S. Senate,,R,Jerry Moran,288
-Bourbon,N Scott twp,U.S. Senate,,LBT,Robert Garrard,18
-Bourbon,Osage twp,U.S. Senate,,D,Patrick Wiesner,48
-Bourbon,Osage twp,U.S. Senate,,R,Jerry Moran,149
-Bourbon,Osage twp,U.S. Senate,,LBT,Robert Garrard,12
-Bourbon,Pawnee twp,U.S. Senate,,D,Patrick Wiesner,23
-Bourbon,Pawnee twp,U.S. Senate,,R,Jerry Moran,112
-Bourbon,Pawnee twp,U.S. Senate,,LBT,Robert Garrard,6
-Bourbon,S Scott twp,U.S. Senate,,D,Patrick Wiesner,125
-Bourbon,S Scott twp,U.S. Senate,,R,Jerry Moran,616
-Bourbon,S Scott twp,U.S. Senate,,LBT,Robert Garrard,29
-Bourbon,Timberhill twp,U.S. Senate,,D,Patrick Wiesner,23
-Bourbon,Timberhill twp,U.S. Senate,,R,Jerry Moran,74
-Bourbon,Timberhill twp,U.S. Senate,,LBT,Robert Garrard,6
-Bourbon,Timberhill twp,U.S. Senate,,D,Patrick Wiesner,5
-Bourbon,Walnut twp,U.S. Senate,,R,Jerry Moran,46
-Bourbon,Walnut twp,U.S. Senate,,LBT,Robert Garrard,1
-Bourbon,Drywood twp,U.S. House,2,D,Britani Potter,28
-Bourbon,Drywood twp,U.S. House,2,R,Lynn Jenkinds,163
-Bourbon,Drywood twp,U.S. House,2,LBT,James Bales,14
-Bourbon,Fort Scott W1,U.S. House,2,D,Patrick Wiesner,98
-Bourbon,Fort Scott W1,U.S. House,2,R,Jerry Moran,236
-Bourbon,Fort Scott W1,U.S. House,2,LBT,Robert Garrard,25
-Bourbon,Fort Scott W2,U.S. House,2,D,Patrick Wiesner,81
-Bourbon,Fort Scott W2,U.S. House,2,R,Jerry Moran,280
-Bourbon,Fort Scott W2,U.S. House,2,LBT,Robert Garrard,28
-Bourbon,Fort Scott W3,U.S. House,2,D,Patrick Wiesner,40
-Bourbon,Fort Scott W3,U.S. House,2,R,Jerry Moran,109
-Bourbon,Fort Scott W3,U.S. House,2,LBT,Robert Garrard,13
-Bourbon,Fort Scott W4,U.S. House,2,D,Patrick Wiesner,84
-Bourbon,Fort Scott W4,U.S. House,2,R,Jerry Moran,281
-Bourbon,Fort Scott W4,U.S. House,2,LBT,Robert Garrard,20
-Bourbon,Fort Scott W5,U.S. House,2,D,Patrick Wiesner,84
-Bourbon,Fort Scott W5,U.S. House,2,R,Jerry Moran,339
-Bourbon,Fort Scott W5,U.S. House,2,LBT,Robert Garrard,29
-Bourbon,Fort Scott W6,U.S. House,2,D,Patrick Wiesner,109
-Bourbon,Fort Scott W6,U.S. House,2,R,Jerry Moran,423
-Bourbon,Fort Scott W6,U.S. House,2,LBT,Robert Garrard,20
-Bourbon,Fort Scott W7,U.S. House,2,D,Patrick Wiesner,105
-Bourbon,Fort Scott W7,U.S. House,2,R,Jerry Moran,382
-Bourbon,Fort Scott W7,U.S. House,2,LBT,Robert Garrard,33
-Bourbon,Franklin twp,U.S. House,2,D,Patrick Wiesner,19
-Bourbon,Franklin twp,U.S. House,2,R,Jerry Moran,118
-Bourbon,Franklin twp,U.S. House,2,LBT,Robert Garrard,6
-Bourbon,Freedom twp,U.S. House,2,D,Patrick Wiesner,27
-Bourbon,Freedom twp,U.S. House,2,R,Jerry Moran,148
-Bourbon,Freedom twp,U.S. House,2,LBT,Robert Garrard,8
-Bourbon,Marion twp,U.S. House,2,D,Patrick Wiesner,75
-Bourbon,Marion twp,U.S. House,2,R,Jerry Moran,397
-Bourbon,Marion twp,U.S. House,2,LBT,Robert Garrard,24
-Bourbon,Marmaton twp,U.S. House,2,D,Patrick Wiesner,60
-Bourbon,Marmaton twp,U.S. House,2,R,Jerry Moran,275
-Bourbon,Marmaton twp,U.S. House,2,LBT,Robert Garrard,16
-Bourbon,Mill Creek twp,U.S. House,2,D,Patrick Wiesner,40
-Bourbon,Mill Creek twp,U.S. House,2,R,Jerry Moran,188
-Bourbon,Mill Creek twp,U.S. House,2,LBT,Robert Garrard,11
-Bourbon,N Scott twp,U.S. House,2,D,Patrick Wiesner,81
-Bourbon,N Scott twp,U.S. House,2,R,Jerry Moran,285
-Bourbon,N Scott twp,U.S. House,2,LBT,Robert Garrard,23
-Bourbon,Osage twp,U.S. House,2,D,Patrick Wiesner,43
-Bourbon,Osage twp,U.S. House,2,R,Jerry Moran,157
-Bourbon,Osage twp,U.S. House,2,LBT,Robert Garrard,10
-Bourbon,Pawnee twp,U.S. House,2,D,Patrick Wiesner,23
-Bourbon,Pawnee twp,U.S. House,2,R,Jerry Moran,117
-Bourbon,Pawnee twp,U.S. House,2,LBT,Robert Garrard,3
-Bourbon,S Scott twp,U.S. House,2,D,Patrick Wiesner,121
-Bourbon,S Scott twp,U.S. House,2,R,Jerry Moran,617
-Bourbon,S Scott twp,U.S. House,2,LBT,Robert Garrard,22
-Bourbon,Timberhill twp,U.S. House,2,D,Patrick Wiesner,23
-Bourbon,Timberhill twp,U.S. House,2,R,Jerry Moran,78
-Bourbon,Timberhill twp,U.S. House,2,LBT,Robert Garrard,2
-Bourbon,Timberhill twp,U.S. House,2,D,Patrick Wiesner,6
-Bourbon,Walnut twp,U.S. House,2,R,Jerry Moran,47
-Bourbon,Walnut twp,U.S. House,2,LBT,Robert Garrard,0
-Bourbon,Drywood twp,State Senate,13,D,Lynn Grant,39
-Bourbon,Drywood twp,State Senate,13,R,Jake LaTurner,165
-Bourbon,Fort Scott W1,State Senate,12,D,Christopher Johnson,5
-Bourbon,Fort Scott W1,State Senate,12,R,Caryn Tyson,8
-Bourbon,Fort Scott W1,State Senate,13,D,Lynn Grant,156
-Bourbon,Fort Scott W1,State Senate,13,R,Jake LaTurner,185
-Bourbon,Fort Scott W2,State Senate,13,D,Lynn Grant,150
-Bourbon,Fort Scott W2,State Senate,13,R,Jake LaTurner,238
-Bourbon,Fort Scott W3,State Senate,13,D,Lynn Grant,68
-Bourbon,Fort Scott W3,State Senate,13,R,Jake LaTurner,93
-Bourbon,Fort Scott W4,State Senate,13,D,Lynn Grant,162
-Bourbon,Fort Scott W4,State Senate,13,R,Jake LaTurner,225
-Bourbon,Fort Scott W5,State Senate,13,D,Lynn Grant,168
-Bourbon,Fort Scott W5,State Senate,13,R,Jake LaTurner,282
-Bourbon,Fort Scott W6,State Senate,13,D,Lynn Grant,201
-Bourbon,Fort Scott W6,State Senate,13,R,Jake LaTurner,345
-Bourbon,Fort Scott W7,State Senate,13,D,Lynn Grant,185
-Bourbon,Fort Scott W7,State Senate,13,R,Jake LaTurner,334
-Bourbon,Franklin twp,State Senate,12,D,Christopher Johnson,23
-Bourbon,Franklin twp,State Senate,12,R,Caryn Tyson,107
-Bourbon,Freedom twp,State Senate,12,D,Christopher Johnson,29
-Bourbon,Freedom twp,State Senate,12,R,Caryn Tyson,147
-Bourbon,Marion twp,State Senate,12,D,Christopher Johnson,91
-Bourbon,Marion twp,State Senate,12,R,Caryn Tyson,358
-Bourbon,Marmaton twp,State Senate,12,D,Christopher Johnson,74
-Bourbon,Marmaton twp,State Senate,12,R,Caryn Tyson,264
-Bourbon,Mill Creek twp,State Senate,12,D,Christopher Johnson,41
-Bourbon,Mill Creek twp,State Senate,12,R,Caryn Tyson,185
-Bourbon,N Scott twp,State Senate,12,D,Christopher Johnson,97
-Bourbon,N Scott twp,State Senate,12,R,Caryn Tyson,286
-Bourbon,Osage twp,State Senate,12,D,Christopher Johnson,41
-Bourbon,Osage twp,State Senate,12,R,Caryn Tyson,161
-Bourbon,Pawnee twp,State Senate,13,D,Lynn Grant,41
-Bourbon,Pawnee twp,State Senate,13,R,Jake LaTurner,97
-Bourbon,S Scott twp,State Senate,13,D,Lynn Grant,241
-Bourbon,S Scott twp,State Senate,13,R,Jake LaTurner,520
-Bourbon,Timberhill twp,State Senate,12,D,Christopher Johnson,13
-Bourbon,Timberhill twp,State Senate,12,R,Caryn Tyson,82
-Bourbon,Walnut twp,State Senate,13,D,Lynn Grant,7
-Bourbon,Walnut twp,State Senate,13,R,Jake LaTurner,47
-Bourbon,Marion twp,State House,2,D,Adam Lusker,320
-Bourbon,Walnut twp,State House,2,D,Adam Lusker,29
-Bourbon,Drywood twp,State House,4,R,Trevor Jacobs,181
-Bourbon,Fort Scott W1,State House,4,R,Trevor Jacobs,308
-Bourbon,Fort Scott W2,State House,4,R,Trevor Jacobs,339
-Bourbon,Fort Scott W3,State House,4,R,Trevor Jacobs,141
-Bourbon,Fort Scott W4,State House,4,R,Trevor Jacobs,327
-Bourbon,Fort Scott W5,State House,4,R,Trevor Jacobs,386
-Bourbon,Fort Scott W6,State House,4,R,Trevor Jacobs,479
-Bourbon,Fort Scott W7,State House,4,R,Trevor Jacobs,460
-Bourbon,Franklin twp,State House,4,R,Trevor Jacobs,127
-Bourbon,Freedom twp,State House,4,R,Trevor Jacobs,164
-Bourbon,Marmaton twp,State House,4,R,Trevor Jacobs,311
-Bourbon,Mill Creek twp,State House,4,R,Trevor Jacobs,212
-Bourbon,N Scott twp,State House,4,R,Trevor Jacobs,349
-Bourbon,Osage twp,State House,4,R,Trevor Jacobs,186
-Bourbon,Pawnee twp,State House,4,R,Trevor Jacobs,120
-Bourbon,S Scott twp,State House,4,R,Trevor Jacobs,678
-Bourbon,Timberhill twp,State House,4,R,Trevor Jacobs,87
+county,precinct,office,district,party,candidate,votes,vtd
+BOURBON,Drywood Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",181,000010
+BOURBON,Fort Scott Ward 1,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",308,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00002F
+BOURBON,Fort Scott Ward 2,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",339,00003A
+BOURBON,Fort Scott Ward 3,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",141,000040
+BOURBON,Fort Scott Ward 4,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",327,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,00005D
+BOURBON,Fort Scott Ward 5,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",386,000060
+BOURBON,Fort Scott Ward 6,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",479,000070
+BOURBON,Fort Scott Ward 7,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",460,000080
+BOURBON,Franklin Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",127,000090
+BOURBON,Freedom Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",164,000100
+BOURBON,Marion Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",320,000110
+BOURBON,Marmaton Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",311,000120
+BOURBON,Mill Creek Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",212,000130
+BOURBON,North Scott Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",349,000140
+BOURBON,Osage Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",186,000150
+BOURBON,Pawnee Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",120,000160
+BOURBON,South Scott Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",678,000170
+BOURBON,Timberhill Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",87,000180
+BOURBON,Walnut Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",29,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",0,900030
+BOURBON,Drywood Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",39,000010
+BOURBON,Drywood Township,Kansas Senate,13,Republican,"LaTurner, Jake",165,000010
+BOURBON,Fort Scott Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",156,00002A
+BOURBON,Fort Scott Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",185,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas Senate,12,Democratic,"Johnston, Christopher B.",5,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,Kansas Senate,12,Republican,"Tyson, Caryn",8,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,Kansas Senate,12,Republican,"Tyson, Caryn",0,00002F
+BOURBON,Fort Scott Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",150,00003A
+BOURBON,Fort Scott Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",238,00003A
+BOURBON,Fort Scott Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",68,000040
+BOURBON,Fort Scott Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",93,000040
+BOURBON,Fort Scott Ward 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",162,00005A
+BOURBON,Fort Scott Ward 4,Kansas Senate,13,Republican,"LaTurner, Jake",225,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,Kansas Senate,13,Republican,"LaTurner, Jake",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,Kansas Senate,13,Republican,"LaTurner, Jake",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Republican,"LaTurner, Jake",0,00005D
+BOURBON,Fort Scott Ward 5,Kansas Senate,13,Democratic,"Grant, Lynn D.",168,000060
+BOURBON,Fort Scott Ward 5,Kansas Senate,13,Republican,"LaTurner, Jake",282,000060
+BOURBON,Fort Scott Ward 6,Kansas Senate,13,Democratic,"Grant, Lynn D.",201,000070
+BOURBON,Fort Scott Ward 6,Kansas Senate,13,Republican,"LaTurner, Jake",345,000070
+BOURBON,Fort Scott Ward 7,Kansas Senate,13,Democratic,"Grant, Lynn D.",185,000080
+BOURBON,Fort Scott Ward 7,Kansas Senate,13,Republican,"LaTurner, Jake",334,000080
+BOURBON,Franklin Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",23,000090
+BOURBON,Franklin Township,Kansas Senate,12,Republican,"Tyson, Caryn",107,000090
+BOURBON,Freedom Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",29,000100
+BOURBON,Freedom Township,Kansas Senate,12,Republican,"Tyson, Caryn",147,000100
+BOURBON,Marion Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",91,000110
+BOURBON,Marion Township,Kansas Senate,12,Republican,"Tyson, Caryn",358,000110
+BOURBON,Marmaton Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",74,000120
+BOURBON,Marmaton Township,Kansas Senate,12,Republican,"Tyson, Caryn",264,000120
+BOURBON,Mill Creek Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",41,000130
+BOURBON,Mill Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",185,000130
+BOURBON,North Scott Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",97,000140
+BOURBON,North Scott Township,Kansas Senate,12,Republican,"Tyson, Caryn",286,000140
+BOURBON,Osage Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",41,000150
+BOURBON,Osage Township,Kansas Senate,12,Republican,"Tyson, Caryn",161,000150
+BOURBON,Pawnee Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",41,000160
+BOURBON,Pawnee Township,Kansas Senate,13,Republican,"LaTurner, Jake",97,000160
+BOURBON,South Scott Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",241,000170
+BOURBON,South Scott Township,Kansas Senate,13,Republican,"LaTurner, Jake",520,000170
+BOURBON,Timberhill Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",13,000180
+BOURBON,Timberhill Township,Kansas Senate,12,Republican,"Tyson, Caryn",82,000180
+BOURBON,Walnut Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",7,000190
+BOURBON,Walnut Township,Kansas Senate,13,Republican,"LaTurner, Jake",47,000190
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,Kansas Senate,13,Republican,"LaTurner, Jake",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,Kansas Senate,13,Republican,"LaTurner, Jake",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,Kansas Senate,13,Republican,"LaTurner, Jake",0,900030
+BOURBON,Drywood Township,President / Vice President,,independent,"Stein, Jill",3,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+BOURBON,Drywood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+BOURBON,Drywood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000010
+BOURBON,Drywood Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+BOURBON,Drywood Township,President / Vice President,,Republican,"Trump, Donald J.",165,000010
+BOURBON,Fort Scott Ward 1,President / Vice President,,independent,"Stein, Jill",9,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,00002A
+BOURBON,Fort Scott Ward 1,President / Vice President,,Republican,"Trump, Donald J.",215,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,independent,"Stein, Jill",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Castle, Darrell L",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Giordani, Rocky",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Hedges, James A",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Kahn, Lynn",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"La Riva, Gloria",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Levinson, Michael S.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Maturen, Michael A",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"McMullin, Evan",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Perry, Darryl",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Schriner, Joe C",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Smith, Mike",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Sood, Ajay",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Sterling, Shawna",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,President / Vice President,,Republican,"Trump, Donald J.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,independent,"Stein, Jill",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Castle, Darrell L",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Giordani, Rocky",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Hedges, James A",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Hoefling, Tom",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Kahn, Lynn",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"La Riva, Gloria",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Levinson, Michael S.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Maturen, Michael A",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"McMullin, Evan",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Perry, Darryl",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Schriner, Joe C",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Smith, Mike",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Sood, Ajay",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Sterling, Shawna",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Libertarian,"Johnson, Gary",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,President / Vice President,,Republican,"Trump, Donald J.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,independent,"Stein, Jill",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Castle, Darrell L",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Giordani, Rocky",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Hedges, James A",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Hoefling, Tom",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Kahn, Lynn",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"La Riva, Gloria",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Levinson, Michael S.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Maturen, Michael A",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"McMullin, Evan",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Perry, Darryl",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Schriner, Joe C",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Smith, Mike",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Sood, Ajay",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Sterling, Shawna",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Libertarian,"Johnson, Gary",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,President / Vice President,,Republican,"Trump, Donald J.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,independent,"Stein, Jill",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Castle, Darrell L",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Giordani, Rocky",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Hedges, James A",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Hoefling, Tom",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Kahn, Lynn",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"La Riva, Gloria",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Levinson, Michael S.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Maturen, Michael A",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"McMullin, Evan",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Perry, Darryl",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Schriner, Joe C",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Smith, Mike",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Sood, Ajay",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Sterling, Shawna",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Libertarian,"Johnson, Gary",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,President / Vice President,,Republican,"Trump, Donald J.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,independent,"Stein, Jill",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Castle, Darrell L",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Giordani, Rocky",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Hedges, James A",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Hoefling, Tom",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Kahn, Lynn",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"La Riva, Gloria",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Levinson, Michael S.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Maturen, Michael A",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"McMullin, Evan",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Perry, Darryl",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Schriner, Joe C",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Smith, Mike",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Sood, Ajay",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Sterling, Shawna",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Libertarian,"Johnson, Gary",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,President / Vice President,,Republican,"Trump, Donald J.",0,00002F
+BOURBON,Fort Scott Ward 2,President / Vice President,,independent,"Stein, Jill",6,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",22,00003A
+BOURBON,Fort Scott Ward 2,President / Vice President,,Republican,"Trump, Donald J.",241,00003A
+BOURBON,Fort Scott Ward 3,President / Vice President,,independent,"Stein, Jill",4,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+BOURBON,Fort Scott Ward 3,President / Vice President,,Republican,"Trump, Donald J.",102,000040
+BOURBON,Fort Scott Ward 4,President / Vice President,,independent,"Stein, Jill",15,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Castle, Darrell L",1,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"McMullin, Evan",3,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",20,00005A
+BOURBON,Fort Scott Ward 4,President / Vice President,,Republican,"Trump, Donald J.",254,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,independent,"Stein, Jill",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00005D
+BOURBON,Fort Scott Ward 5,President / Vice President,,independent,"Stein, Jill",7,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Hedges, James A",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"McMullin, Evan",2,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Smith, Mike",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",18,000060
+BOURBON,Fort Scott Ward 5,President / Vice President,,Republican,"Trump, Donald J.",317,000060
+BOURBON,Fort Scott Ward 6,President / Vice President,,independent,"Stein, Jill",9,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Castle, Darrell L",1,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Hedges, James A",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"McMullin, Evan",2,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Perry, Darryl",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Smith, Mike",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Sood, Ajay",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",144,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Libertarian,"Johnson, Gary",23,000070
+BOURBON,Fort Scott Ward 6,President / Vice President,,Republican,"Trump, Donald J.",373,000070
+BOURBON,Fort Scott Ward 7,President / Vice President,,independent,"Stein, Jill",9,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Hedges, James A",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"McMullin, Evan",1,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Perry, Darryl",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Smith, Mike",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Sood, Ajay",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+BOURBON,Fort Scott Ward 7,President / Vice President,,Republican,"Trump, Donald J.",376,000080
+BOURBON,Franklin Township,President / Vice President,,independent,"Stein, Jill",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+BOURBON,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+BOURBON,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000090
+BOURBON,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+BOURBON,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",113,000090
+BOURBON,Freedom Township,President / Vice President,,independent,"Stein, Jill",5,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+BOURBON,Freedom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+BOURBON,Freedom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000100
+BOURBON,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000100
+BOURBON,Freedom Township,President / Vice President,,Republican,"Trump, Donald J.",151,000100
+BOURBON,Marion Township,President / Vice President,,independent,"Stein, Jill",4,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+BOURBON,Marion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+BOURBON,Marion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000110
+BOURBON,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000110
+BOURBON,Marion Township,President / Vice President,,Republican,"Trump, Donald J.",413,000110
+BOURBON,Marmaton Township,President / Vice President,,independent,"Stein, Jill",5,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"McMullin, Evan",3,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+BOURBON,Marmaton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+BOURBON,Marmaton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,000120
+BOURBON,Marmaton Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000120
+BOURBON,Marmaton Township,President / Vice President,,Republican,"Trump, Donald J.",253,000120
+BOURBON,Mill Creek Township,President / Vice President,,independent,"Stein, Jill",3,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+BOURBON,Mill Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000130
+BOURBON,Mill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+BOURBON,Mill Creek Township,President / Vice President,,Republican,"Trump, Donald J.",179,000130
+BOURBON,North Scott Township,President / Vice President,,independent,"Stein, Jill",8,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+BOURBON,North Scott Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+BOURBON,North Scott Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000140
+BOURBON,North Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000140
+BOURBON,North Scott Township,President / Vice President,,Republican,"Trump, Donald J.",287,000140
+BOURBON,Osage Township,President / Vice President,,independent,"Stein, Jill",6,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+BOURBON,Osage Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+BOURBON,Osage Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000150
+BOURBON,Osage Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000150
+BOURBON,Osage Township,President / Vice President,,Republican,"Trump, Donald J.",163,000150
+BOURBON,Pawnee Township,President / Vice President,,independent,"Stein, Jill",3,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+BOURBON,Pawnee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+BOURBON,Pawnee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000160
+BOURBON,Pawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+BOURBON,Pawnee Township,President / Vice President,,Republican,"Trump, Donald J.",114,000160
+BOURBON,South Scott Township,President / Vice President,,independent,"Stein, Jill",9,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"McMullin, Evan",3,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+BOURBON,South Scott Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+BOURBON,South Scott Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",147,000170
+BOURBON,South Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000170
+BOURBON,South Scott Township,President / Vice President,,Republican,"Trump, Donald J.",581,000170
+BOURBON,Timberhill Township,President / Vice President,,independent,"Stein, Jill",2,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+BOURBON,Timberhill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+BOURBON,Timberhill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000180
+BOURBON,Timberhill Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000180
+BOURBON,Timberhill Township,President / Vice President,,Republican,"Trump, Donald J.",80,000180
+BOURBON,Walnut Township,President / Vice President,,independent,"Stein, Jill",1,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",1,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+BOURBON,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+BOURBON,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000190
+BOURBON,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+BOURBON,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",47,000190
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,independent,"Stein, Jill",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,independent,"Stein, Jill",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,independent,"Stein, Jill",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Hedges, James A",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"McMullin, Evan",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Perry, Darryl",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Smith, Mike",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Sood, Ajay",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+BOURBON,Drywood Township,United States House of Representatives,2,Democratic,"Potter, Britani",28,000010
+BOURBON,Drywood Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000010
+BOURBON,Drywood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",163,000010
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",98,00002A
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,00002A
+BOURBON,Fort Scott Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Democratic,"Potter, Britani",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Democratic,"Potter, Britani",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Democratic,"Potter, Britani",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00002F
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",81,00003A
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,00003A
+BOURBON,Fort Scott Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",280,00003A
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",40,000040
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000040
+BOURBON,Fort Scott Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",109,000040
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",84,00005A
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,00005A
+BOURBON,Fort Scott Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",281,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005D
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Democratic,"Potter, Britani",84,000060
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",29,000060
+BOURBON,Fort Scott Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",339,000060
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Democratic,"Potter, Britani",109,000070
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000070
+BOURBON,Fort Scott Ward 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",423,000070
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Democratic,"Potter, Britani",105,000080
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Libertarian,"Bales, James Houston",33,000080
+BOURBON,Fort Scott Ward 7,United States House of Representatives,2,Republican,"Jenkins, Lynn",382,000080
+BOURBON,Franklin Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,000090
+BOURBON,Franklin Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000090
+BOURBON,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,000090
+BOURBON,Freedom Township,United States House of Representatives,2,Democratic,"Potter, Britani",27,000100
+BOURBON,Freedom Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000100
+BOURBON,Freedom Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",148,000100
+BOURBON,Marion Township,United States House of Representatives,2,Democratic,"Potter, Britani",75,000110
+BOURBON,Marion Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000110
+BOURBON,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",397,000110
+BOURBON,Marmaton Township,United States House of Representatives,2,Democratic,"Potter, Britani",60,000120
+BOURBON,Marmaton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000120
+BOURBON,Marmaton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,000120
+BOURBON,Mill Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",40,000130
+BOURBON,Mill Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000130
+BOURBON,Mill Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",188,000130
+BOURBON,North Scott Township,United States House of Representatives,2,Democratic,"Potter, Britani",81,000140
+BOURBON,North Scott Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000140
+BOURBON,North Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",285,000140
+BOURBON,Osage Township,United States House of Representatives,2,Democratic,"Potter, Britani",43,000150
+BOURBON,Osage Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000150
+BOURBON,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",157,000150
+BOURBON,Pawnee Township,United States House of Representatives,2,Democratic,"Potter, Britani",23,000160
+BOURBON,Pawnee Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000160
+BOURBON,Pawnee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000160
+BOURBON,South Scott Township,United States House of Representatives,2,Democratic,"Potter, Britani",121,000170
+BOURBON,South Scott Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000170
+BOURBON,South Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",617,000170
+BOURBON,Timberhill Township,United States House of Representatives,2,Democratic,"Potter, Britani",23,000180
+BOURBON,Timberhill Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000180
+BOURBON,Timberhill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000180
+BOURBON,Walnut Township,United States House of Representatives,2,Democratic,"Potter, Britani",6,000190
+BOURBON,Walnut Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000190
+BOURBON,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000190
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+BOURBON,Drywood Township,United States Senate,,write - in,"Smith, DJ",0,000010
+BOURBON,Drywood Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000010
+BOURBON,Drywood Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000010
+BOURBON,Drywood Township,United States Senate,,Republican,"Moran, Jerry",158,000010
+BOURBON,Fort Scott Ward 1,United States Senate,,write - in,"Smith, DJ",0,00002A
+BOURBON,Fort Scott Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",110,00002A
+BOURBON,Fort Scott Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",23,00002A
+BOURBON,Fort Scott Ward 1,United States Senate,,Republican,"Moran, Jerry",223,00002A
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,write - in,"Smith, DJ",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,Democratic,"Wiesner, Patrick",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Colonial,United States Senate,,Republican,"Moran, Jerry",0,00002B
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,write - in,"Smith, DJ",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,Democratic,"Wiesner, Patrick",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Halls,United States Senate,,Republican,"Moran, Jerry",0,00002C
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,write - in,"Smith, DJ",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,Democratic,"Wiesner, Patrick",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Barn,United States Senate,,Republican,"Moran, Jerry",0,00002D
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,write - in,"Smith, DJ",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,Democratic,"Wiesner, Patrick",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram A,United States Senate,,Republican,"Moran, Jerry",0,00002E
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,write - in,"Smith, DJ",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,Democratic,"Wiesner, Patrick",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002F
+BOURBON,Fort Scott Ward 1 Exclave Red Ram B,United States Senate,,Republican,"Moran, Jerry",0,00002F
+BOURBON,Fort Scott Ward 2,United States Senate,,write - in,"Smith, DJ",0,00003A
+BOURBON,Fort Scott Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",115,00003A
+BOURBON,Fort Scott Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",29,00003A
+BOURBON,Fort Scott Ward 2,United States Senate,,Republican,"Moran, Jerry",244,00003A
+BOURBON,Fort Scott Ward 3,United States Senate,,write - in,"Smith, DJ",0,000040
+BOURBON,Fort Scott Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",50,000040
+BOURBON,Fort Scott Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",13,000040
+BOURBON,Fort Scott Ward 3,United States Senate,,Republican,"Moran, Jerry",101,000040
+BOURBON,Fort Scott Ward 4,United States Senate,,write - in,"Smith, DJ",0,00005A
+BOURBON,Fort Scott Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",94,00005A
+BOURBON,Fort Scott Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",27,00005A
+BOURBON,Fort Scott Ward 4,United States Senate,,Republican,"Moran, Jerry",265,00005A
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00005B
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00005C
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,write - in,"Smith, DJ",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005D
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,00005D
+BOURBON,Fort Scott Ward 5,United States Senate,,write - in,"Smith, DJ",0,000060
+BOURBON,Fort Scott Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",93,000060
+BOURBON,Fort Scott Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",30,000060
+BOURBON,Fort Scott Ward 5,United States Senate,,Republican,"Moran, Jerry",331,000060
+BOURBON,Fort Scott Ward 6,United States Senate,,write - in,"Smith, DJ",0,000070
+BOURBON,Fort Scott Ward 6,United States Senate,,Democratic,"Wiesner, Patrick",131,000070
+BOURBON,Fort Scott Ward 6,United States Senate,,Libertarian,"Garrard, Robert D.",29,000070
+BOURBON,Fort Scott Ward 6,United States Senate,,Republican,"Moran, Jerry",392,000070
+BOURBON,Fort Scott Ward 7,United States Senate,,write - in,"Smith, DJ",0,000080
+BOURBON,Fort Scott Ward 7,United States Senate,,Democratic,"Wiesner, Patrick",128,000080
+BOURBON,Fort Scott Ward 7,United States Senate,,Libertarian,"Garrard, Robert D.",30,000080
+BOURBON,Fort Scott Ward 7,United States Senate,,Republican,"Moran, Jerry",359,000080
+BOURBON,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000090
+BOURBON,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000090
+BOURBON,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000090
+BOURBON,Franklin Township,United States Senate,,Republican,"Moran, Jerry",109,000090
+BOURBON,Freedom Township,United States Senate,,write - in,"Smith, DJ",0,000100
+BOURBON,Freedom Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000100
+BOURBON,Freedom Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000100
+BOURBON,Freedom Township,United States Senate,,Republican,"Moran, Jerry",143,000100
+BOURBON,Marion Township,United States Senate,,write - in,"Smith, DJ",0,000110
+BOURBON,Marion Township,United States Senate,,Democratic,"Wiesner, Patrick",81,000110
+BOURBON,Marion Township,United States Senate,,Libertarian,"Garrard, Robert D.",26,000110
+BOURBON,Marion Township,United States Senate,,Republican,"Moran, Jerry",386,000110
+BOURBON,Marmaton Township,United States Senate,,write - in,"Smith, DJ",0,000120
+BOURBON,Marmaton Township,United States Senate,,Democratic,"Wiesner, Patrick",77,000120
+BOURBON,Marmaton Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,000120
+BOURBON,Marmaton Township,United States Senate,,Republican,"Moran, Jerry",251,000120
+BOURBON,Mill Creek Township,United States Senate,,write - in,"Smith, DJ",0,000130
+BOURBON,Mill Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000130
+BOURBON,Mill Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000130
+BOURBON,Mill Creek Township,United States Senate,,Republican,"Moran, Jerry",180,000130
+BOURBON,North Scott Township,United States Senate,,write - in,"Smith, DJ",0,000140
+BOURBON,North Scott Township,United States Senate,,Democratic,"Wiesner, Patrick",79,000140
+BOURBON,North Scott Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000140
+BOURBON,North Scott Township,United States Senate,,Republican,"Moran, Jerry",288,000140
+BOURBON,Osage Township,United States Senate,,write - in,"Smith, DJ",0,000150
+BOURBON,Osage Township,United States Senate,,Democratic,"Wiesner, Patrick",48,000150
+BOURBON,Osage Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000150
+BOURBON,Osage Township,United States Senate,,Republican,"Moran, Jerry",149,000150
+BOURBON,Pawnee Township,United States Senate,,write - in,"Smith, DJ",0,000160
+BOURBON,Pawnee Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000160
+BOURBON,Pawnee Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000160
+BOURBON,Pawnee Township,United States Senate,,Republican,"Moran, Jerry",112,000160
+BOURBON,South Scott Township,United States Senate,,write - in,"Smith, DJ",0,000170
+BOURBON,South Scott Township,United States Senate,,Democratic,"Wiesner, Patrick",125,000170
+BOURBON,South Scott Township,United States Senate,,Libertarian,"Garrard, Robert D.",29,000170
+BOURBON,South Scott Township,United States Senate,,Republican,"Moran, Jerry",616,000170
+BOURBON,Timberhill Township,United States Senate,,write - in,"Smith, DJ",0,000180
+BOURBON,Timberhill Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000180
+BOURBON,Timberhill Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000180
+BOURBON,Timberhill Township,United States Senate,,Republican,"Moran, Jerry",74,000180
+BOURBON,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000190
+BOURBON,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000190
+BOURBON,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+BOURBON,Walnut Township,United States Senate,,Republican,"Moran, Jerry",46,000190
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,write - in,"Smith, DJ",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+BOURBON,Fort Scott Ward 6 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,900010
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,write - in,"Smith, DJ",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+BOURBON,Fort Scott Ward 4 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,900020
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,write - in,"Smith, DJ",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+BOURBON,Fort Scott Ward 4 Exclave D,United States Senate,,Republican,"Moran, Jerry",0,900030

--- a/2016/20161108__ks__general__brown__precinct.csv
+++ b/2016/20161108__ks__general__brown__precinct.csv
@@ -1,415 +1,981 @@
-county,precinct,office,district,party,candidate,votes,advance,election_day,provisional
-Brown,Hiawatha City Ward 1,President,,DEM,Clinton and Kaine,50,12,38,0
-Brown,Hiawatha City Ward 1,President,,LIB,Johnson and Weld,12,2,9,1
-Brown,Hiawatha City Ward 1,President,,IND,Stein and Baraka,5,3,2,0
-Brown,Hiawatha City Ward 1,President,,REP,Trump and Pence,102,15,85,2
-Brown,Hiawatha City Ward 1,President,,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 1,President,,,Total,169,32,134,3
-Brown,Hiawatha City Ward 1,U.S. Senate,,LIB,Robert D. Garrard,13,3,9,1
-Brown,Hiawatha City Ward 1,U.S. Senate,,REP,Jerry Moran,117,17,98,2
-Brown,Hiawatha City Ward 1,U.S. Senate,,DEM,Patrick Wiesner,38,11,27,0
-Brown,Hiawatha City Ward 1,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 1,U.S. Senate,,,Total,168,31,134,3
-Brown,Hiawatha City Ward 1,U.S. House,2,LIB,James Houston Bales,11,4,7,0
-Brown,Hiawatha City Ward 1,U.S. House,2,REP,Lynn Jenkins,129,17,109,3
-Brown,Hiawatha City Ward 1,U.S. House,2,DEM,Britani Potter,32,12,20,0
-Brown,Hiawatha City Ward 1,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 1,U.S. House,2,,Total,172,33,136,3
-Brown,Hiawatha City Ward 1,State Senate,1,DEM,Jerry Henry,89,21,68,0
-Brown,Hiawatha City Ward 1,State Senate,1,REP,Dennis D. Pyle,83,12,68,3
-Brown,Hiawatha City Ward 1,State Senate,1,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 1,State Senate,1,,Total,172,33,136,3
-Brown,Hiawatha City Ward 1,State House,62,REP,Randy Garber,148,25,120,3
-Brown,Hiawatha City Ward 1,State House,62,,Write-ins,5,1,4,0
-Brown,Hiawatha City Ward 1,State House,62,,Total,153,26,124,3
-Brown,Hiawatha City Ward 2,President,,DEM,Clinton and Kaine,165,51,110,4
-Brown,Hiawatha City Ward 2,President,,LIB,Johnson and Weld,27,8,18,1
-Brown,Hiawatha City Ward 2,President,,IND,Stein and Baraka,10,3,7,0
-Brown,Hiawatha City Ward 2,President,,REP,Trump and Pence,366,84,278,4
-Brown,Hiawatha City Ward 2,President,,,Write-ins,1,0,1,0
-Brown,Hiawatha City Ward 2,President,,,Total,569,146,414,9
-Brown,Hiawatha City Ward 2,U.S. Senate,,LIB,Robert D. Garrard,17,6,10,1
-Brown,Hiawatha City Ward 2,U.S. Senate,,REP,Jerry Moran,420,98,318,4
-Brown,Hiawatha City Ward 2,U.S. Senate,,DEM,Patrick Wiesner,130,41,86,3
-Brown,Hiawatha City Ward 2,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 2,U.S. Senate,,,Total,567,145,414,8
-Brown,Hiawatha City Ward 2,U.S. House,2,LIB,James Houston Bales,29,9,18,2
-Brown,Hiawatha City Ward 2,U.S. House,2,REP,Lynn Jenkins,408,92,311,5
-Brown,Hiawatha City Ward 2,U.S. House,2,DEM,Britani Potter,131,43,86,2
-Brown,Hiawatha City Ward 2,U.S. House,2,,Write-ins,1,0,1,0
-Brown,Hiawatha City Ward 2,U.S. House,2,,Total,569,144,416,9
-Brown,Hiawatha City Ward 2,State Senate,1,DEM,Jerry Henry,311,85,219,7
-Brown,Hiawatha City Ward 2,State Senate,1,REP,Dennis D. Pyle,246,56,188,2
-Brown,Hiawatha City Ward 2,State Senate,1,,Write-ins,2,0,2,0
-Brown,Hiawatha City Ward 2,State Senate,1,,Total,559,141,409,9
-Brown,Hiawatha City Ward 2,State House,62,REP,Randy Garber,465,104,354,7
-Brown,Hiawatha City Ward 2,State House,62,,Write-ins,20,4,16,0
-Brown,Hiawatha City Ward 2,State House,62,,Total,485,108,370,7
-Brown,Hiawatha City Ward 3,President,,DEM,Clinton and Kaine,120,55,64,1
-Brown,Hiawatha City Ward 3,President,,LIB,Johnson and Weld,23,11,10,2
-Brown,Hiawatha City Ward 3,President,,IND,Stein and Baraka,25,11,14,0
-Brown,Hiawatha City Ward 3,President,,REP,Trump and Pence,303,77,218,8
-Brown,Hiawatha City Ward 3,President,,,Write-ins,3,1,2,0
-Brown,Hiawatha City Ward 3,President,,,Total,474,155,308,11
-Brown,Hiawatha City Ward 3,U.S. Senate,,LIB,Robert D. Garrard,33,16,15,2
-Brown,Hiawatha City Ward 3,U.S. Senate,,REP,Jerry Moran,342,106,231,5
-Brown,Hiawatha City Ward 3,U.S. Senate,,DEM,Patrick Wiesner,96,32,60,4
-Brown,Hiawatha City Ward 3,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 3,U.S. Senate,,,Total,471,154,306,11
-Brown,Hiawatha City Ward 3,U.S. House,2,LIB,James Houston Bales,20,9,11,0
-Brown,Hiawatha City Ward 3,U.S. House,2,REP,Lynn Jenkins,354,105,241,8
-Brown,Hiawatha City Ward 3,U.S. House,2,DEM,Britani Potter,97,40,55,2
-Brown,Hiawatha City Ward 3,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 3,U.S. House,2,,Total,471,154,307,10
-Brown,Hiawatha City Ward 3,State Senate,1,DEM,Jerry Henry,217,88,128,1
-Brown,Hiawatha City Ward 3,State Senate,1,REP,Dennis D. Pyle,254,65,179,10
-Brown,Hiawatha City Ward 3,State Senate,1,,Write-ins,2,1,1,0
-Brown,Hiawatha City Ward 3,State Senate,1,,Total,473,154,308,11
-Brown,Hiawatha City Ward 3,State House,62,REP,Randy Garber,404,130,263,11
-Brown,Hiawatha City Ward 3,State House,62,,Write-ins,11,2,9,0
-Brown,Hiawatha City Ward 3,State House,62,,Total,415,132,272,11
-Brown,Hiawatha City Ward 4,President,,DEM,Clinton and Kaine,14,3,11,0
-Brown,Hiawatha City Ward 4,President,,LIB,Johnson and Weld,2,0,2,0
-Brown,Hiawatha City Ward 4,President,,IND,Stein and Baraka,2,0,2,0
-Brown,Hiawatha City Ward 4,President,,REP,Trump and Pence,49,8,41,0
-Brown,Hiawatha City Ward 4,President,,,Write-ins,2,0,2,0
-Brown,Hiawatha City Ward 4,President,,,Total,69,11,58,0
-Brown,Hiawatha City Ward 4,U.S. Senate,,LIB,Robert D. Garrard,6,0,6,0
-Brown,Hiawatha City Ward 4,U.S. Senate,,REP,Jerry Moran,47,8,39,0
-Brown,Hiawatha City Ward 4,U.S. Senate,,DEM,Patrick Wiesner,15,1,14,0
-Brown,Hiawatha City Ward 4,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 4,U.S. Senate,,,Total,68,9,59,0
-Brown,Hiawatha City Ward 4,U.S. House,2,LIB,James Houston Bales,4,0,4,0
-Brown,Hiawatha City Ward 4,U.S. House,2,REP,Lynn Jenkins,55,9,46,0
-Brown,Hiawatha City Ward 4,U.S. House,2,DEM,Britani Potter,10,2,8,0
-Brown,Hiawatha City Ward 4,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 4,U.S. House,2,,Total,69,11,58,0
-Brown,Hiawatha City Ward 4,State Senate,1,DEM,Jerry Henry,24,4,20,0
-Brown,Hiawatha City Ward 4,State Senate,1,REP,Dennis D. Pyle,44,7,37,0
-Brown,Hiawatha City Ward 4,State Senate,1,,Write-ins,0,0,0,0
-Brown,Hiawatha City Ward 4,State Senate,1,,Total,68,11,57,0
-Brown,Hiawatha City Ward 4,State House,62,REP,Randy Garber,67,10,57,0
-Brown,Hiawatha City Ward 4,State House,62,,Write-ins,1,0,1,0
-Brown,Hiawatha City Ward 4,State House,62,,Total,68,10,58,0
-Brown,Horton City Ward 1,President,,DEM,Clinton and Kaine,54,4,50,0
-Brown,Horton City Ward 1,President,,LIB,Johnson and Weld,9,0,9,0
-Brown,Horton City Ward 1,President,,IND,Stein and Baraka,4,0,4,0
-Brown,Horton City Ward 1,President,,REP,Trump and Pence,174,13,157,4
-Brown,Horton City Ward 1,President,,,Write-ins,2,1,1,0
-Brown,Horton City Ward 1,President,,,Total,243,18,221,4
-Brown,Horton City Ward 1,U.S. Senate,,LIB,Robert D. Garrard,11,3,8,0
-Brown,Horton City Ward 1,U.S. Senate,,REP,Jerry Moran,179,13,162,4
-Brown,Horton City Ward 1,U.S. Senate,,DEM,Patrick Wiesner,54,3,51,0
-Brown,Horton City Ward 1,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Horton City Ward 1,U.S. Senate,,,Total,244,19,221,4
-Brown,Horton City Ward 1,U.S. House,2,LIB,James Houston Bales,7,3,4,0
-Brown,Horton City Ward 1,U.S. House,2,REP,Lynn Jenkins,184,9,171,4
-Brown,Horton City Ward 1,U.S. House,2,DEM,Britani Potter,46,4,42,0
-Brown,Horton City Ward 1,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Horton City Ward 1,U.S. House,2,,Total,237,16,217,4
-Brown,Horton City Ward 1,State Senate,1,DEM,Jerry Henry,96,7,87,2
-Brown,Horton City Ward 1,State Senate,1,REP,Dennis D. Pyle,143,11,130,2
-Brown,Horton City Ward 1,State Senate,1,,Write-ins,0,0,0,0
-Brown,Horton City Ward 1,State Senate,1,,Total,239,18,217,4
-Brown,Horton City Ward 1,State House,62,REP,Randy Garber,209,16,189,4
-Brown,Horton City Ward 1,State House,62,,Write-ins,3,0,3,0
-Brown,Horton City Ward 1,State House,62,,Total,212,16,192,4
-Brown,Horton City Ward 2,President,,DEM,Clinton and Kaine,28,4,24,0
-Brown,Horton City Ward 2,President,,LIB,Johnson and Weld,4,0,4,0
-Brown,Horton City Ward 2,President,,IND,Stein and Baraka,4,1,3,0
-Brown,Horton City Ward 2,President,,REP,Trump and Pence,145,13,130,2
-Brown,Horton City Ward 2,President,,,Write-ins,2,1,1,0
-Brown,Horton City Ward 2,President,,,Total,183,19,162,2
-Brown,Horton City Ward 2,U.S. Senate,,LIB,Robert D. Garrard,5,1,4,0
-Brown,Horton City Ward 2,U.S. Senate,,REP,Jerry Moran,148,12,134,2
-Brown,Horton City Ward 2,U.S. Senate,,DEM,Patrick Wiesner,30,4,26,0
-Brown,Horton City Ward 2,U.S. Senate,,,Write-ins,1,1,0,0
-Brown,Horton City Ward 2,U.S. Senate,,,Total,184,18,164,2
-Brown,Horton City Ward 2,U.S. House,2,LIB,James Houston Bales,7,0,7,0
-Brown,Horton City Ward 2,U.S. House,2,REP,Lynn Jenkins,141,13,126,2
-Brown,Horton City Ward 2,U.S. House,2,DEM,Britani Potter,35,4,31,0
-Brown,Horton City Ward 2,U.S. House,2,,Write-ins,1,1,0,0
-Brown,Horton City Ward 2,U.S. House,2,,Total,184,18,164,2
-Brown,Horton City Ward 2,State Senate,1,DEM,Jerry Henry,63,8,55,0
-Brown,Horton City Ward 2,State Senate,1,REP,Dennis D. Pyle,119,10,107,2
-Brown,Horton City Ward 2,State Senate,1,,Write-ins,1,1,0,0
-Brown,Horton City Ward 2,State Senate,1,,Total,183,19,162,2
-Brown,Horton City Ward 2,State House,62,REP,Randy Garber,163,13,148,2
-Brown,Horton City Ward 2,State House,62,,Write-ins,1,1,0,0
-Brown,Horton City Ward 2,State House,62,,Total,164,14,148,2
-Brown,Horton City Ward 3,President,,DEM,Clinton and Kaine,26,3,21,2
-Brown,Horton City Ward 3,President,,LIB,Johnson and Weld,5,1,4,0
-Brown,Horton City Ward 3,President,,IND,Stein and Baraka,5,0,5,0
-Brown,Horton City Ward 3,President,,REP,Trump and Pence,88,12,71,5
-Brown,Horton City Ward 3,President,,,Write-ins,2,1,1,0
-Brown,Horton City Ward 3,President,,,Total,126,17,102,7
-Brown,Horton City Ward 3,U.S. Senate,,LIB,Robert D. Garrard,6,1,5,0
-Brown,Horton City Ward 3,U.S. Senate,,REP,Jerry Moran,84,12,69,3
-Brown,Horton City Ward 3,U.S. Senate,,DEM,Patrick Wiesner,34,4,27,3
-Brown,Horton City Ward 3,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Horton City Ward 3,U.S. Senate,,,Total,124,17,101,6
-Brown,Horton City Ward 3,U.S. House,2,LIB,James Houston Bales,8,2,6,0
-Brown,Horton City Ward 3,U.S. House,2,REP,Lynn Jenkins,87,13,71,3
-Brown,Horton City Ward 3,U.S. House,2,DEM,Britani Potter,27,2,22,3
-Brown,Horton City Ward 3,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Horton City Ward 3,U.S. House,2,,Total,122,17,99,6
-Brown,Horton City Ward 3,State Senate,1,DEM,Jerry Henry,43,4,36,3
-Brown,Horton City Ward 3,State Senate,1,REP,Dennis D. Pyle,78,13,62,3
-Brown,Horton City Ward 3,State Senate,1,,Write-ins,1,0,1,0
-Brown,Horton City Ward 3,State Senate,1,,Total,122,17,99,6
-Brown,Horton City Ward 3,State House,62,REP,Randy Garber,110,16,88,6
-Brown,Horton City Ward 3,State House,62,,Write-ins,3,0,3,0
-Brown,Horton City Ward 3,State House,62,,Total,113,16,91,6
-Brown,Reserve,President,,DEM,Clinton and Kaine,11,2,9,0
-Brown,Reserve,President,,LIB,Johnson and Weld,0,0,0,0
-Brown,Reserve,President,,IND,Stein and Baraka,5,2,3,0
-Brown,Reserve,President,,REP,Trump and Pence,48,7,41,0
-Brown,Reserve,President,,,Write-ins,0,0,0,0
-Brown,Reserve,President,,,Total,64,11,53,0
-Brown,Reserve,U.S. Senate,,LIB,Robert D. Garrard,4,0,4,0
-Brown,Reserve,U.S. Senate,,REP,Jerry Moran,48,8,40,0
-Brown,Reserve,U.S. Senate,,DEM,Patrick Wiesner,10,3,7,0
-Brown,Reserve,U.S. Senate,,,Write-ins,1,0,1,0
-Brown,Reserve,U.S. Senate,,,Total,63,11,52,0
-Brown,Reserve,U.S. House,2,LIB,James Houston Bales,4,0,4,0
-Brown,Reserve,U.S. House,2,REP,Lynn Jenkins,49,8,41,0
-Brown,Reserve,U.S. House,2,DEM,Britani Potter,13,4,9,0
-Brown,Reserve,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Reserve,U.S. House,2,,Total,66,12,54,0
-Brown,Reserve,State Senate,1,DEM,Jerry Henry,21,5,16,0
-Brown,Reserve,State Senate,1,REP,Dennis D. Pyle,45,8,37,0
-Brown,Reserve,State Senate,1,,Write-ins,0,0,0,0
-Brown,Reserve,State Senate,1,,Total,66,13,53,0
-Brown,Reserve,State House,62,REP,Randy Garber,57,10,47,0
-Brown,Reserve,State House,62,,Write-ins,2,1,1,0
-Brown,Reserve,State House,62,,Total,59,11,48,0
-Brown,Hamlin,President,,DEM,Clinton and Kaine,12,1,11,0
-Brown,Hamlin,President,,LIB,Johnson and Weld,0,0,0,0
-Brown,Hamlin,President,,IND,Stein and Baraka,1,0,1,0
-Brown,Hamlin,President,,REP,Trump and Pence,73,21,52,0
-Brown,Hamlin,President,,,Write-ins,1,0,1,0
-Brown,Hamlin,President,,,Total,87,22,65,0
-Brown,Hamlin,U.S. Senate,,LIB,Robert D. Garrard,1,0,1,0
-Brown,Hamlin,U.S. Senate,,REP,Jerry Moran,77,21,56,0
-Brown,Hamlin,U.S. Senate,,DEM,Patrick Wiesner,9,1,8,0
-Brown,Hamlin,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Hamlin,U.S. Senate,,,Total,87,22,65,0
-Brown,Hamlin,U.S. House,2,LIB,James Houston Bales,3,1,2,0
-Brown,Hamlin,U.S. House,2,REP,Lynn Jenkins,73,20,53,0
-Brown,Hamlin,U.S. House,2,DEM,Britani Potter,10,1,9,0
-Brown,Hamlin,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Hamlin,U.S. House,2,,Total,86,22,64,0
-Brown,Hamlin,State Senate,1,DEM,Jerry Henry,36,6,30,0
-Brown,Hamlin,State Senate,1,REP,Dennis D. Pyle,50,16,34,0
-Brown,Hamlin,State Senate,1,,Write-ins,0,0,0,0
-Brown,Hamlin,State Senate,1,,Total,86,22,64,0
-Brown,Hamlin,State House,62,REP,Randy Garber,80,21,59,0
-Brown,Hamlin,State House,62,,Write-ins,2,0,2,0
-Brown,Hamlin,State House,62,,Total,82,21,61,0
-Brown,Hiawatha Township,President,,DEM,Clinton and Kaine,46,10,34,2
-Brown,Hiawatha Township,President,,LIB,Johnson and Weld,7,1,6,0
-Brown,Hiawatha Township,President,,IND,Stein and Baraka,2,0,2,0
-Brown,Hiawatha Township,President,,REP,Trump and Pence,271,54,213,4
-Brown,Hiawatha Township,President,,,Write-ins,5,2,3,0
-Brown,Hiawatha Township,President,,,Total,331,67,258,6
-Brown,Hiawatha Township,U.S. Senate,,LIB,Robert D. Garrard,16,1,15,0
-Brown,Hiawatha Township,U.S. Senate,,REP,Jerry Moran,274,58,212,4
-Brown,Hiawatha Township,U.S. Senate,,DEM,Patrick Wiesner,35,6,27,2
-Brown,Hiawatha Township,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Hiawatha Township,U.S. Senate,,,Total,325,65,254,6
-Brown,Hiawatha Township,U.S. House,2,LIB,James Houston Bales,17,2,15,0
-Brown,Hiawatha Township,U.S. House,2,REP,Lynn Jenkins,264,56,204,4
-Brown,Hiawatha Township,U.S. House,2,DEM,Britani Potter,45,8,35,2
-Brown,Hiawatha Township,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Hiawatha Township,U.S. House,2,,Total,326,66,254,6
-Brown,Hiawatha Township,State Senate,1,DEM,Jerry Henry,149,33,111,5
-Brown,Hiawatha Township,State Senate,1,REP,Dennis D. Pyle,177,34,142,1
-Brown,Hiawatha Township,State Senate,1,,Write-ins,2,0,2,0
-Brown,Hiawatha Township,State Senate,1,,Total,328,67,255,6
-Brown,Hiawatha Township,State House,62,REP,Randy Garber,289,60,223,6
-Brown,Hiawatha Township,State House,62,,Write-ins,5,1,4,0
-Brown,Hiawatha Township,State House,62,,Total,294,61,227,6
-Brown,Irving,President,,DEM,Clinton and Kaine,27,6,21,0
-Brown,Irving,President,,LIB,Johnson and Weld,4,1,3,0
-Brown,Irving,President,,IND,Stein and Baraka,2,1,1,0
-Brown,Irving,President,,REP,Trump and Pence,103,16,87,0
-Brown,Irving,President,,,Write-ins,0,0,0,0
-Brown,Irving,President,,,Total,136,24,112,0
-Brown,Irving,U.S. Senate,,LIB,Robert D. Garrard,4,0,4,0
-Brown,Irving,U.S. Senate,,REP,Jerry Moran,103,17,86,0
-Brown,Irving,U.S. Senate,,DEM,Patrick Wiesner,26,7,19,0
-Brown,Irving,U.S. Senate,,,Write-ins,1,0,1,0
-Brown,Irving,U.S. Senate,,,Total,134,24,110,0
-Brown,Irving,U.S. House,2,LIB,James Houston Bales,4,0,4,0
-Brown,Irving,U.S. House,2,REP,Lynn Jenkins,106,17,89,0
-Brown,Irving,U.S. House,2,DEM,Britani Potter,22,7,15,0
-Brown,Irving,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Irving,U.S. House,2,,Total,132,24,108,0
-Brown,Irving,State Senate,1,DEM,Jerry Henry,53,12,41,0
-Brown,Irving,State Senate,1,REP,Dennis D. Pyle,78,12,66,0
-Brown,Irving,State Senate,1,,Write-ins,0,0,0,0
-Brown,Irving,State Senate,1,,Total,131,24,107,0
-Brown,Irving,State House,62,REP,Randy Garber,120,21,99,0
-Brown,Irving,State House,62,,Write-ins,3,1,2,0
-Brown,Irving,State House,62,,Total,123,22,101,0
-Brown,Mission,President,,DEM,Clinton and Kaine,44,13,31,0
-Brown,Mission,President,,LIB,Johnson and Weld,10,4,6,0
-Brown,Mission,President,,IND,Stein and Baraka,6,0,6,0
-Brown,Mission,President,,REP,Trump and Pence,257,51,204,2
-Brown,Mission,President,,,Write-ins,2,0,1,1
-Brown,Mission,President,,,Total,319,68,248,3
-Brown,Mission,U.S. Senate,,LIB,Robert D. Garrard,9,2,7,0
-Brown,Mission,U.S. Senate,,REP,Jerry Moran,265,55,209,1
-Brown,Mission,U.S. Senate,,DEM,Patrick Wiesner,44,13,30,1
-Brown,Mission,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Mission,U.S. Senate,,,Total,318,70,246,2
-Brown,Mission,U.S. House,2,LIB,James Houston Bales,10,2,7,1
-Brown,Mission,U.S. House,2,REP,Lynn Jenkins,261,55,204,2
-Brown,Mission,U.S. House,2,DEM,Britani Potter,47,11,36,0
-Brown,Mission,U.S. House,2,,Write-ins,1,0,1,0
-Brown,Mission,U.S. House,2,,Total,319,68,248,3
-Brown,Mission,State Senate,1,DEM,Jerry Henry,153,33,119,1
-Brown,Mission,State Senate,1,REP,Dennis D. Pyle,160,36,122,2
-Brown,Mission,State Senate,1,,Write-ins,3,1,2,0
-Brown,Mission,State Senate,1,,Total,316,70,243,3
-Brown,Mission,State House,62,REP,Randy Garber,271,56,213,2
-Brown,Mission,State House,62,,Write-ins,12,2,10,0
-Brown,Mission,State House,62,,Total,283,58,223,2
-Brown,Morrill,President,,DEM,Clinton and Kaine,24,4,20,0
-Brown,Morrill,President,,LIB,Johnson and Weld,5,2,3,0
-Brown,Morrill,President,,IND,Stein and Baraka,7,1,6,0
-Brown,Morrill,President,,REP,Trump and Pence,177,37,139,1
-Brown,Morrill,President,,,Write-ins,9,1,8,0
-Brown,Morrill,President,,,Total,222,45,176,1
-Brown,Morrill,U.S. Senate,,LIB,Robert D. Garrard,12,5,7,0
-Brown,Morrill,U.S. Senate,,REP,Jerry Moran,192,37,155,0
-Brown,Morrill,U.S. Senate,,DEM,Patrick Wiesner,21,5,15,1
-Brown,Morrill,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Morrill,U.S. Senate,,,Total,225,47,177,1
-Brown,Morrill,U.S. House,2,LIB,James Houston Bales,15,4,11,0
-Brown,Morrill,U.S. House,2,REP,Lynn Jenkins,192,37,154,1
-Brown,Morrill,U.S. House,2,DEM,Britani Potter,20,6,14,0
-Brown,Morrill,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Morrill,U.S. House,2,,Total,227,47,179,1
-Brown,Morrill,State Senate,1,DEM,Jerry Henry,62,13,49,0
-Brown,Morrill,State Senate,1,REP,Dennis D. Pyle,164,34,129,1
-Brown,Morrill,State Senate,1,,Write-ins,0,0,0,0
-Brown,Morrill,State Senate,1,,Total,226,47,178,1
-Brown,Morrill,State House,62,REP,Randy Garber,192,41,150,1
-Brown,Morrill,State House,62,,Write-ins,13,4,9,0
-Brown,Morrill,State House,62,,Total,205,45,159,1
-Brown,Padonia,President,,DEM,Clinton and Kaine,18,2,16,0
-Brown,Padonia,President,,LIB,Johnson and Weld,13,4,9,0
-Brown,Padonia,President,,IND,Stein and Baraka,2,0,2,0
-Brown,Padonia,President,,REP,Trump and Pence,62,22,39,1
-Brown,Padonia,President,,,Write-ins,1,1,0,0
-Brown,Padonia,President,,,Total,96,29,66,1
-Brown,Padonia,U.S. Senate,,LIB,Robert D. Garrard,7,3,4,0
-Brown,Padonia,U.S. Senate,,REP,Jerry Moran,77,25,51,1
-Brown,Padonia,U.S. Senate,,DEM,Patrick Wiesner,13,1,12,0
-Brown,Padonia,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Padonia,U.S. Senate,,,Total,97,29,67,1
-Brown,Padonia,U.S. House,2,LIB,James Houston Bales,5,3,2,0
-Brown,Padonia,U.S. House,2,REP,Lynn Jenkins,80,24,56,0
-Brown,Padonia,U.S. House,2,DEM,Britani Potter,12,2,9,1
-Brown,Padonia,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Padonia,U.S. House,2,,Total,97,29,67,1
-Brown,Padonia,State Senate,1,DEM,Jerry Henry,44,13,30,1
-Brown,Padonia,State Senate,1,REP,Dennis D. Pyle,51,15,36,0
-Brown,Padonia,State Senate,1,,Write-ins,0,0,0,0
-Brown,Padonia,State Senate,1,,Total,95,28,66,1
-Brown,Padonia,State House,62,REP,Randy Garber,83,23,59,1
-Brown,Padonia,State House,62,,Write-ins,1,1,0,0
-Brown,Padonia,State House,62,,Total,84,24,59,1
-Brown,Powhattan,President,,DEM,Clinton and Kaine,101,11,87,3
-Brown,Powhattan,President,,LIB,Johnson and Weld,6,1,5,0
-Brown,Powhattan,President,,IND,Stein and Baraka,10,1,9,0
-Brown,Powhattan,President,,REP,Trump and Pence,139,9,129,1
-Brown,Powhattan,President,,,Write-ins,4,2,2,0
-Brown,Powhattan,President,,,Total,260,24,232,4
-Brown,Powhattan,U.S. Senate,,LIB,Robert D. Garrard,13,0,13,0
-Brown,Powhattan,U.S. Senate,,REP,Jerry Moran,156,18,136,2
-Brown,Powhattan,U.S. Senate,,DEM,Patrick Wiesner,88,5,82,1
-Brown,Powhattan,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Powhattan,U.S. Senate,,,Total,257,23,231,3
-Brown,Powhattan,U.S. House,2,LIB,James Houston Bales,22,1,21,0
-Brown,Powhattan,U.S. House,2,REP,Lynn Jenkins,160,16,141,3
-Brown,Powhattan,U.S. House,2,DEM,Britani Potter,76,5,70,1
-Brown,Powhattan,U.S. House,2,,Write-ins,1,0,1,0
-Brown,Powhattan,U.S. House,2,,Total,259,22,233,4
-Brown,Powhattan,State Senate,1,DEM,Jerry Henry,124,10,112,2
-Brown,Powhattan,State Senate,1,REP,Dennis D. Pyle,133,13,119,1
-Brown,Powhattan,State Senate,1,,Write-ins,1,0,1,0
-Brown,Powhattan,State Senate,1,,Total,258,23,232,3
-Brown,Powhattan,State House,62,REP,Randy Garber,199,19,177,3
-Brown,Powhattan,State House,62,,Write-ins,11,0,11,0
-Brown,Powhattan,State House,62,,Total,210,19,188,3
-Brown,Robinson,President,,DEM,Clinton and Kaine,39,11,28,0
-Brown,Robinson,President,,LIB,Johnson and Weld,14,3,11,0
-Brown,Robinson,President,,IND,Stein and Baraka,2,0,2,0
-Brown,Robinson,President,,REP,Trump and Pence,137,18,115,4
-Brown,Robinson,President,,,Write-ins,4,0,4,0
-Brown,Robinson,President,,,Total,196,32,160,4
-Brown,Robinson,U.S. Senate,,LIB,Robert D. Garrard,14,0,14,0
-Brown,Robinson,U.S. Senate,,REP,Jerry Moran,140,23,113,4
-Brown,Robinson,U.S. Senate,,DEM,Patrick Wiesner,38,9,29,0
-Brown,Robinson,U.S. Senate,,,Write-ins,1,0,1,0
-Brown,Robinson,U.S. Senate,,,Total,193,32,157,4
-Brown,Robinson,U.S. House,2,LIB,James Houston Bales,12,1,10,1
-Brown,Robinson,U.S. House,2,REP,Lynn Jenkins,145,21,121,3
-Brown,Robinson,U.S. House,2,DEM,Britani Potter,37,10,27,0
-Brown,Robinson,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Robinson,U.S. House,2,,Total,194,32,158,4
-Brown,Robinson,State Senate,1,DEM,Jerry Henry,77,15,60,2
-Brown,Robinson,State Senate,1,REP,Dennis D. Pyle,115,16,97,2
-Brown,Robinson,State Senate,1,,Write-ins,0,0,0,0
-Brown,Robinson,State Senate,1,,Total,192,31,157,4
-Brown,Robinson,State House,62,REP,Randy Garber,165,24,137,4
-Brown,Robinson,State House,62,,Write-ins,4,0,4,0
-Brown,Robinson,State House,62,,Total,169,24,141,4
-Brown,Walnut,President,,DEM,Clinton and Kaine,47,3,44,0
-Brown,Walnut,President,,LIB,Johnson and Weld,7,0,6,1
-Brown,Walnut,President,,IND,Stein and Baraka,3,0,3,0
-Brown,Walnut,President,,REP,Trump and Pence,221,28,189,4
-Brown,Walnut,President,,,Write-ins,10,1,9,0
-Brown,Walnut,President,,,Total,288,32,251,5
-Brown,Walnut,U.S. Senate,,LIB,Robert D. Garrard,12,1,11,0
-Brown,Walnut,U.S. Senate,,REP,Jerry Moran,239,28,207,4
-Brown,Walnut,U.S. Senate,,DEM,Patrick Wiesner,37,5,32,0
-Brown,Walnut,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Walnut,U.S. Senate,,,Total,288,34,250,4
-Brown,Walnut,U.S. House,2,LIB,James Houston Bales,14,2,12,0
-Brown,Walnut,U.S. House,2,REP,Lynn Jenkins,232,28,200,4
-Brown,Walnut,U.S. House,2,DEM,Britani Potter,45,4,40,1
-Brown,Walnut,U.S. House,2,,Write-ins,0,0,0,0
-Brown,Walnut,U.S. House,2,,Total,291,34,252,5
-Brown,Walnut,State Senate,1,DEM,Jerry Henry,124,15,108,1
-Brown,Walnut,State Senate,1,REP,Dennis D. Pyle,163,19,140,4
-Brown,Walnut,State Senate,1,,Write-ins,0,0,0,0
-Brown,Walnut,State Senate,1,,Total,287,34,248,5
-Brown,Walnut,State House,62,REP,Randy Garber,237,29,203,5
-Brown,Walnut,State House,62,,Write-ins,14,0,14,0
-Brown,Walnut,State House,62,,Total,251,29,217,5
-Brown,Washington,President,,DEM,Clinton and Kaine,37,12,24,1
-Brown,Washington,President,,LIB,Johnson and Weld,10,1,8,1
-Brown,Washington,President,,IND,Stein and Baraka,2,0,2,0
-Brown,Washington,President,,REP,Trump and Pence,191,44,144,3
-Brown,Washington,President,,,Write-ins,1,0,1,0
-Brown,Washington,President,,,Total,241,57,179,5
-Brown,Washington,U.S. Senate,,LIB,Robert D. Garrard,8,1,7,0
-Brown,Washington,U.S. Senate,,REP,Jerry Moran,197,46,148,3
-Brown,Washington,U.S. Senate,,DEM,Patrick Wiesner,33,7,24,2
-Brown,Washington,U.S. Senate,,,Write-ins,0,0,0,0
-Brown,Washington,U.S. Senate,,,Total,238,54,179,5
-Brown,Washington,U.S. House,2,LIB,James Houston Bales,11,3,8,0
-Brown,Washington,U.S. House,2,REP,Lynn Jenkins,190,39,149,2
-Brown,Washington,U.S. House,2,DEM,Britani Potter,34,12,20,2
-Brown,Washington,U.S. House,2,,Write-ins,1,1,0,0
-Brown,Washington,U.S. House,2,,Total,236,55,177,4
-Brown,Washington,State Senate,1,DEM,Jerry Henry,127,32,91,4
-Brown,Washington,State Senate,1,REP,Dennis D. Pyle,109,23,85,1
-Brown,Washington,State Senate,1,,Write-ins,1,0,1,0
-Brown,Washington,State Senate,1,,Total,237,55,177,5
-Brown,Washington,State House,62,REP,Randy Garber,208,41,163,4
-Brown,Washington,State House,62,,Write-ins,4,2,2,0
-Brown,Washington,State House,62,,Total,212,43,165,4
+county,precinct,office,district,party,candidate,votes,vtd
+BROWN,Hamlin Township,Kansas House of Representatives,62,Republican,"Garber, Randy",80,000010
+BROWN,Hiawatha City Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",148,000020
+BROWN,Hiawatha City Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",465,000030
+BROWN,Hiawatha City Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",404,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00004B
+BROWN,Hiawatha City Ward 4,Kansas House of Representatives,62,Republican,"Garber, Randy",67,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00005B
+BROWN,Hiawatha Township,Kansas House of Representatives,62,Republican,"Garber, Randy",289,000060
+BROWN,Horton Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",209,000070
+BROWN,Horton Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",163,000080
+BROWN,Horton Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",110,00009A
+BROWN,Horton Ward 3 Exclave A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00009B
+BROWN,Horton Ward 3 Exclave B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00009C
+BROWN,Irving Township,Kansas House of Representatives,62,Republican,"Garber, Randy",120,000100
+BROWN,Mission Township,Kansas House of Representatives,62,Republican,"Garber, Randy",271,000110
+BROWN,Morrill Township,Kansas House of Representatives,62,Republican,"Garber, Randy",192,000120
+BROWN,Padonia Township,Kansas House of Representatives,62,Republican,"Garber, Randy",83,000130
+BROWN,Powhattan Township,Kansas House of Representatives,62,Republican,"Garber, Randy",199,000140
+BROWN,Reserve Township,Kansas House of Representatives,62,Republican,"Garber, Randy",57,000150
+BROWN,Robinson Township,Kansas House of Representatives,62,Republican,"Garber, Randy",165,000160
+BROWN,Sabetha Ward 1 Part A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00017A
+BROWN,Sabetha Ward 1 Part B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00017B
+BROWN,Sabetha Ward 4 Part A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00018A
+BROWN,Sabetha Ward 4 Part B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00018B
+BROWN,Sabetha Ward 5,Kansas House of Representatives,62,Republican,"Garber, Randy",0,000190
+BROWN,Walnut Township,Kansas House of Representatives,62,Republican,"Garber, Randy",237,000200
+BROWN,Washington Township,Kansas House of Representatives,62,Republican,"Garber, Randy",208,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900010
+BROWN,Hamlin Township,Kansas Senate,1,Democratic,"Henry, Jerry",36,000010
+BROWN,Hamlin Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",50,000010
+BROWN,Hiawatha City Ward 1,Kansas Senate,1,Democratic,"Henry, Jerry",89,000020
+BROWN,Hiawatha City Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",83,000020
+BROWN,Hiawatha City Ward 2,Kansas Senate,1,Democratic,"Henry, Jerry",311,000030
+BROWN,Hiawatha City Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",246,000030
+BROWN,Hiawatha City Ward 3,Kansas Senate,1,Democratic,"Henry, Jerry",217,00004A
+BROWN,Hiawatha City Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",254,00004A
+BROWN,Hiawatha City Ward 3 Exclave,Kansas Senate,1,Democratic,"Henry, Jerry",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00004B
+BROWN,Hiawatha City Ward 4,Kansas Senate,1,Democratic,"Henry, Jerry",24,00005A
+BROWN,Hiawatha City Ward 4,Kansas Senate,1,Republican,"Pyle, Dennis D.",44,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas Senate,1,Democratic,"Henry, Jerry",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00005B
+BROWN,Hiawatha Township,Kansas Senate,1,Democratic,"Henry, Jerry",149,000060
+BROWN,Hiawatha Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",177,000060
+BROWN,Horton Ward 1,Kansas Senate,1,Democratic,"Henry, Jerry",96,000070
+BROWN,Horton Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",143,000070
+BROWN,Horton Ward 2,Kansas Senate,1,Democratic,"Henry, Jerry",63,000080
+BROWN,Horton Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",119,000080
+BROWN,Horton Ward 3,Kansas Senate,1,Democratic,"Henry, Jerry",43,00009A
+BROWN,Horton Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",78,00009A
+BROWN,Horton Ward 3 Exclave A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00009B
+BROWN,Horton Ward 3 Exclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00009B
+BROWN,Horton Ward 3 Exclave B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00009C
+BROWN,Horton Ward 3 Exclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00009C
+BROWN,Irving Township,Kansas Senate,1,Democratic,"Henry, Jerry",53,000100
+BROWN,Irving Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",78,000100
+BROWN,Mission Township,Kansas Senate,1,Democratic,"Henry, Jerry",153,000110
+BROWN,Mission Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",160,000110
+BROWN,Morrill Township,Kansas Senate,1,Democratic,"Henry, Jerry",62,000120
+BROWN,Morrill Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",164,000120
+BROWN,Padonia Township,Kansas Senate,1,Democratic,"Henry, Jerry",44,000130
+BROWN,Padonia Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",51,000130
+BROWN,Powhattan Township,Kansas Senate,1,Democratic,"Henry, Jerry",124,000140
+BROWN,Powhattan Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",133,000140
+BROWN,Reserve Township,Kansas Senate,1,Democratic,"Henry, Jerry",21,000150
+BROWN,Reserve Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",45,000150
+BROWN,Robinson Township,Kansas Senate,1,Democratic,"Henry, Jerry",77,000160
+BROWN,Robinson Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",115,000160
+BROWN,Sabetha Ward 1 Part A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00017A
+BROWN,Sabetha Ward 1 Part A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00017A
+BROWN,Sabetha Ward 1 Part B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00017B
+BROWN,Sabetha Ward 1 Part B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00017B
+BROWN,Sabetha Ward 4 Part A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00018A
+BROWN,Sabetha Ward 4 Part A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00018A
+BROWN,Sabetha Ward 4 Part B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00018B
+BROWN,Sabetha Ward 4 Part B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00018B
+BROWN,Sabetha Ward 5,Kansas Senate,1,Democratic,"Henry, Jerry",0,000190
+BROWN,Sabetha Ward 5,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,000190
+BROWN,Walnut Township,Kansas Senate,1,Democratic,"Henry, Jerry",124,000200
+BROWN,Walnut Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",163,000200
+BROWN,Washington Township,Kansas Senate,1,Democratic,"Henry, Jerry",127,000210
+BROWN,Washington Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",109,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas Senate,1,Democratic,"Henry, Jerry",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900010
+BROWN,Hamlin Township,President / Vice President,,independent,"Stein, Jill",1,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+BROWN,Hamlin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+BROWN,Hamlin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000010
+BROWN,Hamlin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+BROWN,Hamlin Township,President / Vice President,,Republican,"Trump, Donald J.",73,000010
+BROWN,Hiawatha City Ward 1,President / Vice President,,independent,"Stein, Jill",5,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000020
+BROWN,Hiawatha City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",102,000020
+BROWN,Hiawatha City Ward 2,President / Vice President,,independent,"Stein, Jill",10,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",165,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",27,000030
+BROWN,Hiawatha City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",366,000030
+BROWN,Hiawatha City Ward 3,President / Vice President,,independent,"Stein, Jill",25,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",23,00004A
+BROWN,Hiawatha City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",303,00004A
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00004B
+BROWN,Hiawatha City Ward 4,President / Vice President,,independent,"Stein, Jill",2,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",2,00005A
+BROWN,Hiawatha City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",49,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,independent,"Stein, Jill",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Hedges, James A",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Smith, Mike",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+BROWN,Hiawatha Township,President / Vice President,,independent,"Stein, Jill",2,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+BROWN,Hiawatha Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+BROWN,Hiawatha Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",46,000060
+BROWN,Hiawatha Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+BROWN,Hiawatha Township,President / Vice President,,Republican,"Trump, Donald J.",271,000060
+BROWN,Horton Ward 1,President / Vice President,,independent,"Stein, Jill",4,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+BROWN,Horton Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+BROWN,Horton Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000070
+BROWN,Horton Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000070
+BROWN,Horton Ward 1,President / Vice President,,Republican,"Trump, Donald J.",174,000070
+BROWN,Horton Ward 2,President / Vice President,,independent,"Stein, Jill",4,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+BROWN,Horton Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+BROWN,Horton Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000080
+BROWN,Horton Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+BROWN,Horton Ward 2,President / Vice President,,Republican,"Trump, Donald J.",145,000080
+BROWN,Horton Ward 3,President / Vice President,,independent,"Stein, Jill",5,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009A
+BROWN,Horton Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,00009A
+BROWN,Horton Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,00009A
+BROWN,Horton Ward 3,President / Vice President,,Republican,"Trump, Donald J.",88,00009A
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+BROWN,Horton Ward 3 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00009B
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00009C
+BROWN,Horton Ward 3 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00009C
+BROWN,Irving Township,President / Vice President,,independent,"Stein, Jill",2,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+BROWN,Irving Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+BROWN,Irving Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000100
+BROWN,Irving Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+BROWN,Irving Township,President / Vice President,,Republican,"Trump, Donald J.",103,000100
+BROWN,Mission Township,President / Vice President,,independent,"Stein, Jill",6,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+BROWN,Mission Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+BROWN,Mission Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000110
+BROWN,Mission Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000110
+BROWN,Mission Township,President / Vice President,,Republican,"Trump, Donald J.",257,000110
+BROWN,Morrill Township,President / Vice President,,independent,"Stein, Jill",7,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Castle, Darrell L",2,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"McMullin, Evan",1,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+BROWN,Morrill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+BROWN,Morrill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000120
+BROWN,Morrill Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+BROWN,Morrill Township,President / Vice President,,Republican,"Trump, Donald J.",177,000120
+BROWN,Padonia Township,President / Vice President,,independent,"Stein, Jill",2,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+BROWN,Padonia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+BROWN,Padonia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000130
+BROWN,Padonia Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+BROWN,Padonia Township,President / Vice President,,Republican,"Trump, Donald J.",62,000130
+BROWN,Powhattan Township,President / Vice President,,independent,"Stein, Jill",10,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+BROWN,Powhattan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+BROWN,Powhattan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000140
+BROWN,Powhattan Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+BROWN,Powhattan Township,President / Vice President,,Republican,"Trump, Donald J.",139,000140
+BROWN,Reserve Township,President / Vice President,,independent,"Stein, Jill",5,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+BROWN,Reserve Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+BROWN,Reserve Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000150
+BROWN,Reserve Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+BROWN,Reserve Township,President / Vice President,,Republican,"Trump, Donald J.",48,000150
+BROWN,Robinson Township,President / Vice President,,independent,"Stein, Jill",2,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+BROWN,Robinson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+BROWN,Robinson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,000160
+BROWN,Robinson Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000160
+BROWN,Robinson Township,President / Vice President,,Republican,"Trump, Donald J.",137,000160
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,independent,"Stein, Jill",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Hedges, James A",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Smith, Mike",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00017A
+BROWN,Sabetha Ward 1 Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00017A
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,independent,"Stein, Jill",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Hedges, James A",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"McMullin, Evan",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Perry, Darryl",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Smith, Mike",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Sood, Ajay",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+BROWN,Sabetha Ward 1 Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00017B
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,independent,"Stein, Jill",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Hedges, James A",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Smith, Mike",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018A
+BROWN,Sabetha Ward 4 Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00018A
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,independent,"Stein, Jill",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Hedges, James A",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"McMullin, Evan",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Perry, Darryl",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Smith, Mike",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Sood, Ajay",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+BROWN,Sabetha Ward 4 Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00018B
+BROWN,Sabetha Ward 5,President / Vice President,,independent,"Stein, Jill",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Hedges, James A",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Smith, Mike",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+BROWN,Sabetha Ward 5,President / Vice President,,Republican,"Trump, Donald J.",0,000190
+BROWN,Walnut Township,President / Vice President,,independent,"Stein, Jill",3,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",7,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+BROWN,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+BROWN,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,000200
+BROWN,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000200
+BROWN,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",221,000200
+BROWN,Washington Township,President / Vice President,,independent,"Stein, Jill",2,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+BROWN,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+BROWN,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000210
+BROWN,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000210
+BROWN,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",191,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+BROWN,Hamlin Township,United States House of Representatives,2,Democratic,"Potter, Britani",10,000010
+BROWN,Hamlin Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000010
+BROWN,Hamlin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000010
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",32,000020
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000020
+BROWN,Hiawatha City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",129,000020
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",131,000030
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",29,000030
+BROWN,Hiawatha City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",408,000030
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",97,00004A
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,00004A
+BROWN,Hiawatha City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",354,00004A
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",10,00005A
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,00005A
+BROWN,Hiawatha City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",55,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+BROWN,Hiawatha Township,United States House of Representatives,2,Democratic,"Potter, Britani",45,000060
+BROWN,Hiawatha Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000060
+BROWN,Hiawatha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",264,000060
+BROWN,Horton Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",46,000070
+BROWN,Horton Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000070
+BROWN,Horton Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",184,000070
+BROWN,Horton Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",35,000080
+BROWN,Horton Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000080
+BROWN,Horton Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",141,000080
+BROWN,Horton Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",27,00009A
+BROWN,Horton Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,00009A
+BROWN,Horton Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,00009A
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00009B
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00009C
+BROWN,Irving Township,United States House of Representatives,2,Democratic,"Potter, Britani",22,000100
+BROWN,Irving Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000100
+BROWN,Irving Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000100
+BROWN,Mission Township,United States House of Representatives,2,Democratic,"Potter, Britani",47,000110
+BROWN,Mission Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000110
+BROWN,Mission Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",261,000110
+BROWN,Morrill Township,United States House of Representatives,2,Democratic,"Potter, Britani",20,000120
+BROWN,Morrill Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000120
+BROWN,Morrill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",192,000120
+BROWN,Padonia Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000130
+BROWN,Padonia Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000130
+BROWN,Padonia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000130
+BROWN,Powhattan Township,United States House of Representatives,2,Democratic,"Potter, Britani",76,000140
+BROWN,Powhattan Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000140
+BROWN,Powhattan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",160,000140
+BROWN,Reserve Township,United States House of Representatives,2,Democratic,"Potter, Britani",13,000150
+BROWN,Reserve Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000150
+BROWN,Reserve Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000150
+BROWN,Robinson Township,United States House of Representatives,2,Democratic,"Potter, Britani",37,000160
+BROWN,Robinson Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000160
+BROWN,Robinson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,000160
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017A
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018A
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Democratic,"Potter, Britani",0,000190
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000190
+BROWN,Sabetha Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000190
+BROWN,Walnut Township,United States House of Representatives,2,Democratic,"Potter, Britani",45,000200
+BROWN,Walnut Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000200
+BROWN,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,000200
+BROWN,Washington Township,United States House of Representatives,2,Democratic,"Potter, Britani",34,000210
+BROWN,Washington Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000210
+BROWN,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",190,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+BROWN,Hamlin Township,United States Senate,,write - in,"Smith, DJ",0,000010
+BROWN,Hamlin Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000010
+BROWN,Hamlin Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+BROWN,Hamlin Township,United States Senate,,Republican,"Moran, Jerry",77,000010
+BROWN,Hiawatha City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000020
+BROWN,Hiawatha City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",38,000020
+BROWN,Hiawatha City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",13,000020
+BROWN,Hiawatha City Ward 1,United States Senate,,Republican,"Moran, Jerry",117,000020
+BROWN,Hiawatha City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000030
+BROWN,Hiawatha City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",130,000030
+BROWN,Hiawatha City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,000030
+BROWN,Hiawatha City Ward 2,United States Senate,,Republican,"Moran, Jerry",420,000030
+BROWN,Hiawatha City Ward 3,United States Senate,,write - in,"Smith, DJ",0,00004A
+BROWN,Hiawatha City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",96,00004A
+BROWN,Hiawatha City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",33,00004A
+BROWN,Hiawatha City Ward 3,United States Senate,,Republican,"Moran, Jerry",342,00004A
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004B
+BROWN,Hiawatha City Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00004B
+BROWN,Hiawatha City Ward 4,United States Senate,,write - in,"Smith, DJ",0,00005A
+BROWN,Hiawatha City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",15,00005A
+BROWN,Hiawatha City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",6,00005A
+BROWN,Hiawatha City Ward 4,United States Senate,,Republican,"Moran, Jerry",47,00005A
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,write - in,"Smith, DJ",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+BROWN,Hiawatha City Ward 4 Exclave Club,United States Senate,,Republican,"Moran, Jerry",0,00005B
+BROWN,Hiawatha Township,United States Senate,,write - in,"Smith, DJ",0,000060
+BROWN,Hiawatha Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000060
+BROWN,Hiawatha Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000060
+BROWN,Hiawatha Township,United States Senate,,Republican,"Moran, Jerry",274,000060
+BROWN,Horton Ward 1,United States Senate,,write - in,"Smith, DJ",0,000070
+BROWN,Horton Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",54,000070
+BROWN,Horton Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000070
+BROWN,Horton Ward 1,United States Senate,,Republican,"Moran, Jerry",179,000070
+BROWN,Horton Ward 2,United States Senate,,write - in,"Smith, DJ",0,000080
+BROWN,Horton Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",30,000080
+BROWN,Horton Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",5,000080
+BROWN,Horton Ward 2,United States Senate,,Republican,"Moran, Jerry",148,000080
+BROWN,Horton Ward 3,United States Senate,,write - in,"Smith, DJ",0,00009A
+BROWN,Horton Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",34,00009A
+BROWN,Horton Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",6,00009A
+BROWN,Horton Ward 3,United States Senate,,Republican,"Moran, Jerry",84,00009A
+BROWN,Horton Ward 3 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009B
+BROWN,Horton Ward 3 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00009B
+BROWN,Horton Ward 3 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009C
+BROWN,Horton Ward 3 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00009C
+BROWN,Irving Township,United States Senate,,write - in,"Smith, DJ",0,000100
+BROWN,Irving Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000100
+BROWN,Irving Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000100
+BROWN,Irving Township,United States Senate,,Republican,"Moran, Jerry",103,000100
+BROWN,Mission Township,United States Senate,,write - in,"Smith, DJ",0,000110
+BROWN,Mission Township,United States Senate,,Democratic,"Wiesner, Patrick",44,000110
+BROWN,Mission Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000110
+BROWN,Mission Township,United States Senate,,Republican,"Moran, Jerry",265,000110
+BROWN,Morrill Township,United States Senate,,write - in,"Smith, DJ",0,000120
+BROWN,Morrill Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000120
+BROWN,Morrill Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000120
+BROWN,Morrill Township,United States Senate,,Republican,"Moran, Jerry",192,000120
+BROWN,Padonia Township,United States Senate,,write - in,"Smith, DJ",0,000130
+BROWN,Padonia Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000130
+BROWN,Padonia Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000130
+BROWN,Padonia Township,United States Senate,,Republican,"Moran, Jerry",77,000130
+BROWN,Powhattan Township,United States Senate,,write - in,"Smith, DJ",0,000140
+BROWN,Powhattan Township,United States Senate,,Democratic,"Wiesner, Patrick",88,000140
+BROWN,Powhattan Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000140
+BROWN,Powhattan Township,United States Senate,,Republican,"Moran, Jerry",156,000140
+BROWN,Reserve Township,United States Senate,,write - in,"Smith, DJ",0,000150
+BROWN,Reserve Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000150
+BROWN,Reserve Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000150
+BROWN,Reserve Township,United States Senate,,Republican,"Moran, Jerry",48,000150
+BROWN,Robinson Township,United States Senate,,write - in,"Smith, DJ",0,000160
+BROWN,Robinson Township,United States Senate,,Democratic,"Wiesner, Patrick",38,000160
+BROWN,Robinson Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000160
+BROWN,Robinson Township,United States Senate,,Republican,"Moran, Jerry",140,000160
+BROWN,Sabetha Ward 1 Part A,United States Senate,,write - in,"Smith, DJ",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017A
+BROWN,Sabetha Ward 1 Part A,United States Senate,,Republican,"Moran, Jerry",0,00017A
+BROWN,Sabetha Ward 1 Part B,United States Senate,,write - in,"Smith, DJ",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017B
+BROWN,Sabetha Ward 1 Part B,United States Senate,,Republican,"Moran, Jerry",0,00017B
+BROWN,Sabetha Ward 4 Part A,United States Senate,,write - in,"Smith, DJ",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018A
+BROWN,Sabetha Ward 4 Part A,United States Senate,,Republican,"Moran, Jerry",0,00018A
+BROWN,Sabetha Ward 4 Part B,United States Senate,,write - in,"Smith, DJ",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018B
+BROWN,Sabetha Ward 4 Part B,United States Senate,,Republican,"Moran, Jerry",0,00018B
+BROWN,Sabetha Ward 5,United States Senate,,write - in,"Smith, DJ",0,000190
+BROWN,Sabetha Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",0,000190
+BROWN,Sabetha Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,000190
+BROWN,Sabetha Ward 5,United States Senate,,Republican,"Moran, Jerry",0,000190
+BROWN,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000200
+BROWN,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",37,000200
+BROWN,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000200
+BROWN,Walnut Township,United States Senate,,Republican,"Moran, Jerry",239,000200
+BROWN,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000210
+BROWN,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000210
+BROWN,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000210
+BROWN,Washington Township,United States Senate,,Republican,"Moran, Jerry",197,000210
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+BROWN,Sabetha Ward 1 Part 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__butler__precinct.csv
+++ b/2016/20161108__ks__general__butler__precinct.csv
@@ -1,685 +1,3201 @@
-county,precinct,office,district,party,candidate,votes
-Butler,Andover W1,President,,D,Hillary Clinton,732
-Butler,Andover W2,President,,D,Hillary Clinton,507
-Butler,Andover W3,President,,D,Hillary Clinton,274
-Butler,Andover W4,President,,D,Hillary Clinton,22
-Butler,Augusta City W1,President,,D,Hillary Clinton,212
-Butler,Augusta City W2,President,,D,Hillary Clinton,167
-Butler,Augusta City W3,President,,D,Hillary Clinton,344
-Butler,Augusta City W4,President,,D,Hillary Clinton,251
-Butler,El Dorado W1,President,,D,Hillary Clinton,416
-Butler,El Dorado W2,President,,D,Hillary Clinton,441
-Butler,El Dorado W3,President,,D,Hillary Clinton,273
-Butler,El Dorado W4,President,,D,Hillary Clinton,244
-Butler,Rose Hill City,President,,D,Hillary Clinton,498
-Butler,Rose Hill City,President,,D,Hillary Clinton,225
-Butler,Benton City/Benton Twp,President,,D,Hillary Clinton,247
-Butler,Cassoday/Sycamore Twp,President,,D,Hillary Clinton,22
-Butler,Douglass City/Twp,President,,D,Hillary Clinton,171
-Butler,Elbing City/Fairmount Twp,President,,D,Hillary Clinton,44
-Butler,Latham/Union,President,,D,Hillary Clinton,10
-Butler,Leon/Little Walnut,President,,D,Hillary Clinton,83
-Butler,Potwin/Plum Grove,President,,D,Hillary Clinton,63
-Butler,Towanda City,President,,D,Hillary Clinton,133
-Butler,Towanda Twp,President,,D,Hillary Clinton,88
-Butler,Whitewater/Milton - 72,President,,D,Hillary Clinton,57
-Butler,Whitewater/Milton - 75,President,,D,Hillary Clinton,29
-Butler,Augusta Twp - 16,President,,D,Hillary Clinton,70
-Butler,Augusta Twp - 14,President,,D,Hillary Clinton,44
-Butler,Bloomington Twp,President,,D,Hillary Clinton,40
-Butler,Bruno Twp North - 77,President,,D,Hillary Clinton,118
-Butler,Bruno Twp South - 77,President,,D,Hillary Clinton,24
-Butler,Bruno Twp North - 99,President,,D,Hillary Clinton,67
-Butler,Bruno Twp South - 99,President,,D,Hillary Clinton,27
-Butler,Chelsea Twp,President,,D,Hillary Clinton,25
-Butler,Clay Twp,President,,D,Hillary Clinton,7
-Butler,Clifford Twp,President,,D,Hillary Clinton,15
-Butler,El Dorado Twp East,President,,D,Hillary Clinton,23
-Butler,El Dorado Twp West,President,,D,Hillary Clinton,41
-Butler,Fairview Twp,President,,D,Hillary Clinton,54
-Butler,Glencoe Twp,President,,D,Hillary Clinton,23
-Butler,Hickory Twp,President,,D,Hillary Clinton,4
-Butler,Lincoln Twp,President,,D,Hillary Clinton,15
-Butler,Logan Twp,President,,D,Hillary Clinton,16
-Butler,Murdock Twp,President,,D,Hillary Clinton,24
-Butler,Prospect Twp,President,,D,Hillary Clinton,112
-Butler,Rock Creek Twp,President,,D,Hillary Clinton,21
-Butler,Rosalia Twp,President,,D,Hillary Clinton,44
-Butler,Spring Twp,President,,D,Hillary Clinton,147
-Butler,Walnut Twp,President,,D,Hillary Clinton,59
-Butler,Andover W1,President,,LBT,Gary Johnson,190
-Butler,Andover W2,President,,LBT,Gary Johnson,107
-Butler,Andover W3,President,,LBT,Gary Johnson,67
-Butler,Andover W4,President,,LBT,Gary Johnson,5
-Butler,Augusta City W1,President,,LBT,Gary Johnson,53
-Butler,Augusta City W2,President,,LBT,Gary Johnson,27
-Butler,Augusta City W3,President,,LBT,Gary Johnson,52
-Butler,Augusta City W4,President,,LBT,Gary Johnson,61
-Butler,El Dorado W1,President,,LBT,Gary Johnson,62
-Butler,El Dorado W2,President,,LBT,Gary Johnson,69
-Butler,El Dorado W3,President,,LBT,Gary Johnson,54
-Butler,El Dorado W4,President,,LBT,Gary Johnson,39
-Butler,Rose Hill City,President,,LBT,Gary Johnson,106
-Butler,Rose Hill City,President,,LBT,Gary Johnson,62
-Butler,Benton City/Benton Twp,President,,LBT,Gary Johnson,61
-Butler,Cassoday/Sycamore Twp,President,,LBT,Gary Johnson,9
-Butler,Douglass City/Twp,President,,LBT,Gary Johnson,48
-Butler,Elbing City/Fairmount Twp,President,,LBT,Gary Johnson,9
-Butler,Latham/Union,President,,LBT,Gary Johnson,4
-Butler,Leon/Little Walnut,President,,LBT,Gary Johnson,20
-Butler,Potwin/Plum Grove,President,,LBT,Gary Johnson,11
-Butler,Towanda City,President,,LBT,Gary Johnson,27
-Butler,Towanda Twp,President,,LBT,Gary Johnson,28
-Butler,Whitewater/Milton - 72,President,,LBT,Gary Johnson,15
-Butler,Whitewater/Milton - 75,President,,LBT,Gary Johnson,3
-Butler,Augusta Twp - 16,President,,LBT,Gary Johnson,11
-Butler,Augusta Twp - 14,President,,LBT,Gary Johnson,12
-Butler,Bloomington Twp,President,,LBT,Gary Johnson,13
-Butler,Bruno Twp North - 77,President,,LBT,Gary Johnson,28
-Butler,Bruno Twp South - 77,President,,LBT,Gary Johnson,3
-Butler,Bruno Twp North - 99,President,,LBT,Gary Johnson,20
-Butler,Bruno Twp South - 99,President,,LBT,Gary Johnson,5
-Butler,Chelsea Twp,President,,LBT,Gary Johnson,3
-Butler,Clay Twp,President,,LBT,Gary Johnson,2
-Butler,Clifford Twp,President,,LBT,Gary Johnson,2
-Butler,El Dorado Twp East,President,,LBT,Gary Johnson,10
-Butler,El Dorado Twp West,President,,LBT,Gary Johnson,16
-Butler,Fairview Twp,President,,LBT,Gary Johnson,10
-Butler,Glencoe Twp,President,,LBT,Gary Johnson,1
-Butler,Hickory Twp,President,,LBT,Gary Johnson,0
-Butler,Lincoln Twp,President,,LBT,Gary Johnson,4
-Butler,Logan Twp,President,,LBT,Gary Johnson,2
-Butler,Murdock Twp,President,,LBT,Gary Johnson,3
-Butler,Prospect Twp,President,,LBT,Gary Johnson,23
-Butler,Rock Creek Twp,President,,LBT,Gary Johnson,5
-Butler,Rosalia Twp,President,,LBT,Gary Johnson,11
-Butler,Spring Twp,President,,LBT,Gary Johnson,34
-Butler,Walnut Twp,President,,LBT,Gary Johnson,8
-Butler,Andover W1,President,,IND,Jill Stein,41
-Butler,Andover W2,President,,IND,Jill Stein,21
-Butler,Andover W3,President,,IND,Jill Stein,15
-Butler,Andover W4,President,,IND,Jill Stein,0
-Butler,Augusta City W1,President,,IND,Jill Stein,19
-Butler,Augusta City W2,President,,IND,Jill Stein,11
-Butler,Augusta City W3,President,,IND,Jill Stein,21
-Butler,Augusta City W4,President,,IND,Jill Stein,15
-Butler,El Dorado W1,President,,IND,Jill Stein,24
-Butler,El Dorado W2,President,,IND,Jill Stein,29
-Butler,El Dorado W3,President,,IND,Jill Stein,17
-Butler,El Dorado W4,President,,IND,Jill Stein,12
-Butler,Rose Hill City,President,,IND,Jill Stein,26
-Butler,Rose Hill City,President,,IND,Jill Stein,18
-Butler,Benton City/Benton Twp,President,,IND,Jill Stein,11
-Butler,Cassoday/Sycamore Twp,President,,IND,Jill Stein,2
-Butler,Douglass City/Twp,President,,IND,Jill Stein,11
-Butler,Elbing City/Fairmount Twp,President,,IND,Jill Stein,5
-Butler,Latham/Union,President,,IND,Jill Stein,1
-Butler,Leon/Little Walnut,President,,IND,Jill Stein,5
-Butler,Potwin/Plum Grove,President,,IND,Jill Stein,6
-Butler,Towanda City,President,,IND,Jill Stein,9
-Butler,Towanda Twp,President,,IND,Jill Stein,5
-Butler,Whitewater/Milton - 72,President,,IND,Jill Stein,3
-Butler,Whitewater/Milton - 75,President,,IND,Jill Stein,0
-Butler,Augusta Twp - 16,President,,IND,Jill Stein,9
-Butler,Augusta Twp - 14,President,,IND,Jill Stein,1
-Butler,Bloomington Twp,President,,IND,Jill Stein,4
-Butler,Bruno Twp North - 77,President,,IND,Jill Stein,1
-Butler,Bruno Twp South - 77,President,,IND,Jill Stein,2
-Butler,Bruno Twp North - 99,President,,IND,Jill Stein,2
-Butler,Bruno Twp South - 99,President,,IND,Jill Stein,2
-Butler,Chelsea Twp,President,,IND,Jill Stein,1
-Butler,Clay Twp,President,,IND,Jill Stein,2
-Butler,Clifford Twp,President,,IND,Jill Stein,1
-Butler,El Dorado Twp East,President,,IND,Jill Stein,4
-Butler,El Dorado Twp West,President,,IND,Jill Stein,1
-Butler,Fairview Twp,President,,IND,Jill Stein,0
-Butler,Glencoe Twp,President,,IND,Jill Stein,1
-Butler,Hickory Twp,President,,IND,Jill Stein,0
-Butler,Lincoln Twp,President,,IND,Jill Stein,2
-Butler,Logan Twp,President,,IND,Jill Stein,1
-Butler,Murdock Twp,President,,IND,Jill Stein,4
-Butler,Prospect Twp,President,,IND,Jill Stein,8
-Butler,Rock Creek Twp,President,,IND,Jill Stein,2
-Butler,Rosalia Twp,President,,IND,Jill Stein,3
-Butler,Spring Twp,President,,IND,Jill Stein,12
-Butler,Walnut Twp,President,,IND,Jill Stein,5
-Butler,Andover W1,President,,R,Donald Trump,1636
-Butler,Andover W2,President,,R,Donald Trump,1104
-Butler,Andover W3,President,,R,Donald Trump,641
-Butler,Andover W4,President,,R,Donald Trump,96
-Butler,Augusta City W1,President,,R,Donald Trump,522
-Butler,Augusta City W2,President,,R,Donald Trump,431
-Butler,Augusta City W3,President,,R,Donald Trump,729
-Butler,Augusta City W4,President,,R,Donald Trump,739
-Butler,El Dorado W1,President,,R,Donald Trump,1007
-Butler,El Dorado W2,President,,R,Donald Trump,811
-Butler,El Dorado W3,President,,R,Donald Trump,632
-Butler,El Dorado W4,President,,R,Donald Trump,485
-Butler,Rose Hill City,President,,R,Donald Trump,1628
-Butler,Rose Hill City,President,,R,Donald Trump,836
-Butler,Benton City/Benton Twp,President,,R,Donald Trump,899
-Butler,Cassoday/Sycamore Twp,President,,R,Donald Trump,121
-Butler,Douglass City/Twp,President,,R,Donald Trump,603
-Butler,Elbing City/Fairmount Twp,President,,R,Donald Trump,231
-Butler,Latham/Union,President,,R,Donald Trump,58
-Butler,Leon/Little Walnut,President,,R,Donald Trump,260
-Butler,Potwin/Plum Grove,President,,R,Donald Trump,165
-Butler,Towanda City,President,,R,Donald Trump,420
-Butler,Towanda Twp,President,,R,Donald Trump,490
-Butler,Whitewater/Milton - 72,President,,R,Donald Trump,255
-Butler,Whitewater/Milton - 75,President,,R,Donald Trump,169
-Butler,Augusta Twp - 16,President,,R,Donald Trump,347
-Butler,Augusta Twp - 14,President,,R,Donald Trump,114
-Butler,Bloomington Twp,President,,R,Donald Trump,183
-Butler,Bruno Twp North - 77,President,,R,Donald Trump,401
-Butler,Bruno Twp South - 77,President,,R,Donald Trump,101
-Butler,Bruno Twp North - 99,President,,R,Donald Trump,236
-Butler,Bruno Twp South - 99,President,,R,Donald Trump,115
-Butler,Chelsea Twp,President,,R,Donald Trump,91
-Butler,Clay Twp,President,,R,Donald Trump,31
-Butler,Clifford Twp,President,,R,Donald Trump,88
-Butler,El Dorado Twp East,President,,R,Donald Trump,59
-Butler,El Dorado Twp West,President,,R,Donald Trump,188
-Butler,Fairview Twp,President,,R,Donald Trump,195
-Butler,Glencoe Twp,President,,R,Donald Trump,66
-Butler,Hickory Twp,President,,R,Donald Trump,44
-Butler,Lincoln Twp,President,,R,Donald Trump,103
-Butler,Logan Twp,President,,R,Donald Trump,37
-Butler,Murdock Twp,President,,R,Donald Trump,185
-Butler,Prospect Twp,President,,R,Donald Trump,399
-Butler,Rock Creek Twp,President,,R,Donald Trump,113
-Butler,Rosalia Twp,President,,R,Donald Trump,210
-Butler,Spring Twp,President,,R,Donald Trump,544
-Butler,Walnut Twp,President,,R,Donald Trump,253
-Butler,Andover W1,U.S. Senate,,LBT,Robert Garrard,162
-Butler,Andover W2,U.S. Senate,,LBT,Robert Garrard,127
-Butler,Andover W3,U.S. Senate,,LBT,Robert Garrard,71
-Butler,Andover W4,U.S. Senate,,LBT,Robert Garrard,2
-Butler,Augusta City W1,U.S. Senate,,LBT,Robert Garrard,84
-Butler,Augusta City W2,U.S. Senate,,LBT,Robert Garrard,60
-Butler,Augusta City W3,U.S. Senate,,LBT,Robert Garrard,70
-Butler,Augusta City W4,U.S. Senate,,LBT,Robert Garrard,56
-Butler,El Dorado W1,U.S. Senate,,LBT,Robert Garrard,84
-Butler,El Dorado W2,U.S. Senate,,LBT,Robert Garrard,105
-Butler,El Dorado W3,U.S. Senate,,LBT,Robert Garrard,74
-Butler,El Dorado W4,U.S. Senate,,LBT,Robert Garrard,59
-Butler,Rose Hill City,U.S. Senate,,LBT,Robert Garrard,151
-Butler,Rose Hill City,U.S. Senate,,LBT,Robert Garrard,82
-Butler,Benton City/Benton Twp,U.S. Senate,,LBT,Robert Garrard,72
-Butler,Cassoday/Sycamore Twp,U.S. Senate,,LBT,Robert Garrard,10
-Butler,Douglass City/Twp,U.S. Senate,,LBT,Robert Garrard,64
-Butler,Elbing City/Fairmount Twp,U.S. Senate,,LBT,Robert Garrard,11
-Butler,Latham/Union,U.S. Senate,,LBT,Robert Garrard,5
-Butler,Leon/Little Walnut,U.S. Senate,,LBT,Robert Garrard,30
-Butler,Potwin/Plum Grove,U.S. Senate,,LBT,Robert Garrard,14
-Butler,Towanda City,U.S. Senate,,LBT,Robert Garrard,49
-Butler,Towanda Twp,U.S. Senate,,LBT,Robert Garrard,40
-Butler,Whitewater/Milton - 72,U.S. Senate,,LBT,Robert Garrard,24
-Butler,Whitewater/Milton - 75,U.S. Senate,,LBT,Robert Garrard,5
-Butler,Augusta Twp - 16,U.S. Senate,,LBT,Robert Garrard,40
-Butler,Augusta Twp - 14,U.S. Senate,,LBT,Robert Garrard,11
-Butler,Bloomington Twp,U.S. Senate,,LBT,Robert Garrard,23
-Butler,Bruno Twp North - 77,U.S. Senate,,LBT,Robert Garrard,48
-Butler,Bruno Twp South - 77,U.S. Senate,,LBT,Robert Garrard,9
-Butler,Bruno Twp North - 99,U.S. Senate,,LBT,Robert Garrard,26
-Butler,Bruno Twp South - 99,U.S. Senate,,LBT,Robert Garrard,11
-Butler,Chelsea Twp,U.S. Senate,,LBT,Robert Garrard,6
-Butler,Clay Twp,U.S. Senate,,LBT,Robert Garrard,4
-Butler,Clifford Twp,U.S. Senate,,LBT,Robert Garrard,2
-Butler,El Dorado Twp East,U.S. Senate,,LBT,Robert Garrard,11
-Butler,El Dorado Twp West,U.S. Senate,,LBT,Robert Garrard,12
-Butler,Fairview Twp,U.S. Senate,,LBT,Robert Garrard,19
-Butler,Glencoe Twp,U.S. Senate,,LBT,Robert Garrard,3
-Butler,Hickory Twp,U.S. Senate,,LBT,Robert Garrard,0
-Butler,Lincoln Twp,U.S. Senate,,LBT,Robert Garrard,10
-Butler,Logan Twp,U.S. Senate,,LBT,Robert Garrard,1
-Butler,Murdock Twp,U.S. Senate,,LBT,Robert Garrard,5
-Butler,Prospect Twp,U.S. Senate,,LBT,Robert Garrard,42
-Butler,Rock Creek Twp,U.S. Senate,,LBT,Robert Garrard,8
-Butler,Rosalia Twp,U.S. Senate,,LBT,Robert Garrard,15
-Butler,Spring Twp,U.S. Senate,,LBT,Robert Garrard,64
-Butler,Walnut Twp,U.S. Senate,,LBT,Robert Garrard,27
-Butler,Andover W1,U.S. Senate,,R,Jerry Moran,1843
-Butler,Andover W2,U.S. Senate,,R,Jerry Moran,1158
-Butler,Andover W3,U.S. Senate,,R,Jerry Moran,679
-Butler,Andover W4,U.S. Senate,,R,Jerry Moran,105
-Butler,Augusta City W1,U.S. Senate,,R,Jerry Moran,526
-Butler,Augusta City W2,U.S. Senate,,R,Jerry Moran,412
-Butler,Augusta City W3,U.S. Senate,,R,Jerry Moran,785
-Butler,Augusta City W4,U.S. Senate,,R,Jerry Moran,807
-Butler,El Dorado W1,U.S. Senate,,R,Jerry Moran,1111
-Butler,El Dorado W2,U.S. Senate,,R,Jerry Moran,856
-Butler,El Dorado W3,U.S. Senate,,R,Jerry Moran,653
-Butler,El Dorado W4,U.S. Senate,,R,Jerry Moran,487
-Butler,Rose Hill City,U.S. Senate,,R,Jerry Moran,1650
-Butler,Rose Hill City,U.S. Senate,,R,Jerry Moran,843
-Butler,Benton City/Benton Twp,U.S. Senate,,R,Jerry Moran,925
-Butler,Cassoday/Sycamore Twp,U.S. Senate,,R,Jerry Moran,126
-Butler,Douglass City/Twp,U.S. Senate,,R,Jerry Moran,602
-Butler,Elbing City/Fairmount Twp,U.S. Senate,,R,Jerry Moran,254
-Butler,Latham/Union,U.S. Senate,,R,Jerry Moran,58
-Butler,Leon/Little Walnut,U.S. Senate,,R,Jerry Moran,264
-Butler,Potwin/Plum Grove,U.S. Senate,,R,Jerry Moran,171
-Butler,Towanda City,U.S. Senate,,R,Jerry Moran,404
-Butler,Towanda Twp,U.S. Senate,,R,Jerry Moran,488
-Butler,Whitewater/Milton - 72,U.S. Senate,,R,Jerry Moran,257
-Butler,Whitewater/Milton - 75,U.S. Senate,,R,Jerry Moran,182
-Butler,Augusta Twp - 16,U.S. Senate,,R,Jerry Moran,323
-Butler,Augusta Twp - 14,U.S. Senate,,R,Jerry Moran,120
-Butler,Bloomington Twp,U.S. Senate,,R,Jerry Moran,174
-Butler,Bruno Twp North - 77,U.S. Senate,,R,Jerry Moran,415
-Butler,Bruno Twp South - 77,U.S. Senate,,R,Jerry Moran,102
-Butler,Bruno Twp North - 99,U.S. Senate,,R,Jerry Moran,248
-Butler,Bruno Twp South - 99,U.S. Senate,,R,Jerry Moran,117
-Butler,Chelsea Twp,U.S. Senate,,R,Jerry Moran,87
-Butler,Clay Twp,U.S. Senate,,R,Jerry Moran,32
-Butler,Clifford Twp,U.S. Senate,,R,Jerry Moran,92
-Butler,El Dorado Twp East,U.S. Senate,,R,Jerry Moran,64
-Butler,El Dorado Twp West,U.S. Senate,,R,Jerry Moran,193
-Butler,Fairview Twp,U.S. Senate,,R,Jerry Moran,195
-Butler,Glencoe Twp,U.S. Senate,,R,Jerry Moran,64
-Butler,Hickory Twp,U.S. Senate,,R,Jerry Moran,41
-Butler,Lincoln Twp,U.S. Senate,,R,Jerry Moran,105
-Butler,Logan Twp,U.S. Senate,,R,Jerry Moran,40
-Butler,Murdock Twp,U.S. Senate,,R,Jerry Moran,180
-Butler,Prospect Twp,U.S. Senate,,R,Jerry Moran,400
-Butler,Rock Creek Twp,U.S. Senate,,R,Jerry Moran,108
-Butler,Rosalia Twp,U.S. Senate,,R,Jerry Moran,206
-Butler,Spring Twp,U.S. Senate,,R,Jerry Moran,511
-Butler,Walnut Twp,U.S. Senate,,R,Jerry Moran,240
-Butler,Andover W1,U.S. Senate,,D,Patrick Wiesner,648
-Butler,Andover W2,U.S. Senate,,D,Patrick Wiesner,454
-Butler,Andover W3,U.S. Senate,,D,Patrick Wiesner,242
-Butler,Andover W4,U.S. Senate,,D,Patrick Wiesner,21
-Butler,Augusta City W1,U.S. Senate,,D,Patrick Wiesner,191
-Butler,Augusta City W2,U.S. Senate,,D,Patrick Wiesner,155
-Butler,Augusta City W3,U.S. Senate,,D,Patrick Wiesner,301
-Butler,Augusta City W4,U.S. Senate,,D,Patrick Wiesner,205
-Butler,El Dorado W1,U.S. Senate,,D,Patrick Wiesner,339
-Butler,El Dorado W2,U.S. Senate,,D,Patrick Wiesner,380
-Butler,El Dorado W3,U.S. Senate,,D,Patrick Wiesner,239
-Butler,El Dorado W4,U.S. Senate,,D,Patrick Wiesner,222
-Butler,Rose Hill City,U.S. Senate,,D,Patrick Wiesner,451
-Butler,Rose Hill City,U.S. Senate,,D,Patrick Wiesner,212
-Butler,Benton City/Benton Twp,U.S. Senate,,D,Patrick Wiesner,223
-Butler,Cassoday/Sycamore Twp,U.S. Senate,,D,Patrick Wiesner,19
-Butler,Douglass City/Twp,U.S. Senate,,D,Patrick Wiesner,173
-Butler,Elbing City/Fairmount Twp,U.S. Senate,,D,Patrick Wiesner,38
-Butler,Latham/Union,U.S. Senate,,D,Patrick Wiesner,10
-Butler,Leon/Little Walnut,U.S. Senate,,D,Patrick Wiesner,78
-Butler,Potwin/Plum Grove,U.S. Senate,,D,Patrick Wiesner,59
-Butler,Towanda City,U.S. Senate,,D,Patrick Wiesner,127
-Butler,Towanda Twp,U.S. Senate,,D,Patrick Wiesner,81
-Butler,Whitewater/Milton - 72,U.S. Senate,,D,Patrick Wiesner,52
-Butler,Whitewater/Milton - 75,U.S. Senate,,D,Patrick Wiesner,22
-Butler,Augusta Twp - 16,U.S. Senate,,D,Patrick Wiesner,66
-Butler,Augusta Twp - 14,U.S. Senate,,D,Patrick Wiesner,40
-Butler,Bloomington Twp,U.S. Senate,,D,Patrick Wiesner,45
-Butler,Bruno Twp North - 77,U.S. Senate,,D,Patrick Wiesner,99
-Butler,Bruno Twp South - 77,U.S. Senate,,D,Patrick Wiesner,20
-Butler,Bruno Twp North - 99,U.S. Senate,,D,Patrick Wiesner,54
-Butler,Bruno Twp South - 99,U.S. Senate,,D,Patrick Wiesner,25
-Butler,Chelsea Twp,U.S. Senate,,D,Patrick Wiesner,28
-Butler,Clay Twp,U.S. Senate,,D,Patrick Wiesner,6
-Butler,Clifford Twp,U.S. Senate,,D,Patrick Wiesner,12
-Butler,El Dorado Twp East,U.S. Senate,,D,Patrick Wiesner,22
-Butler,El Dorado Twp West,U.S. Senate,,D,Patrick Wiesner,44
-Butler,Fairview Twp,U.S. Senate,,D,Patrick Wiesner,42
-Butler,Glencoe Twp,U.S. Senate,,D,Patrick Wiesner,24
-Butler,Hickory Twp,U.S. Senate,,D,Patrick Wiesner,6
-Butler,Lincoln Twp,U.S. Senate,,D,Patrick Wiesner,15
-Butler,Logan Twp,U.S. Senate,,D,Patrick Wiesner,15
-Butler,Murdock Twp,U.S. Senate,,D,Patrick Wiesner,31
-Butler,Prospect Twp,U.S. Senate,,D,Patrick Wiesner,102
-Butler,Rock Creek Twp,U.S. Senate,,D,Patrick Wiesner,24
-Butler,Rosalia Twp,U.S. Senate,,D,Patrick Wiesner,41
-Butler,Spring Twp,U.S. Senate,,D,Patrick Wiesner,154
-Butler,Walnut Twp,U.S. Senate,,D,Patrick Wiesner,58
-Butler,Andover W1,U.S. House,4,D,Daniel Giroux,675
-Butler,Andover W2,U.S. House,4,D,Daniel Giroux,468
-Butler,Andover W3,U.S. House,4,D,Daniel Giroux,242
-Butler,Andover W4,U.S. House,4,D,Daniel Giroux,20
-Butler,Augusta City W1,U.S. House,4,D,Daniel Giroux,198
-Butler,Augusta City W2,U.S. House,4,D,Daniel Giroux,153
-Butler,Augusta City W3,U.S. House,4,D,Daniel Giroux,325
-Butler,Augusta City W4,U.S. House,4,D,Daniel Giroux,223
-Butler,El Dorado W1,U.S. House,4,D,Daniel Giroux,379
-Butler,El Dorado W2,U.S. House,4,D,Daniel Giroux,394
-Butler,El Dorado W3,U.S. House,4,D,Daniel Giroux,253
-Butler,El Dorado W4,U.S. House,4,D,Daniel Giroux,227
-Butler,Rose Hill City,U.S. House,4,D,Daniel Giroux,460
-Butler,Rose Hill City,U.S. House,4,D,Daniel Giroux,228
-Butler,Benton City/Benton Twp,U.S. House,4,D,Daniel Giroux,235
-Butler,Cassoday/Sycamore Twp,U.S. House,4,D,Daniel Giroux,24
-Butler,Douglass City/Twp,U.S. House,4,D,Daniel Giroux,177
-Butler,Elbing City/Fairmount Twp,U.S. House,4,D,Daniel Giroux,43
-Butler,Latham/Union,U.S. House,4,D,Daniel Giroux,11
-Butler,Leon/Little Walnut,U.S. House,4,D,Daniel Giroux,79
-Butler,Potwin/Plum Grove,U.S. House,4,D,Daniel Giroux,56
-Butler,Towanda City,U.S. House,4,D,Daniel Giroux,137
-Butler,Towanda Twp,U.S. House,4,D,Daniel Giroux,73
-Butler,Whitewater/Milton - 72,U.S. House,4,D,Daniel Giroux,60
-Butler,Whitewater/Milton - 75,U.S. House,4,D,Daniel Giroux,29
-Butler,Augusta Twp - 16,U.S. House,4,D,Daniel Giroux,68
-Butler,Augusta Twp - 14,U.S. House,4,D,Daniel Giroux,38
-Butler,Bloomington Twp,U.S. House,4,D,Daniel Giroux,48
-Butler,Bruno Twp North - 77,U.S. House,4,D,Daniel Giroux,102
-Butler,Bruno Twp South - 77,U.S. House,4,D,Daniel Giroux,25
-Butler,Bruno Twp North - 99,U.S. House,4,D,Daniel Giroux,62
-Butler,Bruno Twp South - 99,U.S. House,4,D,Daniel Giroux,26
-Butler,Chelsea Twp,U.S. House,4,D,Daniel Giroux,24
-Butler,Clay Twp,U.S. House,4,D,Daniel Giroux,8
-Butler,Clifford Twp,U.S. House,4,D,Daniel Giroux,17
-Butler,El Dorado Twp East,U.S. House,4,D,Daniel Giroux,26
-Butler,El Dorado Twp West,U.S. House,4,D,Daniel Giroux,45
-Butler,Fairview Twp,U.S. House,4,D,Daniel Giroux,45
-Butler,Glencoe Twp,U.S. House,4,D,Daniel Giroux,26
-Butler,Hickory Twp,U.S. House,4,D,Daniel Giroux,9
-Butler,Lincoln Twp,U.S. House,4,D,Daniel Giroux,15
-Butler,Logan Twp,U.S. House,4,D,Daniel Giroux,14
-Butler,Murdock Twp,U.S. House,4,D,Daniel Giroux,32
-Butler,Prospect Twp,U.S. House,4,D,Daniel Giroux,105
-Butler,Rock Creek Twp,U.S. House,4,D,Daniel Giroux,20
-Butler,Rosalia Twp,U.S. House,4,D,Daniel Giroux,48
-Butler,Spring Twp,U.S. House,4,D,Daniel Giroux,149
-Butler,Walnut Twp,U.S. House,4,D,Daniel Giroux,58
-Butler,Andover W1,U.S. House,4,R,Mike Pompeo,1787
-Butler,Andover W2,U.S. House,4,R,Mike Pompeo,1150
-Butler,Andover W3,U.S. House,4,R,Mike Pompeo,669
-Butler,Andover W4,U.S. House,4,R,Mike Pompeo,96
-Butler,Augusta City W1,U.S. House,4,R,Mike Pompeo,512
-Butler,Augusta City W2,U.S. House,4,R,Mike Pompeo,409
-Butler,Augusta City W3,U.S. House,4,R,Mike Pompeo,757
-Butler,Augusta City W4,U.S. House,4,R,Mike Pompeo,781
-Butler,El Dorado W1,U.S. House,4,R,Mike Pompeo,1063
-Butler,El Dorado W2,U.S. House,4,R,Mike Pompeo,809
-Butler,El Dorado W3,U.S. House,4,R,Mike Pompeo,633
-Butler,El Dorado W4,U.S. House,4,R,Mike Pompeo,477
-Butler,Rose Hill City,U.S. House,4,R,Mike Pompeo,1614
-Butler,Rose Hill City,U.S. House,4,R,Mike Pompeo,811
-Butler,Benton City/Benton Twp,U.S. House,4,R,Mike Pompeo,907
-Butler,Cassoday/Sycamore Twp,U.S. House,4,R,Mike Pompeo,129
-Butler,Douglass City/Twp,U.S. House,4,R,Mike Pompeo,572
-Butler,Elbing City/Fairmount Twp,U.S. House,4,R,Mike Pompeo,241
-Butler,Latham/Union,U.S. House,4,R,Mike Pompeo,51
-Butler,Leon/Little Walnut,U.S. House,4,R,Mike Pompeo,248
-Butler,Potwin/Plum Grove,U.S. House,4,R,Mike Pompeo,163
-Butler,Towanda City,U.S. House,4,R,Mike Pompeo,382
-Butler,Towanda Twp,U.S. House,4,R,Mike Pompeo,496
-Butler,Whitewater/Milton - 72,U.S. House,4,R,Mike Pompeo,249
-Butler,Whitewater/Milton - 75,U.S. House,4,R,Mike Pompeo,173
-Butler,Augusta Twp - 16,U.S. House,4,R,Mike Pompeo,324
-Butler,Augusta Twp - 14,U.S. House,4,R,Mike Pompeo,119
-Butler,Bloomington Twp,U.S. House,4,R,Mike Pompeo,164
-Butler,Bruno Twp North - 77,U.S. House,4,R,Mike Pompeo,409
-Butler,Bruno Twp South - 77,U.S. House,4,R,Mike Pompeo,92
-Butler,Bruno Twp North - 99,U.S. House,4,R,Mike Pompeo,234
-Butler,Bruno Twp South - 99,U.S. House,4,R,Mike Pompeo,115
-Butler,Chelsea Twp,U.S. House,4,R,Mike Pompeo,90
-Butler,Clay Twp,U.S. House,4,R,Mike Pompeo,32
-Butler,Clifford Twp,U.S. House,4,R,Mike Pompeo,86
-Butler,El Dorado Twp East,U.S. House,4,R,Mike Pompeo,64
-Butler,El Dorado Twp West,U.S. House,4,R,Mike Pompeo,190
-Butler,Fairview Twp,U.S. House,4,R,Mike Pompeo,189
-Butler,Glencoe Twp,U.S. House,4,R,Mike Pompeo,55
-Butler,Hickory Twp,U.S. House,4,R,Mike Pompeo,39
-Butler,Lincoln Twp,U.S. House,4,R,Mike Pompeo,105
-Butler,Logan Twp,U.S. House,4,R,Mike Pompeo,39
-Butler,Murdock Twp,U.S. House,4,R,Mike Pompeo,175
-Butler,Prospect Twp,U.S. House,4,R,Mike Pompeo,391
-Butler,Rock Creek Twp,U.S. House,4,R,Mike Pompeo,107
-Butler,Rosalia Twp,U.S. House,4,R,Mike Pompeo,197
-Butler,Spring Twp,U.S. House,4,R,Mike Pompeo,510
-Butler,Walnut Twp,U.S. House,4,R,Mike Pompeo,230
-Butler,Andover W1,U.S. House,4,LBT,Gorden Bakken,72
-Butler,Andover W2,U.S. House,4,LBT,Gorden Bakken,60
-Butler,Andover W3,U.S. House,4,LBT,Gorden Bakken,33
-Butler,Andover W4,U.S. House,4,LBT,Gorden Bakken,5
-Butler,Augusta City W1,U.S. House,4,LBT,Gorden Bakken,44
-Butler,Augusta City W2,U.S. House,4,LBT,Gorden Bakken,15
-Butler,Augusta City W3,U.S. House,4,LBT,Gorden Bakken,25
-Butler,Augusta City W4,U.S. House,4,LBT,Gorden Bakken,28
-Butler,El Dorado W1,U.S. House,4,LBT,Gorden Bakken,33
-Butler,El Dorado W2,U.S. House,4,LBT,Gorden Bakken,45
-Butler,El Dorado W3,U.S. House,4,LBT,Gorden Bakken,30
-Butler,El Dorado W4,U.S. House,4,LBT,Gorden Bakken,31
-Butler,Rose Hill City,U.S. House,4,LBT,Gorden Bakken,72
-Butler,Rose Hill City,U.S. House,4,LBT,Gorden Bakken,35
-Butler,Benton City/Benton Twp,U.S. House,4,LBT,Gorden Bakken,35
-Butler,Cassoday/Sycamore Twp,U.S. House,4,LBT,Gorden Bakken,1
-Butler,Douglass City/Twp,U.S. House,4,LBT,Gorden Bakken,25
-Butler,Elbing City/Fairmount Twp,U.S. House,4,LBT,Gorden Bakken,4
-Butler,Latham/Union,U.S. House,4,LBT,Gorden Bakken,3
-Butler,Leon/Little Walnut,U.S. House,4,LBT,Gorden Bakken,16
-Butler,Potwin/Plum Grove,U.S. House,4,LBT,Gorden Bakken,9
-Butler,Towanda City,U.S. House,4,LBT,Gorden Bakken,20
-Butler,Towanda Twp,U.S. House,4,LBT,Gorden Bakken,15
-Butler,Whitewater/Milton - 72,U.S. House,4,LBT,Gorden Bakken,5
-Butler,Whitewater/Milton - 75,U.S. House,4,LBT,Gorden Bakken,1
-Butler,Augusta Twp - 16,U.S. House,4,LBT,Gorden Bakken,18
-Butler,Augusta Twp - 14,U.S. House,4,LBT,Gorden Bakken,4
-Butler,Bloomington Twp,U.S. House,4,LBT,Gorden Bakken,10
-Butler,Bruno Twp North - 77,U.S. House,4,LBT,Gorden Bakken,13
-Butler,Bruno Twp South - 77,U.S. House,4,LBT,Gorden Bakken,4
-Butler,Bruno Twp North - 99,U.S. House,4,LBT,Gorden Bakken,12
-Butler,Bruno Twp South - 99,U.S. House,4,LBT,Gorden Bakken,5
-Butler,Chelsea Twp,U.S. House,4,LBT,Gorden Bakken,2
-Butler,Clay Twp,U.S. House,4,LBT,Gorden Bakken,0
-Butler,Clifford Twp,U.S. House,4,LBT,Gorden Bakken,1
-Butler,El Dorado Twp East,U.S. House,4,LBT,Gorden Bakken,4
-Butler,El Dorado Twp West,U.S. House,4,LBT,Gorden Bakken,9
-Butler,Fairview Twp,U.S. House,4,LBT,Gorden Bakken,8
-Butler,Glencoe Twp,U.S. House,4,LBT,Gorden Bakken,4
-Butler,Hickory Twp,U.S. House,4,LBT,Gorden Bakken,0
-Butler,Lincoln Twp,U.S. House,4,LBT,Gorden Bakken,2
-Butler,Logan Twp,U.S. House,4,LBT,Gorden Bakken,1
-Butler,Murdock Twp,U.S. House,4,LBT,Gorden Bakken,3
-Butler,Prospect Twp,U.S. House,4,LBT,Gorden Bakken,10
-Butler,Rock Creek Twp,U.S. House,4,LBT,Gorden Bakken,2
-Butler,Rosalia Twp,U.S. House,4,LBT,Gorden Bakken,4
-Butler,Spring Twp,U.S. House,4,LBT,Gorden Bakken,25
-Butler,Walnut Twp,U.S. House,4,LBT,Gorden Bakken,8
-Butler,Andover W1,U.S. House,4,IND,Miranda Allen,130
-Butler,Andover W2,U.S. House,4,IND,Miranda Allen,77
-Butler,Andover W3,U.S. House,4,IND,Miranda Allen,52
-Butler,Andover W4,U.S. House,4,IND,Miranda Allen,6
-Butler,Augusta City W1,U.S. House,4,IND,Miranda Allen,52
-Butler,Augusta City W2,U.S. House,4,IND,Miranda Allen,51
-Butler,Augusta City W3,U.S. House,4,IND,Miranda Allen,53
-Butler,Augusta City W4,U.S. House,4,IND,Miranda Allen,41
-Butler,El Dorado W1,U.S. House,4,IND,Miranda Allen,65
-Butler,El Dorado W2,U.S. House,4,IND,Miranda Allen,104
-Butler,El Dorado W3,U.S. House,4,IND,Miranda Allen,60
-Butler,El Dorado W4,U.S. House,4,IND,Miranda Allen,40
-Butler,Rose Hill City,U.S. House,4,IND,Miranda Allen,127
-Butler,Rose Hill City,U.S. House,4,IND,Miranda Allen,69
-Butler,Benton City/Benton Twp,U.S. House,4,IND,Miranda Allen,54
-Butler,Cassoday/Sycamore Twp,U.S. House,4,IND,Miranda Allen,2
-Butler,Douglass City/Twp,U.S. House,4,IND,Miranda Allen,64
-Butler,Elbing City/Fairmount Twp,U.S. House,4,IND,Miranda Allen,13
-Butler,Latham/Union,U.S. House,4,IND,Miranda Allen,6
-Butler,Leon/Little Walnut,U.S. House,4,IND,Miranda Allen,31
-Butler,Potwin/Plum Grove,U.S. House,4,IND,Miranda Allen,18
-Butler,Towanda City,U.S. House,4,IND,Miranda Allen,45
-Butler,Towanda Twp,U.S. House,4,IND,Miranda Allen,29
-Butler,Whitewater/Milton - 72,U.S. House,4,IND,Miranda Allen,19
-Butler,Whitewater/Milton - 75,U.S. House,4,IND,Miranda Allen,5
-Butler,Augusta Twp - 16,U.S. House,4,IND,Miranda Allen,23
-Butler,Augusta Twp - 14,U.S. House,4,IND,Miranda Allen,11
-Butler,Bloomington Twp,U.S. House,4,IND,Miranda Allen,20
-Butler,Bruno Twp North - 77,U.S. House,4,IND,Miranda Allen,38
-Butler,Bruno Twp South - 77,U.S. House,4,IND,Miranda Allen,9
-Butler,Bruno Twp North - 99,U.S. House,4,IND,Miranda Allen,20
-Butler,Bruno Twp South - 99,U.S. House,4,IND,Miranda Allen,7
-Butler,Chelsea Twp,U.S. House,4,IND,Miranda Allen,4
-Butler,Clay Twp,U.S. House,4,IND,Miranda Allen,2
-Butler,Clifford Twp,U.S. House,4,IND,Miranda Allen,3
-Butler,El Dorado Twp East,U.S. House,4,IND,Miranda Allen,4
-Butler,El Dorado Twp West,U.S. House,4,IND,Miranda Allen,6
-Butler,Fairview Twp,U.S. House,4,IND,Miranda Allen,14
-Butler,Glencoe Twp,U.S. House,4,IND,Miranda Allen,6
-Butler,Hickory Twp,U.S. House,4,IND,Miranda Allen,0
-Butler,Lincoln Twp,U.S. House,4,IND,Miranda Allen,8
-Butler,Logan Twp,U.S. House,4,IND,Miranda Allen,2
-Butler,Murdock Twp,U.S. House,4,IND,Miranda Allen,6
-Butler,Prospect Twp,U.S. House,4,IND,Miranda Allen,37
-Butler,Rock Creek Twp,U.S. House,4,IND,Miranda Allen,12
-Butler,Rosalia Twp,U.S. House,4,IND,Miranda Allen,15
-Butler,Spring Twp,U.S. House,4,IND,Miranda Allen,47
-Butler,Walnut Twp,U.S. House,4,IND,Miranda Allen,25
-Butler,El Dorado W1,State Senate,14,R,Bruce Givens,1224
-Butler,El Dorado W2,State Senate,14,R,Bruce Givens,1006
-Butler,El Dorado W3,State Senate,14,R,Bruce Givens,720
-Butler,El Dorado W4,State Senate,14,R,Bruce Givens,532
-Butler,Cassoday/Sycamore Twp,State Senate,14,R,Bruce Givens,125
-Butler,Douglass City/Twp,State Senate,14,R,Bruce Givens,618
-Butler,Elbing City/Fairmount Twp,State Senate,14,R,Bruce Givens,245
-Butler,Latham/Union,State Senate,14,R,Bruce Givens,54
-Butler,Leon/Little Walnut,State Senate,14,R,Bruce Givens,273
-Butler,Potwin/Plum Grove,State Senate,14,R,Bruce Givens,168
-Butler,Towanda City,State Senate,14,R,Bruce Givens,432
-Butler,Towanda Twp,State Senate,14,R,Bruce Givens,509
-Butler,Augusta Twp - 14,State Senate,14,R,Bruce Givens,127
-Butler,Bloomington Twp,State Senate,14,R,Bruce Givens,182
-Butler,Chelsea Twp,State Senate,14,R,Bruce Givens,89
-Butler,Clay Twp,State Senate,14,R,Bruce Givens,30
-Butler,Clifford Twp,State Senate,14,R,Bruce Givens,90
-Butler,El Dorado Twp East,State Senate,14,R,Bruce Givens,66
-Butler,El Dorado Twp West,State Senate,14,R,Bruce Givens,190
-Butler,Fairview Twp,State Senate,14,R,Bruce Givens,203
-Butler,Glencoe Twp,State Senate,14,R,Bruce Givens,63
-Butler,Hickory Twp,State Senate,14,R,Bruce Givens,36
-Butler,Lincoln Twp,State Senate,14,R,Bruce Givens,100
-Butler,Logan Twp,State Senate,14,R,Bruce Givens,40
-Butler,Prospect Twp,State Senate,14,R,Bruce Givens,416
-Butler,Rock Creek Twp,State Senate,14,R,Bruce Givens,112
-Butler,Rosalia Twp,State Senate,14,R,Bruce Givens,222
-Butler,Spring Twp,State Senate,14,R,Bruce Givens,538
-Butler,Walnut Twp,State Senate,14,R,Bruce Givens,237
-Butler,El Dorado W1,State Senate,14,D,Mark Pringle,286
-Butler,El Dorado W2,State Senate,14,D,Mark Pringle,327
-Butler,El Dorado W3,State Senate,14,D,Mark Pringle,249
-Butler,El Dorado W4,State Senate,14,D,Mark Pringle,229
-Butler,Cassoday/Sycamore Twp,State Senate,14,D,Mark Pringle,26
-Butler,Douglass City/Twp,State Senate,14,D,Mark Pringle,187
-Butler,Elbing City/Fairmount Twp,State Senate,14,D,Mark Pringle,49
-Butler,Latham/Union,State Senate,14,D,Mark Pringle,15
-Butler,Leon/Little Walnut,State Senate,14,D,Mark Pringle,91
-Butler,Potwin/Plum Grove,State Senate,14,D,Mark Pringle,72
-Butler,Towanda City,State Senate,14,D,Mark Pringle,146
-Butler,Towanda Twp,State Senate,14,D,Mark Pringle,90
-Butler,Augusta Twp - 14,State Senate,14,D,Mark Pringle,39
-Butler,Bloomington Twp,State Senate,14,D,Mark Pringle,49
-Butler,Chelsea Twp,State Senate,14,D,Mark Pringle,25
-Butler,Clay Twp,State Senate,14,D,Mark Pringle,11
-Butler,Clifford Twp,State Senate,14,D,Mark Pringle,14
-Butler,El Dorado Twp East,State Senate,14,D,Mark Pringle,30
-Butler,El Dorado Twp West,State Senate,14,D,Mark Pringle,50
-Butler,Fairview Twp,State Senate,14,D,Mark Pringle,44
-Butler,Glencoe Twp,State Senate,14,D,Mark Pringle,27
-Butler,Hickory Twp,State Senate,14,D,Mark Pringle,11
-Butler,Lincoln Twp,State Senate,14,D,Mark Pringle,18
-Butler,Logan Twp,State Senate,14,D,Mark Pringle,15
-Butler,Prospect Twp,State Senate,14,D,Mark Pringle,117
-Butler,Rock Creek Twp,State Senate,14,D,Mark Pringle,25
-Butler,Rosalia Twp,State Senate,14,D,Mark Pringle,35
-Butler,Spring Twp,State Senate,14,D,Mark Pringle,161
-Butler,Walnut Twp,State Senate,14,D,Mark Pringle,78
-Butler,Andover W1,State Senate,16,D,Gabriel Costilla,922
-Butler,Andover W2,State Senate,16,D,Gabriel Costilla,656
-Butler,Andover W3,State Senate,16,D,Gabriel Costilla,339
-Butler,Andover W4,State Senate,16,D,Gabriel Costilla,30
-Butler,Augusta City W1,State Senate,16,D,Gabriel Costilla,291
-Butler,Augusta City W2,State Senate,16,D,Gabriel Costilla,223
-Butler,Augusta City W3,State Senate,16,D,Gabriel Costilla,451
-Butler,Augusta City W4,State Senate,16,D,Gabriel Costilla,389
-Butler,Rose Hill City,State Senate,16,D,Gabriel Costilla,674
-Butler,Rose Hill City,State Senate,16,D,Gabriel Costilla,345
-Butler,Benton City/Benton Twp,State Senate,16,D,Gabriel Costilla,323
-Butler,Whitewater/Milton - 72,State Senate,16,D,Gabriel Costilla,83
-Butler,Whitewater/Milton - 75,State Senate,16,D,Gabriel Costilla,36
-Butler,Augusta Twp - 16,State Senate,16,D,Gabriel Costilla,117
-Butler,Bruno Twp North - 77,State Senate,16,D,Gabriel Costilla,158
-Butler,Bruno Twp South - 77,State Senate,16,D,Gabriel Costilla,29
-Butler,Bruno Twp North - 99,State Senate,16,D,Gabriel Costilla,89
-Butler,Bruno Twp South - 99,State Senate,16,D,Gabriel Costilla,45
-Butler,Murdock Twp,State Senate,16,D,Gabriel Costilla,42
-Butler,Andover W1,State Senate,16,R,Ty Masterson,1699
-Butler,Andover W2,State Senate,16,R,Ty Masterson,1070
-Butler,Andover W3,State Senate,16,R,Ty Masterson,643
-Butler,Andover W4,State Senate,16,R,Ty Masterson,97
-Butler,Augusta City W1,State Senate,16,R,Ty Masterson,501
-Butler,Augusta City W2,State Senate,16,R,Ty Masterson,398
-Butler,Augusta City W3,State Senate,16,R,Ty Masterson,678
-Butler,Augusta City W4,State Senate,16,R,Ty Masterson,661
-Butler,Rose Hill City,State Senate,16,R,Ty Masterson,1564
-Butler,Rose Hill City,State Senate,16,R,Ty Masterson,784
-Butler,Benton City/Benton Twp,State Senate,16,R,Ty Masterson,889
-Butler,Whitewater/Milton - 72,State Senate,16,R,Ty Masterson,248
-Butler,Whitewater/Milton - 75,State Senate,16,R,Ty Masterson,179
-Butler,Augusta Twp - 16,State Senate,16,R,Ty Masterson,309
-Butler,Bruno Twp North - 77,State Senate,16,R,Ty Masterson,402
-Butler,Bruno Twp South - 77,State Senate,16,R,Ty Masterson,98
-Butler,Bruno Twp North - 99,State Senate,16,R,Ty Masterson,233
-Butler,Bruno Twp South - 99,State Senate,16,R,Ty Masterson,108
-Butler,Murdock Twp,State Senate,16,R,Ty Masterson,172
-Butler,Latham/Union,State House,12,D,Jean Schodorf,21
-Butler,Leon/Little Walnut,State House,12,D,Jean Schodorf,146
-Butler,Bloomington Twp,State House,12,D,Jean Schodorf,68
-Butler,Clay Twp,State House,12,D,Jean Schodorf,11
-Butler,Glencoe Twp,State House,12,D,Jean Schodorf,34
-Butler,Hickory Twp,State House,12,D,Jean Schodorf,12
-Butler,Logan Twp,State House,12,D,Jean Schodorf,22
-Butler,Rock Creek Twp,State House,12,D,Jean Schodorf,33
-Butler,Rosalia Twp,State House,12,D,Jean Schodorf,67
-Butler,Spring Twp,State House,12,D,Jean Schodorf,244
-Butler,Latham/Union,State House,12,R,Doug Blex,50
-Butler,Leon/Little Walnut,State House,12,R,Doug Blex,223
-Butler,Bloomington Twp,State House,12,R,Doug Blex,167
-Butler,Clay Twp,State House,12,R,Doug Blex,30
-Butler,Glencoe Twp,State House,12,R,Doug Blex,57
-Butler,Hickory Twp,State House,12,R,Doug Blex,33
-Butler,Logan Twp,State House,12,R,Doug Blex,34
-Butler,Rock Creek Twp,State House,12,R,Doug Blex,102
-Butler,Rosalia Twp,State House,12,R,Doug Blex,189
-Butler,Spring Twp,State House,12,R,Doug Blex,457
-Butler,Whitewater,State House,72,D,Tim Hodge,91
-Butler,Whitewater,State House,72,R,Marc Rhoades,241
-Butler,El Dorado W1,State House,75,R,Mary Good,1425
-Butler,El Dorado W2,State House,75,R,Mary Good,1220
-Butler,El Dorado W3,State House,75,R,Mary Good,893
-Butler,El Dorado W4,State House,75,R,Mary Good,712
-Butler,Cassoday/Sycamore Twp,State House,75,R,Mary Good,141
-Butler,Elbing City/Fairmount Twp,State House,75,R,Mary Good,253
-Butler,Potwin/Plum Grove,State House,75,R,Mary Good,201
-Butler,Towanda City,State House,75,R,Mary Good,527
-Butler,Towanda Twp,State House,75,R,Mary Good,562
-Butler,Whitewater/Milton - 75,State House,75,R,Mary Good,173
-Butler,Chelsea Twp,State House,75,R,Mary Good,103
-Butler,Clifford Twp,State House,75,R,Mary Good,99
-Butler,El Dorado Twp East,State House,75,R,Mary Good,79
-Butler,El Dorado Twp West,State House,75,R,Mary Good,234
-Butler,Fairview Twp,State House,75,R,Mary Good,234
-Butler,Lincoln Twp,State House,75,R,Mary Good,111
-Butler,Murdock Twp,State House,75,R,Mary Good,191
-Butler,Prospect Twp,State House,75,R,Mary Good,492
-Butler,Andover W4,State House,77,R,Kristey Williams,110
-Butler,Augusta City W1,State House,77,R,Kristey Williams,696
-Butler,Augusta City W2,State House,77,R,Kristey Williams,540
-Butler,Augusta City W3,State House,77,R,Kristey Williams,976
-Butler,Augusta City W4,State House,77,R,Kristey Williams,922
-Butler,Rose Hill City,State House,77,R,Kristey Williams,1926
-Butler,Rose Hill City,State House,77,R,Kristey Williams,984
-Butler,Douglass City/Twp,State House,77,R,Kristey Williams,717
-Butler,Augusta Twp - 16,State House,77,R,Kristey Williams,388
-Butler,Augusta Twp - 14,State House,77,R,Kristey Williams,152
-Butler,Bruno Twp North - 77,State House,77,R,Kristey Williams,496
-Butler,Bruno Twp South - 77,State House,77,R,Kristey Williams,111
-Butler,Walnut Twp,State House,77,R,Kristey Williams,283
-Butler,Benton City/Benton Twp,State House,85,D,Patty Beamer,328
-Butler,Benton City/Benton Twp,State House,85,R,Chuck Weber,860
-Butler,Andover W1,State House,99,R,Susan Humphries,2237
-Butler,Andover W2,State House,99,R,Susan Humphries,1445
-Butler,Andover W3,State House,99,R,Susan Humphries,838
-Butler,Bruno Twp North - 99,State House,99,R,Susan Humphries,288
-Butler,Bruno Twp South - 99,State House,99,R,Susan Humphries,132
+county,precinct,office,district,party,candidate,votes,vtd
+BUTLER,Andover Ward 01,Kansas House of Representatives,99,Republican,"Humphries, Susan",2237,00001A
+BUTLER,Andover Exclave A,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00001L
+BUTLER,Andover Exclave C,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00001N
+BUTLER,Andover Exclave D Sewage Plant,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00001O
+BUTLER,Augusta City Ward 1,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",696,00002A
+BUTLER,Augusta City Ward 1 Exclave A,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave B,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,00002C
+BUTLER,Augusta City Ward 2,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",540,000030
+BUTLER,Augusta City Ward 3,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",976,00004A
+BUTLER,Augusta City Ward 3 Exclave,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,00004B
+BUTLER,Augusta City Ward 4,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",922,000050
+BUTLER,Benton Township / City,Kansas House of Representatives,85,Democratic,"Beamer, Patty",328,000070
+BUTLER,Benton Township / City,Kansas House of Representatives,85,Republican,"Weber, Chuck",860,000070
+BUTLER,Bloomington Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",68,000080
+BUTLER,Bloomington Township,Kansas House of Representatives,12,Republican,"Blex, Doug",167,000080
+BUTLER,Bruno Township Enclave B,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00009C
+BUTLER,Bruno Township Enclave D Part A,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00009E
+BUTLER,Bruno Township Enclave D Part B,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00009F
+BUTLER,Bruno Township Enclave D Part C,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00009G
+BUTLER,Bruno Township Enclave D Part D,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00009H
+BUTLER,Bruno Township Enclave D Part E,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,00009I
+BUTLER,Bruno Township Enclave C,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,000090
+BUTLER,Sycamore/Cassoday,Kansas House of Representatives,75,Republican,"Good, Mary Martha",141,000100
+BUTLER,Clay Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",11,000110
+BUTLER,Clay Township,Kansas House of Representatives,12,Republican,"Blex, Doug",30,000110
+BUTLER,Clifford Township,Kansas House of Representatives,75,Republican,"Good, Mary Martha",99,000120
+BUTLER,Douglass Township/City,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",717,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas House of Representatives,75,Republican,"Good, Mary Martha",1425,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas House of Representatives,75,Republican,"Good, Mary Martha",1220,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 2,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,000170
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,000180
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas House of Representatives,75,Republican,"Good, Mary Martha",893,000190
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,000200
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,000210
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas House of Representatives,75,Republican,"Good, Mary Martha",712,000220
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,00023B
+BUTLER,Fairmount Township/Elbing,Kansas House of Representatives,75,Republican,"Good, Mary Martha",253,000240
+BUTLER,Fairview Township,Kansas House of Representatives,75,Republican,"Good, Mary Martha",234,000250
+BUTLER,Glencoe Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",34,000260
+BUTLER,Glencoe Township,Kansas House of Representatives,12,Republican,"Blex, Doug",57,000260
+BUTLER,Hickory Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",12,000270
+BUTLER,Hickory Township,Kansas House of Representatives,12,Republican,"Blex, Doug",33,000270
+BUTLER,Lincoln Township,Kansas House of Representatives,75,Republican,"Good, Mary Martha",111,000280
+BUTLER,Little Walnut Township/Leon,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",146,000290
+BUTLER,Little Walnut Township/Leon,Kansas House of Representatives,12,Republican,"Blex, Doug",223,000290
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,00030A
+BUTLER,Logan Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",22,000300
+BUTLER,Logan Township,Kansas House of Representatives,12,Republican,"Blex, Doug",34,000300
+BUTLER,Murdock Township,Kansas House of Representatives,75,Republican,"Good, Mary Martha",191,000320
+BUTLER,El Dorado Township West,Kansas House of Representatives,75,Republican,"Good, Mary Martha",234,000330
+BUTLER,Pleasant Township,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",1927,000340
+BUTLER,Plum Grove Township/Potwin,Kansas House of Representatives,75,Republican,"Good, Mary Martha",201,000350
+BUTLER,Prospect Township,Kansas House of Representatives,75,Republican,"Good, Mary Martha",492,000360
+BUTLER,Rock Creek Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",33,000380
+BUTLER,Rock Creek Township,Kansas House of Representatives,12,Republican,"Blex, Doug",102,000380
+BUTLER,Rosalia Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",67,000390
+BUTLER,Rosalia Township,Kansas House of Representatives,12,Republican,"Blex, Doug",189,000390
+BUTLER,Spring Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",244,000410
+BUTLER,Spring Township,Kansas House of Representatives,12,Republican,"Blex, Doug",457,000410
+BUTLER,Towanda Township/City,Kansas House of Representatives,75,Republican,"Good, Mary Martha",1089,000430
+BUTLER,Union Township / Latham,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",21,000440
+BUTLER,Union Township / Latham,Kansas House of Representatives,12,Republican,"Blex, Doug",50,000440
+BUTLER,Walnut Township,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",284,000450
+BUTLER,Augusta Township S14,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",152,120040
+BUTLER,Augusta Township S16,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",388,120050
+BUTLER,Whitewater / Milton Township H72,Kansas House of Representatives,72,Democratic,"Hodge, Tim",91,120080
+BUTLER,Whitewater / Milton Township H72,Kansas House of Representatives,72,Republican,"Rhoades, Marc",241,120080
+BUTLER,Whitewater / Milton Township H75,Kansas House of Representatives,75,Republican,"Good, Mary Martha",173,120090
+BUTLER,Andover Ward 02,Kansas House of Representatives,99,Republican,"Humphries, Susan",1445,140010
+BUTLER,Andover Ward 03,Kansas House of Representatives,99,Republican,"Humphries, Susan",838,140020
+BUTLER,Andover Ward 04,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",110,140030
+BUTLER,Bruno Township North H77,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",496,140040
+BUTLER,Bruno Township North H99,Kansas House of Representatives,99,Republican,"Humphries, Susan",288,140050
+BUTLER,Bruno Township South H77,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",111,140060
+BUTLER,Bruno Township South H99,Kansas House of Representatives,99,Republican,"Humphries, Susan",132,140070
+BUTLER,El Dorado Township East,Kansas House of Representatives,75,Republican,"Good, Mary Martha",79,140080
+BUTLER,Rose Hill City,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,200010
+BUTLER,Richland Township,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",984,200020
+BUTLER,Richland Township H77,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,800040
+BUTLER,Chelsea Township,Kansas House of Representatives,75,Republican,"Good, Mary Martha",103,800050
+BUTLER,Andover Sewage Plant,Kansas House of Representatives,99,Republican,"Humphries, Susan",0,800060
+BUTLER,Augusta City Ward 1 Exclave C,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave D,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80010B
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,80020A
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,80020B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,80030B
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,80030D
+BUTLER,Richland Township H77 Exclave A,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80040A
+BUTLER,Richland Township H77 Exclave B,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80040B
+BUTLER,Rose Hill City Exclave A,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80070A
+BUTLER,Rose Hill City Exclave B,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80070B
+BUTLER,Rose Hill City Exclave C,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80070C
+BUTLER,Rose Hill City Exclave D,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80070D
+BUTLER,Rose Hill City Exclave E,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80070E
+BUTLER,Rose Hill City Exclave F,Kansas House of Representatives,77,Republican,"Williams, Kristey S.",0,80070F
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,Kansas House of Representatives,75,Republican,"Good, Mary Martha",0,90000A
+BUTLER,Andover Ward 01,Kansas Senate,16,Democratic,"Costilla, Gabriel",922,00001A
+BUTLER,Andover Ward 01,Kansas Senate,16,Republican,"Masterson, Ty",1699,00001A
+BUTLER,Andover Exclave A,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00001L
+BUTLER,Andover Exclave A,Kansas Senate,16,Republican,"Masterson, Ty",0,00001L
+BUTLER,Andover Exclave C,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00001N
+BUTLER,Andover Exclave C,Kansas Senate,16,Republican,"Masterson, Ty",0,00001N
+BUTLER,Andover Exclave D Sewage Plant,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,Kansas Senate,16,Republican,"Masterson, Ty",0,00001O
+BUTLER,Augusta City Ward 1,Kansas Senate,16,Democratic,"Costilla, Gabriel",291,00002A
+BUTLER,Augusta City Ward 1,Kansas Senate,16,Republican,"Masterson, Ty",501,00002A
+BUTLER,Augusta City Ward 1 Exclave A,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,Kansas Senate,16,Republican,"Masterson, Ty",0,00002B
+BUTLER,Augusta City Ward 1 Exclave B,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,Kansas Senate,16,Republican,"Masterson, Ty",0,00002C
+BUTLER,Augusta City Ward 2,Kansas Senate,16,Democratic,"Costilla, Gabriel",223,000030
+BUTLER,Augusta City Ward 2,Kansas Senate,16,Republican,"Masterson, Ty",398,000030
+BUTLER,Augusta City Ward 3,Kansas Senate,16,Democratic,"Costilla, Gabriel",451,00004A
+BUTLER,Augusta City Ward 3,Kansas Senate,16,Republican,"Masterson, Ty",678,00004A
+BUTLER,Augusta City Ward 3 Exclave,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,Kansas Senate,16,Republican,"Masterson, Ty",0,00004B
+BUTLER,Augusta City Ward 4,Kansas Senate,16,Democratic,"Costilla, Gabriel",389,000050
+BUTLER,Augusta City Ward 4,Kansas Senate,16,Republican,"Masterson, Ty",661,000050
+BUTLER,Benton Township / City,Kansas Senate,16,Democratic,"Costilla, Gabriel",323,000070
+BUTLER,Benton Township / City,Kansas Senate,16,Republican,"Masterson, Ty",889,000070
+BUTLER,Bloomington Township,Kansas Senate,14,Democratic,"Pringle, Mark",49,000080
+BUTLER,Bloomington Township,Kansas Senate,14,Republican,"Givens, Bruce",182,000080
+BUTLER,Bruno Township Enclave B,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00009C
+BUTLER,Bruno Township Enclave B,Kansas Senate,16,Republican,"Masterson, Ty",0,00009C
+BUTLER,Bruno Township Enclave D Part A,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00009E
+BUTLER,Bruno Township Enclave D Part A,Kansas Senate,16,Republican,"Masterson, Ty",0,00009E
+BUTLER,Bruno Township Enclave D Part B,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00009F
+BUTLER,Bruno Township Enclave D Part B,Kansas Senate,16,Republican,"Masterson, Ty",0,00009F
+BUTLER,Bruno Township Enclave D Part C,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00009G
+BUTLER,Bruno Township Enclave D Part C,Kansas Senate,16,Republican,"Masterson, Ty",0,00009G
+BUTLER,Bruno Township Enclave D Part D,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00009H
+BUTLER,Bruno Township Enclave D Part D,Kansas Senate,16,Republican,"Masterson, Ty",0,00009H
+BUTLER,Bruno Township Enclave D Part E,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,00009I
+BUTLER,Bruno Township Enclave D Part E,Kansas Senate,16,Republican,"Masterson, Ty",0,00009I
+BUTLER,Bruno Township Enclave C,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,000090
+BUTLER,Bruno Township Enclave C,Kansas Senate,16,Republican,"Masterson, Ty",0,000090
+BUTLER,Sycamore/Cassoday,Kansas Senate,14,Democratic,"Pringle, Mark",26,000100
+BUTLER,Sycamore/Cassoday,Kansas Senate,14,Republican,"Givens, Bruce",125,000100
+BUTLER,Clay Township,Kansas Senate,14,Democratic,"Pringle, Mark",11,000110
+BUTLER,Clay Township,Kansas Senate,14,Republican,"Givens, Bruce",30,000110
+BUTLER,Clifford Township,Kansas Senate,14,Democratic,"Pringle, Mark",14,000120
+BUTLER,Clifford Township,Kansas Senate,14,Republican,"Givens, Bruce",90,000120
+BUTLER,Douglass Township/City,Kansas Senate,14,Democratic,"Pringle, Mark",187,000130
+BUTLER,Douglass Township/City,Kansas Senate,14,Republican,"Givens, Bruce",618,000130
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas Senate,14,Democratic,"Pringle, Mark",286,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,Kansas Senate,14,Republican,"Givens, Bruce",1224,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,Kansas Senate,14,Republican,"Givens, Bruce",0,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas Senate,14,Democratic,"Pringle, Mark",327,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,Kansas Senate,14,Republican,"Givens, Bruce",1006,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,Kansas Senate,14,Democratic,"Pringle, Mark",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,Kansas Senate,14,Republican,"Givens, Bruce",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,Kansas Senate,14,Democratic,"Pringle, Mark",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,Kansas Senate,14,Republican,"Givens, Bruce",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,Kansas Senate,14,Republican,"Givens, Bruce",0,000170
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas Senate,14,Democratic,"Pringle, Mark",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,Kansas Senate,14,Republican,"Givens, Bruce",0,000180
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas Senate,14,Democratic,"Pringle, Mark",249,000190
+BUTLER,El Dorado Ward 3 Precinct 1,Kansas Senate,14,Republican,"Givens, Bruce",720,000190
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,Kansas Senate,14,Republican,"Givens, Bruce",0,000200
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas Senate,14,Democratic,"Pringle, Mark",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,Kansas Senate,14,Republican,"Givens, Bruce",0,000210
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas Senate,14,Democratic,"Pringle, Mark",229,000220
+BUTLER,El Dorado Ward 4 Precinct 1,Kansas Senate,14,Republican,"Givens, Bruce",532,000220
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,Kansas Senate,14,Republican,"Givens, Bruce",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas Senate,14,Democratic,"Pringle, Mark",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,Kansas Senate,14,Republican,"Givens, Bruce",0,00023B
+BUTLER,Fairmount Township/Elbing,Kansas Senate,14,Democratic,"Pringle, Mark",49,000240
+BUTLER,Fairmount Township/Elbing,Kansas Senate,14,Republican,"Givens, Bruce",245,000240
+BUTLER,Fairview Township,Kansas Senate,14,Democratic,"Pringle, Mark",44,000250
+BUTLER,Fairview Township,Kansas Senate,14,Republican,"Givens, Bruce",203,000250
+BUTLER,Glencoe Township,Kansas Senate,14,Democratic,"Pringle, Mark",27,000260
+BUTLER,Glencoe Township,Kansas Senate,14,Republican,"Givens, Bruce",63,000260
+BUTLER,Hickory Township,Kansas Senate,14,Democratic,"Pringle, Mark",11,000270
+BUTLER,Hickory Township,Kansas Senate,14,Republican,"Givens, Bruce",36,000270
+BUTLER,Lincoln Township,Kansas Senate,14,Democratic,"Pringle, Mark",18,000280
+BUTLER,Lincoln Township,Kansas Senate,14,Republican,"Givens, Bruce",100,000280
+BUTLER,Little Walnut Township/Leon,Kansas Senate,14,Democratic,"Pringle, Mark",91,000290
+BUTLER,Little Walnut Township/Leon,Kansas Senate,14,Republican,"Givens, Bruce",273,000290
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,Kansas Senate,14,Democratic,"Pringle, Mark",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,Kansas Senate,14,Republican,"Givens, Bruce",0,00030A
+BUTLER,Logan Township,Kansas Senate,14,Democratic,"Pringle, Mark",15,000300
+BUTLER,Logan Township,Kansas Senate,14,Republican,"Givens, Bruce",40,000300
+BUTLER,Murdock Township,Kansas Senate,16,Democratic,"Costilla, Gabriel",42,000320
+BUTLER,Murdock Township,Kansas Senate,16,Republican,"Masterson, Ty",172,000320
+BUTLER,El Dorado Township West,Kansas Senate,14,Democratic,"Pringle, Mark",50,000330
+BUTLER,El Dorado Township West,Kansas Senate,14,Republican,"Givens, Bruce",190,000330
+BUTLER,Pleasant Township,Kansas Senate,16,Democratic,"Costilla, Gabriel",674,000340
+BUTLER,Pleasant Township,Kansas Senate,16,Republican,"Masterson, Ty",1565,000340
+BUTLER,Plum Grove Township/Potwin,Kansas Senate,14,Democratic,"Pringle, Mark",72,000350
+BUTLER,Plum Grove Township/Potwin,Kansas Senate,14,Republican,"Givens, Bruce",168,000350
+BUTLER,Prospect Township,Kansas Senate,14,Democratic,"Pringle, Mark",117,000360
+BUTLER,Prospect Township,Kansas Senate,14,Republican,"Givens, Bruce",416,000360
+BUTLER,Rock Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",25,000380
+BUTLER,Rock Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",112,000380
+BUTLER,Rosalia Township,Kansas Senate,14,Democratic,"Pringle, Mark",35,000390
+BUTLER,Rosalia Township,Kansas Senate,14,Republican,"Givens, Bruce",222,000390
+BUTLER,Spring Township,Kansas Senate,14,Democratic,"Pringle, Mark",161,000410
+BUTLER,Spring Township,Kansas Senate,14,Republican,"Givens, Bruce",538,000410
+BUTLER,Towanda Township/City,Kansas Senate,14,Democratic,"Pringle, Mark",236,000430
+BUTLER,Towanda Township/City,Kansas Senate,14,Republican,"Givens, Bruce",941,000430
+BUTLER,Union Township / Latham,Kansas Senate,14,Democratic,"Pringle, Mark",15,000440
+BUTLER,Union Township / Latham,Kansas Senate,14,Republican,"Givens, Bruce",54,000440
+BUTLER,Walnut Township,Kansas Senate,14,Democratic,"Pringle, Mark",78,000450
+BUTLER,Walnut Township,Kansas Senate,14,Republican,"Givens, Bruce",238,000450
+BUTLER,Augusta Township S14,Kansas Senate,14,Democratic,"Pringle, Mark",39,120040
+BUTLER,Augusta Township S14,Kansas Senate,14,Republican,"Givens, Bruce",127,120040
+BUTLER,Augusta Township S16,Kansas Senate,16,Democratic,"Costilla, Gabriel",117,120050
+BUTLER,Augusta Township S16,Kansas Senate,16,Republican,"Masterson, Ty",309,120050
+BUTLER,Whitewater / Milton Township H72,Kansas Senate,16,Democratic,"Costilla, Gabriel",83,120080
+BUTLER,Whitewater / Milton Township H72,Kansas Senate,16,Republican,"Masterson, Ty",248,120080
+BUTLER,Whitewater / Milton Township H75,Kansas Senate,16,Democratic,"Costilla, Gabriel",36,120090
+BUTLER,Whitewater / Milton Township H75,Kansas Senate,16,Republican,"Masterson, Ty",179,120090
+BUTLER,Andover Ward 02,Kansas Senate,16,Democratic,"Costilla, Gabriel",656,140010
+BUTLER,Andover Ward 02,Kansas Senate,16,Republican,"Masterson, Ty",1070,140010
+BUTLER,Andover Ward 03,Kansas Senate,16,Democratic,"Costilla, Gabriel",339,140020
+BUTLER,Andover Ward 03,Kansas Senate,16,Republican,"Masterson, Ty",643,140020
+BUTLER,Andover Ward 04,Kansas Senate,16,Democratic,"Costilla, Gabriel",30,140030
+BUTLER,Andover Ward 04,Kansas Senate,16,Republican,"Masterson, Ty",97,140030
+BUTLER,Bruno Township North H77,Kansas Senate,16,Democratic,"Costilla, Gabriel",158,140040
+BUTLER,Bruno Township North H77,Kansas Senate,16,Republican,"Masterson, Ty",402,140040
+BUTLER,Bruno Township North H99,Kansas Senate,16,Democratic,"Costilla, Gabriel",89,140050
+BUTLER,Bruno Township North H99,Kansas Senate,16,Republican,"Masterson, Ty",233,140050
+BUTLER,Bruno Township South H77,Kansas Senate,16,Democratic,"Costilla, Gabriel",29,140060
+BUTLER,Bruno Township South H77,Kansas Senate,16,Republican,"Masterson, Ty",98,140060
+BUTLER,Bruno Township South H99,Kansas Senate,16,Democratic,"Costilla, Gabriel",45,140070
+BUTLER,Bruno Township South H99,Kansas Senate,16,Republican,"Masterson, Ty",108,140070
+BUTLER,El Dorado Township East,Kansas Senate,14,Democratic,"Pringle, Mark",30,140080
+BUTLER,El Dorado Township East,Kansas Senate,14,Republican,"Givens, Bruce",66,140080
+BUTLER,Rose Hill City,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,200010
+BUTLER,Rose Hill City,Kansas Senate,16,Republican,"Masterson, Ty",0,200010
+BUTLER,Richland Township,Kansas Senate,16,Democratic,"Costilla, Gabriel",345,200020
+BUTLER,Richland Township,Kansas Senate,16,Republican,"Masterson, Ty",784,200020
+BUTLER,Richland Township H77,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,800040
+BUTLER,Richland Township H77,Kansas Senate,16,Republican,"Masterson, Ty",0,800040
+BUTLER,Chelsea Township,Kansas Senate,14,Democratic,"Pringle, Mark",25,800050
+BUTLER,Chelsea Township,Kansas Senate,14,Republican,"Givens, Bruce",89,800050
+BUTLER,Andover Sewage Plant,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,800060
+BUTLER,Andover Sewage Plant,Kansas Senate,16,Republican,"Masterson, Ty",0,800060
+BUTLER,Augusta City Ward 1 Exclave C,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,Kansas Senate,16,Republican,"Masterson, Ty",0,80010A
+BUTLER,Augusta City Ward 1 Exclave D,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,Kansas Senate,16,Republican,"Masterson, Ty",0,80010B
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,Kansas Senate,14,Democratic,"Pringle, Mark",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,Kansas Senate,14,Republican,"Givens, Bruce",0,80020A
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,Kansas Senate,14,Democratic,"Pringle, Mark",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,Kansas Senate,14,Republican,"Givens, Bruce",0,80020B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,Kansas Senate,14,Democratic,"Pringle, Mark",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,Kansas Senate,14,Republican,"Givens, Bruce",0,80030B
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,Kansas Senate,14,Democratic,"Pringle, Mark",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,Kansas Senate,14,Republican,"Givens, Bruce",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,Kansas Senate,14,Democratic,"Pringle, Mark",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,Kansas Senate,14,Republican,"Givens, Bruce",0,80030D
+BUTLER,Richland Township H77 Exclave A,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80040A
+BUTLER,Richland Township H77 Exclave A,Kansas Senate,16,Republican,"Masterson, Ty",0,80040A
+BUTLER,Richland Township H77 Exclave B,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80040B
+BUTLER,Richland Township H77 Exclave B,Kansas Senate,16,Republican,"Masterson, Ty",0,80040B
+BUTLER,Rose Hill City Exclave A,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80070A
+BUTLER,Rose Hill City Exclave A,Kansas Senate,16,Republican,"Masterson, Ty",0,80070A
+BUTLER,Rose Hill City Exclave B,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80070B
+BUTLER,Rose Hill City Exclave B,Kansas Senate,16,Republican,"Masterson, Ty",0,80070B
+BUTLER,Rose Hill City Exclave C,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80070C
+BUTLER,Rose Hill City Exclave C,Kansas Senate,16,Republican,"Masterson, Ty",0,80070C
+BUTLER,Rose Hill City Exclave D,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80070D
+BUTLER,Rose Hill City Exclave D,Kansas Senate,16,Republican,"Masterson, Ty",0,80070D
+BUTLER,Rose Hill City Exclave E,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80070E
+BUTLER,Rose Hill City Exclave E,Kansas Senate,16,Republican,"Masterson, Ty",0,80070E
+BUTLER,Rose Hill City Exclave F,Kansas Senate,16,Democratic,"Costilla, Gabriel",0,80070F
+BUTLER,Rose Hill City Exclave F,Kansas Senate,16,Republican,"Masterson, Ty",0,80070F
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,Kansas Senate,14,Democratic,"Pringle, Mark",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,Kansas Senate,14,Republican,"Givens, Bruce",0,90000A
+BUTLER,Andover Ward 01,President / Vice President,,independent,"Stein, Jill",41,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Castle, Darrell L",4,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Giordani, Rocky",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Hedges, James A",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Kahn, Lynn",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"La Riva, Gloria",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Levinson, Michael S.",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Maturen, Michael A",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"McMullin, Evan",52,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Perry, Darryl",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Schriner, Joe C",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Smith, Mike",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Sood, Ajay",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Sterling, Shawna",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001A
+BUTLER,Andover Ward 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",732,00001A
+BUTLER,Andover Ward 01,President / Vice President,,Libertarian,"Johnson, Gary",190,00001A
+BUTLER,Andover Ward 01,President / Vice President,,Republican,"Trump, Donald J.",1636,00001A
+BUTLER,Andover Exclave A,President / Vice President,,independent,"Stein, Jill",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001L
+BUTLER,Andover Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00001L
+BUTLER,Andover Exclave C,President / Vice President,,independent,"Stein, Jill",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00001N
+BUTLER,Andover Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00001N
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,independent,"Stein, Jill",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Castle, Darrell L",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Giordani, Rocky",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Hedges, James A",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Hoefling, Tom",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Kahn, Lynn",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"La Riva, Gloria",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Levinson, Michael S.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Maturen, Michael A",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"McMullin, Evan",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Perry, Darryl",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Schriner, Joe C",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Smith, Mike",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Sood, Ajay",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Sterling, Shawna",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,Libertarian,"Johnson, Gary",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,President / Vice President,,Republican,"Trump, Donald J.",0,00001O
+BUTLER,Augusta City Ward 1,President / Vice President,,independent,"Stein, Jill",19,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",212,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",53,00002A
+BUTLER,Augusta City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",522,00002A
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00002C
+BUTLER,Augusta City Ward 2,President / Vice President,,independent,"Stein, Jill",11,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",167,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",27,000030
+BUTLER,Augusta City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",431,000030
+BUTLER,Augusta City Ward 3,President / Vice President,,independent,"Stein, Jill",21,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"McMullin, Evan",6,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",344,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",52,00004A
+BUTLER,Augusta City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",729,00004A
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00004B
+BUTLER,Augusta City Ward 4,President / Vice President,,independent,"Stein, Jill",15,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"McMullin, Evan",7,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",251,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",61,000050
+BUTLER,Augusta City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",739,000050
+BUTLER,Benton Township / City,President / Vice President,,independent,"Stein, Jill",11,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Castle, Darrell L",4,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Hedges, James A",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"McMullin, Evan",11,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Perry, Darryl",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Smith, Mike",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Sood, Ajay",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+BUTLER,Benton Township / City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+BUTLER,Benton Township / City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",247,000070
+BUTLER,Benton Township / City,President / Vice President,,Libertarian,"Johnson, Gary",61,000070
+BUTLER,Benton Township / City,President / Vice President,,Republican,"Trump, Donald J.",899,000070
+BUTLER,Bloomington Township,President / Vice President,,independent,"Stein, Jill",4,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Castle, Darrell L",1,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"McMullin, Evan",2,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+BUTLER,Bloomington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+BUTLER,Bloomington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000080
+BUTLER,Bloomington Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+BUTLER,Bloomington Township,President / Vice President,,Republican,"Trump, Donald J.",183,000080
+BUTLER,Bruno Township Enclave B,President / Vice President,,independent,"Stein, Jill",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00009C
+BUTLER,Bruno Township Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00009C
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,independent,"Stein, Jill",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Hedges, James A",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"McMullin, Evan",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Perry, Darryl",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Smith, Mike",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Sood, Ajay",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00009E
+BUTLER,Bruno Township Enclave D Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00009E
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,independent,"Stein, Jill",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Hedges, James A",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"McMullin, Evan",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Perry, Darryl",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Smith, Mike",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Sood, Ajay",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00009F
+BUTLER,Bruno Township Enclave D Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00009F
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,independent,"Stein, Jill",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Castle, Darrell L",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Giordani, Rocky",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Hedges, James A",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Hoefling, Tom",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Kahn, Lynn",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"La Riva, Gloria",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Levinson, Michael S.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Maturen, Michael A",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"McMullin, Evan",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Perry, Darryl",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Schriner, Joe C",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Smith, Mike",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Sood, Ajay",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Sterling, Shawna",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,00009G
+BUTLER,Bruno Township Enclave D Part C,President / Vice President,,Republican,"Trump, Donald J.",0,00009G
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,independent,"Stein, Jill",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Castle, Darrell L",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Giordani, Rocky",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Hedges, James A",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Hoefling, Tom",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Kahn, Lynn",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"La Riva, Gloria",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Levinson, Michael S.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Maturen, Michael A",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"McMullin, Evan",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Perry, Darryl",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Schriner, Joe C",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Smith, Mike",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Sood, Ajay",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Sterling, Shawna",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,Libertarian,"Johnson, Gary",0,00009H
+BUTLER,Bruno Township Enclave D Part D,President / Vice President,,Republican,"Trump, Donald J.",0,00009H
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,independent,"Stein, Jill",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Castle, Darrell L",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Giordani, Rocky",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Hedges, James A",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Hoefling, Tom",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Kahn, Lynn",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"La Riva, Gloria",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Levinson, Michael S.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Maturen, Michael A",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"McMullin, Evan",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Perry, Darryl",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Schriner, Joe C",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Smith, Mike",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Sood, Ajay",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Sterling, Shawna",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,Libertarian,"Johnson, Gary",0,00009I
+BUTLER,Bruno Township Enclave D Part E,President / Vice President,,Republican,"Trump, Donald J.",0,00009I
+BUTLER,Bruno Township Enclave C,President / Vice President,,independent,"Stein, Jill",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Hedges, James A",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"McMullin, Evan",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Perry, Darryl",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Smith, Mike",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Sood, Ajay",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+BUTLER,Bruno Township Enclave C,President / Vice President,,Republican,"Trump, Donald J.",0,000090
+BUTLER,Sycamore/Cassoday,President / Vice President,,independent,"Stein, Jill",2,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Hedges, James A",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"McMullin, Evan",2,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Perry, Darryl",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Smith, Mike",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Sood, Ajay",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+BUTLER,Sycamore/Cassoday,President / Vice President,,Republican,"Trump, Donald J.",121,000100
+BUTLER,Clay Township,President / Vice President,,independent,"Stein, Jill",2,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"McMullin, Evan",1,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+BUTLER,Clay Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+BUTLER,Clay Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000110
+BUTLER,Clay Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+BUTLER,Clay Township,President / Vice President,,Republican,"Trump, Donald J.",31,000110
+BUTLER,Clifford Township,President / Vice President,,independent,"Stein, Jill",1,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"McMullin, Evan",2,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+BUTLER,Clifford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+BUTLER,Clifford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000120
+BUTLER,Clifford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+BUTLER,Clifford Township,President / Vice President,,Republican,"Trump, Donald J.",88,000120
+BUTLER,Douglass Township/City,President / Vice President,,independent,"Stein, Jill",11,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Hedges, James A",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"McMullin, Evan",2,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Perry, Darryl",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Smith, Mike",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Sood, Ajay",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+BUTLER,Douglass Township/City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",171,000130
+BUTLER,Douglass Township/City,President / Vice President,,Libertarian,"Johnson, Gary",48,000130
+BUTLER,Douglass Township/City,President / Vice President,,Republican,"Trump, Donald J.",603,000130
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",24,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",2,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",9,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",416,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",62,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",1007,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",0,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",29,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",5,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",441,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",69,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",811,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",0,000180
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",17,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",2,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",273,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",54,000190
+BUTLER,El Dorado Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",632,000190
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,independent,"Stein, Jill",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",0,000210
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",12,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",1,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",244,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",39,000220
+BUTLER,El Dorado Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",485,000220
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",0,00023B
+BUTLER,Fairmount Township/Elbing,President / Vice President,,independent,"Stein, Jill",5,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Castle, Darrell L",2,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Hedges, James A",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"McMullin, Evan",5,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Perry, Darryl",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Smith, Mike",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Sood, Ajay",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Libertarian,"Johnson, Gary",9,000240
+BUTLER,Fairmount Township/Elbing,President / Vice President,,Republican,"Trump, Donald J.",231,000240
+BUTLER,Fairview Township,President / Vice President,,independent,"Stein, Jill",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",1,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+BUTLER,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+BUTLER,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000250
+BUTLER,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000250
+BUTLER,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",195,000250
+BUTLER,Glencoe Township,President / Vice President,,independent,"Stein, Jill",1,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+BUTLER,Glencoe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+BUTLER,Glencoe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000260
+BUTLER,Glencoe Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+BUTLER,Glencoe Township,President / Vice President,,Republican,"Trump, Donald J.",66,000260
+BUTLER,Hickory Township,President / Vice President,,independent,"Stein, Jill",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+BUTLER,Hickory Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+BUTLER,Hickory Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000270
+BUTLER,Hickory Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+BUTLER,Hickory Township,President / Vice President,,Republican,"Trump, Donald J.",44,000270
+BUTLER,Lincoln Township,President / Vice President,,independent,"Stein, Jill",2,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+BUTLER,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+BUTLER,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000280
+BUTLER,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000280
+BUTLER,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",103,000280
+BUTLER,Little Walnut Township/Leon,President / Vice President,,independent,"Stein, Jill",5,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Hedges, James A",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Maturen, Michael A",1,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"McMullin, Evan",2,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Perry, Darryl",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Smith, Mike",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Sood, Ajay",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Libertarian,"Johnson, Gary",20,000290
+BUTLER,Little Walnut Township/Leon,President / Vice President,,Republican,"Trump, Donald J.",260,000290
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00030A
+BUTLER,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"McMullin, Evan",2,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+BUTLER,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+BUTLER,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000300
+BUTLER,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000300
+BUTLER,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",37,000300
+BUTLER,Murdock Township,President / Vice President,,independent,"Stein, Jill",4,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Castle, Darrell L",1,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"McMullin, Evan",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+BUTLER,Murdock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+BUTLER,Murdock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000320
+BUTLER,Murdock Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000320
+BUTLER,Murdock Township,President / Vice President,,Republican,"Trump, Donald J.",185,000320
+BUTLER,El Dorado Township West,President / Vice President,,independent,"Stein, Jill",1,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Hedges, James A",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"McMullin, Evan",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Perry, Darryl",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Smith, Mike",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Sood, Ajay",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+BUTLER,El Dorado Township West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000330
+BUTLER,El Dorado Township West,President / Vice President,,Libertarian,"Johnson, Gary",16,000330
+BUTLER,El Dorado Township West,President / Vice President,,Republican,"Trump, Donald J.",188,000330
+BUTLER,Pleasant Township,President / Vice President,,independent,"Stein, Jill",26,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",4,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",3,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",3,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",10,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+BUTLER,Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+BUTLER,Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",498,000340
+BUTLER,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",106,000340
+BUTLER,Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",1629,000340
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,independent,"Stein, Jill",6,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Hedges, James A",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"McMullin, Evan",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Perry, Darryl",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Smith, Mike",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Sood, Ajay",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Libertarian,"Johnson, Gary",11,000350
+BUTLER,Plum Grove Township/Potwin,President / Vice President,,Republican,"Trump, Donald J.",165,000350
+BUTLER,Prospect Township,President / Vice President,,independent,"Stein, Jill",8,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Hedges, James A",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Maturen, Michael A",1,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"McMullin, Evan",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Perry, Darryl",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Smith, Mike",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Sood, Ajay",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+BUTLER,Prospect Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+BUTLER,Prospect Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",112,000360
+BUTLER,Prospect Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000360
+BUTLER,Prospect Township,President / Vice President,,Republican,"Trump, Donald J.",399,000360
+BUTLER,Rock Creek Township,President / Vice President,,independent,"Stein, Jill",2,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+BUTLER,Rock Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000380
+BUTLER,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000380
+BUTLER,Rock Creek Township,President / Vice President,,Republican,"Trump, Donald J.",113,000380
+BUTLER,Rosalia Township,President / Vice President,,independent,"Stein, Jill",3,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Hedges, James A",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"McMullin, Evan",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Perry, Darryl",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Smith, Mike",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Sood, Ajay",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000390
+BUTLER,Rosalia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000390
+BUTLER,Rosalia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000390
+BUTLER,Rosalia Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000390
+BUTLER,Rosalia Township,President / Vice President,,Republican,"Trump, Donald J.",210,000390
+BUTLER,Spring Township,President / Vice President,,independent,"Stein, Jill",12,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Castle, Darrell L",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Hedges, James A",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"McMullin, Evan",2,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Perry, Darryl",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Smith, Mike",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Sood, Ajay",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+BUTLER,Spring Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+BUTLER,Spring Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",147,000410
+BUTLER,Spring Township,President / Vice President,,Libertarian,"Johnson, Gary",34,000410
+BUTLER,Spring Township,President / Vice President,,Republican,"Trump, Donald J.",544,000410
+BUTLER,Towanda Township/City,President / Vice President,,independent,"Stein, Jill",14,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Hedges, James A",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"McMullin, Evan",7,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Perry, Darryl",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Smith, Mike",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Sood, Ajay",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+BUTLER,Towanda Township/City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",221,000430
+BUTLER,Towanda Township/City,President / Vice President,,Libertarian,"Johnson, Gary",55,000430
+BUTLER,Towanda Township/City,President / Vice President,,Republican,"Trump, Donald J.",910,000430
+BUTLER,Union Township / Latham,President / Vice President,,independent,"Stein, Jill",1,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Basiago, Andrew D.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Castle, Darrell L",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Giordani, Rocky",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Hedges, James A",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Kahn, Lynn",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"La Riva, Gloria",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Levinson, Michael S.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Maturen, Michael A",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"McMullin, Evan",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Moorehead, Monica G.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Perry, Darryl",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Schriner, Joe C",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Smith, Mike",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Sood, Ajay",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Sterling, Shawna",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Valdivia, Anthony J",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000440
+BUTLER,Union Township / Latham,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000440
+BUTLER,Union Township / Latham,President / Vice President,,Libertarian,"Johnson, Gary",4,000440
+BUTLER,Union Township / Latham,President / Vice President,,Republican,"Trump, Donald J.",58,000440
+BUTLER,Walnut Township,President / Vice President,,independent,"Stein, Jill",5,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",1,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+BUTLER,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+BUTLER,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000450
+BUTLER,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000450
+BUTLER,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",254,000450
+BUTLER,Augusta Township S14,President / Vice President,,independent,"Stein, Jill",1,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Hedges, James A",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"McMullin, Evan",1,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Perry, Darryl",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Smith, Mike",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Sood, Ajay",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+BUTLER,Augusta Township S14,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,120040
+BUTLER,Augusta Township S14,President / Vice President,,Libertarian,"Johnson, Gary",12,120040
+BUTLER,Augusta Township S14,President / Vice President,,Republican,"Trump, Donald J.",114,120040
+BUTLER,Augusta Township S16,President / Vice President,,independent,"Stein, Jill",9,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Hedges, James A",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"McMullin, Evan",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Perry, Darryl",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Smith, Mike",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Sood, Ajay",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+BUTLER,Augusta Township S16,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,120050
+BUTLER,Augusta Township S16,President / Vice President,,Libertarian,"Johnson, Gary",11,120050
+BUTLER,Augusta Township S16,President / Vice President,,Republican,"Trump, Donald J.",347,120050
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,independent,"Stein, Jill",3,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Hedges, James A",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"McMullin, Evan",2,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Perry, Darryl",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Smith, Mike",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Sood, Ajay",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Libertarian,"Johnson, Gary",15,120080
+BUTLER,Whitewater / Milton Township H72,President / Vice President,,Republican,"Trump, Donald J.",255,120080
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,independent,"Stein, Jill",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Hedges, James A",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"McMullin, Evan",1,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Perry, Darryl",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Smith, Mike",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Sood, Ajay",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Libertarian,"Johnson, Gary",3,120090
+BUTLER,Whitewater / Milton Township H75,President / Vice President,,Republican,"Trump, Donald J.",169,120090
+BUTLER,Andover Ward 02,President / Vice President,,independent,"Stein, Jill",21,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Hedges, James A",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Maturen, Michael A",2,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"McMullin, Evan",9,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Perry, Darryl",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Smith, Mike",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Sood, Ajay",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+BUTLER,Andover Ward 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",507,140010
+BUTLER,Andover Ward 02,President / Vice President,,Libertarian,"Johnson, Gary",107,140010
+BUTLER,Andover Ward 02,President / Vice President,,Republican,"Trump, Donald J.",1104,140010
+BUTLER,Andover Ward 03,President / Vice President,,independent,"Stein, Jill",15,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Castle, Darrell L",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Giordani, Rocky",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Hedges, James A",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Hoefling, Tom",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Kahn, Lynn",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"La Riva, Gloria",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Levinson, Michael S.",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Maturen, Michael A",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"McMullin, Evan",7,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Perry, Darryl",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Schriner, Joe C",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Smith, Mike",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Sood, Ajay",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Sterling, Shawna",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140020
+BUTLER,Andover Ward 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",274,140020
+BUTLER,Andover Ward 03,President / Vice President,,Libertarian,"Johnson, Gary",67,140020
+BUTLER,Andover Ward 03,President / Vice President,,Republican,"Trump, Donald J.",641,140020
+BUTLER,Andover Ward 04,President / Vice President,,independent,"Stein, Jill",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Castle, Darrell L",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Giordani, Rocky",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Hedges, James A",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Hoefling, Tom",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Kahn, Lynn",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"La Riva, Gloria",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Levinson, Michael S.",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Maturen, Michael A",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"McMullin, Evan",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Perry, Darryl",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Schriner, Joe C",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Smith, Mike",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Sood, Ajay",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Sterling, Shawna",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140030
+BUTLER,Andover Ward 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,140030
+BUTLER,Andover Ward 04,President / Vice President,,Libertarian,"Johnson, Gary",5,140030
+BUTLER,Andover Ward 04,President / Vice President,,Republican,"Trump, Donald J.",96,140030
+BUTLER,Bruno Township North H77,President / Vice President,,independent,"Stein, Jill",1,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Basiago, Andrew D.",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Castle, Darrell L",2,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Giordani, Rocky",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Hedges, James A",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Hoefling, Tom",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Kahn, Lynn",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"La Riva, Gloria",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Levinson, Michael S.",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Maturen, Michael A",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"McMullin, Evan",3,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Moorehead, Monica G.",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Perry, Darryl",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Schriner, Joe C",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Smith, Mike",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Sood, Ajay",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Sterling, Shawna",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Valdivia, Anthony J",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140040
+BUTLER,Bruno Township North H77,President / Vice President,,Democratic,"Clinton, Hillary Rodham",118,140040
+BUTLER,Bruno Township North H77,President / Vice President,,Libertarian,"Johnson, Gary",28,140040
+BUTLER,Bruno Township North H77,President / Vice President,,Republican,"Trump, Donald J.",401,140040
+BUTLER,Bruno Township North H99,President / Vice President,,independent,"Stein, Jill",2,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Basiago, Andrew D.",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Castle, Darrell L",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Giordani, Rocky",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Hedges, James A",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Hoefling, Tom",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Kahn, Lynn",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"La Riva, Gloria",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Levinson, Michael S.",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Maturen, Michael A",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"McMullin, Evan",1,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Moorehead, Monica G.",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Perry, Darryl",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Schriner, Joe C",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Smith, Mike",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Sood, Ajay",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Sterling, Shawna",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Valdivia, Anthony J",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140050
+BUTLER,Bruno Township North H99,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,140050
+BUTLER,Bruno Township North H99,President / Vice President,,Libertarian,"Johnson, Gary",20,140050
+BUTLER,Bruno Township North H99,President / Vice President,,Republican,"Trump, Donald J.",236,140050
+BUTLER,Bruno Township South H77,President / Vice President,,independent,"Stein, Jill",2,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Basiago, Andrew D.",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Castle, Darrell L",1,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Giordani, Rocky",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Hedges, James A",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Hoefling, Tom",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Kahn, Lynn",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"La Riva, Gloria",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Levinson, Michael S.",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Maturen, Michael A",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"McMullin, Evan",1,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Moorehead, Monica G.",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Perry, Darryl",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Schriner, Joe C",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Smith, Mike",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Sood, Ajay",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Sterling, Shawna",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Valdivia, Anthony J",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140060
+BUTLER,Bruno Township South H77,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,140060
+BUTLER,Bruno Township South H77,President / Vice President,,Libertarian,"Johnson, Gary",3,140060
+BUTLER,Bruno Township South H77,President / Vice President,,Republican,"Trump, Donald J.",101,140060
+BUTLER,Bruno Township South H99,President / Vice President,,independent,"Stein, Jill",2,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Basiago, Andrew D.",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Castle, Darrell L",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Giordani, Rocky",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Hedges, James A",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Hoefling, Tom",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Kahn, Lynn",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"La Riva, Gloria",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Levinson, Michael S.",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Maturen, Michael A",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"McMullin, Evan",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Moorehead, Monica G.",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Perry, Darryl",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Schriner, Joe C",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Smith, Mike",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Sood, Ajay",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Sterling, Shawna",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Valdivia, Anthony J",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140070
+BUTLER,Bruno Township South H99,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,140070
+BUTLER,Bruno Township South H99,President / Vice President,,Libertarian,"Johnson, Gary",5,140070
+BUTLER,Bruno Township South H99,President / Vice President,,Republican,"Trump, Donald J.",115,140070
+BUTLER,El Dorado Township East,President / Vice President,,independent,"Stein, Jill",4,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Basiago, Andrew D.",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Castle, Darrell L",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Giordani, Rocky",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Hedges, James A",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Hoefling, Tom",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Kahn, Lynn",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"La Riva, Gloria",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Levinson, Michael S.",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Maturen, Michael A",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"McMullin, Evan",1,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Moorehead, Monica G.",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Perry, Darryl",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Schriner, Joe C",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Smith, Mike",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Sood, Ajay",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Sterling, Shawna",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Valdivia, Anthony J",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140080
+BUTLER,El Dorado Township East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,140080
+BUTLER,El Dorado Township East,President / Vice President,,Libertarian,"Johnson, Gary",10,140080
+BUTLER,El Dorado Township East,President / Vice President,,Republican,"Trump, Donald J.",59,140080
+BUTLER,Rose Hill City,President / Vice President,,independent,"Stein, Jill",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Basiago, Andrew D.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Castle, Darrell L",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Giordani, Rocky",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Hedges, James A",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Kahn, Lynn",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"La Riva, Gloria",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Levinson, Michael S.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Maturen, Michael A",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"McMullin, Evan",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Moorehead, Monica G.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Perry, Darryl",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Schriner, Joe C",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Smith, Mike",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Sood, Ajay",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Sterling, Shawna",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Valdivia, Anthony J",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200010
+BUTLER,Rose Hill City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200010
+BUTLER,Rose Hill City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,200010
+BUTLER,Rose Hill City,President / Vice President,,Libertarian,"Johnson, Gary",0,200010
+BUTLER,Rose Hill City,President / Vice President,,Republican,"Trump, Donald J.",0,200010
+BUTLER,Richland Township,President / Vice President,,independent,"Stein, Jill",18,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",1,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"McMullin, Evan",6,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200020
+BUTLER,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200020
+BUTLER,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",225,200020
+BUTLER,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",62,200020
+BUTLER,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",836,200020
+BUTLER,Richland Township H77,President / Vice President,,independent,"Stein, Jill",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Basiago, Andrew D.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Castle, Darrell L",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Giordani, Rocky",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Hedges, James A",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Hoefling, Tom",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Kahn, Lynn",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"La Riva, Gloria",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Levinson, Michael S.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Maturen, Michael A",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"McMullin, Evan",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Moorehead, Monica G.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Perry, Darryl",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Schriner, Joe C",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Smith, Mike",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Sood, Ajay",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Sterling, Shawna",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Valdivia, Anthony J",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800040
+BUTLER,Richland Township H77,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800040
+BUTLER,Richland Township H77,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,800040
+BUTLER,Richland Township H77,President / Vice President,,Libertarian,"Johnson, Gary",0,800040
+BUTLER,Richland Township H77,President / Vice President,,Republican,"Trump, Donald J.",0,800040
+BUTLER,Chelsea Township,President / Vice President,,independent,"Stein, Jill",1,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Castle, Darrell L",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Giordani, Rocky",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Hedges, James A",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Hoefling, Tom",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Kahn, Lynn",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"La Riva, Gloria",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Levinson, Michael S.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Maturen, Michael A",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"McMullin, Evan",1,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Perry, Darryl",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Schriner, Joe C",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Smith, Mike",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Sood, Ajay",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Sterling, Shawna",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800050
+BUTLER,Chelsea Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800050
+BUTLER,Chelsea Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,800050
+BUTLER,Chelsea Township,President / Vice President,,Libertarian,"Johnson, Gary",3,800050
+BUTLER,Chelsea Township,President / Vice President,,Republican,"Trump, Donald J.",91,800050
+BUTLER,Andover Sewage Plant,President / Vice President,,independent,"Stein, Jill",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Basiago, Andrew D.",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Castle, Darrell L",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Giordani, Rocky",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Hedges, James A",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Hoefling, Tom",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Kahn, Lynn",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"La Riva, Gloria",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Levinson, Michael S.",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Maturen, Michael A",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"McMullin, Evan",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Moorehead, Monica G.",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Perry, Darryl",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Schriner, Joe C",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Smith, Mike",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Sood, Ajay",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Sterling, Shawna",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Valdivia, Anthony J",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,Libertarian,"Johnson, Gary",0,800060
+BUTLER,Andover Sewage Plant,President / Vice President,,Republican,"Trump, Donald J.",0,800060
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,independent,"Stein, Jill",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,independent,"Stein, Jill",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Basiago, Andrew D.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Castle, Darrell L",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Giordani, Rocky",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Hedges, James A",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Kahn, Lynn",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"La Riva, Gloria",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Levinson, Michael S.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Maturen, Michael A",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"McMullin, Evan",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Moorehead, Monica G.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Perry, Darryl",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Schriner, Joe C",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Smith, Mike",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Sood, Ajay",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Sterling, Shawna",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Valdivia, Anthony J",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,President / Vice President,,Republican,"Trump, Donald J.",0,80010B
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,independent,"Stein, Jill",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,80020A
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,independent,"Stein, Jill",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,80020B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,independent,"Stein, Jill",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Basiago, Andrew D.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Castle, Darrell L",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Giordani, Rocky",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Hedges, James A",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Hoefling, Tom",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Kahn, Lynn",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"La Riva, Gloria",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Levinson, Michael S.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Maturen, Michael A",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"McMullin, Evan",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Moorehead, Monica G.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Perry, Darryl",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Schriner, Joe C",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Smith, Mike",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Sood, Ajay",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Sterling, Shawna",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Valdivia, Anthony J",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,Libertarian,"Johnson, Gary",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,President / Vice President,,Republican,"Trump, Donald J.",0,80030B
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,independent,"Stein, Jill",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,independent,"Stein, Jill",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Basiago, Andrew D.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Castle, Darrell L",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Giordani, Rocky",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Hedges, James A",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Kahn, Lynn",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"La Riva, Gloria",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Levinson, Michael S.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Maturen, Michael A",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"McMullin, Evan",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Moorehead, Monica G.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Perry, Darryl",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Schriner, Joe C",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Smith, Mike",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Sood, Ajay",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Sterling, Shawna",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Valdivia, Anthony J",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,President / Vice President,,Republican,"Trump, Donald J.",0,80030D
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,independent,"Stein, Jill",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,80040A
+BUTLER,Richland Township H77 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,80040A
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,independent,"Stein, Jill",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,80040B
+BUTLER,Richland Township H77 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,80040B
+BUTLER,Rose Hill City Exclave A,President / Vice President,,independent,"Stein, Jill",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Hedges, James A",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Smith, Mike",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,80070A
+BUTLER,Rose Hill City Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,80070A
+BUTLER,Rose Hill City Exclave B,President / Vice President,,independent,"Stein, Jill",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Hedges, James A",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Smith, Mike",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,80070B
+BUTLER,Rose Hill City Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,80070B
+BUTLER,Rose Hill City Exclave C,President / Vice President,,independent,"Stein, Jill",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Hedges, James A",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Smith, Mike",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,80070C
+BUTLER,Rose Hill City Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,80070C
+BUTLER,Rose Hill City Exclave D,President / Vice President,,independent,"Stein, Jill",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Basiago, Andrew D.",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Castle, Darrell L",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Giordani, Rocky",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Hedges, James A",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Hoefling, Tom",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Kahn, Lynn",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"La Riva, Gloria",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Levinson, Michael S.",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Maturen, Michael A",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"McMullin, Evan",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Moorehead, Monica G.",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Perry, Darryl",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Schriner, Joe C",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Smith, Mike",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Sood, Ajay",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Sterling, Shawna",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Valdivia, Anthony J",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,80070D
+BUTLER,Rose Hill City Exclave D,President / Vice President,,Republican,"Trump, Donald J.",0,80070D
+BUTLER,Rose Hill City Exclave E,President / Vice President,,independent,"Stein, Jill",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Basiago, Andrew D.",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Castle, Darrell L",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Giordani, Rocky",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Hedges, James A",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Hoefling, Tom",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Kahn, Lynn",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"La Riva, Gloria",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Levinson, Michael S.",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Maturen, Michael A",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"McMullin, Evan",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Moorehead, Monica G.",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Perry, Darryl",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Schriner, Joe C",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Smith, Mike",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Sood, Ajay",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Sterling, Shawna",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Valdivia, Anthony J",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,Libertarian,"Johnson, Gary",0,80070E
+BUTLER,Rose Hill City Exclave E,President / Vice President,,Republican,"Trump, Donald J.",0,80070E
+BUTLER,Rose Hill City Exclave F,President / Vice President,,independent,"Stein, Jill",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Basiago, Andrew D.",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Castle, Darrell L",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Giordani, Rocky",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Hedges, James A",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Hoefling, Tom",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Kahn, Lynn",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"La Riva, Gloria",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Levinson, Michael S.",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Maturen, Michael A",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"McMullin, Evan",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Moorehead, Monica G.",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Perry, Darryl",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Schoenke, Marshall R.",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Schriner, Joe C",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Smith, Mike",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Sood, Ajay",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Sterling, Shawna",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Valdivia, Anthony J",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,Libertarian,"Johnson, Gary",0,80070F
+BUTLER,Rose Hill City Exclave F,President / Vice President,,Republican,"Trump, Donald J.",0,80070F
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,90000A
+BUTLER,Andover Ward 01,United States House of Representatives,4,independent,"Allen, Miranda",130,00001A
+BUTLER,Andover Ward 01,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",675,00001A
+BUTLER,Andover Ward 01,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",72,00001A
+BUTLER,Andover Ward 01,United States House of Representatives,4,Republican,"Pompeo, Michael",1787,00001A
+BUTLER,Andover Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,00001L
+BUTLER,Andover Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00001L
+BUTLER,Andover Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00001L
+BUTLER,Andover Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00001L
+BUTLER,Andover Exclave C,United States House of Representatives,4,independent,"Allen, Miranda",0,00001N
+BUTLER,Andover Exclave C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00001N
+BUTLER,Andover Exclave C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00001N
+BUTLER,Andover Exclave C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00001N
+BUTLER,Andover Exclave D Sewage Plant,United States House of Representatives,4,independent,"Allen, Miranda",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00001O
+BUTLER,Andover Exclave D Sewage Plant,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00001O
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",52,00002A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",198,00002A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",44,00002A
+BUTLER,Augusta City Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",512,00002A
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00002B
+BUTLER,Augusta City Ward 1 Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00002C
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",51,000030
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",153,000030
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",15,000030
+BUTLER,Augusta City Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",409,000030
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,independent,"Allen, Miranda",53,00004A
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",325,00004A
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",25,00004A
+BUTLER,Augusta City Ward 3,United States House of Representatives,4,Republican,"Pompeo, Michael",757,00004A
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00004B
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,independent,"Allen, Miranda",41,000050
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",223,000050
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",28,000050
+BUTLER,Augusta City Ward 4,United States House of Representatives,4,Republican,"Pompeo, Michael",781,000050
+BUTLER,Benton Township / City,United States House of Representatives,4,independent,"Allen, Miranda",54,000070
+BUTLER,Benton Township / City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",235,000070
+BUTLER,Benton Township / City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",35,000070
+BUTLER,Benton Township / City,United States House of Representatives,4,Republican,"Pompeo, Michael",907,000070
+BUTLER,Bloomington Township,United States House of Representatives,4,independent,"Allen, Miranda",20,000080
+BUTLER,Bloomington Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",48,000080
+BUTLER,Bloomington Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000080
+BUTLER,Bloomington Township,United States House of Representatives,4,Republican,"Pompeo, Michael",164,000080
+BUTLER,Bruno Township Enclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,00009C
+BUTLER,Bruno Township Enclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00009C
+BUTLER,Bruno Township Enclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00009C
+BUTLER,Bruno Township Enclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00009C
+BUTLER,Bruno Township Enclave D Part A,United States House of Representatives,4,independent,"Allen, Miranda",0,00009E
+BUTLER,Bruno Township Enclave D Part A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00009E
+BUTLER,Bruno Township Enclave D Part B,United States House of Representatives,4,independent,"Allen, Miranda",0,00009F
+BUTLER,Bruno Township Enclave D Part B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00009F
+BUTLER,Bruno Township Enclave D Part C,United States House of Representatives,4,independent,"Allen, Miranda",0,00009G
+BUTLER,Bruno Township Enclave D Part C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00009G
+BUTLER,Bruno Township Enclave D Part D,United States House of Representatives,4,independent,"Allen, Miranda",0,00009H
+BUTLER,Bruno Township Enclave D Part D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00009H
+BUTLER,Bruno Township Enclave D Part E,United States House of Representatives,4,independent,"Allen, Miranda",0,00009I
+BUTLER,Bruno Township Enclave D Part E,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00009I
+BUTLER,Bruno Township Enclave C,United States House of Representatives,4,independent,"Allen, Miranda",0,000090
+BUTLER,Bruno Township Enclave C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000090
+BUTLER,Bruno Township Enclave C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000090
+BUTLER,Bruno Township Enclave C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,000090
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,independent,"Allen, Miranda",2,000100
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,000100
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000100
+BUTLER,Sycamore/Cassoday,United States House of Representatives,4,Republican,"Pompeo, Michael",129,000100
+BUTLER,Clay Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000110
+BUTLER,Clay Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000110
+BUTLER,Clay Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000110
+BUTLER,Clay Township,United States House of Representatives,4,Republican,"Pompeo, Michael",32,000110
+BUTLER,Clifford Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000120
+BUTLER,Clifford Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",17,000120
+BUTLER,Clifford Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000120
+BUTLER,Clifford Township,United States House of Representatives,4,Republican,"Pompeo, Michael",86,000120
+BUTLER,Douglass Township/City,United States House of Representatives,4,independent,"Allen, Miranda",64,000130
+BUTLER,Douglass Township/City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",177,000130
+BUTLER,Douglass Township/City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",25,000130
+BUTLER,Douglass Township/City,United States House of Representatives,4,Republican,"Pompeo, Michael",572,000130
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",65,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",379,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",33,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",1063,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",104,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",394,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",45,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",809,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",0,000170
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,independent,"Allen, Miranda",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Michael",0,000180
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",60,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",253,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",30,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",633,000190
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",0,000200
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,independent,"Allen, Miranda",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Michael",0,000210
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",40,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",227,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",31,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",477,000220
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,independent,"Allen, Miranda",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00023B
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,independent,"Allen, Miranda",13,000240
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",43,000240
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000240
+BUTLER,Fairmount Township/Elbing,United States House of Representatives,4,Republican,"Pompeo, Michael",241,000240
+BUTLER,Fairview Township,United States House of Representatives,4,independent,"Allen, Miranda",14,000250
+BUTLER,Fairview Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",45,000250
+BUTLER,Fairview Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000250
+BUTLER,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Michael",189,000250
+BUTLER,Glencoe Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000260
+BUTLER,Glencoe Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",26,000260
+BUTLER,Glencoe Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000260
+BUTLER,Glencoe Township,United States House of Representatives,4,Republican,"Pompeo, Michael",55,000260
+BUTLER,Hickory Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000270
+BUTLER,Hickory Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",9,000270
+BUTLER,Hickory Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000270
+BUTLER,Hickory Township,United States House of Representatives,4,Republican,"Pompeo, Michael",39,000270
+BUTLER,Lincoln Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000280
+BUTLER,Lincoln Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",15,000280
+BUTLER,Lincoln Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000280
+BUTLER,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Michael",105,000280
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,independent,"Allen, Miranda",31,000290
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",79,000290
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",16,000290
+BUTLER,Little Walnut Township/Leon,United States House of Representatives,4,Republican,"Pompeo, Michael",248,000290
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00030A
+BUTLER,Logan Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000300
+BUTLER,Logan Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",14,000300
+BUTLER,Logan Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000300
+BUTLER,Logan Township,United States House of Representatives,4,Republican,"Pompeo, Michael",39,000300
+BUTLER,Murdock Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000320
+BUTLER,Murdock Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",32,000320
+BUTLER,Murdock Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000320
+BUTLER,Murdock Township,United States House of Representatives,4,Republican,"Pompeo, Michael",175,000320
+BUTLER,El Dorado Township West,United States House of Representatives,4,independent,"Allen, Miranda",6,000330
+BUTLER,El Dorado Township West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",45,000330
+BUTLER,El Dorado Township West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",9,000330
+BUTLER,El Dorado Township West,United States House of Representatives,4,Republican,"Pompeo, Michael",190,000330
+BUTLER,Pleasant Township,United States House of Representatives,4,independent,"Allen, Miranda",127,000340
+BUTLER,Pleasant Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",460,000340
+BUTLER,Pleasant Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",72,000340
+BUTLER,Pleasant Township,United States House of Representatives,4,Republican,"Pompeo, Michael",1615,000340
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,independent,"Allen, Miranda",18,000350
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",56,000350
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",9,000350
+BUTLER,Plum Grove Township/Potwin,United States House of Representatives,4,Republican,"Pompeo, Michael",163,000350
+BUTLER,Prospect Township,United States House of Representatives,4,independent,"Allen, Miranda",37,000360
+BUTLER,Prospect Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",105,000360
+BUTLER,Prospect Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000360
+BUTLER,Prospect Township,United States House of Representatives,4,Republican,"Pompeo, Michael",391,000360
+BUTLER,Rock Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000380
+BUTLER,Rock Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",20,000380
+BUTLER,Rock Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000380
+BUTLER,Rock Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",107,000380
+BUTLER,Rosalia Township,United States House of Representatives,4,independent,"Allen, Miranda",15,000390
+BUTLER,Rosalia Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",48,000390
+BUTLER,Rosalia Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000390
+BUTLER,Rosalia Township,United States House of Representatives,4,Republican,"Pompeo, Michael",197,000390
+BUTLER,Spring Township,United States House of Representatives,4,independent,"Allen, Miranda",47,000410
+BUTLER,Spring Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",149,000410
+BUTLER,Spring Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",25,000410
+BUTLER,Spring Township,United States House of Representatives,4,Republican,"Pompeo, Michael",510,000410
+BUTLER,Towanda Township/City,United States House of Representatives,4,independent,"Allen, Miranda",74,000430
+BUTLER,Towanda Township/City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",210,000430
+BUTLER,Towanda Township/City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",35,000430
+BUTLER,Towanda Township/City,United States House of Representatives,4,Republican,"Pompeo, Michael",878,000430
+BUTLER,Union Township / Latham,United States House of Representatives,4,independent,"Allen, Miranda",6,000440
+BUTLER,Union Township / Latham,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000440
+BUTLER,Union Township / Latham,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000440
+BUTLER,Union Township / Latham,United States House of Representatives,4,Republican,"Pompeo, Michael",51,000440
+BUTLER,Walnut Township,United States House of Representatives,4,independent,"Allen, Miranda",25,000450
+BUTLER,Walnut Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",58,000450
+BUTLER,Walnut Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000450
+BUTLER,Walnut Township,United States House of Representatives,4,Republican,"Pompeo, Michael",231,000450
+BUTLER,Augusta Township S14,United States House of Representatives,4,independent,"Allen, Miranda",11,120040
+BUTLER,Augusta Township S14,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",38,120040
+BUTLER,Augusta Township S14,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,120040
+BUTLER,Augusta Township S14,United States House of Representatives,4,Republican,"Pompeo, Michael",119,120040
+BUTLER,Augusta Township S16,United States House of Representatives,4,independent,"Allen, Miranda",23,120050
+BUTLER,Augusta Township S16,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",68,120050
+BUTLER,Augusta Township S16,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",18,120050
+BUTLER,Augusta Township S16,United States House of Representatives,4,Republican,"Pompeo, Michael",324,120050
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,independent,"Allen, Miranda",19,120080
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",60,120080
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,120080
+BUTLER,Whitewater / Milton Township H72,United States House of Representatives,4,Republican,"Pompeo, Michael",249,120080
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,independent,"Allen, Miranda",5,120090
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",29,120090
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,120090
+BUTLER,Whitewater / Milton Township H75,United States House of Representatives,4,Republican,"Pompeo, Michael",173,120090
+BUTLER,Andover Ward 02,United States House of Representatives,4,independent,"Allen, Miranda",77,140010
+BUTLER,Andover Ward 02,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",468,140010
+BUTLER,Andover Ward 02,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",60,140010
+BUTLER,Andover Ward 02,United States House of Representatives,4,Republican,"Pompeo, Michael",1150,140010
+BUTLER,Andover Ward 03,United States House of Representatives,4,independent,"Allen, Miranda",52,140020
+BUTLER,Andover Ward 03,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",242,140020
+BUTLER,Andover Ward 03,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",33,140020
+BUTLER,Andover Ward 03,United States House of Representatives,4,Republican,"Pompeo, Michael",669,140020
+BUTLER,Andover Ward 04,United States House of Representatives,4,independent,"Allen, Miranda",6,140030
+BUTLER,Andover Ward 04,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",20,140030
+BUTLER,Andover Ward 04,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,140030
+BUTLER,Andover Ward 04,United States House of Representatives,4,Republican,"Pompeo, Michael",96,140030
+BUTLER,Bruno Township North H77,United States House of Representatives,4,independent,"Allen, Miranda",38,140040
+BUTLER,Bruno Township North H77,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",102,140040
+BUTLER,Bruno Township North H77,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,140040
+BUTLER,Bruno Township North H77,United States House of Representatives,4,Republican,"Pompeo, Michael",409,140040
+BUTLER,Bruno Township North H99,United States House of Representatives,4,independent,"Allen, Miranda",20,140050
+BUTLER,Bruno Township North H99,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",62,140050
+BUTLER,Bruno Township North H99,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,140050
+BUTLER,Bruno Township North H99,United States House of Representatives,4,Republican,"Pompeo, Michael",234,140050
+BUTLER,Bruno Township South H77,United States House of Representatives,4,independent,"Allen, Miranda",9,140060
+BUTLER,Bruno Township South H77,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",25,140060
+BUTLER,Bruno Township South H77,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,140060
+BUTLER,Bruno Township South H77,United States House of Representatives,4,Republican,"Pompeo, Michael",92,140060
+BUTLER,Bruno Township South H99,United States House of Representatives,4,independent,"Allen, Miranda",7,140070
+BUTLER,Bruno Township South H99,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",26,140070
+BUTLER,Bruno Township South H99,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,140070
+BUTLER,Bruno Township South H99,United States House of Representatives,4,Republican,"Pompeo, Michael",115,140070
+BUTLER,El Dorado Township East,United States House of Representatives,4,independent,"Allen, Miranda",4,140080
+BUTLER,El Dorado Township East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",26,140080
+BUTLER,El Dorado Township East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,140080
+BUTLER,El Dorado Township East,United States House of Representatives,4,Republican,"Pompeo, Michael",64,140080
+BUTLER,Rose Hill City,United States House of Representatives,4,independent,"Allen, Miranda",0,200010
+BUTLER,Rose Hill City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,200010
+BUTLER,Rose Hill City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,200010
+BUTLER,Rose Hill City,United States House of Representatives,4,Republican,"Pompeo, Michael",0,200010
+BUTLER,Richland Township,United States House of Representatives,4,independent,"Allen, Miranda",69,200020
+BUTLER,Richland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",228,200020
+BUTLER,Richland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",35,200020
+BUTLER,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",811,200020
+BUTLER,Richland Township H77,United States House of Representatives,4,independent,"Allen, Miranda",0,800040
+BUTLER,Richland Township H77,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,800040
+BUTLER,Richland Township H77,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,800040
+BUTLER,Richland Township H77,United States House of Representatives,4,Republican,"Pompeo, Michael",0,800040
+BUTLER,Chelsea Township,United States House of Representatives,4,independent,"Allen, Miranda",4,800050
+BUTLER,Chelsea Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,800050
+BUTLER,Chelsea Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,800050
+BUTLER,Chelsea Township,United States House of Representatives,4,Republican,"Pompeo, Michael",90,800050
+BUTLER,Andover Sewage Plant,United States House of Representatives,4,independent,"Allen, Miranda",0,800060
+BUTLER,Andover Sewage Plant,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,800060
+BUTLER,Andover Sewage Plant,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,800060
+BUTLER,Andover Sewage Plant,United States House of Representatives,4,Republican,"Pompeo, Michael",0,800060
+BUTLER,Augusta City Ward 1 Exclave C,United States House of Representatives,4,independent,"Allen, Miranda",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80010A
+BUTLER,Augusta City Ward 1 Exclave D,United States House of Representatives,4,independent,"Allen, Miranda",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80010B
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80020A
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80020B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States House of Representatives,4,independent,"Allen, Miranda",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80030B
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States House of Representatives,4,independent,"Allen, Miranda",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States House of Representatives,4,independent,"Allen, Miranda",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80030D
+BUTLER,Richland Township H77 Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,80040A
+BUTLER,Richland Township H77 Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80040A
+BUTLER,Richland Township H77 Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80040A
+BUTLER,Richland Township H77 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80040A
+BUTLER,Richland Township H77 Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,80040B
+BUTLER,Richland Township H77 Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80040B
+BUTLER,Richland Township H77 Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80040B
+BUTLER,Richland Township H77 Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80040B
+BUTLER,Rose Hill City Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,80070A
+BUTLER,Rose Hill City Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80070A
+BUTLER,Rose Hill City Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80070A
+BUTLER,Rose Hill City Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80070A
+BUTLER,Rose Hill City Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,80070B
+BUTLER,Rose Hill City Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80070B
+BUTLER,Rose Hill City Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80070B
+BUTLER,Rose Hill City Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80070B
+BUTLER,Rose Hill City Exclave C,United States House of Representatives,4,independent,"Allen, Miranda",0,80070C
+BUTLER,Rose Hill City Exclave C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80070C
+BUTLER,Rose Hill City Exclave C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80070C
+BUTLER,Rose Hill City Exclave C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80070C
+BUTLER,Rose Hill City Exclave D,United States House of Representatives,4,independent,"Allen, Miranda",0,80070D
+BUTLER,Rose Hill City Exclave D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80070D
+BUTLER,Rose Hill City Exclave D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80070D
+BUTLER,Rose Hill City Exclave D,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80070D
+BUTLER,Rose Hill City Exclave E,United States House of Representatives,4,independent,"Allen, Miranda",0,80070E
+BUTLER,Rose Hill City Exclave E,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80070E
+BUTLER,Rose Hill City Exclave E,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80070E
+BUTLER,Rose Hill City Exclave E,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80070E
+BUTLER,Rose Hill City Exclave F,United States House of Representatives,4,independent,"Allen, Miranda",0,80070F
+BUTLER,Rose Hill City Exclave F,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,80070F
+BUTLER,Rose Hill City Exclave F,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,80070F
+BUTLER,Rose Hill City Exclave F,United States House of Representatives,4,Republican,"Pompeo, Michael",0,80070F
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,90000A
+BUTLER,Andover Ward 01,United States Senate,,write - in,"Smith, DJ",0,00001A
+BUTLER,Andover Ward 01,United States Senate,,Democratic,"Wiesner, Patrick",648,00001A
+BUTLER,Andover Ward 01,United States Senate,,Libertarian,"Garrard, Robert D.",162,00001A
+BUTLER,Andover Ward 01,United States Senate,,Republican,"Moran, Jerry",1843,00001A
+BUTLER,Augusta City Ward 1,United States Senate,,write - in,"Smith, DJ",0,00002A
+BUTLER,Augusta City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",191,00002A
+BUTLER,Augusta City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",84,00002A
+BUTLER,Augusta City Ward 1,United States Senate,,Republican,"Moran, Jerry",526,00002A
+BUTLER,Augusta City Ward 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002B
+BUTLER,Augusta City Ward 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00002B
+BUTLER,Augusta City Ward 1 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002C
+BUTLER,Augusta City Ward 1 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00002C
+BUTLER,Augusta City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000030
+BUTLER,Augusta City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",155,000030
+BUTLER,Augusta City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",60,000030
+BUTLER,Augusta City Ward 2,United States Senate,,Republican,"Moran, Jerry",412,000030
+BUTLER,Augusta City Ward 3,United States Senate,,write - in,"Smith, DJ",0,00004A
+BUTLER,Augusta City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",301,00004A
+BUTLER,Augusta City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",70,00004A
+BUTLER,Augusta City Ward 3,United States Senate,,Republican,"Moran, Jerry",785,00004A
+BUTLER,Augusta City Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004B
+BUTLER,Augusta City Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00004B
+BUTLER,Augusta City Ward 4,United States Senate,,write - in,"Smith, DJ",0,000050
+BUTLER,Augusta City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",205,000050
+BUTLER,Augusta City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",56,000050
+BUTLER,Augusta City Ward 4,United States Senate,,Republican,"Moran, Jerry",807,000050
+BUTLER,Benton Township / City,United States Senate,,write - in,"Smith, DJ",0,000070
+BUTLER,Benton Township / City,United States Senate,,Democratic,"Wiesner, Patrick",223,000070
+BUTLER,Benton Township / City,United States Senate,,Libertarian,"Garrard, Robert D.",72,000070
+BUTLER,Benton Township / City,United States Senate,,Republican,"Moran, Jerry",925,000070
+BUTLER,Bloomington Township,United States Senate,,write - in,"Smith, DJ",0,000080
+BUTLER,Bloomington Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000080
+BUTLER,Bloomington Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,000080
+BUTLER,Bloomington Township,United States Senate,,Republican,"Moran, Jerry",174,000080
+BUTLER,Bruno Township Enclave B,United States Senate,,write - in,"Smith, DJ",0,00009C
+BUTLER,Bruno Township Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00009C
+BUTLER,Bruno Township Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009C
+BUTLER,Bruno Township Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00009C
+BUTLER,Bruno Township Enclave D Part A,United States Senate,,write - in,"Smith, DJ",0,00009E
+BUTLER,Bruno Township Enclave D Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00009E
+BUTLER,Bruno Township Enclave D Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009E
+BUTLER,Bruno Township Enclave D Part A,United States Senate,,Republican,"Moran, Jerry",0,00009E
+BUTLER,Bruno Township Enclave D Part B,United States Senate,,write - in,"Smith, DJ",0,00009F
+BUTLER,Bruno Township Enclave D Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00009F
+BUTLER,Bruno Township Enclave D Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009F
+BUTLER,Bruno Township Enclave D Part B,United States Senate,,Republican,"Moran, Jerry",0,00009F
+BUTLER,Bruno Township Enclave D Part C,United States Senate,,write - in,"Smith, DJ",0,00009G
+BUTLER,Bruno Township Enclave D Part C,United States Senate,,Democratic,"Wiesner, Patrick",0,00009G
+BUTLER,Bruno Township Enclave D Part C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009G
+BUTLER,Bruno Township Enclave D Part C,United States Senate,,Republican,"Moran, Jerry",0,00009G
+BUTLER,Bruno Township Enclave D Part D,United States Senate,,write - in,"Smith, DJ",0,00009H
+BUTLER,Bruno Township Enclave D Part D,United States Senate,,Democratic,"Wiesner, Patrick",0,00009H
+BUTLER,Bruno Township Enclave D Part D,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009H
+BUTLER,Bruno Township Enclave D Part D,United States Senate,,Republican,"Moran, Jerry",0,00009H
+BUTLER,Bruno Township Enclave D Part E,United States Senate,,write - in,"Smith, DJ",0,00009I
+BUTLER,Bruno Township Enclave D Part E,United States Senate,,Democratic,"Wiesner, Patrick",0,00009I
+BUTLER,Bruno Township Enclave D Part E,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009I
+BUTLER,Bruno Township Enclave D Part E,United States Senate,,Republican,"Moran, Jerry",0,00009I
+BUTLER,Bruno Township Enclave C,United States Senate,,write - in,"Smith, DJ",0,000090
+BUTLER,Bruno Township Enclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,000090
+BUTLER,Bruno Township Enclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+BUTLER,Bruno Township Enclave C,United States Senate,,Republican,"Moran, Jerry",0,000090
+BUTLER,Sycamore/Cassoday,United States Senate,,write - in,"Smith, DJ",0,000100
+BUTLER,Sycamore/Cassoday,United States Senate,,Democratic,"Wiesner, Patrick",19,000100
+BUTLER,Sycamore/Cassoday,United States Senate,,Libertarian,"Garrard, Robert D.",10,000100
+BUTLER,Sycamore/Cassoday,United States Senate,,Republican,"Moran, Jerry",126,000100
+BUTLER,Clay Township,United States Senate,,write - in,"Smith, DJ",0,000110
+BUTLER,Clay Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000110
+BUTLER,Clay Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000110
+BUTLER,Clay Township,United States Senate,,Republican,"Moran, Jerry",32,000110
+BUTLER,Clifford Township,United States Senate,,write - in,"Smith, DJ",0,000120
+BUTLER,Clifford Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000120
+BUTLER,Clifford Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000120
+BUTLER,Clifford Township,United States Senate,,Republican,"Moran, Jerry",92,000120
+BUTLER,Douglass Township/City,United States Senate,,write - in,"Smith, DJ",0,000130
+BUTLER,Douglass Township/City,United States Senate,,Democratic,"Wiesner, Patrick",173,000130
+BUTLER,Douglass Township/City,United States Senate,,Libertarian,"Garrard, Robert D.",64,000130
+BUTLER,Douglass Township/City,United States Senate,,Republican,"Moran, Jerry",602,000130
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",339,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",84,00014A
+BUTLER,El Dorado Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",1111,00014A
+BUTLER,El Dorado Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,00015A
+BUTLER,El Dorado Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",0,00015A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",380,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",105,00016A
+BUTLER,El Dorado Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",856,00016A
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00016B
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 1 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00016C
+BUTLER,El Dorado Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,000170
+BUTLER,El Dorado Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",0,000170
+BUTLER,El Dorado Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+BUTLER,El Dorado Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",0,000180
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",239,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",74,000190
+BUTLER,El Dorado Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",653,000190
+BUTLER,El Dorado Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,000200
+BUTLER,El Dorado Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",0,000200
+BUTLER,El Dorado Ward 3 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,000210
+BUTLER,El Dorado Ward 3 Precinct 3,United States Senate,,Republican,"Moran, Jerry",0,000210
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",222,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",59,000220
+BUTLER,El Dorado Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",487,000220
+BUTLER,El Dorado Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",0,00023A
+BUTLER,El Dorado Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,00023B
+BUTLER,El Dorado Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",0,00023B
+BUTLER,Fairmount Township/Elbing,United States Senate,,write - in,"Smith, DJ",0,000240
+BUTLER,Fairmount Township/Elbing,United States Senate,,Democratic,"Wiesner, Patrick",38,000240
+BUTLER,Fairmount Township/Elbing,United States Senate,,Libertarian,"Garrard, Robert D.",11,000240
+BUTLER,Fairmount Township/Elbing,United States Senate,,Republican,"Moran, Jerry",254,000240
+BUTLER,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000250
+BUTLER,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000250
+BUTLER,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000250
+BUTLER,Fairview Township,United States Senate,,Republican,"Moran, Jerry",195,000250
+BUTLER,Glencoe Township,United States Senate,,write - in,"Smith, DJ",0,000260
+BUTLER,Glencoe Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000260
+BUTLER,Glencoe Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000260
+BUTLER,Glencoe Township,United States Senate,,Republican,"Moran, Jerry",64,000260
+BUTLER,Hickory Township,United States Senate,,write - in,"Smith, DJ",0,000270
+BUTLER,Hickory Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000270
+BUTLER,Hickory Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000270
+BUTLER,Hickory Township,United States Senate,,Republican,"Moran, Jerry",41,000270
+BUTLER,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000280
+BUTLER,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000280
+BUTLER,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000280
+BUTLER,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",105,000280
+BUTLER,Little Walnut Township/Leon,United States Senate,,write - in,"Smith, DJ",0,000290
+BUTLER,Little Walnut Township/Leon,United States Senate,,Democratic,"Wiesner, Patrick",78,000290
+BUTLER,Little Walnut Township/Leon,United States Senate,,Libertarian,"Garrard, Robert D.",30,000290
+BUTLER,Little Walnut Township/Leon,United States Senate,,Republican,"Moran, Jerry",264,000290
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00030A
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00030A
+BUTLER,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000300
+BUTLER,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000300
+BUTLER,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000300
+BUTLER,Logan Township,United States Senate,,Republican,"Moran, Jerry",40,000300
+BUTLER,Murdock Township,United States Senate,,write - in,"Smith, DJ",0,000320
+BUTLER,Murdock Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000320
+BUTLER,Murdock Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000320
+BUTLER,Murdock Township,United States Senate,,Republican,"Moran, Jerry",180,000320
+BUTLER,El Dorado Township West,United States Senate,,write - in,"Smith, DJ",0,000330
+BUTLER,El Dorado Township West,United States Senate,,Democratic,"Wiesner, Patrick",44,000330
+BUTLER,El Dorado Township West,United States Senate,,Libertarian,"Garrard, Robert D.",12,000330
+BUTLER,El Dorado Township West,United States Senate,,Republican,"Moran, Jerry",193,000330
+BUTLER,Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,000340
+BUTLER,Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",451,000340
+BUTLER,Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",151,000340
+BUTLER,Pleasant Township,United States Senate,,Republican,"Moran, Jerry",1651,000340
+BUTLER,Plum Grove Township/Potwin,United States Senate,,write - in,"Smith, DJ",0,000350
+BUTLER,Plum Grove Township/Potwin,United States Senate,,Democratic,"Wiesner, Patrick",59,000350
+BUTLER,Plum Grove Township/Potwin,United States Senate,,Libertarian,"Garrard, Robert D.",14,000350
+BUTLER,Plum Grove Township/Potwin,United States Senate,,Republican,"Moran, Jerry",171,000350
+BUTLER,Prospect Township,United States Senate,,write - in,"Smith, DJ",0,000360
+BUTLER,Prospect Township,United States Senate,,Democratic,"Wiesner, Patrick",102,000360
+BUTLER,Prospect Township,United States Senate,,Libertarian,"Garrard, Robert D.",42,000360
+BUTLER,Prospect Township,United States Senate,,Republican,"Moran, Jerry",400,000360
+BUTLER,Rock Creek Township,United States Senate,,write - in,"Smith, DJ",0,000380
+BUTLER,Rock Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000380
+BUTLER,Rock Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000380
+BUTLER,Rock Creek Township,United States Senate,,Republican,"Moran, Jerry",108,000380
+BUTLER,Rosalia Township,United States Senate,,write - in,"Smith, DJ",0,000390
+BUTLER,Rosalia Township,United States Senate,,Democratic,"Wiesner, Patrick",41,000390
+BUTLER,Rosalia Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000390
+BUTLER,Rosalia Township,United States Senate,,Republican,"Moran, Jerry",206,000390
+BUTLER,Spring Township,United States Senate,,write - in,"Smith, DJ",0,000410
+BUTLER,Spring Township,United States Senate,,Democratic,"Wiesner, Patrick",154,000410
+BUTLER,Spring Township,United States Senate,,Libertarian,"Garrard, Robert D.",64,000410
+BUTLER,Spring Township,United States Senate,,Republican,"Moran, Jerry",511,000410
+BUTLER,Towanda Township/City,United States Senate,,write - in,"Smith, DJ",0,000430
+BUTLER,Towanda Township/City,United States Senate,,Democratic,"Wiesner, Patrick",208,000430
+BUTLER,Towanda Township/City,United States Senate,,Libertarian,"Garrard, Robert D.",89,000430
+BUTLER,Towanda Township/City,United States Senate,,Republican,"Moran, Jerry",892,000430
+BUTLER,Union Township / Latham,United States Senate,,write - in,"Smith, DJ",0,000440
+BUTLER,Union Township / Latham,United States Senate,,Democratic,"Wiesner, Patrick",10,000440
+BUTLER,Union Township / Latham,United States Senate,,Libertarian,"Garrard, Robert D.",5,000440
+BUTLER,Union Township / Latham,United States Senate,,Republican,"Moran, Jerry",58,000440
+BUTLER,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000450
+BUTLER,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",58,000450
+BUTLER,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",27,000450
+BUTLER,Walnut Township,United States Senate,,Republican,"Moran, Jerry",241,000450
+BUTLER,Augusta Township S14,United States Senate,,write - in,"Smith, DJ",0,120040
+BUTLER,Augusta Township S14,United States Senate,,Democratic,"Wiesner, Patrick",40,120040
+BUTLER,Augusta Township S14,United States Senate,,Libertarian,"Garrard, Robert D.",11,120040
+BUTLER,Augusta Township S14,United States Senate,,Republican,"Moran, Jerry",120,120040
+BUTLER,Augusta Township S16,United States Senate,,write - in,"Smith, DJ",0,120050
+BUTLER,Augusta Township S16,United States Senate,,Democratic,"Wiesner, Patrick",66,120050
+BUTLER,Augusta Township S16,United States Senate,,Libertarian,"Garrard, Robert D.",40,120050
+BUTLER,Augusta Township S16,United States Senate,,Republican,"Moran, Jerry",323,120050
+BUTLER,Whitewater / Milton Township H72,United States Senate,,write - in,"Smith, DJ",0,120080
+BUTLER,Whitewater / Milton Township H72,United States Senate,,Democratic,"Wiesner, Patrick",52,120080
+BUTLER,Whitewater / Milton Township H72,United States Senate,,Libertarian,"Garrard, Robert D.",24,120080
+BUTLER,Whitewater / Milton Township H72,United States Senate,,Republican,"Moran, Jerry",257,120080
+BUTLER,Whitewater / Milton Township H75,United States Senate,,write - in,"Smith, DJ",0,120090
+BUTLER,Whitewater / Milton Township H75,United States Senate,,Democratic,"Wiesner, Patrick",22,120090
+BUTLER,Whitewater / Milton Township H75,United States Senate,,Libertarian,"Garrard, Robert D.",5,120090
+BUTLER,Whitewater / Milton Township H75,United States Senate,,Republican,"Moran, Jerry",182,120090
+BUTLER,Andover Ward 02,United States Senate,,write - in,"Smith, DJ",0,140010
+BUTLER,Andover Ward 02,United States Senate,,Democratic,"Wiesner, Patrick",454,140010
+BUTLER,Andover Ward 02,United States Senate,,Libertarian,"Garrard, Robert D.",127,140010
+BUTLER,Andover Ward 02,United States Senate,,Republican,"Moran, Jerry",1158,140010
+BUTLER,Andover Ward 03,United States Senate,,write - in,"Smith, DJ",0,140020
+BUTLER,Andover Ward 03,United States Senate,,Democratic,"Wiesner, Patrick",242,140020
+BUTLER,Andover Ward 03,United States Senate,,Libertarian,"Garrard, Robert D.",71,140020
+BUTLER,Andover Ward 03,United States Senate,,Republican,"Moran, Jerry",679,140020
+BUTLER,Andover Ward 04,United States Senate,,write - in,"Smith, DJ",0,140030
+BUTLER,Andover Ward 04,United States Senate,,Democratic,"Wiesner, Patrick",21,140030
+BUTLER,Andover Ward 04,United States Senate,,Libertarian,"Garrard, Robert D.",2,140030
+BUTLER,Andover Ward 04,United States Senate,,Republican,"Moran, Jerry",105,140030
+BUTLER,Bruno Township North H77,United States Senate,,write - in,"Smith, DJ",0,140040
+BUTLER,Bruno Township North H77,United States Senate,,Democratic,"Wiesner, Patrick",99,140040
+BUTLER,Bruno Township North H77,United States Senate,,Libertarian,"Garrard, Robert D.",48,140040
+BUTLER,Bruno Township North H77,United States Senate,,Republican,"Moran, Jerry",415,140040
+BUTLER,Bruno Township North H99,United States Senate,,write - in,"Smith, DJ",0,140050
+BUTLER,Bruno Township North H99,United States Senate,,Democratic,"Wiesner, Patrick",54,140050
+BUTLER,Bruno Township North H99,United States Senate,,Libertarian,"Garrard, Robert D.",26,140050
+BUTLER,Bruno Township North H99,United States Senate,,Republican,"Moran, Jerry",248,140050
+BUTLER,Bruno Township South H77,United States Senate,,write - in,"Smith, DJ",0,140060
+BUTLER,Bruno Township South H77,United States Senate,,Democratic,"Wiesner, Patrick",20,140060
+BUTLER,Bruno Township South H77,United States Senate,,Libertarian,"Garrard, Robert D.",9,140060
+BUTLER,Bruno Township South H77,United States Senate,,Republican,"Moran, Jerry",102,140060
+BUTLER,Bruno Township South H99,United States Senate,,write - in,"Smith, DJ",0,140070
+BUTLER,Bruno Township South H99,United States Senate,,Democratic,"Wiesner, Patrick",25,140070
+BUTLER,Bruno Township South H99,United States Senate,,Libertarian,"Garrard, Robert D.",11,140070
+BUTLER,Bruno Township South H99,United States Senate,,Republican,"Moran, Jerry",117,140070
+BUTLER,El Dorado Township East,United States Senate,,write - in,"Smith, DJ",0,140080
+BUTLER,El Dorado Township East,United States Senate,,Democratic,"Wiesner, Patrick",22,140080
+BUTLER,El Dorado Township East,United States Senate,,Libertarian,"Garrard, Robert D.",11,140080
+BUTLER,El Dorado Township East,United States Senate,,Republican,"Moran, Jerry",64,140080
+BUTLER,Rose Hill City,United States Senate,,write - in,"Smith, DJ",0,200010
+BUTLER,Rose Hill City,United States Senate,,Democratic,"Wiesner, Patrick",0,200010
+BUTLER,Rose Hill City,United States Senate,,Libertarian,"Garrard, Robert D.",0,200010
+BUTLER,Rose Hill City,United States Senate,,Republican,"Moran, Jerry",0,200010
+BUTLER,Richland Township,United States Senate,,write - in,"Smith, DJ",0,200020
+BUTLER,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",212,200020
+BUTLER,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",82,200020
+BUTLER,Richland Township,United States Senate,,Republican,"Moran, Jerry",843,200020
+BUTLER,Richland Township H77,United States Senate,,write - in,"Smith, DJ",0,800040
+BUTLER,Richland Township H77,United States Senate,,Democratic,"Wiesner, Patrick",0,800040
+BUTLER,Richland Township H77,United States Senate,,Libertarian,"Garrard, Robert D.",0,800040
+BUTLER,Richland Township H77,United States Senate,,Republican,"Moran, Jerry",0,800040
+BUTLER,Chelsea Township,United States Senate,,write - in,"Smith, DJ",0,800050
+BUTLER,Chelsea Township,United States Senate,,Democratic,"Wiesner, Patrick",28,800050
+BUTLER,Chelsea Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,800050
+BUTLER,Chelsea Township,United States Senate,,Republican,"Moran, Jerry",87,800050
+BUTLER,Augusta City Ward 1 Exclave C,United States Senate,,write - in,"Smith, DJ",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,80010A
+BUTLER,Augusta City Ward 1 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,80010A
+BUTLER,Augusta City Ward 1 Exclave D,United States Senate,,write - in,"Smith, DJ",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,United States Senate,,Democratic,"Wiesner, Patrick",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,United States Senate,,Libertarian,"Garrard, Robert D.",0,80010B
+BUTLER,Augusta City Ward 1 Exclave D,United States Senate,,Republican,"Moran, Jerry",0,80010B
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States Senate,,write - in,"Smith, DJ",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,80020A
+BUTLER,El Dorado Ward 1 Precinct 2 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,80020A
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,write - in,"Smith, DJ",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,80020B
+BUTLER,El Dorado City Ward 1 Precinct 2 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,80020B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States Senate,,write - in,"Smith, DJ",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States Senate,,Democratic,"Wiesner, Patrick",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States Senate,,Libertarian,"Garrard, Robert D.",0,80030B
+BUTLER,El Dorado City Ward 4 Precinct 3 375,United States Senate,,Republican,"Moran, Jerry",0,80030B
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States Senate,,write - in,"Smith, DJ",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,80030C
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States Senate,,write - in,"Smith, DJ",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States Senate,,Democratic,"Wiesner, Patrick",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States Senate,,Libertarian,"Garrard, Robert D.",0,80030D
+BUTLER,El Dorado Ward 4 Precinct 3 Exclave D,United States Senate,,Republican,"Moran, Jerry",0,80030D
+BUTLER,Richland Township H77 Exclave A,United States Senate,,write - in,"Smith, DJ",0,80040A
+BUTLER,Richland Township H77 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,80040A
+BUTLER,Richland Township H77 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,80040A
+BUTLER,Richland Township H77 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,80040A
+BUTLER,Richland Township H77 Exclave B,United States Senate,,write - in,"Smith, DJ",0,80040B
+BUTLER,Richland Township H77 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,80040B
+BUTLER,Richland Township H77 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,80040B
+BUTLER,Richland Township H77 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,80040B
+BUTLER,Rose Hill City Exclave A,United States Senate,,write - in,"Smith, DJ",0,80070A
+BUTLER,Rose Hill City Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,80070A
+BUTLER,Rose Hill City Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,80070A
+BUTLER,Rose Hill City Exclave A,United States Senate,,Republican,"Moran, Jerry",0,80070A
+BUTLER,Rose Hill City Exclave B,United States Senate,,write - in,"Smith, DJ",0,80070B
+BUTLER,Rose Hill City Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,80070B
+BUTLER,Rose Hill City Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,80070B
+BUTLER,Rose Hill City Exclave B,United States Senate,,Republican,"Moran, Jerry",0,80070B
+BUTLER,Rose Hill City Exclave C,United States Senate,,write - in,"Smith, DJ",0,80070C
+BUTLER,Rose Hill City Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,80070C
+BUTLER,Rose Hill City Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,80070C
+BUTLER,Rose Hill City Exclave C,United States Senate,,Republican,"Moran, Jerry",0,80070C
+BUTLER,Rose Hill City Exclave D,United States Senate,,write - in,"Smith, DJ",0,80070D
+BUTLER,Rose Hill City Exclave D,United States Senate,,Democratic,"Wiesner, Patrick",0,80070D
+BUTLER,Rose Hill City Exclave D,United States Senate,,Libertarian,"Garrard, Robert D.",0,80070D
+BUTLER,Rose Hill City Exclave D,United States Senate,,Republican,"Moran, Jerry",0,80070D
+BUTLER,Rose Hill City Exclave E,United States Senate,,write - in,"Smith, DJ",0,80070E
+BUTLER,Rose Hill City Exclave E,United States Senate,,Democratic,"Wiesner, Patrick",0,80070E
+BUTLER,Rose Hill City Exclave E,United States Senate,,Libertarian,"Garrard, Robert D.",0,80070E
+BUTLER,Rose Hill City Exclave E,United States Senate,,Republican,"Moran, Jerry",0,80070E
+BUTLER,Rose Hill City Exclave F,United States Senate,,write - in,"Smith, DJ",0,80070F
+BUTLER,Rose Hill City Exclave F,United States Senate,,Democratic,"Wiesner, Patrick",0,80070F
+BUTLER,Rose Hill City Exclave F,United States Senate,,Libertarian,"Garrard, Robert D.",0,80070F
+BUTLER,Rose Hill City Exclave F,United States Senate,,Republican,"Moran, Jerry",0,80070F
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,90000A
+BUTLER,El Dorado Ward 4 Precinct 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,90000A

--- a/2016/20161108__ks__general__chase__precinct.csv
+++ b/2016/20161108__ks__general__chase__precinct.csv
@@ -1,408 +1,408 @@
-county,precinct,office,district,candidate,party,votes
-Chase,Bazaar Township,President,,"Stein, Jill  ",independent,1
-Chase,Bazaar Township,President,,"Basiago, Andrew D. ",,0
-Chase,Bazaar Township,President,,"Castle, Darrell L ",,0
-Chase,Bazaar Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Bazaar Township,President,,"Giordani, Rocky  ",,0
-Chase,Bazaar Township,President,,"Hedges, James A ",,0
-Chase,Bazaar Township,President,,"Hoefling, Tom  ",,0
-Chase,Bazaar Township,President,,"Kahn, Lynn  ",,0
-Chase,Bazaar Township,President,,"La Riva, Gloria  ",,0
-Chase,Bazaar Township,President,,"Levinson, Michael S. ",,0
-Chase,Bazaar Township,President,,"Maturen, Michael A ",,0
-Chase,Bazaar Township,President,,"McMullin, Evan  ",,0
-Chase,Bazaar Township,President,,"Moorehead, Monica G. ",,0
-Chase,Bazaar Township,President,,"Perry, Darryl  ",,0
-Chase,Bazaar Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Bazaar Township,President,,"Schriner, Joe C ",,0
-Chase,Bazaar Township,President,,"Smith, Mike  ",,0
-Chase,Bazaar Township,President,,"Sood, Ajay  ",,0
-Chase,Bazaar Township,President,,"Sterling, Shawna  ",,0
-Chase,Bazaar Township,President,,"Valdivia, Anthony J ",,0
-Chase,Bazaar Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Bazaar Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Bazaar Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Chase,Bazaar Township,President,,"Johnson, Gary  ",Libertarian,0
-Chase,Bazaar Township,President,,"Trump, Donald J. ",Republican,51
-Chase,Cedar Township,President,,"Stein, Jill  ",independent,0
-Chase,Cedar Township,President,,"Basiago, Andrew D. ",,0
-Chase,Cedar Township,President,,"Castle, Darrell L ",,0
-Chase,Cedar Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Cedar Township,President,,"Giordani, Rocky  ",,0
-Chase,Cedar Township,President,,"Hedges, James A ",,0
-Chase,Cedar Township,President,,"Hoefling, Tom  ",,0
-Chase,Cedar Township,President,,"Kahn, Lynn  ",,0
-Chase,Cedar Township,President,,"La Riva, Gloria  ",,0
-Chase,Cedar Township,President,,"Levinson, Michael S. ",,0
-Chase,Cedar Township,President,,"Maturen, Michael A ",,0
-Chase,Cedar Township,President,,"McMullin, Evan  ",,0
-Chase,Cedar Township,President,,"Moorehead, Monica G. ",,0
-Chase,Cedar Township,President,,"Perry, Darryl  ",,0
-Chase,Cedar Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Cedar Township,President,,"Schriner, Joe C ",,0
-Chase,Cedar Township,President,,"Smith, Mike  ",,0
-Chase,Cedar Township,President,,"Sood, Ajay  ",,0
-Chase,Cedar Township,President,,"Sterling, Shawna  ",,0
-Chase,Cedar Township,President,,"Valdivia, Anthony J ",,0
-Chase,Cedar Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Cedar Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Cedar Township,President,,"Clinton, Hillary Rodham ",Democratic,10
-Chase,Cedar Township,President,,"Johnson, Gary  ",Libertarian,1
-Chase,Cedar Township,President,,"Trump, Donald J. ",Republican,39
-Chase,Cottonwood Township,President,,"Stein, Jill  ",independent,0
-Chase,Cottonwood Township,President,,"Basiago, Andrew D. ",,0
-Chase,Cottonwood Township,President,,"Castle, Darrell L ",,0
-Chase,Cottonwood Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Cottonwood Township,President,,"Giordani, Rocky  ",,0
-Chase,Cottonwood Township,President,,"Hedges, James A ",,0
-Chase,Cottonwood Township,President,,"Hoefling, Tom  ",,0
-Chase,Cottonwood Township,President,,"Kahn, Lynn  ",,0
-Chase,Cottonwood Township,President,,"La Riva, Gloria  ",,0
-Chase,Cottonwood Township,President,,"Levinson, Michael S. ",,0
-Chase,Cottonwood Township,President,,"Maturen, Michael A ",,0
-Chase,Cottonwood Township,President,,"McMullin, Evan  ",,1
-Chase,Cottonwood Township,President,,"Moorehead, Monica G. ",,0
-Chase,Cottonwood Township,President,,"Perry, Darryl  ",,0
-Chase,Cottonwood Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Cottonwood Township,President,,"Schriner, Joe C ",,0
-Chase,Cottonwood Township,President,,"Smith, Mike  ",,0
-Chase,Cottonwood Township,President,,"Sood, Ajay  ",,0
-Chase,Cottonwood Township,President,,"Sterling, Shawna  ",,0
-Chase,Cottonwood Township,President,,"Valdivia, Anthony J ",,0
-Chase,Cottonwood Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Cottonwood Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Cottonwood Township,President,,"Clinton, Hillary Rodham ",Democratic,21
-Chase,Cottonwood Township,President,,"Johnson, Gary  ",Libertarian,2
-Chase,Cottonwood Township,President,,"Trump, Donald J. ",Republican,47
-Chase,Diamond Township,President,,"Stein, Jill  ",independent,2
-Chase,Diamond Township,President,,"Basiago, Andrew D. ",,0
-Chase,Diamond Township,President,,"Castle, Darrell L ",,0
-Chase,Diamond Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Diamond Township,President,,"Giordani, Rocky  ",,0
-Chase,Diamond Township,President,,"Hedges, James A ",,0
-Chase,Diamond Township,President,,"Hoefling, Tom  ",,0
-Chase,Diamond Township,President,,"Kahn, Lynn  ",,0
-Chase,Diamond Township,President,,"La Riva, Gloria  ",,0
-Chase,Diamond Township,President,,"Levinson, Michael S. ",,0
-Chase,Diamond Township,President,,"Maturen, Michael A ",,0
-Chase,Diamond Township,President,,"McMullin, Evan  ",,3
-Chase,Diamond Township,President,,"Moorehead, Monica G. ",,0
-Chase,Diamond Township,President,,"Perry, Darryl  ",,0
-Chase,Diamond Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Diamond Township,President,,"Schriner, Joe C ",,0
-Chase,Diamond Township,President,,"Smith, Mike  ",,0
-Chase,Diamond Township,President,,"Sood, Ajay  ",,0
-Chase,Diamond Township,President,,"Sterling, Shawna  ",,0
-Chase,Diamond Township,President,,"Valdivia, Anthony J ",,0
-Chase,Diamond Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Diamond Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Diamond Township,President,,"Clinton, Hillary Rodham ",Democratic,17
-Chase,Diamond Township,President,,"Johnson, Gary  ",Libertarian,7
-Chase,Diamond Township,President,,"Trump, Donald J. ",Republican,97
-Chase,East Falls Township,President,,"Stein, Jill  ",independent,3
-Chase,East Falls Township,President,,"Basiago, Andrew D. ",,0
-Chase,East Falls Township,President,,"Castle, Darrell L ",,0
-Chase,East Falls Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,East Falls Township,President,,"Giordani, Rocky  ",,0
-Chase,East Falls Township,President,,"Hedges, James A ",,0
-Chase,East Falls Township,President,,"Hoefling, Tom  ",,0
-Chase,East Falls Township,President,,"Kahn, Lynn  ",,0
-Chase,East Falls Township,President,,"La Riva, Gloria  ",,0
-Chase,East Falls Township,President,,"Levinson, Michael S. ",,0
-Chase,East Falls Township,President,,"Maturen, Michael A ",,0
-Chase,East Falls Township,President,,"McMullin, Evan  ",,0
-Chase,East Falls Township,President,,"Moorehead, Monica G. ",,0
-Chase,East Falls Township,President,,"Perry, Darryl  ",,0
-Chase,East Falls Township,President,,"Schoenke, Marshall R. ",,0
-Chase,East Falls Township,President,,"Schriner, Joe C ",,0
-Chase,East Falls Township,President,,"Smith, Mike  ",,0
-Chase,East Falls Township,President,,"Sood, Ajay  ",,0
-Chase,East Falls Township,President,,"Sterling, Shawna  ",,0
-Chase,East Falls Township,President,,"Valdivia, Anthony J ",,0
-Chase,East Falls Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,East Falls Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,East Falls Township,President,,"Clinton, Hillary Rodham ",Democratic,40
-Chase,East Falls Township,President,,"Johnson, Gary  ",Libertarian,4
-Chase,East Falls Township,President,,"Trump, Donald J. ",Republican,172
-Chase,East Strong Township,President,,"Stein, Jill  ",independent,7
-Chase,East Strong Township,President,,"Basiago, Andrew D. ",,0
-Chase,East Strong Township,President,,"Castle, Darrell L ",,0
-Chase,East Strong Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,East Strong Township,President,,"Giordani, Rocky  ",,0
-Chase,East Strong Township,President,,"Hedges, James A ",,0
-Chase,East Strong Township,President,,"Hoefling, Tom  ",,0
-Chase,East Strong Township,President,,"Kahn, Lynn  ",,0
-Chase,East Strong Township,President,,"La Riva, Gloria  ",,0
-Chase,East Strong Township,President,,"Levinson, Michael S. ",,0
-Chase,East Strong Township,President,,"Maturen, Michael A ",,0
-Chase,East Strong Township,President,,"McMullin, Evan  ",,0
-Chase,East Strong Township,President,,"Moorehead, Monica G. ",,0
-Chase,East Strong Township,President,,"Perry, Darryl  ",,0
-Chase,East Strong Township,President,,"Schoenke, Marshall R. ",,0
-Chase,East Strong Township,President,,"Schriner, Joe C ",,0
-Chase,East Strong Township,President,,"Smith, Mike  ",,0
-Chase,East Strong Township,President,,"Sood, Ajay  ",,0
-Chase,East Strong Township,President,,"Sterling, Shawna  ",,0
-Chase,East Strong Township,President,,"Valdivia, Anthony J ",,0
-Chase,East Strong Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,East Strong Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,East Strong Township,President,,"Clinton, Hillary Rodham ",Democratic,57
-Chase,East Strong Township,President,,"Johnson, Gary  ",Libertarian,9
-Chase,East Strong Township,President,,"Trump, Donald J. ",Republican,153
-Chase,Homestead Township,President,,"Stein, Jill  ",independent,2
-Chase,Homestead Township,President,,"Basiago, Andrew D. ",,0
-Chase,Homestead Township,President,,"Castle, Darrell L ",,0
-Chase,Homestead Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Homestead Township,President,,"Giordani, Rocky  ",,0
-Chase,Homestead Township,President,,"Hedges, James A ",,0
-Chase,Homestead Township,President,,"Hoefling, Tom  ",,0
-Chase,Homestead Township,President,,"Kahn, Lynn  ",,0
-Chase,Homestead Township,President,,"La Riva, Gloria  ",,0
-Chase,Homestead Township,President,,"Levinson, Michael S. ",,0
-Chase,Homestead Township,President,,"Maturen, Michael A ",,0
-Chase,Homestead Township,President,,"McMullin, Evan  ",,0
-Chase,Homestead Township,President,,"Moorehead, Monica G. ",,0
-Chase,Homestead Township,President,,"Perry, Darryl  ",,0
-Chase,Homestead Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Homestead Township,President,,"Schriner, Joe C ",,0
-Chase,Homestead Township,President,,"Smith, Mike  ",,0
-Chase,Homestead Township,President,,"Sood, Ajay  ",,0
-Chase,Homestead Township,President,,"Sterling, Shawna  ",,0
-Chase,Homestead Township,President,,"Valdivia, Anthony J ",,0
-Chase,Homestead Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Homestead Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Homestead Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Chase,Homestead Township,President,,"Johnson, Gary  ",Libertarian,2
-Chase,Homestead Township,President,,"Trump, Donald J. ",Republican,21
-Chase,Matfield Township,President,,"Stein, Jill  ",independent,0
-Chase,Matfield Township,President,,"Basiago, Andrew D. ",,0
-Chase,Matfield Township,President,,"Castle, Darrell L ",,0
-Chase,Matfield Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Matfield Township,President,,"Giordani, Rocky  ",,0
-Chase,Matfield Township,President,,"Hedges, James A ",,0
-Chase,Matfield Township,President,,"Hoefling, Tom  ",,0
-Chase,Matfield Township,President,,"Kahn, Lynn  ",,0
-Chase,Matfield Township,President,,"La Riva, Gloria  ",,0
-Chase,Matfield Township,President,,"Levinson, Michael S. ",,0
-Chase,Matfield Township,President,,"Maturen, Michael A ",,0
-Chase,Matfield Township,President,,"McMullin, Evan  ",,0
-Chase,Matfield Township,President,,"Moorehead, Monica G. ",,0
-Chase,Matfield Township,President,,"Perry, Darryl  ",,0
-Chase,Matfield Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Matfield Township,President,,"Schriner, Joe C ",,0
-Chase,Matfield Township,President,,"Smith, Mike  ",,0
-Chase,Matfield Township,President,,"Sood, Ajay  ",,0
-Chase,Matfield Township,President,,"Sterling, Shawna  ",,0
-Chase,Matfield Township,President,,"Valdivia, Anthony J ",,0
-Chase,Matfield Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Matfield Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Matfield Township,President,,"Clinton, Hillary Rodham ",Democratic,26
-Chase,Matfield Township,President,,"Johnson, Gary  ",Libertarian,2
-Chase,Matfield Township,President,,"Trump, Donald J. ",Republican,44
-Chase,Toledo Township,President,,"Stein, Jill  ",independent,1
-Chase,Toledo Township,President,,"Basiago, Andrew D. ",,0
-Chase,Toledo Township,President,,"Castle, Darrell L ",,0
-Chase,Toledo Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,Toledo Township,President,,"Giordani, Rocky  ",,0
-Chase,Toledo Township,President,,"Hedges, James A ",,0
-Chase,Toledo Township,President,,"Hoefling, Tom  ",,0
-Chase,Toledo Township,President,,"Kahn, Lynn  ",,0
-Chase,Toledo Township,President,,"La Riva, Gloria  ",,0
-Chase,Toledo Township,President,,"Levinson, Michael S. ",,0
-Chase,Toledo Township,President,,"Maturen, Michael A ",,0
-Chase,Toledo Township,President,,"McMullin, Evan  ",,3
-Chase,Toledo Township,President,,"Moorehead, Monica G. ",,0
-Chase,Toledo Township,President,,"Perry, Darryl  ",,0
-Chase,Toledo Township,President,,"Schoenke, Marshall R. ",,0
-Chase,Toledo Township,President,,"Schriner, Joe C ",,0
-Chase,Toledo Township,President,,"Smith, Mike  ",,0
-Chase,Toledo Township,President,,"Sood, Ajay  ",,0
-Chase,Toledo Township,President,,"Sterling, Shawna  ",,0
-Chase,Toledo Township,President,,"Valdivia, Anthony J ",,0
-Chase,Toledo Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,Toledo Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,Toledo Township,President,,"Clinton, Hillary Rodham ",Democratic,44
-Chase,Toledo Township,President,,"Johnson, Gary  ",Libertarian,3
-Chase,Toledo Township,President,,"Trump, Donald J. ",Republican,127
-Chase,West Falls Township,President,,"Stein, Jill  ",independent,12
-Chase,West Falls Township,President,,"Basiago, Andrew D. ",,0
-Chase,West Falls Township,President,,"Castle, Darrell L ",,1
-Chase,West Falls Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,West Falls Township,President,,"Giordani, Rocky  ",,0
-Chase,West Falls Township,President,,"Hedges, James A ",,0
-Chase,West Falls Township,President,,"Hoefling, Tom  ",,0
-Chase,West Falls Township,President,,"Kahn, Lynn  ",,0
-Chase,West Falls Township,President,,"La Riva, Gloria  ",,0
-Chase,West Falls Township,President,,"Levinson, Michael S. ",,0
-Chase,West Falls Township,President,,"Maturen, Michael A ",,0
-Chase,West Falls Township,President,,"McMullin, Evan  ",,0
-Chase,West Falls Township,President,,"Moorehead, Monica G. ",,0
-Chase,West Falls Township,President,,"Perry, Darryl  ",,0
-Chase,West Falls Township,President,,"Schoenke, Marshall R. ",,0
-Chase,West Falls Township,President,,"Schriner, Joe C ",,0
-Chase,West Falls Township,President,,"Smith, Mike  ",,0
-Chase,West Falls Township,President,,"Sood, Ajay  ",,0
-Chase,West Falls Township,President,,"Sterling, Shawna  ",,0
-Chase,West Falls Township,President,,"Valdivia, Anthony J ",,0
-Chase,West Falls Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,West Falls Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,West Falls Township,President,,"Clinton, Hillary Rodham ",Democratic,74
-Chase,West Falls Township,President,,"Johnson, Gary  ",Libertarian,12
-Chase,West Falls Township,President,,"Trump, Donald J. ",Republican,183
-Chase,West Strong Township,President,,"Stein, Jill  ",independent,3
-Chase,West Strong Township,President,,"Basiago, Andrew D. ",,0
-Chase,West Strong Township,President,,"Castle, Darrell L ",,0
-Chase,West Strong Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Chase,West Strong Township,President,,"Giordani, Rocky  ",,0
-Chase,West Strong Township,President,,"Hedges, James A ",,0
-Chase,West Strong Township,President,,"Hoefling, Tom  ",,0
-Chase,West Strong Township,President,,"Kahn, Lynn  ",,0
-Chase,West Strong Township,President,,"La Riva, Gloria  ",,0
-Chase,West Strong Township,President,,"Levinson, Michael S. ",,0
-Chase,West Strong Township,President,,"Maturen, Michael A ",,0
-Chase,West Strong Township,President,,"McMullin, Evan  ",,0
-Chase,West Strong Township,President,,"Moorehead, Monica G. ",,0
-Chase,West Strong Township,President,,"Perry, Darryl  ",,0
-Chase,West Strong Township,President,,"Schoenke, Marshall R. ",,0
-Chase,West Strong Township,President,,"Schriner, Joe C ",,0
-Chase,West Strong Township,President,,"Smith, Mike  ",,0
-Chase,West Strong Township,President,,"Sood, Ajay  ",,0
-Chase,West Strong Township,President,,"Sterling, Shawna  ",,0
-Chase,West Strong Township,President,,"Valdivia, Anthony J ",,0
-Chase,West Strong Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Chase,West Strong Township,President,,"Wysinger, Demetra Jefferson ",,0
-Chase,West Strong Township,President,,"Clinton, Hillary Rodham ",Democratic,15
-Chase,West Strong Township,President,,"Johnson, Gary  ",Libertarian,3
-Chase,West Strong Township,President,,"Trump, Donald J. ",Republican,35
-Chase,Bazaar Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Bazaar Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Chase,Bazaar Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Chase,Bazaar Township,U.S. Senate,,"Moran, Jerry  ",Republican,53
-Chase,Cedar Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Cedar Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,8
-Chase,Cedar Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Chase,Cedar Township,U.S. Senate,,"Moran, Jerry  ",Republican,36
-Chase,Cottonwood Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Cottonwood Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,15
-Chase,Cottonwood Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,14
-Chase,Cottonwood Township,U.S. Senate,,"Moran, Jerry  ",Republican,43
-Chase,Diamond Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Diamond Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Chase,Diamond Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Chase,Diamond Township,U.S. Senate,,"Moran, Jerry  ",Republican,106
-Chase,East Falls Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,East Falls Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,31
-Chase,East Falls Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,17
-Chase,East Falls Township,U.S. Senate,,"Moran, Jerry  ",Republican,180
-Chase,East Strong Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,East Strong Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,55
-Chase,East Strong Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,15
-Chase,East Strong Township,U.S. Senate,,"Moran, Jerry  ",Republican,152
-Chase,Homestead Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Homestead Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Chase,Homestead Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Chase,Homestead Township,U.S. Senate,,"Moran, Jerry  ",Republican,24
-Chase,Matfield Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Matfield Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,23
-Chase,Matfield Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Chase,Matfield Township,U.S. Senate,,"Moran, Jerry  ",Republican,49
-Chase,Toledo Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,Toledo Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,42
-Chase,Toledo Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Chase,Toledo Township,U.S. Senate,,"Moran, Jerry  ",Republican,129
-Chase,West Falls Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,West Falls Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,62
-Chase,West Falls Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,17
-Chase,West Falls Township,U.S. Senate,,"Moran, Jerry  ",Republican,212
-Chase,West Strong Township,U.S. Senate,,"Smith, DJ  ",,0
-Chase,West Strong Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,17
-Chase,West Strong Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Chase,West Strong Township,U.S. Senate,,"Moran, Jerry  ",Republican,37
-Chase,Bazaar Township,U.S. House,1,"LaPolice, Alan  ",independent,9
-Chase,Bazaar Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Chase,Bazaar Township,U.S. House,1,"Burt, Kerry  ",Libertarian,6
-Chase,Bazaar Township,U.S. House,1,"Marshall, Roger  ",Republican,37
-Chase,Cedar Township,U.S. House,1,"LaPolice, Alan  ",independent,9
-Chase,Cedar Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,Cedar Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Chase,Cedar Township,U.S. House,1,"Marshall, Roger  ",Republican,34
-Chase,Cottonwood Township,U.S. House,1,"LaPolice, Alan  ",independent,16
-Chase,Cottonwood Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,Cottonwood Township,U.S. House,1,"Burt, Kerry  ",Libertarian,10
-Chase,Cottonwood Township,U.S. House,1,"Marshall, Roger  ",Republican,42
-Chase,Diamond Township,U.S. House,1,"LaPolice, Alan  ",independent,18
-Chase,Diamond Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Chase,Diamond Township,U.S. House,1,"Burt, Kerry  ",Libertarian,7
-Chase,Diamond Township,U.S. House,1,"Marshall, Roger  ",Republican,95
-Chase,East Falls Township,U.S. House,1,"LaPolice, Alan  ",independent,36
-Chase,East Falls Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Chase,East Falls Township,U.S. House,1,"Burt, Kerry  ",Libertarian,16
-Chase,East Falls Township,U.S. House,1,"Marshall, Roger  ",Republican,170
-Chase,East Strong Township,U.S. House,1,"LaPolice, Alan  ",independent,59
-Chase,East Strong Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,East Strong Township,U.S. House,1,"Burt, Kerry  ",Libertarian,10
-Chase,East Strong Township,U.S. House,1,"Marshall, Roger  ",Republican,150
-Chase,Homestead Township,U.S. House,1,"LaPolice, Alan  ",independent,11
-Chase,Homestead Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,Homestead Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Chase,Homestead Township,U.S. House,1,"Marshall, Roger  ",Republican,21
-Chase,Matfield Township,U.S. House,1,"LaPolice, Alan  ",independent,28
-Chase,Matfield Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,Matfield Township,U.S. House,1,"Burt, Kerry  ",Libertarian,5
-Chase,Matfield Township,U.S. House,1,"Marshall, Roger  ",Republican,26
-Chase,Toledo Township,U.S. House,1,"LaPolice, Alan  ",independent,42
-Chase,Toledo Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,Toledo Township,U.S. House,1,"Burt, Kerry  ",Libertarian,13
-Chase,Toledo Township,U.S. House,1,"Marshall, Roger  ",Republican,120
-Chase,West Falls Township,U.S. House,1,"LaPolice, Alan  ",independent,52
-Chase,West Falls Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,West Falls Township,U.S. House,1,"Burt, Kerry  ",Libertarian,24
-Chase,West Falls Township,U.S. House,1,"Marshall, Roger  ",Republican,205
-Chase,West Strong Township,U.S. House,1,"LaPolice, Alan  ",independent,19
-Chase,West Strong Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Chase,West Strong Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Chase,West Strong Township,U.S. House,1,"Marshall, Roger  ",Republican,33
-Chase,Bazaar Township,State Senate,35,"Morris, Levi  ",Democratic,7
-Chase,Bazaar Township,State Senate,35,"Wilborn, Richard  ",Republican,46
-Chase,Cedar Township,State Senate,35,"Morris, Levi  ",Democratic,15
-Chase,Cedar Township,State Senate,35,"Wilborn, Richard  ",Republican,35
-Chase,Cottonwood Township,State Senate,35,"Morris, Levi  ",Democratic,18
-Chase,Cottonwood Township,State Senate,35,"Wilborn, Richard  ",Republican,49
-Chase,Diamond Township,State Senate,35,"Morris, Levi  ",Democratic,29
-Chase,Diamond Township,State Senate,35,"Wilborn, Richard  ",Republican,94
-Chase,East Falls Township,State Senate,35,"Morris, Levi  ",Democratic,45
-Chase,East Falls Township,State Senate,35,"Wilborn, Richard  ",Republican,178
-Chase,East Strong Township,State Senate,35,"Morris, Levi  ",Democratic,75
-Chase,East Strong Township,State Senate,35,"Wilborn, Richard  ",Republican,139
-Chase,Homestead Township,State Senate,35,"Morris, Levi  ",Democratic,13
-Chase,Homestead Township,State Senate,35,"Wilborn, Richard  ",Republican,20
-Chase,Matfield Township,State Senate,35,"Morris, Levi  ",Democratic,27
-Chase,Matfield Township,State Senate,35,"Wilborn, Richard  ",Republican,43
-Chase,Toledo Township,State Senate,35,"Morris, Levi  ",Democratic,55
-Chase,Toledo Township,State Senate,35,"Wilborn, Richard  ",Republican,118
-Chase,West Falls Township,State Senate,35,"Morris, Levi  ",Democratic,90
-Chase,West Falls Township,State Senate,35,"Wilborn, Richard  ",Republican,194
-Chase,West Strong Township,State Senate,35,"Morris, Levi  ",Democratic,24
-Chase,West Strong Township,State Senate,35,"Wilborn, Richard  ",Republican,30
-Chase,Bazaar Township,State House,68,"Blevins, Laura  ",Democratic,3
-Chase,Bazaar Township,State House,68,"Baker, Dave  ",Republican,51
-Chase,Cedar Township,State House,68,"Blevins, Laura  ",Democratic,14
-Chase,Cedar Township,State House,68,"Baker, Dave  ",Republican,32
-Chase,Cottonwood Township,State House,68,"Blevins, Laura  ",Democratic,22
-Chase,Cottonwood Township,State House,68,"Baker, Dave  ",Republican,50
-Chase,Diamond Township,State House,68,"Blevins, Laura  ",Democratic,21
-Chase,Diamond Township,State House,68,"Baker, Dave  ",Republican,102
-Chase,East Falls Township,State House,68,"Blevins, Laura  ",Democratic,30
-Chase,East Falls Township,State House,68,"Baker, Dave  ",Republican,189
-Chase,East Strong Township,State House,68,"Blevins, Laura  ",Democratic,54
-Chase,East Strong Township,State House,68,"Baker, Dave  ",Republican,163
-Chase,Homestead Township,State House,68,"Blevins, Laura  ",Democratic,10
-Chase,Homestead Township,State House,68,"Baker, Dave  ",Republican,22
-Chase,Matfield Township,State House,68,"Blevins, Laura  ",Democratic,21
-Chase,Matfield Township,State House,68,"Baker, Dave  ",Republican,49
-Chase,Toledo Township,State House,68,"Blevins, Laura  ",Democratic,42
-Chase,Toledo Township,State House,68,"Baker, Dave  ",Republican,135
-Chase,West Falls Township,State House,68,"Blevins, Laura  ",Democratic,61
-Chase,West Falls Township,State House,68,"Baker, Dave  ",Republican,216
-Chase,West Strong Township,State House,68,"Blevins, Laura  ",Democratic,18
-Chase,West Strong Township,State House,68,"Baker, Dave  ",Republican,36
+county,precinct,office,district,party,candidate,votes,vtd
+CHASE,Bazaar Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",3,000010
+CHASE,Bazaar Township,Kansas House of Representatives,68,Republican,"Baker, Dave",51,000010
+CHASE,Cedar Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",14,000020
+CHASE,Cedar Township,Kansas House of Representatives,68,Republican,"Baker, Dave",32,000020
+CHASE,Cottonwood Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",22,000030
+CHASE,Cottonwood Township,Kansas House of Representatives,68,Republican,"Baker, Dave",50,000030
+CHASE,Diamond Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",21,000040
+CHASE,Diamond Township,Kansas House of Representatives,68,Republican,"Baker, Dave",102,000040
+CHASE,East Falls Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",30,000050
+CHASE,East Falls Township,Kansas House of Representatives,68,Republican,"Baker, Dave",189,000050
+CHASE,East Strong Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",54,000060
+CHASE,East Strong Township,Kansas House of Representatives,68,Republican,"Baker, Dave",163,000060
+CHASE,Homestead Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",10,000070
+CHASE,Homestead Township,Kansas House of Representatives,68,Republican,"Baker, Dave",22,000070
+CHASE,Matfield Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",21,000080
+CHASE,Matfield Township,Kansas House of Representatives,68,Republican,"Baker, Dave",49,000080
+CHASE,Toledo Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",42,000090
+CHASE,Toledo Township,Kansas House of Representatives,68,Republican,"Baker, Dave",135,000090
+CHASE,West Falls Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",61,000100
+CHASE,West Falls Township,Kansas House of Representatives,68,Republican,"Baker, Dave",216,000100
+CHASE,West Strong Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",18,000110
+CHASE,West Strong Township,Kansas House of Representatives,68,Republican,"Baker, Dave",36,000110
+CHASE,Bazaar Township,Kansas Senate,35,Democratic,"Morris, Levi",7,000010
+CHASE,Bazaar Township,Kansas Senate,35,Republican,"Wilborn, Richard",46,000010
+CHASE,Cedar Township,Kansas Senate,35,Democratic,"Morris, Levi",15,000020
+CHASE,Cedar Township,Kansas Senate,35,Republican,"Wilborn, Richard",35,000020
+CHASE,Cottonwood Township,Kansas Senate,35,Democratic,"Morris, Levi",18,000030
+CHASE,Cottonwood Township,Kansas Senate,35,Republican,"Wilborn, Richard",49,000030
+CHASE,Diamond Township,Kansas Senate,35,Democratic,"Morris, Levi",29,000040
+CHASE,Diamond Township,Kansas Senate,35,Republican,"Wilborn, Richard",94,000040
+CHASE,East Falls Township,Kansas Senate,35,Democratic,"Morris, Levi",45,000050
+CHASE,East Falls Township,Kansas Senate,35,Republican,"Wilborn, Richard",178,000050
+CHASE,East Strong Township,Kansas Senate,35,Democratic,"Morris, Levi",75,000060
+CHASE,East Strong Township,Kansas Senate,35,Republican,"Wilborn, Richard",139,000060
+CHASE,Homestead Township,Kansas Senate,35,Democratic,"Morris, Levi",13,000070
+CHASE,Homestead Township,Kansas Senate,35,Republican,"Wilborn, Richard",20,000070
+CHASE,Matfield Township,Kansas Senate,35,Democratic,"Morris, Levi",27,000080
+CHASE,Matfield Township,Kansas Senate,35,Republican,"Wilborn, Richard",43,000080
+CHASE,Toledo Township,Kansas Senate,35,Democratic,"Morris, Levi",55,000090
+CHASE,Toledo Township,Kansas Senate,35,Republican,"Wilborn, Richard",118,000090
+CHASE,West Falls Township,Kansas Senate,35,Democratic,"Morris, Levi",90,000100
+CHASE,West Falls Township,Kansas Senate,35,Republican,"Wilborn, Richard",194,000100
+CHASE,West Strong Township,Kansas Senate,35,Democratic,"Morris, Levi",24,000110
+CHASE,West Strong Township,Kansas Senate,35,Republican,"Wilborn, Richard",30,000110
+CHASE,Bazaar Township,President / Vice President,,independent,"Stein, Jill",1,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CHASE,Bazaar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CHASE,Bazaar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000010
+CHASE,Bazaar Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CHASE,Bazaar Township,President / Vice President,,Republican,"Trump, Donald J.",51,000010
+CHASE,Cedar Township,President / Vice President,,independent,"Stein, Jill",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CHASE,Cedar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CHASE,Cedar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000020
+CHASE,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+CHASE,Cedar Township,President / Vice President,,Republican,"Trump, Donald J.",39,000020
+CHASE,Cottonwood Township,President / Vice President,,independent,"Stein, Jill",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"McMullin, Evan",1,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CHASE,Cottonwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CHASE,Cottonwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000030
+CHASE,Cottonwood Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+CHASE,Cottonwood Township,President / Vice President,,Republican,"Trump, Donald J.",47,000030
+CHASE,Diamond Township,President / Vice President,,independent,"Stein, Jill",2,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"McMullin, Evan",3,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CHASE,Diamond Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CHASE,Diamond Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000040
+CHASE,Diamond Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000040
+CHASE,Diamond Township,President / Vice President,,Republican,"Trump, Donald J.",97,000040
+CHASE,East Falls Township,President / Vice President,,independent,"Stein, Jill",3,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CHASE,East Falls Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CHASE,East Falls Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000050
+CHASE,East Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+CHASE,East Falls Township,President / Vice President,,Republican,"Trump, Donald J.",172,000050
+CHASE,East Strong Township,President / Vice President,,independent,"Stein, Jill",7,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+CHASE,East Strong Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+CHASE,East Strong Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000060
+CHASE,East Strong Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000060
+CHASE,East Strong Township,President / Vice President,,Republican,"Trump, Donald J.",153,000060
+CHASE,Homestead Township,President / Vice President,,independent,"Stein, Jill",2,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CHASE,Homestead Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CHASE,Homestead Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000070
+CHASE,Homestead Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+CHASE,Homestead Township,President / Vice President,,Republican,"Trump, Donald J.",21,000070
+CHASE,Matfield Township,President / Vice President,,independent,"Stein, Jill",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+CHASE,Matfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+CHASE,Matfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000080
+CHASE,Matfield Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+CHASE,Matfield Township,President / Vice President,,Republican,"Trump, Donald J.",44,000080
+CHASE,Toledo Township,President / Vice President,,independent,"Stein, Jill",1,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"McMullin, Evan",3,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+CHASE,Toledo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+CHASE,Toledo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000090
+CHASE,Toledo Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+CHASE,Toledo Township,President / Vice President,,Republican,"Trump, Donald J.",127,000090
+CHASE,West Falls Township,President / Vice President,,independent,"Stein, Jill",12,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Castle, Darrell L",1,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+CHASE,West Falls Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+CHASE,West Falls Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000100
+CHASE,West Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000100
+CHASE,West Falls Township,President / Vice President,,Republican,"Trump, Donald J.",183,000100
+CHASE,West Strong Township,President / Vice President,,independent,"Stein, Jill",3,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+CHASE,West Strong Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+CHASE,West Strong Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000110
+CHASE,West Strong Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+CHASE,West Strong Township,President / Vice President,,Republican,"Trump, Donald J.",35,000110
+CHASE,Bazaar Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000010
+CHASE,Bazaar Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+CHASE,Bazaar Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000010
+CHASE,Bazaar Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000010
+CHASE,Cedar Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000020
+CHASE,Cedar Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+CHASE,Cedar Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000020
+CHASE,Cedar Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000020
+CHASE,Cottonwood Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000030
+CHASE,Cottonwood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+CHASE,Cottonwood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000030
+CHASE,Cottonwood Township,United States House of Representatives,1,Republican,"Marshall, Roger",42,000030
+CHASE,Diamond Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000040
+CHASE,Diamond Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+CHASE,Diamond Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000040
+CHASE,Diamond Township,United States House of Representatives,1,Republican,"Marshall, Roger",95,000040
+CHASE,East Falls Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000050
+CHASE,East Falls Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+CHASE,East Falls Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000050
+CHASE,East Falls Township,United States House of Representatives,1,Republican,"Marshall, Roger",170,000050
+CHASE,East Strong Township,United States House of Representatives,1,independent,"LaPolice, Alan",59,000060
+CHASE,East Strong Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+CHASE,East Strong Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000060
+CHASE,East Strong Township,United States House of Representatives,1,Republican,"Marshall, Roger",150,000060
+CHASE,Homestead Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000070
+CHASE,Homestead Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+CHASE,Homestead Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000070
+CHASE,Homestead Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000070
+CHASE,Matfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",28,000080
+CHASE,Matfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+CHASE,Matfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000080
+CHASE,Matfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000080
+CHASE,Toledo Township,United States House of Representatives,1,independent,"LaPolice, Alan",42,000090
+CHASE,Toledo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+CHASE,Toledo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000090
+CHASE,Toledo Township,United States House of Representatives,1,Republican,"Marshall, Roger",120,000090
+CHASE,West Falls Township,United States House of Representatives,1,independent,"LaPolice, Alan",52,000100
+CHASE,West Falls Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+CHASE,West Falls Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000100
+CHASE,West Falls Township,United States House of Representatives,1,Republican,"Marshall, Roger",205,000100
+CHASE,West Strong Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000110
+CHASE,West Strong Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+CHASE,West Strong Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000110
+CHASE,West Strong Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000110
+CHASE,Bazaar Township,United States Senate,,write - in,"Smith, DJ",0,000010
+CHASE,Bazaar Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+CHASE,Bazaar Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+CHASE,Bazaar Township,United States Senate,,Republican,"Moran, Jerry",53,000010
+CHASE,Cedar Township,United States Senate,,write - in,"Smith, DJ",0,000020
+CHASE,Cedar Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000020
+CHASE,Cedar Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000020
+CHASE,Cedar Township,United States Senate,,Republican,"Moran, Jerry",36,000020
+CHASE,Cottonwood Township,United States Senate,,write - in,"Smith, DJ",0,000030
+CHASE,Cottonwood Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000030
+CHASE,Cottonwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000030
+CHASE,Cottonwood Township,United States Senate,,Republican,"Moran, Jerry",43,000030
+CHASE,Diamond Township,United States Senate,,write - in,"Smith, DJ",0,000040
+CHASE,Diamond Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000040
+CHASE,Diamond Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000040
+CHASE,Diamond Township,United States Senate,,Republican,"Moran, Jerry",106,000040
+CHASE,East Falls Township,United States Senate,,write - in,"Smith, DJ",0,000050
+CHASE,East Falls Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000050
+CHASE,East Falls Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000050
+CHASE,East Falls Township,United States Senate,,Republican,"Moran, Jerry",180,000050
+CHASE,East Strong Township,United States Senate,,write - in,"Smith, DJ",0,000060
+CHASE,East Strong Township,United States Senate,,Democratic,"Wiesner, Patrick",55,000060
+CHASE,East Strong Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000060
+CHASE,East Strong Township,United States Senate,,Republican,"Moran, Jerry",152,000060
+CHASE,Homestead Township,United States Senate,,write - in,"Smith, DJ",0,000070
+CHASE,Homestead Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000070
+CHASE,Homestead Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+CHASE,Homestead Township,United States Senate,,Republican,"Moran, Jerry",24,000070
+CHASE,Matfield Township,United States Senate,,write - in,"Smith, DJ",0,000080
+CHASE,Matfield Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000080
+CHASE,Matfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+CHASE,Matfield Township,United States Senate,,Republican,"Moran, Jerry",49,000080
+CHASE,Toledo Township,United States Senate,,write - in,"Smith, DJ",0,000090
+CHASE,Toledo Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000090
+CHASE,Toledo Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000090
+CHASE,Toledo Township,United States Senate,,Republican,"Moran, Jerry",129,000090
+CHASE,West Falls Township,United States Senate,,write - in,"Smith, DJ",0,000100
+CHASE,West Falls Township,United States Senate,,Democratic,"Wiesner, Patrick",62,000100
+CHASE,West Falls Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000100
+CHASE,West Falls Township,United States Senate,,Republican,"Moran, Jerry",212,000100
+CHASE,West Strong Township,United States Senate,,write - in,"Smith, DJ",0,000110
+CHASE,West Strong Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000110
+CHASE,West Strong Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+CHASE,West Strong Township,United States Senate,,Republican,"Moran, Jerry",37,000110

--- a/2016/20161108__ks__general__chautauqua__precinct.csv
+++ b/2016/20161108__ks__general__chautauqua__precinct.csv
@@ -1,519 +1,519 @@
-county,precinct,office,district,candidate,party,votes
-Chautauqua,Caneyville Township,President,,"Stein, Jill  ",independent,0
-Chautauqua,Caneyville Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Caneyville Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Caneyville Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Caneyville Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Caneyville Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Caneyville Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Caneyville Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Caneyville Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Caneyville Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Caneyville Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Caneyville Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Caneyville Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Caneyville Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Chautauqua,Caneyville Township,President,,"Johnson, Gary  ",Libertarian,3
-Chautauqua,Caneyville Township,President,,"Trump, Donald J. ",Republican,39
-Chautauqua,Center Township,President,,"Stein, Jill  ",independent,0
-Chautauqua,Center Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Center Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Center Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Center Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Center Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Center Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Center Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Center Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Center Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Center Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Center Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Center Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Center Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Center Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Center Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Center Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Center Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Center Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Center Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Center Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Center Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Center Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Chautauqua,Center Township,President,,"Johnson, Gary  ",Libertarian,0
-Chautauqua,Center Township,President,,"Trump, Donald J. ",Republican,35
-Chautauqua,Chautauqua,President,,"Stein, Jill  ",independent,1
-Chautauqua,Chautauqua,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Chautauqua,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Chautauqua,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Chautauqua,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Chautauqua,President,,"Hedges, James A ",write - in,0
-Chautauqua,Chautauqua,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Chautauqua,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Chautauqua,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Chautauqua,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Chautauqua,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Chautauqua,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Chautauqua,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Chautauqua,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Chautauqua,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Chautauqua,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Chautauqua,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Chautauqua,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Chautauqua,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Chautauqua,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Chautauqua,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Chautauqua,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Chautauqua,President,,"Clinton, Hillary Rodham ",Democratic,12
-Chautauqua,Chautauqua,President,,"Johnson, Gary  ",Libertarian,2
-Chautauqua,Chautauqua,President,,"Trump, Donald J. ",Republican,89
-Chautauqua,Harrison Township,President,,"Stein, Jill  ",independent,0
-Chautauqua,Harrison Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Harrison Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Harrison Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Harrison Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Harrison Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Harrison Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Harrison Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Harrison Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Harrison Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Harrison Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Harrison Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Harrison Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Harrison Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Harrison Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Harrison Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Harrison Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Harrison Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Harrison Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Harrison Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Harrison Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Harrison Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Harrison Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Chautauqua,Harrison Township,President,,"Johnson, Gary  ",Libertarian,0
-Chautauqua,Harrison Township,President,,"Trump, Donald J. ",Republican,29
-Chautauqua,Hendricks Township,President,,"Stein, Jill  ",independent,0
-Chautauqua,Hendricks Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Hendricks Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Hendricks Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Hendricks Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Hendricks Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Hendricks Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Hendricks Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Hendricks Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Hendricks Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Hendricks Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Hendricks Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Hendricks Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Hendricks Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Chautauqua,Hendricks Township,President,,"Johnson, Gary  ",Libertarian,0
-Chautauqua,Hendricks Township,President,,"Trump, Donald J. ",Republican,36
-Chautauqua,Jefferson Township,President,,"Stein, Jill  ",independent,4
-Chautauqua,Jefferson Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Jefferson Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Jefferson Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Jefferson Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Jefferson Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Jefferson Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Jefferson Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Jefferson Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Jefferson Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Jefferson Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Jefferson Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Jefferson Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Jefferson Township,President,,"Clinton, Hillary Rodham ",Democratic,34
-Chautauqua,Jefferson Township,President,,"Johnson, Gary  ",Libertarian,6
-Chautauqua,Jefferson Township,President,,"Trump, Donald J. ",Republican,156
-Chautauqua,Lafayette Township,President,,"Stein, Jill  ",independent,0
-Chautauqua,Lafayette Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Lafayette Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Lafayette Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Lafayette Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Lafayette Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Lafayette Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Lafayette Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Lafayette Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Lafayette Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Lafayette Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Lafayette Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Lafayette Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Lafayette Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-Chautauqua,Lafayette Township,President,,"Johnson, Gary  ",Libertarian,1
-Chautauqua,Lafayette Township,President,,"Trump, Donald J. ",Republican,21
-Chautauqua,Little Caney Township,President,,"Stein, Jill  ",independent,1
-Chautauqua,Little Caney Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Little Caney Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Little Caney Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Little Caney Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Little Caney Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Little Caney Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Little Caney Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Little Caney Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Little Caney Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Little Caney Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Little Caney Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Little Caney Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Little Caney Township,President,,"Clinton, Hillary Rodham ",Democratic,13
-Chautauqua,Little Caney Township,President,,"Johnson, Gary  ",Libertarian,1
-Chautauqua,Little Caney Township,President,,"Trump, Donald J. ",Republican,112
-Chautauqua,North Sedan,President,,"Stein, Jill  ",independent,8
-Chautauqua,North Sedan,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,North Sedan,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,North Sedan,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,North Sedan,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,North Sedan,President,,"Hedges, James A ",write - in,0
-Chautauqua,North Sedan,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,North Sedan,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,North Sedan,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,North Sedan,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,North Sedan,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,North Sedan,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,North Sedan,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,North Sedan,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,North Sedan,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,North Sedan,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,North Sedan,President,,"Smith, Mike  ",write - in,0
-Chautauqua,North Sedan,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,North Sedan,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,North Sedan,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,North Sedan,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,North Sedan,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,North Sedan,President,,"Clinton, Hillary Rodham ",Democratic,67
-Chautauqua,North Sedan,President,,"Johnson, Gary  ",Libertarian,6
-Chautauqua,North Sedan,President,,"Trump, Donald J. ",Republican,258
-Chautauqua,Peru,President,,"Stein, Jill  ",independent,3
-Chautauqua,Peru,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Peru,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Peru,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Peru,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Peru,President,,"Hedges, James A ",write - in,0
-Chautauqua,Peru,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Peru,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Peru,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Peru,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Peru,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Peru,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Peru,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Peru,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Peru,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Peru,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Peru,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Peru,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Peru,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Peru,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Peru,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Peru,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Peru,President,,"Clinton, Hillary Rodham ",Democratic,9
-Chautauqua,Peru,President,,"Johnson, Gary  ",Libertarian,3
-Chautauqua,Peru,President,,"Trump, Donald J. ",Republican,125
-Chautauqua,Salt Creek Township,President,,"Stein, Jill  ",independent,1
-Chautauqua,Salt Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Salt Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Salt Creek Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Salt Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Chautauqua,Salt Creek Township,President,,"Johnson, Gary  ",Libertarian,0
-Chautauqua,Salt Creek Township,President,,"Trump, Donald J. ",Republican,53
-Chautauqua,South Sedan,President,,"Stein, Jill  ",independent,4
-Chautauqua,South Sedan,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,South Sedan,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,South Sedan,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,South Sedan,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,South Sedan,President,,"Hedges, James A ",write - in,0
-Chautauqua,South Sedan,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,South Sedan,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,South Sedan,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,South Sedan,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,South Sedan,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,South Sedan,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,South Sedan,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,South Sedan,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,South Sedan,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,South Sedan,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,South Sedan,President,,"Smith, Mike  ",write - in,0
-Chautauqua,South Sedan,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,South Sedan,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,South Sedan,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,South Sedan,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,South Sedan,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,South Sedan,President,,"Clinton, Hillary Rodham ",Democratic,28
-Chautauqua,South Sedan,President,,"Johnson, Gary  ",Libertarian,3
-Chautauqua,South Sedan,President,,"Trump, Donald J. ",Republican,201
-Chautauqua,Summit Township,President,,"Stein, Jill  ",independent,1
-Chautauqua,Summit Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Summit Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Summit Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Summit Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Summit Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Summit Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Summit Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Summit Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Summit Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Summit Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Summit Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Summit Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Summit Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Summit Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Summit Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Summit Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Summit Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Summit Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Summit Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Summit Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Summit Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Summit Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Chautauqua,Summit Township,President,,"Johnson, Gary  ",Libertarian,0
-Chautauqua,Summit Township,President,,"Trump, Donald J. ",Republican,42
-Chautauqua,Washington Township,President,,"Stein, Jill  ",independent,0
-Chautauqua,Washington Township,President,,"Basiago, Andrew D. ",write - in,0
-Chautauqua,Washington Township,President,,"Castle, Darrell L ",write - in,0
-Chautauqua,Washington Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Chautauqua,Washington Township,President,,"Giordani, Rocky  ",write - in,0
-Chautauqua,Washington Township,President,,"Hedges, James A ",write - in,0
-Chautauqua,Washington Township,President,,"Hoefling, Tom  ",write - in,0
-Chautauqua,Washington Township,President,,"Kahn, Lynn  ",write - in,0
-Chautauqua,Washington Township,President,,"La Riva, Gloria  ",write - in,0
-Chautauqua,Washington Township,President,,"Levinson, Michael S. ",write - in,0
-Chautauqua,Washington Township,President,,"Maturen, Michael A ",write - in,0
-Chautauqua,Washington Township,President,,"McMullin, Evan  ",write - in,0
-Chautauqua,Washington Township,President,,"Moorehead, Monica G. ",write - in,0
-Chautauqua,Washington Township,President,,"Perry, Darryl  ",write - in,0
-Chautauqua,Washington Township,President,,"Schoenke, Marshall R. ",write - in,0
-Chautauqua,Washington Township,President,,"Schriner, Joe C ",write - in,0
-Chautauqua,Washington Township,President,,"Smith, Mike  ",write - in,0
-Chautauqua,Washington Township,President,,"Sood, Ajay  ",write - in,0
-Chautauqua,Washington Township,President,,"Sterling, Shawna  ",write - in,0
-Chautauqua,Washington Township,President,,"Valdivia, Anthony J ",write - in,0
-Chautauqua,Washington Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Chautauqua,Washington Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Chautauqua,Washington Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Chautauqua,Washington Township,President,,"Johnson, Gary  ",Libertarian,0
-Chautauqua,Washington Township,President,,"Trump, Donald J. ",Republican,40
-Chautauqua,Caneyville Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Caneyville Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Chautauqua,Caneyville Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Chautauqua,Caneyville Township,U.S. Senate,,"Moran, Jerry  ",Republican,39
-Chautauqua,Center Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Center Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Chautauqua,Center Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Chautauqua,Center Township,U.S. Senate,,"Moran, Jerry  ",Republican,35
-Chautauqua,Chautauqua,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Chautauqua,U.S. Senate,,"Wiesner, Patrick  ",Democratic,11
-Chautauqua,Chautauqua,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Chautauqua,Chautauqua,U.S. Senate,,"Moran, Jerry  ",Republican,92
-Chautauqua,Harrison Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Harrison Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Chautauqua,Harrison Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Chautauqua,Harrison Township,U.S. Senate,,"Moran, Jerry  ",Republican,30
-Chautauqua,Hendricks Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Hendricks Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Chautauqua,Hendricks Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Chautauqua,Hendricks Township,U.S. Senate,,"Moran, Jerry  ",Republican,29
-Chautauqua,Jefferson Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Jefferson Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,35
-Chautauqua,Jefferson Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Chautauqua,Jefferson Township,U.S. Senate,,"Moran, Jerry  ",Republican,153
-Chautauqua,Lafayette Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Lafayette Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Chautauqua,Lafayette Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Chautauqua,Lafayette Township,U.S. Senate,,"Moran, Jerry  ",Republican,19
-Chautauqua,Little Caney Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Little Caney Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,15
-Chautauqua,Little Caney Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-Chautauqua,Little Caney Township,U.S. Senate,,"Moran, Jerry  ",Republican,101
-Chautauqua,North Sedan,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,North Sedan,U.S. Senate,,"Wiesner, Patrick  ",Democratic,62
-Chautauqua,North Sedan,U.S. Senate,,"Garrard, Robert D. ",Libertarian,18
-Chautauqua,North Sedan,U.S. Senate,,"Moran, Jerry  ",Republican,257
-Chautauqua,Peru,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Peru,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Chautauqua,Peru,U.S. Senate,,"Garrard, Robert D. ",Libertarian,13
-Chautauqua,Peru,U.S. Senate,,"Moran, Jerry  ",Republican,116
-Chautauqua,Salt Creek Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Salt Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,8
-Chautauqua,Salt Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Chautauqua,Salt Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,51
-Chautauqua,South Sedan,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,South Sedan,U.S. Senate,,"Wiesner, Patrick  ",Democratic,32
-Chautauqua,South Sedan,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Chautauqua,South Sedan,U.S. Senate,,"Moran, Jerry  ",Republican,184
-Chautauqua,Summit Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Summit Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Chautauqua,Summit Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Chautauqua,Summit Township,U.S. Senate,,"Moran, Jerry  ",Republican,41
-Chautauqua,Washington Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Chautauqua,Washington Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Chautauqua,Washington Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Chautauqua,Washington Township,U.S. Senate,,"Moran, Jerry  ",Republican,39
-Chautauqua,Caneyville Township,U.S. House,4,"Allen, Miranda  ",independent,5
-Chautauqua,Caneyville Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,4
-Chautauqua,Caneyville Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Chautauqua,Caneyville Township,U.S. House,4,"Pompeo, Michael  ",Republican,36
-Chautauqua,Center Township,U.S. House,4,"Allen, Miranda  ",independent,0
-Chautauqua,Center Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Chautauqua,Center Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Chautauqua,Center Township,U.S. House,4,"Pompeo, Michael  ",Republican,35
-Chautauqua,Chautauqua,U.S. House,4,"Allen, Miranda  ",independent,4
-Chautauqua,Chautauqua,U.S. House,4,"Giroux, Daniel B. ",Democratic,11
-Chautauqua,Chautauqua,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Chautauqua,Chautauqua,U.S. House,4,"Pompeo, Michael  ",Republican,88
-Chautauqua,Harrison Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Chautauqua,Harrison Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,2
-Chautauqua,Harrison Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Chautauqua,Harrison Township,U.S. House,4,"Pompeo, Michael  ",Republican,31
-Chautauqua,Hendricks Township,U.S. House,4,"Allen, Miranda  ",independent,5
-Chautauqua,Hendricks Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,8
-Chautauqua,Hendricks Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Chautauqua,Hendricks Township,U.S. House,4,"Pompeo, Michael  ",Republican,29
-Chautauqua,Jefferson Township,U.S. House,4,"Allen, Miranda  ",independent,14
-Chautauqua,Jefferson Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,27
-Chautauqua,Jefferson Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,5
-Chautauqua,Jefferson Township,U.S. House,4,"Pompeo, Michael  ",Republican,154
-Chautauqua,Lafayette Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Chautauqua,Lafayette Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,3
-Chautauqua,Lafayette Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Chautauqua,Lafayette Township,U.S. House,4,"Pompeo, Michael  ",Republican,19
-Chautauqua,Little Caney Township,U.S. House,4,"Allen, Miranda  ",independent,11
-Chautauqua,Little Caney Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,12
-Chautauqua,Little Caney Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Chautauqua,Little Caney Township,U.S. House,4,"Pompeo, Michael  ",Republican,99
-Chautauqua,North Sedan,U.S. House,4,"Allen, Miranda  ",independent,24
-Chautauqua,North Sedan,U.S. House,4,"Giroux, Daniel B. ",Democratic,56
-Chautauqua,North Sedan,U.S. House,4,"Bakken, Gorden J. ",Libertarian,5
-Chautauqua,North Sedan,U.S. House,4,"Pompeo, Michael  ",Republican,245
-Chautauqua,Peru,U.S. House,4,"Allen, Miranda  ",independent,12
-Chautauqua,Peru,U.S. House,4,"Giroux, Daniel B. ",Democratic,10
-Chautauqua,Peru,U.S. House,4,"Bakken, Gorden J. ",Libertarian,6
-Chautauqua,Peru,U.S. House,4,"Pompeo, Michael  ",Republican,112
-Chautauqua,Salt Creek Township,U.S. House,4,"Allen, Miranda  ",independent,2
-Chautauqua,Salt Creek Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,8
-Chautauqua,Salt Creek Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Chautauqua,Salt Creek Township,U.S. House,4,"Pompeo, Michael  ",Republican,49
-Chautauqua,South Sedan,U.S. House,4,"Allen, Miranda  ",independent,13
-Chautauqua,South Sedan,U.S. House,4,"Giroux, Daniel B. ",Democratic,28
-Chautauqua,South Sedan,U.S. House,4,"Bakken, Gorden J. ",Libertarian,6
-Chautauqua,South Sedan,U.S. House,4,"Pompeo, Michael  ",Republican,182
-Chautauqua,Summit Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Chautauqua,Summit Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,4
-Chautauqua,Summit Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Chautauqua,Summit Township,U.S. House,4,"Pompeo, Michael  ",Republican,41
-Chautauqua,Washington Township,U.S. House,4,"Allen, Miranda  ",independent,2
-Chautauqua,Washington Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,1
-Chautauqua,Washington Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Chautauqua,Washington Township,U.S. House,4,"Pompeo, Michael  ",Republican,37
-Chautauqua,Caneyville Township,State Senate,14,"Pringle, Mark  ",Democratic,8
-Chautauqua,Caneyville Township,State Senate,14,"Givens, Bruce  ",Republican,38
-Chautauqua,Center Township,State Senate,14,"Pringle, Mark  ",Democratic,5
-Chautauqua,Center Township,State Senate,14,"Givens, Bruce  ",Republican,29
-Chautauqua,Chautauqua,State Senate,14,"Pringle, Mark  ",Democratic,19
-Chautauqua,Chautauqua,State Senate,14,"Givens, Bruce  ",Republican,81
-Chautauqua,Harrison Township,State Senate,14,"Pringle, Mark  ",Democratic,5
-Chautauqua,Harrison Township,State Senate,14,"Givens, Bruce  ",Republican,26
-Chautauqua,Hendricks Township,State Senate,14,"Pringle, Mark  ",Democratic,14
-Chautauqua,Hendricks Township,State Senate,14,"Givens, Bruce  ",Republican,29
-Chautauqua,Jefferson Township,State Senate,14,"Pringle, Mark  ",Democratic,57
-Chautauqua,Jefferson Township,State Senate,14,"Givens, Bruce  ",Republican,137
-Chautauqua,Lafayette Township,State Senate,14,"Pringle, Mark  ",Democratic,3
-Chautauqua,Lafayette Township,State Senate,14,"Givens, Bruce  ",Republican,22
-Chautauqua,Little Caney Township,State Senate,14,"Pringle, Mark  ",Democratic,19
-Chautauqua,Little Caney Township,State Senate,14,"Givens, Bruce  ",Republican,102
-Chautauqua,North Sedan,State Senate,14,"Pringle, Mark  ",Democratic,95
-Chautauqua,North Sedan,State Senate,14,"Givens, Bruce  ",Republican,234
-Chautauqua,Peru,State Senate,14,"Pringle, Mark  ",Democratic,20
-Chautauqua,Peru,State Senate,14,"Givens, Bruce  ",Republican,118
-Chautauqua,Salt Creek Township,State Senate,14,"Pringle, Mark  ",Democratic,12
-Chautauqua,Salt Creek Township,State Senate,14,"Givens, Bruce  ",Republican,48
-Chautauqua,South Sedan,State Senate,14,"Pringle, Mark  ",Democratic,50
-Chautauqua,South Sedan,State Senate,14,"Givens, Bruce  ",Republican,173
-Chautauqua,Summit Township,State Senate,14,"Pringle, Mark  ",Democratic,8
-Chautauqua,Summit Township,State Senate,14,"Givens, Bruce  ",Republican,39
-Chautauqua,Washington Township,State Senate,14,"Pringle, Mark  ",Democratic,8
-Chautauqua,Washington Township,State Senate,14,"Givens, Bruce  ",Republican,33
-Chautauqua,Caneyville Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,10
-Chautauqua,Caneyville Township,State House,12,"Blex, Doug  ",Republican,36
-Chautauqua,Center Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,1
-Chautauqua,Center Township,State House,12,"Blex, Doug  ",Republican,35
-Chautauqua,Chautauqua,State House,12,"Schodorf, Jean Kurtis ",Democratic,22
-Chautauqua,Chautauqua,State House,12,"Blex, Doug  ",Republican,85
-Chautauqua,Harrison Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,8
-Chautauqua,Harrison Township,State House,12,"Blex, Doug  ",Republican,25
-Chautauqua,Hendricks Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,21
-Chautauqua,Hendricks Township,State House,12,"Blex, Doug  ",Republican,22
-Chautauqua,Jefferson Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,79
-Chautauqua,Jefferson Township,State House,12,"Blex, Doug  ",Republican,117
-Chautauqua,Lafayette Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,6
-Chautauqua,Lafayette Township,State House,12,"Blex, Doug  ",Republican,19
-Chautauqua,Little Caney Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,24
-Chautauqua,Little Caney Township,State House,12,"Blex, Doug  ",Republican,102
-Chautauqua,North Sedan,State House,12,"Schodorf, Jean Kurtis ",Democratic,138
-Chautauqua,North Sedan,State House,12,"Blex, Doug  ",Republican,200
-Chautauqua,Peru,State House,12,"Schodorf, Jean Kurtis ",Democratic,28
-Chautauqua,Peru,State House,12,"Blex, Doug  ",Republican,112
-Chautauqua,Salt Creek Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,13
-Chautauqua,Salt Creek Township,State House,12,"Blex, Doug  ",Republican,47
-Chautauqua,South Sedan,State House,12,"Schodorf, Jean Kurtis ",Democratic,69
-Chautauqua,South Sedan,State House,12,"Blex, Doug  ",Republican,159
-Chautauqua,Summit Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,6
-Chautauqua,Summit Township,State House,12,"Blex, Doug  ",Republican,42
-Chautauqua,Washington Township,State House,12,"Schodorf, Jean Kurtis ",Democratic,12
-Chautauqua,Washington Township,State House,12,"Blex, Doug  ",Republican,28
+county,precinct,office,district,party,candidate,votes,vtd
+CHAUTAUQUA,Caneyville Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",10,000010
+CHAUTAUQUA,Caneyville Township,Kansas House of Representatives,12,Republican,"Blex, Doug",36,000010
+CHAUTAUQUA,Center Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",1,000020
+CHAUTAUQUA,Center Township,Kansas House of Representatives,12,Republican,"Blex, Doug",35,000020
+CHAUTAUQUA,Chautauqua,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",22,000030
+CHAUTAUQUA,Chautauqua,Kansas House of Representatives,12,Republican,"Blex, Doug",85,000030
+CHAUTAUQUA,Harrison Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",8,000040
+CHAUTAUQUA,Harrison Township,Kansas House of Representatives,12,Republican,"Blex, Doug",25,000040
+CHAUTAUQUA,Hendricks Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",21,000050
+CHAUTAUQUA,Hendricks Township,Kansas House of Representatives,12,Republican,"Blex, Doug",22,000050
+CHAUTAUQUA,Jefferson Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",79,000060
+CHAUTAUQUA,Jefferson Township,Kansas House of Representatives,12,Republican,"Blex, Doug",117,000060
+CHAUTAUQUA,Lafayette Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",6,000070
+CHAUTAUQUA,Lafayette Township,Kansas House of Representatives,12,Republican,"Blex, Doug",19,000070
+CHAUTAUQUA,Little Caney Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",24,000080
+CHAUTAUQUA,Little Caney Township,Kansas House of Representatives,12,Republican,"Blex, Doug",102,000080
+CHAUTAUQUA,North Sedan,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",138,000090
+CHAUTAUQUA,North Sedan,Kansas House of Representatives,12,Republican,"Blex, Doug",200,000090
+CHAUTAUQUA,Peru,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",28,000100
+CHAUTAUQUA,Peru,Kansas House of Representatives,12,Republican,"Blex, Doug",112,000100
+CHAUTAUQUA,Salt Creek Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",13,000110
+CHAUTAUQUA,Salt Creek Township,Kansas House of Representatives,12,Republican,"Blex, Doug",47,000110
+CHAUTAUQUA,South Sedan,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",69,000120
+CHAUTAUQUA,South Sedan,Kansas House of Representatives,12,Republican,"Blex, Doug",159,000120
+CHAUTAUQUA,Summit Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",6,000130
+CHAUTAUQUA,Summit Township,Kansas House of Representatives,12,Republican,"Blex, Doug",42,000130
+CHAUTAUQUA,Washington Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",12,000140
+CHAUTAUQUA,Washington Township,Kansas House of Representatives,12,Republican,"Blex, Doug",28,000140
+CHAUTAUQUA,Caneyville Township,Kansas Senate,14,Democratic,"Pringle, Mark",8,000010
+CHAUTAUQUA,Caneyville Township,Kansas Senate,14,Republican,"Givens, Bruce",38,000010
+CHAUTAUQUA,Center Township,Kansas Senate,14,Democratic,"Pringle, Mark",5,000020
+CHAUTAUQUA,Center Township,Kansas Senate,14,Republican,"Givens, Bruce",29,000020
+CHAUTAUQUA,Chautauqua,Kansas Senate,14,Democratic,"Pringle, Mark",19,000030
+CHAUTAUQUA,Chautauqua,Kansas Senate,14,Republican,"Givens, Bruce",81,000030
+CHAUTAUQUA,Harrison Township,Kansas Senate,14,Democratic,"Pringle, Mark",5,000040
+CHAUTAUQUA,Harrison Township,Kansas Senate,14,Republican,"Givens, Bruce",26,000040
+CHAUTAUQUA,Hendricks Township,Kansas Senate,14,Democratic,"Pringle, Mark",14,000050
+CHAUTAUQUA,Hendricks Township,Kansas Senate,14,Republican,"Givens, Bruce",29,000050
+CHAUTAUQUA,Jefferson Township,Kansas Senate,14,Democratic,"Pringle, Mark",57,000060
+CHAUTAUQUA,Jefferson Township,Kansas Senate,14,Republican,"Givens, Bruce",137,000060
+CHAUTAUQUA,Lafayette Township,Kansas Senate,14,Democratic,"Pringle, Mark",3,000070
+CHAUTAUQUA,Lafayette Township,Kansas Senate,14,Republican,"Givens, Bruce",22,000070
+CHAUTAUQUA,Little Caney Township,Kansas Senate,14,Democratic,"Pringle, Mark",19,000080
+CHAUTAUQUA,Little Caney Township,Kansas Senate,14,Republican,"Givens, Bruce",102,000080
+CHAUTAUQUA,North Sedan,Kansas Senate,14,Democratic,"Pringle, Mark",95,000090
+CHAUTAUQUA,North Sedan,Kansas Senate,14,Republican,"Givens, Bruce",234,000090
+CHAUTAUQUA,Peru,Kansas Senate,14,Democratic,"Pringle, Mark",20,000100
+CHAUTAUQUA,Peru,Kansas Senate,14,Republican,"Givens, Bruce",118,000100
+CHAUTAUQUA,Salt Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",12,000110
+CHAUTAUQUA,Salt Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",48,000110
+CHAUTAUQUA,South Sedan,Kansas Senate,14,Democratic,"Pringle, Mark",50,000120
+CHAUTAUQUA,South Sedan,Kansas Senate,14,Republican,"Givens, Bruce",173,000120
+CHAUTAUQUA,Summit Township,Kansas Senate,14,Democratic,"Pringle, Mark",8,000130
+CHAUTAUQUA,Summit Township,Kansas Senate,14,Republican,"Givens, Bruce",39,000130
+CHAUTAUQUA,Washington Township,Kansas Senate,14,Democratic,"Pringle, Mark",8,000140
+CHAUTAUQUA,Washington Township,Kansas Senate,14,Republican,"Givens, Bruce",33,000140
+CHAUTAUQUA,Caneyville Township,President / Vice President,,independent,"Stein, Jill",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+CHAUTAUQUA,Caneyville Township,President / Vice President,,Republican,"Trump, Donald J.",39,000010
+CHAUTAUQUA,Center Township,President / Vice President,,independent,"Stein, Jill",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+CHAUTAUQUA,Center Township,President / Vice President,,Republican,"Trump, Donald J.",35,000020
+CHAUTAUQUA,Chautauqua,President / Vice President,,independent,"Stein, Jill",1,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Hedges, James A",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"McMullin, Evan",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Smith, Mike",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+CHAUTAUQUA,Chautauqua,President / Vice President,,Republican,"Trump, Donald J.",89,000030
+CHAUTAUQUA,Harrison Township,President / Vice President,,independent,"Stein, Jill",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CHAUTAUQUA,Harrison Township,President / Vice President,,Republican,"Trump, Donald J.",29,000040
+CHAUTAUQUA,Hendricks Township,President / Vice President,,independent,"Stein, Jill",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+CHAUTAUQUA,Hendricks Township,President / Vice President,,Republican,"Trump, Donald J.",36,000050
+CHAUTAUQUA,Jefferson Township,President / Vice President,,independent,"Stein, Jill",4,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000060
+CHAUTAUQUA,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",156,000060
+CHAUTAUQUA,Lafayette Township,President / Vice President,,independent,"Stein, Jill",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+CHAUTAUQUA,Lafayette Township,President / Vice President,,Republican,"Trump, Donald J.",21,000070
+CHAUTAUQUA,Little Caney Township,President / Vice President,,independent,"Stein, Jill",1,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+CHAUTAUQUA,Little Caney Township,President / Vice President,,Republican,"Trump, Donald J.",112,000080
+CHAUTAUQUA,North Sedan,President / Vice President,,independent,"Stein, Jill",8,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Hedges, James A",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"McMullin, Evan",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Perry, Darryl",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Smith, Mike",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Sood, Ajay",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+CHAUTAUQUA,North Sedan,President / Vice President,,Republican,"Trump, Donald J.",258,000090
+CHAUTAUQUA,Peru,President / Vice President,,independent,"Stein, Jill",3,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Hedges, James A",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"McMullin, Evan",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Perry, Darryl",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Smith, Mike",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Sood, Ajay",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+CHAUTAUQUA,Peru,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000100
+CHAUTAUQUA,Peru,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+CHAUTAUQUA,Peru,President / Vice President,,Republican,"Trump, Donald J.",125,000100
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,independent,"Stein, Jill",1,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+CHAUTAUQUA,Salt Creek Township,President / Vice President,,Republican,"Trump, Donald J.",53,000110
+CHAUTAUQUA,South Sedan,President / Vice President,,independent,"Stein, Jill",4,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Hedges, James A",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"McMullin, Evan",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Perry, Darryl",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Smith, Mike",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Sood, Ajay",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+CHAUTAUQUA,South Sedan,President / Vice President,,Republican,"Trump, Donald J.",201,000120
+CHAUTAUQUA,Summit Township,President / Vice President,,independent,"Stein, Jill",1,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+CHAUTAUQUA,Summit Township,President / Vice President,,Republican,"Trump, Donald J.",42,000130
+CHAUTAUQUA,Washington Township,President / Vice President,,independent,"Stein, Jill",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+CHAUTAUQUA,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",40,000140
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000010
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000010
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000010
+CHAUTAUQUA,Caneyville Township,United States House of Representatives,4,Republican,"Pompeo, Michael",36,000010
+CHAUTAUQUA,Center Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000020
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000020
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000020
+CHAUTAUQUA,Center Township,United States House of Representatives,4,Republican,"Pompeo, Michael",35,000020
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,independent,"Allen, Miranda",4,000030
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000030
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000030
+CHAUTAUQUA,Chautauqua,United States House of Representatives,4,Republican,"Pompeo, Michael",88,000030
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000040
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,000040
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000040
+CHAUTAUQUA,Harrison Township,United States House of Representatives,4,Republican,"Pompeo, Michael",31,000040
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000050
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000050
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000050
+CHAUTAUQUA,Hendricks Township,United States House of Representatives,4,Republican,"Pompeo, Michael",29,000050
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,independent,"Allen, Miranda",14,000060
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",27,000060
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000060
+CHAUTAUQUA,Jefferson Township,United States House of Representatives,4,Republican,"Pompeo, Michael",154,000060
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000070
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000070
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000070
+CHAUTAUQUA,Lafayette Township,United States House of Representatives,4,Republican,"Pompeo, Michael",19,000070
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,independent,"Allen, Miranda",11,000080
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",12,000080
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000080
+CHAUTAUQUA,Little Caney Township,United States House of Representatives,4,Republican,"Pompeo, Michael",99,000080
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,independent,"Allen, Miranda",24,000090
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",56,000090
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000090
+CHAUTAUQUA,North Sedan,United States House of Representatives,4,Republican,"Pompeo, Michael",245,000090
+CHAUTAUQUA,Peru,United States House of Representatives,4,independent,"Allen, Miranda",12,000100
+CHAUTAUQUA,Peru,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",10,000100
+CHAUTAUQUA,Peru,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000100
+CHAUTAUQUA,Peru,United States House of Representatives,4,Republican,"Pompeo, Michael",112,000100
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000110
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000110
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000110
+CHAUTAUQUA,Salt Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",49,000110
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,independent,"Allen, Miranda",13,000120
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",28,000120
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000120
+CHAUTAUQUA,South Sedan,United States House of Representatives,4,Republican,"Pompeo, Michael",182,000120
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000130
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000130
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000130
+CHAUTAUQUA,Summit Township,United States House of Representatives,4,Republican,"Pompeo, Michael",41,000130
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000140
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000140
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000140
+CHAUTAUQUA,Washington Township,United States House of Representatives,4,Republican,"Pompeo, Michael",37,000140
+CHAUTAUQUA,Caneyville Township,United States Senate,,write - in,"Smith, DJ",0,000010
+CHAUTAUQUA,Caneyville Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000010
+CHAUTAUQUA,Caneyville Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000010
+CHAUTAUQUA,Caneyville Township,United States Senate,,Republican,"Moran, Jerry",39,000010
+CHAUTAUQUA,Center Township,United States Senate,,write - in,"Smith, DJ",0,000020
+CHAUTAUQUA,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+CHAUTAUQUA,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+CHAUTAUQUA,Center Township,United States Senate,,Republican,"Moran, Jerry",35,000020
+CHAUTAUQUA,Chautauqua,United States Senate,,write - in,"Smith, DJ",0,000030
+CHAUTAUQUA,Chautauqua,United States Senate,,Democratic,"Wiesner, Patrick",11,000030
+CHAUTAUQUA,Chautauqua,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+CHAUTAUQUA,Chautauqua,United States Senate,,Republican,"Moran, Jerry",92,000030
+CHAUTAUQUA,Harrison Township,United States Senate,,write - in,"Smith, DJ",0,000040
+CHAUTAUQUA,Harrison Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000040
+CHAUTAUQUA,Harrison Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+CHAUTAUQUA,Harrison Township,United States Senate,,Republican,"Moran, Jerry",30,000040
+CHAUTAUQUA,Hendricks Township,United States Senate,,write - in,"Smith, DJ",0,000050
+CHAUTAUQUA,Hendricks Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000050
+CHAUTAUQUA,Hendricks Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000050
+CHAUTAUQUA,Hendricks Township,United States Senate,,Republican,"Moran, Jerry",29,000050
+CHAUTAUQUA,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000060
+CHAUTAUQUA,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000060
+CHAUTAUQUA,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000060
+CHAUTAUQUA,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",153,000060
+CHAUTAUQUA,Lafayette Township,United States Senate,,write - in,"Smith, DJ",0,000070
+CHAUTAUQUA,Lafayette Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000070
+CHAUTAUQUA,Lafayette Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+CHAUTAUQUA,Lafayette Township,United States Senate,,Republican,"Moran, Jerry",19,000070
+CHAUTAUQUA,Little Caney Township,United States Senate,,write - in,"Smith, DJ",0,000080
+CHAUTAUQUA,Little Caney Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000080
+CHAUTAUQUA,Little Caney Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+CHAUTAUQUA,Little Caney Township,United States Senate,,Republican,"Moran, Jerry",101,000080
+CHAUTAUQUA,North Sedan,United States Senate,,write - in,"Smith, DJ",0,000090
+CHAUTAUQUA,North Sedan,United States Senate,,Democratic,"Wiesner, Patrick",62,000090
+CHAUTAUQUA,North Sedan,United States Senate,,Libertarian,"Garrard, Robert D.",18,000090
+CHAUTAUQUA,North Sedan,United States Senate,,Republican,"Moran, Jerry",257,000090
+CHAUTAUQUA,Peru,United States Senate,,write - in,"Smith, DJ",0,000100
+CHAUTAUQUA,Peru,United States Senate,,Democratic,"Wiesner, Patrick",9,000100
+CHAUTAUQUA,Peru,United States Senate,,Libertarian,"Garrard, Robert D.",13,000100
+CHAUTAUQUA,Peru,United States Senate,,Republican,"Moran, Jerry",116,000100
+CHAUTAUQUA,Salt Creek Township,United States Senate,,write - in,"Smith, DJ",0,000110
+CHAUTAUQUA,Salt Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000110
+CHAUTAUQUA,Salt Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+CHAUTAUQUA,Salt Creek Township,United States Senate,,Republican,"Moran, Jerry",51,000110
+CHAUTAUQUA,South Sedan,United States Senate,,write - in,"Smith, DJ",0,000120
+CHAUTAUQUA,South Sedan,United States Senate,,Democratic,"Wiesner, Patrick",32,000120
+CHAUTAUQUA,South Sedan,United States Senate,,Libertarian,"Garrard, Robert D.",12,000120
+CHAUTAUQUA,South Sedan,United States Senate,,Republican,"Moran, Jerry",184,000120
+CHAUTAUQUA,Summit Township,United States Senate,,write - in,"Smith, DJ",0,000130
+CHAUTAUQUA,Summit Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000130
+CHAUTAUQUA,Summit Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+CHAUTAUQUA,Summit Township,United States Senate,,Republican,"Moran, Jerry",41,000130
+CHAUTAUQUA,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000140
+CHAUTAUQUA,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000140
+CHAUTAUQUA,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000140
+CHAUTAUQUA,Washington Township,United States Senate,,Republican,"Moran, Jerry",39,000140

--- a/2016/20161108__ks__general__cherokee__precinct.csv
+++ b/2016/20161108__ks__general__cherokee__precinct.csv
@@ -1,680 +1,1821 @@
-county,precinct,office,district,party,candidate,votes
-Cherokee,01 Baxter Sprs W1,Voters,,,Registration,724
-Cherokee,01 Baxter Sprs W1,Voters,,,Ballots,303
-Cherokee,01 Baxter Sprs W1,President,,D,Hillary Clinton,75
-Cherokee,01 Baxter Sprs W1,President,,LBT,Gary Johnson,10
-Cherokee,01 Baxter Sprs W1,President,,IND,Jill Stein,6
-Cherokee,01 Baxter Sprs W1,President,,R,Donald Trump,205
-Cherokee,01 Baxter Sprs W1,President,,,Write-ins,1
-Cherokee,01 Baxter Sprs W1,U.S. Senate,,LBT,Robert Garrard,11
-Cherokee,01 Baxter Sprs W1,U.S. Senate,,R,Jerry Moran,199
-Cherokee,01 Baxter Sprs W1,U.S. Senate,,D,Patrick Wiesner,86
-Cherokee,01 Baxter Sprs W1,U.S. House,2,LBT,James Bales,23
-Cherokee,01 Baxter Sprs W1,U.S. House,2,R,Lynn Jenkins,211
-Cherokee,01 Baxter Sprs W1,U.S. House,2,D,Britani Potter,65
-Cherokee,01 Baxter Sprs W1,State Senate,13,D,Lynn Grant,98
-Cherokee,01 Baxter Sprs W1,State Senate,13,R,Jake LaTurner,200
-Cherokee,01 Baxter Sprs W1,State House,1,R,Michael Houser,244
-Cherokee,01 Baxter Sprs W1,State House,1,,Write-ins,3
-Cherokee,02 Baxter Sprs W2,Voters,,,Registration,800
-Cherokee,02 Baxter Sprs W2,Voters,,,Ballots,258
-Cherokee,02 Baxter Sprs W2,President,,D,Hillary Clinton,57
-Cherokee,02 Baxter Sprs W2,President,,LBT,Gary Johnson,11
-Cherokee,02 Baxter Sprs W2,President,,IND,Jill Stein,6
-Cherokee,02 Baxter Sprs W2,President,,R,Donald Trump,180
-Cherokee,02 Baxter Sprs W2,President,,,Write-ins,4
-Cherokee,02 Baxter Sprs W2,U.S. Senate,,LBT,Robert Garrard,22
-Cherokee,02 Baxter Sprs W2,U.S. Senate,,R,Jerry Moran,163
-Cherokee,02 Baxter Sprs W2,U.S. Senate,,D,Patrick Wiesner,61
-Cherokee,02 Baxter Sprs W2,U.S. House,2,LBT,James Bales,21
-Cherokee,02 Baxter Sprs W2,U.S. House,2,R,Lynn Jenkins,175
-Cherokee,02 Baxter Sprs W2,U.S. House,2,D,Britani Potter,48
-Cherokee,02 Baxter Sprs W2,State Senate,13,D,Lynn Grant,77
-Cherokee,02 Baxter Sprs W2,State Senate,13,R,Jake LaTurner,172
-Cherokee,02 Baxter Sprs W2,State House,1,R,Michael Houser,223
-Cherokee,02 Baxter Sprs W2,State House,1,,Write-ins,2
-Cherokee,03 Baxter Sprs W3,Voters,,,Registration,1246
-Cherokee,03 Baxter Sprs W3,Voters,,,Ballots,657
-Cherokee,03 Baxter Sprs W3,President,,D,Hillary Clinton,149
-Cherokee,03 Baxter Sprs W3,President,,LBT,Gary Johnson,24
-Cherokee,03 Baxter Sprs W3,President,,IND,Jill Stein,9
-Cherokee,03 Baxter Sprs W3,President,,R,Donald Trump,463
-Cherokee,03 Baxter Sprs W3,President,,,Write-ins,8
-Cherokee,03 Baxter Sprs W3,U.S. Senate,,LBT,Robert Garrard,29
-Cherokee,03 Baxter Sprs W3,U.S. Senate,,R,Jerry Moran,438
-Cherokee,03 Baxter Sprs W3,U.S. Senate,,D,Patrick Wiesner,169
-Cherokee,03 Baxter Sprs W3,U.S. House,2,LBT,James Bales,36
-Cherokee,03 Baxter Sprs W3,U.S. House,2,R,Lynn Jenkins,476
-Cherokee,03 Baxter Sprs W3,U.S. House,2,D,Britani Potter,130
-Cherokee,03 Baxter Sprs W3,U.S. House,2,,Write-ins,1
-Cherokee,03 Baxter Sprs W3,State Senate,13,D,Lynn Grant,224
-Cherokee,03 Baxter Sprs W3,State Senate,13,R,Jake LaTurner,418
-Cherokee,03 Baxter Sprs W3,State Senate,13,,Write-ins,1
-Cherokee,03 Baxter Sprs W3,State House,1,R,Michael Houser,528
-Cherokee,03 Baxter Sprs W3,State House,1,,Write-ins,16
-Cherokee,04 Baxter Sprs W4,Voters,,,Registration,908
-Cherokee,04 Baxter Sprs W4,Voters,,,Ballots,344
-Cherokee,04 Baxter Sprs W4,President,,D,Hillary Clinton,66
-Cherokee,04 Baxter Sprs W4,President,,LBT,Gary Johnson,8
-Cherokee,04 Baxter Sprs W4,President,,IND,Jill Stein,8
-Cherokee,04 Baxter Sprs W4,President,,R,Donald Trump,257
-Cherokee,04 Baxter Sprs W4,President,,,Write-ins,3
-Cherokee,04 Baxter Sprs W4,U.S. Senate,,LBT,Robert Garrard,22
-Cherokee,04 Baxter Sprs W4,U.S. Senate,,R,Jerry Moran,243
-Cherokee,04 Baxter Sprs W4,U.S. Senate,,D,Patrick Wiesner,71
-Cherokee,04 Baxter Sprs W4,U.S. House,2,LBT,James Bales,24
-Cherokee,04 Baxter Sprs W4,U.S. House,2,R,Lynn Jenkins,255
-Cherokee,04 Baxter Sprs W4,U.S. House,2,D,Britani Potter,57
-Cherokee,04 Baxter Sprs W4,U.S. House,2,,Write-ins,2
-Cherokee,04 Baxter Sprs W4,State Senate,13,D,Lynn Grant,106
-Cherokee,04 Baxter Sprs W4,State Senate,13,R,Jake LaTurner,232
-Cherokee,04 Baxter Sprs W4,State House,1,R,Michael Houser,276
-Cherokee,04 Baxter Sprs W4,State House,1,,Write-ins,12
-Cherokee,05 Columbus W1,Voters,,,Registration,452
-Cherokee,05 Columbus W1,Voters,,,Ballots,218
-Cherokee,05 Columbus W1,President,,D,Hillary Clinton,57
-Cherokee,05 Columbus W1,President,,LBT,Gary Johnson,12
-Cherokee,05 Columbus W1,President,,IND,Jill Stein,1
-Cherokee,05 Columbus W1,President,,R,Donald Trump,145
-Cherokee,05 Columbus W1,President,,,Write-ins,2
-Cherokee,05 Columbus W1,U.S. Senate,,LBT,Robert Garrard,16
-Cherokee,05 Columbus W1,U.S. Senate,,R,Jerry Moran,148
-Cherokee,05 Columbus W1,U.S. Senate,,D,Patrick Wiesner,51
-Cherokee,05 Columbus W1,U.S. House,2,LBT,James Bales,181
-Cherokee,05 Columbus W1,U.S. House,2,R,Lynn Jenkins,151
-Cherokee,05 Columbus W1,U.S. House,2,D,Britani Potter,43
-Cherokee,05 Columbus W1,U.S. House,2,,Write-ins,1
-Cherokee,05 Columbus W1,State Senate,13,D,Lynn Grant,83
-Cherokee,05 Columbus W1,State Senate,13,R,Jake LaTurner,132
-Cherokee,05 Columbus W1,State House,1,R,Michael Houser,188
-Cherokee,05 Columbus W1,State House,1,,Write-ins,5
-Cherokee,06 Columbus W2,Voters,,,Registration,505
-Cherokee,06 Columbus W2,Voters,,,Ballots,331
-Cherokee,06 Columbus W2,President,,D,Hillary Clinton,92
-Cherokee,06 Columbus W2,President,,LBT,Gary Johnson,13
-Cherokee,06 Columbus W2,President,,IND,Jill Stein,2
-Cherokee,06 Columbus W2,President,,R,Donald Trump,214
-Cherokee,06 Columbus W2,President,,,Write-ins,6
-Cherokee,06 Columbus W2,U.S. Senate,,LBT,Robert Garrard,15
-Cherokee,06 Columbus W2,U.S. Senate,,R,Jerry Moran,224
-Cherokee,06 Columbus W2,U.S. Senate,,D,Patrick Wiesner,85
-Cherokee,06 Columbus W2,U.S. Senate,,,Write-ins,1
-Cherokee,06 Columbus W2,U.S. House,2,LBT,James Bales,21
-Cherokee,06 Columbus W2,U.S. House,2,R,Lynn Jenkins,234
-Cherokee,06 Columbus W2,U.S. House,2,D,Britani Potter,72
-Cherokee,06 Columbus W2,U.S. House,2,,Write-ins,1
-Cherokee,06 Columbus W2,State Senate,13,D,Lynn Grant,133
-Cherokee,06 Columbus W2,State Senate,13,R,Jake LaTurner,191
-Cherokee,06 Columbus W2,State Senate,13,,Write-ins,3
-Cherokee,06 Columbus W2,State House,1,R,Michael Houser,252
-Cherokee,06 Columbus W2,State House,1,,Write-ins,11
-Cherokee,07 Columbus W3,Voters,,,Registration,477
-Cherokee,07 Columbus W3,Voters,,,Ballots,279
-Cherokee,07 Columbus W3,President,,D,Hillary Clinton,71
-Cherokee,07 Columbus W3,President,,LBT,Gary Johnson,15
-Cherokee,07 Columbus W3,President,,IND,Jill Stein,1
-Cherokee,07 Columbus W3,President,,R,Donald Trump,185
-Cherokee,07 Columbus W3,President,,,Write-ins,2
-Cherokee,07 Columbus W3,U.S. Senate,,LBT,Robert Garrard,9
-Cherokee,07 Columbus W3,U.S. Senate,,R,Jerry Moran,177
-Cherokee,07 Columbus W3,U.S. Senate,,D,Patrick Wiesner,83
-Cherokee,07 Columbus W3,U.S. Senate,,,Write-ins,1
-Cherokee,07 Columbus W3,U.S. House,2,LBT,James Bales,10
-Cherokee,07 Columbus W3,U.S. House,2,R,Lynn Jenkins,191
-Cherokee,07 Columbus W3,U.S. House,2,D,Britani Potter,72
-Cherokee,07 Columbus W3,U.S. House,2,,Write-ins,1
-Cherokee,07 Columbus W3,State Senate,13,D,Lynn Grant,126
-Cherokee,07 Columbus W3,State Senate,13,R,Jake LaTurner,148
-Cherokee,07 Columbus W3,State House,1,R,Michael Houser,210
-Cherokee,07 Columbus W3,State House,1,,Write-ins,13
-Cherokee,08 Columbus W4,Voters,,,Registration,451
-Cherokee,08 Columbus W4,Voters,,,Ballots,235
-Cherokee,08 Columbus W4,President,,D,Hillary Clinton,58
-Cherokee,08 Columbus W4,President,,LBT,Gary Johnson,14
-Cherokee,08 Columbus W4,President,,IND,Jill Stein,2
-Cherokee,08 Columbus W4,President,,R,Donald Trump,154
-Cherokee,08 Columbus W4,President,,,Write-ins,5
-Cherokee,08 Columbus W4,U.S. Senate,,LBT,Robert Garrard,16
-Cherokee,08 Columbus W4,U.S. Senate,,R,Jerry Moran,160
-Cherokee,08 Columbus W4,U.S. Senate,,D,Patrick Wiesner,53
-Cherokee,08 Columbus W4,U.S. House,2,LBT,James Bales,18
-Cherokee,08 Columbus W4,U.S. House,2,R,Lynn Jenkins,151
-Cherokee,08 Columbus W4,U.S. House,2,D,Britani Potter,62
-Cherokee,08 Columbus W4,State Senate,13,D,Lynn Grant,88
-Cherokee,08 Columbus W4,State Senate,13,R,Jake LaTurner,145
-Cherokee,08 Columbus W4,State House,1,R,Michael Houser,186
-Cherokee,08 Columbus W4,State House,1,,Write-ins,7
-Cherokee,09 Columbus W5,Voters,,,Registration,451
-Cherokee,09 Columbus W5,Voters,,,Ballots,226
-Cherokee,09 Columbus W5,President,,D,Hillary Clinton,52
-Cherokee,09 Columbus W5,President,,LBT,Gary Johnson,5
-Cherokee,09 Columbus W5,President,,IND,Jill Stein,8
-Cherokee,09 Columbus W5,President,,R,Donald Trump,158
-Cherokee,09 Columbus W5,President,,,Write-ins,1
-Cherokee,09 Columbus W5,U.S. Senate,,LBT,Robert Garrard,11
-Cherokee,09 Columbus W5,U.S. Senate,,R,Jerry Moran,143
-Cherokee,09 Columbus W5,U.S. Senate,,D,Patrick Wiesner,60
-Cherokee,09 Columbus W5,U.S. Senate,,,Write-ins,1
-Cherokee,09 Columbus W5,U.S. House,2,LBT,James Bales,15
-Cherokee,09 Columbus W5,U.S. House,2,R,Lynn Jenkins,154
-Cherokee,09 Columbus W5,U.S. House,2,D,Britani Potter,46
-Cherokee,09 Columbus W5,U.S. House,2,,Write-ins,2
-Cherokee,09 Columbus W5,State Senate,13,D,Lynn Grant,80
-Cherokee,09 Columbus W5,State Senate,13,R,Jake LaTurner,139
-Cherokee,09 Columbus W5,State Senate,13,,Write-ins,1
-Cherokee,09 Columbus W5,State House,1,R,Michael Houser,187
-Cherokee,09 Columbus W5,State House,1,,Write-ins,4
-Cherokee,10 Galena W1,Voters,,,Registration,748
-Cherokee,10 Galena W1,Voters,,,Ballots,264
-Cherokee,10 Galena W1,President,,D,Hillary Clinton,61
-Cherokee,10 Galena W1,President,,LBT,Gary Johnson,9
-Cherokee,10 Galena W1,President,,IND,Jill Stein,2
-Cherokee,10 Galena W1,President,,R,Donald Trump,189
-Cherokee,10 Galena W1,President,,,Write-ins,3
-Cherokee,10 Galena W1,U.S. Senate,,LBT,Robert Garrard,16
-Cherokee,10 Galena W1,U.S. Senate,,R,Jerry Moran,172
-Cherokee,10 Galena W1,U.S. Senate,,D,Patrick Wiesner,70
-Cherokee,10 Galena W1,U.S. Senate,,,Write-ins,1
-Cherokee,10 Galena W1,U.S. House,2,LBT,James Bales,17
-Cherokee,10 Galena W1,U.S. House,2,R,Lynn Jenkins,192
-Cherokee,10 Galena W1,U.S. House,2,D,Britani Potter,47
-Cherokee,10 Galena W1,U.S. House,2,,Write-ins,1
-Cherokee,10 Galena W1,State Senate,13,D,Lynn Grant,82
-Cherokee,10 Galena W1,State Senate,13,R,Jake LaTurner,177
-Cherokee,10 Galena W1,State Senate,13,,Write-ins,1
-Cherokee,10 Galena W1,State House,1,R,Michael Houser,209
-Cherokee,10 Galena W1,State House,1,,Write-ins,7
-Cherokee,11 Galena W2,Voters,,,Registration,558
-Cherokee,11 Galena W2,Voters,,,Ballots,215
-Cherokee,11 Galena W2,President,,D,Hillary Clinton,44
-Cherokee,11 Galena W2,President,,LBT,Gary Johnson,11
-Cherokee,11 Galena W2,President,,IND,Jill Stein,3
-Cherokee,11 Galena W2,President,,R,Donald Trump,155
-Cherokee,11 Galena W2,U.S. Senate,,LBT,Robert Garrard,17
-Cherokee,11 Galena W2,U.S. Senate,,R,Jerry Moran,132
-Cherokee,11 Galena W2,U.S. Senate,,D,Patrick Wiesner,54
-Cherokee,11 Galena W2,U.S. House,2,LBT,James Bales,16
-Cherokee,11 Galena W2,U.S. House,2,R,Lynn Jenkins,145
-Cherokee,11 Galena W2,U.S. House,2,D,Britani Potter,46
-Cherokee,11 Galena W2,State Senate,13,D,Lynn Grant,65
-Cherokee,11 Galena W2,State Senate,13,R,Jake LaTurner,144
-Cherokee,11 Galena W2,State Senate,13,,Write-ins,2
-Cherokee,11 Galena W2,State House,1,R,Michael Houser,175
-Cherokee,11 Galena W2,State House,1,,Write-ins,5
-Cherokee,12 Galena W3,Voters,,,Registration,775
-Cherokee,12 Galena W3,Voters,,,Ballots,349
-Cherokee,12 Galena W3,President,,D,Hillary Clinton,105
-Cherokee,12 Galena W3,President,,LBT,Gary Johnson,7
-Cherokee,12 Galena W3,President,,IND,Jill Stein,1
-Cherokee,12 Galena W3,President,,R,Donald Trump,231
-Cherokee,12 Galena W3,President,,,Write-ins,2
-Cherokee,12 Galena W3,U.S. Senate,,LBT,Robert Garrard,19
-Cherokee,12 Galena W3,U.S. Senate,,R,Jerry Moran,214
-Cherokee,12 Galena W3,U.S. Senate,,D,Patrick Wiesner,102
-Cherokee,12 Galena W3,U.S. House,2,LBT,James Bales,18
-Cherokee,12 Galena W3,U.S. House,2,R,Lynn Jenkins,232
-Cherokee,12 Galena W3,U.S. House,2,D,Britani Potter,92
-Cherokee,12 Galena W3,State Senate,13,D,Lynn Grant,125
-Cherokee,12 Galena W3,State Senate,13,R,Jake LaTurner,216
-Cherokee,12 Galena W3,State House,1,R,Michael Houser,273
-Cherokee,12 Galena W3,State House,1,,Write-ins,11
-Cherokee,13 Galena W4,Voters,,,Registration,471
-Cherokee,13 Galena W4,Voters,,,Ballots,178
-Cherokee,13 Galena W4,President,,D,Hillary Clinton,38
-Cherokee,13 Galena W4,President,,LBT,Gary Johnson,9
-Cherokee,13 Galena W4,President,,IND,Jill Stein,3
-Cherokee,13 Galena W4,President,,R,Donald Trump,123
-Cherokee,13 Galena W4,President,,,Write-ins,4
-Cherokee,13 Galena W4,U.S. Senate,,LBT,Robert Garrard,10
-Cherokee,13 Galena W4,U.S. Senate,,R,Jerry Moran,112
-Cherokee,13 Galena W4,U.S. Senate,,D,Patrick Wiesner,4
-Cherokee,13 Galena W4,U.S. House,2,LBT,James Bales,12
-Cherokee,13 Galena W4,U.S. House,2,R,Lynn Jenkins,118
-Cherokee,13 Galena W4,U.S. House,2,D,Britani Potter,43
-Cherokee,13 Galena W4,State Senate,13,D,Lynn Grant,55
-Cherokee,13 Galena W4,State Senate,13,R,Jake LaTurner,120
-Cherokee,13 Galena W4,State House,1,R,Michael Houser,144
-Cherokee,13 Galena W4,State House,1,,Write-ins,6
-Cherokee,14 Scammon W1,Voters,,,Registration,75
-Cherokee,14 Scammon W1,Voters,,,Ballots,48
-Cherokee,14 Scammon W1,President,,D,Hillary Clinton,19
-Cherokee,14 Scammon W1,President,,LBT,Gary Johnson,1
-Cherokee,14 Scammon W1,President,,IND,Jill Stein,1
-Cherokee,14 Scammon W1,President,,R,Donald Trump,25
-Cherokee,14 Scammon W1,President,,,Write-ins,1
-Cherokee,14 Scammon W1,U.S. Senate,,LBT,Robert Garrard,1
-Cherokee,14 Scammon W1,U.S. Senate,,R,Jerry Moran,24
-Cherokee,14 Scammon W1,U.S. Senate,,D,Patrick Wiesner,19
-Cherokee,14 Scammon W1,U.S. Senate,,,Write-ins,1
-Cherokee,14 Scammon W1,U.S. House,2,LBT,James Bales,4
-Cherokee,14 Scammon W1,U.S. House,2,R,Lynn Jenkins,23
-Cherokee,14 Scammon W1,U.S. House,2,D,Britani Potter,19
-Cherokee,14 Scammon W1,State Senate,13,D,Lynn Grant,30
-Cherokee,14 Scammon W1,State Senate,13,R,Jake LaTurner,18
-Cherokee,14 Scammon W1,State House,1,R,Michael Houser,35
-Cherokee,14 Scammon W1,State House,1,,Write-ins,2
-Cherokee,15 Scammon W2,Voters,,,Registration,139
-Cherokee,15 Scammon W2,Voters,,,Ballots,75
-Cherokee,15 Scammon W2,President,,D,Hillary Clinton,15
-Cherokee,15 Scammon W2,President,,LBT,Gary Johnson,6
-Cherokee,15 Scammon W2,President,,IND,Jill Stein,1
-Cherokee,15 Scammon W2,President,,R,Donald Trump,51
-Cherokee,15 Scammon W2,U.S. Senate,,LBT,Robert Garrard,9
-Cherokee,15 Scammon W2,U.S. Senate,,R,Jerry Moran,44
-Cherokee,15 Scammon W2,U.S. Senate,,D,Patrick Wiesner,20
-Cherokee,15 Scammon W2,U.S. Senate,,,Write-ins,1
-Cherokee,15 Scammon W2,U.S. House,2,LBT,James Bales,5
-Cherokee,15 Scammon W2,U.S. House,2,R,Lynn Jenkins,50
-Cherokee,15 Scammon W2,U.S. House,2,D,Britani Potter,19
-Cherokee,15 Scammon W2,U.S. House,2,,Write-ins,1
-Cherokee,15 Scammon W2,State Senate,13,D,Lynn Grant,33
-Cherokee,15 Scammon W2,State Senate,13,R,Jake LaTurner,40
-Cherokee,15 Scammon W2,State Senate,13,,Write-ins,1
-Cherokee,15 Scammon W2,State House,1,R,Michael Houser,65
-Cherokee,15 Scammon W2,State House,1,,Write-ins,4
-Cherokee,16 Scammon W3,Voters,,,Registration,134
-Cherokee,16 Scammon W3,Voters,,,Ballots,74
-Cherokee,16 Scammon W3,President,,D,Hillary Clinton,17
-Cherokee,16 Scammon W3,President,,LBT,Gary Johnson,3
-Cherokee,16 Scammon W3,President,,IND,Jill Stein,1
-Cherokee,16 Scammon W3,President,,R,Donald Trump,53
-Cherokee,16 Scammon W3,U.S. Senate,,LBT,Robert Garrard,2
-Cherokee,16 Scammon W3,U.S. Senate,,R,Jerry Moran,47
-Cherokee,16 Scammon W3,U.S. Senate,,D,Patrick Wiesner,20
-Cherokee,16 Scammon W3,U.S. House,2,LBT,James Bales,3
-Cherokee,16 Scammon W3,U.S. House,2,R,Lynn Jenkins,50
-Cherokee,16 Scammon W3,U.S. House,2,D,Britani Potter,19
-Cherokee,16 Scammon W3,State Senate,13,D,Lynn Grant,31
-Cherokee,16 Scammon W3,State Senate,13,R,Jake LaTurner,41
-Cherokee,16 Scammon W3,State House,1,R,Michael Houser,55
-Cherokee,16 Scammon W3,State House,1,,Write-ins,2
-Cherokee,17 Weir  W1,Voters,,,Registration,122
-Cherokee,17 Weir  W1,Voters,,,Ballots,62
-Cherokee,17 Weir  W1,President,,D,Hillary Clinton,25
-Cherokee,17 Weir  W1,President,,LBT,Gary Johnson,1
-Cherokee,17 Weir  W1,President,,IND,Jill Stein,1
-Cherokee,17 Weir  W1,President,,R,Donald Trump,34
-Cherokee,17 Weir  W1,President,,,Write-ins,1
-Cherokee,17 Weir  W1,U.S. Senate,,LBT,Robert Garrard,2
-Cherokee,17 Weir  W1,U.S. Senate,,R,Jerry Moran,33
-Cherokee,17 Weir  W1,U.S. Senate,,D,Patrick Wiesner,27
-Cherokee,17 Weir  W1,U.S. House,2,LBT,James Bales,4
-Cherokee,17 Weir  W1,U.S. House,2,R,Lynn Jenkins,38
-Cherokee,17 Weir  W1,U.S. House,2,D,Britani Potter,20
-Cherokee,17 Weir  W1,State Senate,13,D,Lynn Grant,37
-Cherokee,17 Weir  W1,State Senate,13,R,Jake LaTurner,25
-Cherokee,17 Weir  W1,State House,1,R,Michael Houser,44
-Cherokee,17 Weir  W1,State House,1,,Write-ins,8
-Cherokee,18 Weir W2,Voters,,,Registration,275
-Cherokee,18 Weir W2,Voters,,,Ballots,123
-Cherokee,18 Weir W2,President,,D,Hillary Clinton,52
-Cherokee,18 Weir W2,President,,LBT,Gary Johnson,8
-Cherokee,18 Weir W2,President,,IND,Jill Stein,4
-Cherokee,18 Weir W2,President,,R,Donald Trump,56
-Cherokee,18 Weir W2,President,,,Write-ins,1
-Cherokee,18 Weir W2,U.S. Senate,,LBT,Robert Garrard,4
-Cherokee,18 Weir W2,U.S. Senate,,R,Jerry Moran,54
-Cherokee,18 Weir W2,U.S. Senate,,D,Patrick Wiesner,58
-Cherokee,18 Weir W2,U.S. Senate,,,Write-ins,1
-Cherokee,18 Weir W2,U.S. House,2,LBT,James Bales,7
-Cherokee,18 Weir W2,U.S. House,2,R,Lynn Jenkins,66
-Cherokee,18 Weir W2,U.S. House,2,D,Britani Potter,47
-Cherokee,18 Weir W2,State Senate,13,D,Lynn Grant,68
-Cherokee,18 Weir W2,State Senate,13,R,Jake LaTurner,51
-Cherokee,18 Weir W2,State Senate,13,,Write-ins,2
-Cherokee,18 Weir W2,State House,1,R,Michael Houser,89
-Cherokee,18 Weir W2,State House,1,,Write-ins,9
-Cherokee,19 Weir W3,Voters,,,Registration,130
-Cherokee,19 Weir W3,Voters,,,Ballots,74
-Cherokee,19 Weir W3,President,,D,Hillary Clinton,22
-Cherokee,19 Weir W3,President,,LBT,Gary Johnson,2
-Cherokee,19 Weir W3,President,,IND,Jill Stein,1
-Cherokee,19 Weir W3,President,,R,Donald Trump,44
-Cherokee,19 Weir W3,President,,,Write-ins,1
-Cherokee,19 Weir W3,U.S. Senate,,LBT,Robert Garrard,8
-Cherokee,19 Weir W3,U.S. Senate,,R,Jerry Moran,39
-Cherokee,19 Weir W3,U.S. Senate,,D,Patrick Wiesner,24
-Cherokee,19 Weir W3,U.S. House,2,LBT,James Bales,4
-Cherokee,19 Weir W3,U.S. House,2,R,Lynn Jenkins,46
-Cherokee,19 Weir W3,U.S. House,2,D,Britani Potter,22
-Cherokee,19 Weir W3,State Senate,13,D,Lynn Grant,39
-Cherokee,19 Weir W3,State Senate,13,R,Jake LaTurner,35
-Cherokee,19 Weir W3,State House,1,R,Michael Houser,55
-Cherokee,19 Weir W3,State House,1,,Write-ins,3
-Cherokee,20 Cherokee,Voters,,,Registration,236
-Cherokee,20 Cherokee,Voters,,,Ballots,166
-Cherokee,20 Cherokee,President,,D,Hillary Clinton,54
-Cherokee,20 Cherokee,President,,LBT,Gary Johnson,6
-Cherokee,20 Cherokee,President,,IND,Jill Stein,3
-Cherokee,20 Cherokee,President,,R,Donald Trump,4
-Cherokee,20 Cherokee,President,,,Write-ins,6
-Cherokee,20 Cherokee,U.S. Senate,,LBT,Robert Garrard,16
-Cherokee,20 Cherokee,U.S. Senate,,R,Jerry Moran,95
-Cherokee,20 Cherokee,U.S. Senate,,D,Patrick Wiesner,54
-Cherokee,20 Cherokee,U.S. House,2,LBT,James Bales,9
-Cherokee,20 Cherokee,U.S. House,2,R,Lynn Jenkins,99
-Cherokee,20 Cherokee,U.S. House,2,D,Britani Potter,57
-Cherokee,20 Cherokee,State Senate,13,,Write-ins,1
-Cherokee,20 Cherokee,State Senate,13,D,Lynn Grant,77
-Cherokee,20 Cherokee,State Senate,13,R,Jake LaTurner,86
-Cherokee,20 Cherokee,State House,1,R,Michael Houser,129
-Cherokee,20 Cherokee,State House,1,,Write-ins,9
-Cherokee,21 Crawford,Voters,,,Registration,495
-Cherokee,21 Crawford,Voters,,,Ballots,357
-Cherokee,21 Crawford,President,,D,Hillary Clinton,60
-Cherokee,21 Crawford,President,,LBT,Gary Johnson,7
-Cherokee,21 Crawford,President,,IND,Jill Stein,3
-Cherokee,21 Crawford,President,,R,Donald Trump,282
-Cherokee,21 Crawford,President,,,Write-ins,3
-Cherokee,21 Crawford,U.S. Senate,,LBT,Robert Garrard,13
-Cherokee,21 Crawford,U.S. Senate,,R,Jerry Moran,267
-Cherokee,21 Crawford,U.S. Senate,,D,Patrick Wiesner,66
-Cherokee,21 Crawford,U.S. Senate,,,Write-ins,1
-Cherokee,21 Crawford,U.S. House,2,LBT,James Bales,19
-Cherokee,21 Crawford,U.S. House,2,R,Lynn Jenkins,273
-Cherokee,21 Crawford,U.S. House,2,D,Britani Potter,55
-Cherokee,21 Crawford,State Senate,13,,Write-ins,1
-Cherokee,21 Crawford,State Senate,13,D,Lynn Grant,116
-Cherokee,21 Crawford,State Senate,13,R,Jake LaTurner,231
-Cherokee,21 Crawford,State House,1,R,Michael Houser,297
-Cherokee,21 Crawford,State House,1,,Write-ins,3
-Cherokee,22 Garden-Lowell,Voters,,,Registration,1843
-Cherokee,22 Garden-Lowell,Voters,,,Ballots,984
-Cherokee,22 Garden-Lowell,President,,D,Hillary Clinton,237
-Cherokee,22 Garden-Lowell,President,,LBT,Gary Johnson,26
-Cherokee,22 Garden-Lowell,President,,IND,Jill Stein,18
-Cherokee,22 Garden-Lowell,President,,R,Donald Trump,680
-Cherokee,22 Garden-Lowell,President,,,Write-ins,16
-Cherokee,22 Garden-Lowell,U.S. Senate,,LBT,Robert Garrard,49
-Cherokee,22 Garden-Lowell,U.S. Senate,,R,Jerry Moran,661
-Cherokee,22 Garden-Lowell,U.S. Senate,,D,Patrick Wiesner,262
-Cherokee,22 Garden-Lowell,U.S. House,2,LBT,James Bales,48
-Cherokee,22 Garden-Lowell,U.S. House,2,R,Lynn Jenkins,706
-Cherokee,22 Garden-Lowell,U.S. House,2,D,Britani Potter,220
-Cherokee,22 Garden-Lowell,State Senate,13,D,Lynn Grant,342
-Cherokee,22 Garden-Lowell,State Senate,13,R,Jake LaTurner,630
-Cherokee,22 Garden-Lowell,State Senate,13,,Write-ins,1
-Cherokee,22 Garden-Lowell,State House,1,R,Michael Houser,811
-Cherokee,22 Garden-Lowell,State House,1,,Write-ins,28
-Cherokee,23 Garden-Stanley,Voters,,,Registration,512
-Cherokee,23 Garden-Stanley,Voters,,,Ballots,285
-Cherokee,23 Garden-Stanley,President,,D,Hillary Clinton,54
-Cherokee,23 Garden-Stanley,President,,LBT,Gary Johnson,11
-Cherokee,23 Garden-Stanley,President,,IND,Jill Stein,5
-Cherokee,23 Garden-Stanley,President,,R,Donald Trump,214
-Cherokee,23 Garden-Stanley,President,,,Write-ins,1
-Cherokee,23 Garden-Stanley,U.S. Senate,,LBT,Robert Garrard,17
-Cherokee,23 Garden-Stanley,U.S. Senate,,R,Jerry Moran,203
-Cherokee,23 Garden-Stanley,U.S. Senate,,D,Patrick Wiesner,56
-Cherokee,23 Garden-Stanley,U.S. House,2,LBT,James Bales,19
-Cherokee,23 Garden-Stanley,U.S. House,2,R,Lynn Jenkins,211
-Cherokee,23 Garden-Stanley,U.S. House,2,D,Britani Potter,48
-Cherokee,23 Garden-Stanley,State Senate,13,,Write-ins,1
-Cherokee,23 Garden-Stanley,State Senate,13,D,Lynn Grant,84
-Cherokee,23 Garden-Stanley,State Senate,13,R,Jake LaTurner,196
-Cherokee,23 Garden-Stanley,State House,1,R,Michael Houser,236
-Cherokee,23 Garden-Stanley,State House,1,,Write-ins,9
-Cherokee,24 Lola,Voters,,,Registration,245
-Cherokee,24 Lola,Voters,,,Ballots,151
-Cherokee,24 Lola,President,,D,Hillary Clinton,31
-Cherokee,24 Lola,President,,LBT,Gary Johnson,6
-Cherokee,24 Lola,President,,IND,Jill Stein,2
-Cherokee,24 Lola,President,,R,Donald Trump,107
-Cherokee,24 Lola,President,,,Write-ins,3
-Cherokee,24 Lola,U.S. Senate,,LBT,Robert Garrard,9
-Cherokee,24 Lola,U.S. Senate,,R,Jerry Moran,107
-Cherokee,24 Lola,U.S. Senate,,D,Patrick Wiesner,30
-Cherokee,24 Lola,U.S. Senate,,,Write-ins,1
-Cherokee,24 Lola,U.S. House,2,LBT,James Bales,4
-Cherokee,24 Lola,U.S. House,2,R,Lynn Jenkins,122
-Cherokee,24 Lola,U.S. House,2,D,Britani Potter,24
-Cherokee,24 Lola,State Senate,13,D,Lynn Grant,45
-Cherokee,24 Lola,State Senate,13,R,Jake LaTurner,103
-Cherokee,24 Lola,State House,1,R,Michael Houser,128
-Cherokee,25 Lowell,Voters,,,Registration,536
-Cherokee,25 Lowell,Voters,,,Ballots,314
-Cherokee,25 Lowell,President,,D,Hillary Clinton,49
-Cherokee,25 Lowell,President,,LBT,Gary Johnson,4
-Cherokee,25 Lowell,President,,IND,Jill Stein,6
-Cherokee,25 Lowell,President,,R,Donald Trump,251
-Cherokee,25 Lowell,President,,,Write-ins,2
-Cherokee,25 Lowell,U.S. Senate,,LBT,Robert Garrard,10
-Cherokee,25 Lowell,U.S. Senate,,R,Jerry Moran,235
-Cherokee,25 Lowell,U.S. Senate,,D,Patrick Wiesner,59
-Cherokee,25 Lowell,U.S. Senate,,,Write-ins,1
-Cherokee,25 Lowell,U.S. House,2,LBT,James Bales,7
-Cherokee,25 Lowell,U.S. House,2,R,Lynn Jenkins,253
-Cherokee,25 Lowell,U.S. House,2,D,Britani Potter,48
-Cherokee,25 Lowell,State Senate,13,D,Lynn Grant,88
-Cherokee,25 Lowell,State Senate,13,R,Jake LaTurner,221
-Cherokee,25 Lowell,State Senate,13,,Write-ins,1
-Cherokee,25 Lowell,State House,1,R,Michael Houser,273
-Cherokee,25 Lowell,State House,1,,Write-ins,4
-Cherokee,26 Lyon-Lyon,Voters,,,Registration,329
-Cherokee,26 Lyon-Lyon,Voters,,,Ballots,190
-Cherokee,26 Lyon-Lyon,President,,D,Hillary Clinton,28
-Cherokee,26 Lyon-Lyon,President,,LBT,Gary Johnson,6
-Cherokee,26 Lyon-Lyon,President,,IND,Jill Stein,1
-Cherokee,26 Lyon-Lyon,President,,R,Donald Trump,149
-Cherokee,26 Lyon-Lyon,President,,,Write-ins,2
-Cherokee,26 Lyon-Lyon,U.S. Senate,,LBT,Robert Garrard,3
-Cherokee,26 Lyon-Lyon,U.S. Senate,,R,Jerry Moran,149
-Cherokee,26 Lyon-Lyon,U.S. Senate,,D,Patrick Wiesner,34
-Cherokee,26 Lyon-Lyon,U.S. House,2,LBT,James Bales,12
-Cherokee,26 Lyon-Lyon,U.S. House,2,R,Lynn Jenkins,150
-Cherokee,26 Lyon-Lyon,U.S. House,2,D,Britani Potter,25
-Cherokee,26 Lyon-Lyon,State Senate,13,D,Lynn Grant,41
-Cherokee,26 Lyon-Lyon,State Senate,13,R,Jake LaTurner,145
-Cherokee,26 Lyon-Lyon,State House,1,R,Michael Houser,159
-Cherokee,26 Lyon-Lyon,State House,1,,Write-ins,5
-Cherokee,27 Mineral,Voters,,,Registration,150
-Cherokee,27 Mineral,Voters,,,Ballots,94
-Cherokee,27 Mineral,President,,D,Hillary Clinton,15
-Cherokee,27 Mineral,President,,LBT,Gary Johnson,2
-Cherokee,27 Mineral,President,,IND,Jill Stein,0
-Cherokee,27 Mineral,President,,R,Donald Trump,75
-Cherokee,27 Mineral,President,,,Write-ins,2
-Cherokee,27 Mineral,U.S. Senate,,LBT,Robert Garrard,5
-Cherokee,27 Mineral,U.S. Senate,,R,Jerry Moran,74
-Cherokee,27 Mineral,U.S. Senate,,D,Patrick Wiesner,13
-Cherokee,27 Mineral,U.S. Senate,,,Write-ins,1
-Cherokee,27 Mineral,U.S. House,2,LBT,James Bales,4
-Cherokee,27 Mineral,U.S. House,2,R,Lynn Jenkins,78
-Cherokee,27 Mineral,U.S. House,2,D,Britani Potter,10
-Cherokee,27 Mineral,State Senate,13,D,Lynn Grant,16
-Cherokee,27 Mineral,State Senate,13,R,Jake LaTurner,76
-Cherokee,27 Mineral,State House,1,R,Michael Houser,81
-Cherokee,28 Neosho-Faulkner,Voters,,,Registration,84
-Cherokee,28 Neosho-Faulkner,Voters,,,Ballots,48
-Cherokee,28 Neosho-Faulkner,President,,D,Hillary Clinton,5
-Cherokee,28 Neosho-Faulkner,President,,LBT,Gary Johnson,2
-Cherokee,28 Neosho-Faulkner,President,,IND,Jill Stein,2
-Cherokee,28 Neosho-Faulkner,President,,R,Donald Trump,37
-Cherokee,28 Neosho-Faulkner,President,,,Write-ins,2
-Cherokee,28 Neosho-Faulkner,U.S. Senate,,LBT,Robert Garrard,2
-Cherokee,28 Neosho-Faulkner,U.S. Senate,,R,Jerry Moran,38
-Cherokee,28 Neosho-Faulkner,U.S. Senate,,D,Patrick Wiesner,5
-Cherokee,28 Neosho-Faulkner,U.S. House,2,LBT,James Bales,3
-Cherokee,28 Neosho-Faulkner,U.S. House,2,R,Lynn Jenkins,40
-Cherokee,28 Neosho-Faulkner,U.S. House,2,D,Britani Potter,3
-Cherokee,28 Neosho-Faulkner,State Senate,13,D,Lynn Grant,10
-Cherokee,28 Neosho-Faulkner,State Senate,13,R,Jake LaTurner,35
-Cherokee,28 Neosho-Faulkner,State House,1,R,Michael Houser,40
-Cherokee,28 Neosho-Faulkner,State House,1,,Write-ins,1
-Cherokee,29 Neosho-Melrose,Voters,,,Registration,127
-Cherokee,29 Neosho-Melrose,Voters,,,Ballots,73
-Cherokee,29 Neosho-Melrose,President,,D,Hillary Clinton,9
-Cherokee,29 Neosho-Melrose,President,,LBT,Gary Johnson,5
-Cherokee,29 Neosho-Melrose,President,,IND,Jill Stein,1
-Cherokee,29 Neosho-Melrose,President,,R,Donald Trump,58
-Cherokee,29 Neosho-Melrose,State Senate,13,,Write-ins,1
-Cherokee,29 Neosho-Melrose,U.S. Senate,,LBT,Robert Garrard,4
-Cherokee,29 Neosho-Melrose,U.S. Senate,,R,Jerry Moran,49
-Cherokee,29 Neosho-Melrose,U.S. Senate,,D,Patrick Wiesner,14
-Cherokee,29 Neosho-Melrose,U.S. House,2,LBT,James Bales,7
-Cherokee,29 Neosho-Melrose,U.S. House,2,R,Lynn Jenkins,54
-Cherokee,29 Neosho-Melrose,U.S. House,2,D,Britani Potter,12
-Cherokee,29 Neosho-Melrose,State Senate,13,D,Lynn Grant,16
-Cherokee,29 Neosho-Melrose,State Senate,13,R,Jake LaTurner,55
-Cherokee,29 Neosho-Melrose,State House,1,R,Michael Houser,60
-Cherokee,29 Neosho-Melrose,State House,1,,Write-ins,1
-Cherokee,30 Pleasant View,Voters,,,Registration,471
-Cherokee,30 Pleasant View,Voters,,,Ballots,306
-Cherokee,30 Pleasant View,President,,D,Hillary Clinton,67
-Cherokee,30 Pleasant View,President,,LBT,Gary Johnson,9
-Cherokee,30 Pleasant View,President,,IND,Jill Stein,4
-Cherokee,30 Pleasant View,President,,R,Donald Trump,222
-Cherokee,30 Pleasant View,President,,,Write-ins,3
-Cherokee,30 Pleasant View,U.S. Senate,,LBT,Robert Garrard,15
-Cherokee,30 Pleasant View,U.S. Senate,,R,Jerry Moran,227
-Cherokee,30 Pleasant View,U.S. Senate,,D,Patrick Wiesner,58
-Cherokee,30 Pleasant View,U.S. House,2,,Write-ins,1
-Cherokee,30 Pleasant View,U.S. House,2,LBT,James Bales,16
-Cherokee,30 Pleasant View,U.S. House,2,R,Lynn Jenkins,224
-Cherokee,30 Pleasant View,U.S. House,2,D,Britani Potter,60
-Cherokee,30 Pleasant View,State Senate,13,D,Lynn Grant,87
-Cherokee,30 Pleasant View,State Senate,13,R,Jake LaTurner,215
-Cherokee,30 Pleasant View,State House,1,R,Michael Houser,252
-Cherokee,30 Pleasant View,State House,1,,Write-ins,6
-Cherokee,31 Ross-Belleview,Voters,,,Registration,140
-Cherokee,31 Ross-Belleview,Voters,,,Ballots,87
-Cherokee,31 Ross-Belleview,President,,D,Hillary Clinton,19
-Cherokee,31 Ross-Belleview,President,,LBT,Gary Johnson,0
-Cherokee,31 Ross-Belleview,President,,IND,Jill Stein,1
-Cherokee,31 Ross-Belleview,President,,R,Donald Trump,65
-Cherokee,31 Ross-Belleview,U.S. Senate,,LBT,Robert Garrard,6
-Cherokee,31 Ross-Belleview,U.S. Senate,,R,Jerry Moran,61
-Cherokee,31 Ross-Belleview,U.S. Senate,,D,Patrick Wiesner,17
-Cherokee,31 Ross-Belleview,U.S. House,2,LBT,James Bales,5
-Cherokee,31 Ross-Belleview,U.S. House,2,R,Lynn Jenkins,63
-Cherokee,31 Ross-Belleview,U.S. House,2,D,Britani Potter,18
-Cherokee,31 Ross-Belleview,State Senate,13,D,Lynn Grant,26
-Cherokee,31 Ross-Belleview,State Senate,13,R,Jake LaTurner,58
-Cherokee,31 Ross-Belleview,State House,1,R,Michael Houser,73
-Cherokee,32 Ross-Roseland,Voters,,,Registration,200
-Cherokee,32 Ross-Roseland,Voters,,,Ballots,123
-Cherokee,32 Ross-Roseland,President,,D,Hillary Clinton,42
-Cherokee,32 Ross-Roseland,President,,LBT,Gary Johnson,5
-Cherokee,32 Ross-Roseland,President,,IND,Jill Stein,4
-Cherokee,32 Ross-Roseland,President,,R,Donald Trump,66
-Cherokee,32 Ross-Roseland,President,,,Write-ins,2
-Cherokee,32 Ross-Roseland,U.S. Senate,,LBT,Robert Garrard,9
-Cherokee,32 Ross-Roseland,U.S. Senate,,R,Jerry Moran,67
-Cherokee,32 Ross-Roseland,U.S. Senate,,D,Patrick Wiesner,44
-Cherokee,32 Ross-Roseland,U.S. House,2,LBT,James Bales,5
-Cherokee,32 Ross-Roseland,U.S. House,2,R,Lynn Jenkins,69
-Cherokee,32 Ross-Roseland,U.S. House,2,D,Britani Potter,43
-Cherokee,32 Ross-Roseland,U.S. House,2,,Write-ins,1
-Cherokee,32 Ross-Roseland,State Senate,13,D,Lynn Grant,58
-Cherokee,32 Ross-Roseland,State Senate,13,R,Jake LaTurner,64
-Cherokee,32 Ross-Roseland,State House,1,R,Michael Houser,79
-Cherokee,32 Ross-Roseland,State House,1,,Write-ins,6
-Cherokee,33 Ross-W Mineral,Voters,,,Registration,189
-Cherokee,33 Ross-W Mineral,Voters,,,Ballots,124
-Cherokee,33 Ross-W Mineral,President,,D,Hillary Clinton,37
-Cherokee,33 Ross-W Mineral,President,,LBT,Gary Johnson,6
-Cherokee,33 Ross-W Mineral,President,,IND,Jill Stein,5
-Cherokee,33 Ross-W Mineral,President,,R,Donald Trump,75
-Cherokee,33 Ross-W Mineral,U.S. House,2,,Write-ins,1
-Cherokee,33 Ross-W Mineral,U.S. Senate,,LBT,Robert Garrard,7
-Cherokee,33 Ross-W Mineral,U.S. Senate,,R,Jerry Moran,71
-Cherokee,33 Ross-W Mineral,U.S. Senate,,D,Patrick Wiesner,43
-Cherokee,33 Ross-W Mineral,U.S. House,2,LBT,James Bales,5
-Cherokee,33 Ross-W Mineral,U.S. House,2,R,Lynn Jenkins,78
-Cherokee,33 Ross-W Mineral,U.S. House,2,D,Britani Potter,39
-Cherokee,33 Ross-W Mineral,State Senate,13,D,Lynn Grant,50
-Cherokee,33 Ross-W Mineral,State Senate,13,R,Jake LaTurner,72
-Cherokee,33 Ross-W Mineral,State Senate,13,,Write-ins,1
-Cherokee,33 Ross-W Mineral,State House,1,R,Michael Houser,98
-Cherokee,33 Ross-W Mineral,State House,1,,Write-ins,5
-Cherokee,34 Salamanca,Voters,,,Registration,439
-Cherokee,34 Salamanca,Voters,,,Ballots,320
-Cherokee,34 Salamanca,President,,D,Hillary Clinton,70
-Cherokee,34 Salamanca,President,,LBT,Gary Johnson,8
-Cherokee,34 Salamanca,President,,IND,Jill Stein,1
-Cherokee,34 Salamanca,President,,R,Donald Trump,230
-Cherokee,34 Salamanca,President,,,Write-ins,7
-Cherokee,34 Salamanca,U.S. Senate,,LBT,Robert Garrard,3
-Cherokee,34 Salamanca,U.S. Senate,,R,Jerry Moran,236
-Cherokee,34 Salamanca,U.S. Senate,,D,Patrick Wiesner,75
-Cherokee,34 Salamanca,U.S. House,2,LBT,James Bales,6
-Cherokee,34 Salamanca,U.S. House,2,R,Lynn Jenkins,241
-Cherokee,34 Salamanca,U.S. House,2,D,Britani Potter,64
-Cherokee,34 Salamanca,U.S. House,2,,Write-ins,1
-Cherokee,34 Salamanca,State Senate,13,D,Lynn Grant,117
-Cherokee,34 Salamanca,State Senate,13,R,Jake LaTurner,197
-Cherokee,34 Salamanca,State Senate,13,,Write-ins,1
-Cherokee,34 Salamanca,State House,1,R,Michael Houser,239
-Cherokee,34 Salamanca,State House,1,,Write-ins,12
-Cherokee,35 Shawnee,Voters,,,Registration,414
-Cherokee,35 Shawnee,Voters,,,Ballots,246
-Cherokee,35 Shawnee,President,,D,Hillary Clinton,37
-Cherokee,35 Shawnee,President,,LBT,Gary Johnson,4
-Cherokee,35 Shawnee,President,,IND,Jill Stein,5
-Cherokee,35 Shawnee,President,,R,Donald Trump,194
-Cherokee,35 Shawnee,President,,,Write-ins,4
-Cherokee,35 Shawnee,U.S. Senate,,LBT,Robert Garrard,10
-Cherokee,35 Shawnee,U.S. Senate,,R,Jerry Moran,189
-Cherokee,35 Shawnee,U.S. Senate,,D,Patrick Wiesner,43
-Cherokee,35 Shawnee,U.S. Senate,,,Write-ins,1
-Cherokee,35 Shawnee,U.S. House,2,LBT,James Bales,8
-Cherokee,35 Shawnee,U.S. House,2,R,Lynn Jenkins,195
-Cherokee,35 Shawnee,U.S. House,2,D,Britani Potter,40
-Cherokee,35 Shawnee,State Senate,13,D,Lynn Grant,67
-Cherokee,35 Shawnee,State Senate,13,R,Jake LaTurner,177
-Cherokee,35 Shawnee,State House,1,R,Michael Houser,205
-Cherokee,35 Shawnee,State House,1,,Write-ins,8
-Cherokee,36 Sheridan,Voters,,,Registration,162
-Cherokee,36 Sheridan,Voters,,,Ballots,116
-Cherokee,36 Sheridan,President,,D,Hillary Clinton,21
-Cherokee,36 Sheridan,President,,LBT,Gary Johnson,7
-Cherokee,36 Sheridan,President,,IND,Jill Stein,1
-Cherokee,36 Sheridan,President,,R,Donald Trump,86
-Cherokee,36 Sheridan,U.S. Senate,,LBT,Robert Garrard,8
-Cherokee,36 Sheridan,U.S. Senate,,R,Jerry Moran,79
-Cherokee,36 Sheridan,U.S. Senate,,D,Patrick Wiesner,26
-Cherokee,36 Sheridan,U.S. House,2,LBT,James Bales,4
-Cherokee,36 Sheridan,U.S. House,2,R,Lynn Jenkins,80
-Cherokee,36 Sheridan,U.S. House,2,D,Britani Potter,29
-Cherokee,36 Sheridan,State Senate,13,,Write-ins,1
-Cherokee,36 Sheridan,State Senate,13,D,Lynn Grant,41
-Cherokee,36 Sheridan,State Senate,13,R,Jake LaTurner,73
-Cherokee,36 Sheridan,State House,1,R,Michael Houser,98
-Cherokee,36 Sheridan,State House,1,,Write-ins,2
-Cherokee,37 Spring Valley-Neutral,Voters,,,Registration,484
-Cherokee,37 Spring Valley-Neutral,Voters,,,Ballots,308
-Cherokee,37 Spring Valley-Neutral,President,,D,Hillary Clinton,56
-Cherokee,37 Spring Valley-Neutral,President,,LBT,Gary Johnson,11
-Cherokee,37 Spring Valley-Neutral,President,,IND,Jill Stein,3
-Cherokee,37 Spring Valley-Neutral,President,,R,Donald Trump,231
-Cherokee,37 Spring Valley-Neutral,President,,,Write-ins,4
-Cherokee,37 Spring Valley-Neutral,U.S. Senate,,LBT,Robert Garrard,17
-Cherokee,37 Spring Valley-Neutral,U.S. Senate,,R,Jerry Moran,218
-Cherokee,37 Spring Valley-Neutral,U.S. Senate,,D,Patrick Wiesner,66
-Cherokee,37 Spring Valley-Neutral,U.S. Senate,,,Write-ins,1
-Cherokee,37 Spring Valley-Neutral,U.S. House,2,LBT,James Bales,21
-Cherokee,37 Spring Valley-Neutral,U.S. House,2,R,Lynn Jenkins,219
-Cherokee,37 Spring Valley-Neutral,U.S. House,2,D,Britani Potter,63
-Cherokee,37 Spring Valley-Neutral,U.S. House,2,,Write-ins,1
-Cherokee,37 Spring Valley-Neutral,State Senate,13,D,Lynn Grant,101
-Cherokee,37 Spring Valley-Neutral,State Senate,13,R,Jake LaTurner,202
-Cherokee,37 Spring Valley-Neutral,State House,1,R,Michael Houser,257
-Cherokee,37 Spring Valley-Neutral,State House,1,,Write-ins,9
-Cherokee,37 Spring Valley-Neutral,State Senate,13,,Write-ins,2
-Cherokee,38 Spring Valley-Spr Val,Voters,,,Registration,346
-Cherokee,38 Spring Valley-Spr Val,Voters,,,Ballots,194
-Cherokee,38 Spring Valley-Spr Val,President,,D,Hillary Clinton,39
-Cherokee,38 Spring Valley-Spr Val,President,,LBT,Gary Johnson,2
-Cherokee,38 Spring Valley-Spr Val,President,,IND,Jill Stein,4
-Cherokee,38 Spring Valley-Spr Val,President,,R,Donald Trump,144
-Cherokee,38 Spring Valley-Spr Val,President,,,Write-ins,3
-Cherokee,38 Spring Valley-Spr Val,U.S. Senate,,LBT,Robert Garrard,7
-Cherokee,38 Spring Valley-Spr Val,U.S. Senate,,R,Jerry Moran,146
-Cherokee,38 Spring Valley-Spr Val,U.S. Senate,,D,Patrick Wiesner,38
-Cherokee,38 Spring Valley-Spr Val,U.S. House,2,LBT,James Bales,11
-Cherokee,38 Spring Valley-Spr Val,U.S. House,2,R,Lynn Jenkins,143
-Cherokee,38 Spring Valley-Spr Val,U.S. House,2,D,Britani Potter,39
-Cherokee,38 Spring Valley-Spr Val,State Senate,13,D,Lynn Grant,54
-Cherokee,38 Spring Valley-Spr Val,State Senate,13,R,Jake LaTurner,138
-Cherokee,38 Spring Valley-Spr Val,State House,1,R,Michael Houser,166
-Cherokee,38 Spring Valley-Spr Val,State House,1,,Write-ins,2
+county,precinct,office,district,party,candidate,votes,vtd
+CHEROKEE,Baxter Springs Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",244,000010
+CHEROKEE,Baxter Springs Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",223,000020
+CHEROKEE,Baxter Springs Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",528,000030
+CHEROKEE,Baxter Springs Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",276,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00004B
+CHEROKEE,Cherokee Township,Kansas House of Representatives,1,Republican,"Houser, Michael",129,000050
+CHEROKEE,Columbus Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",188,000060
+CHEROKEE,Columbus Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",252,000070
+CHEROKEE,Columbus Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",210,000080
+CHEROKEE,Columbus Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",186,000090
+CHEROKEE,Columbus Ward 5,Kansas House of Representatives,1,Republican,"Houser, Michael",187,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00010B
+CHEROKEE,Crawford Township,Kansas House of Representatives,1,Republican,"Houser, Michael",297,000110
+CHEROKEE,Galena Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",209,000120
+CHEROKEE,Galena Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",175,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00013D
+CHEROKEE,Galena Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",273,000140
+CHEROKEE,Galena Ward 4,Kansas House of Representatives,1,Republican,"Houser, Michael",144,00015A
+CHEROKEE,Galena Ward 4 Exclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00015B
+CHEROKEE,Garden Township Lowell,Kansas House of Representatives,1,Republican,"Houser, Michael",811,000170
+CHEROKEE,Garden Township Stanley Mine,Kansas House of Representatives,1,Republican,"Houser, Michael",236,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00018C
+CHEROKEE,Lola Township,Kansas House of Representatives,1,Republican,"Houser, Michael",128,000190
+CHEROKEE,Lowell Township,Kansas House of Representatives,1,Republican,"Houser, Michael",273,000200
+CHEROKEE,Mineral Township,Kansas House of Representatives,1,Republican,"Houser, Michael",81,000220
+CHEROKEE,Neosho Township Faulkner,Kansas House of Representatives,1,Republican,"Houser, Michael",40,000230
+CHEROKEE,Neosho Township Melrose,Kansas House of Representatives,1,Republican,"Houser, Michael",60,000240
+CHEROKEE,Pleasant View Township,Kansas House of Representatives,1,Republican,"Houser, Michael",252,000250
+CHEROKEE,Roseland City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,000260
+CHEROKEE,Ross Township Belleview,Kansas House of Representatives,1,Republican,"Houser, Michael",73,000270
+CHEROKEE,Ross Township Roseland,Kansas House of Representatives,1,Republican,"Houser, Michael",79,000280
+CHEROKEE,Ross Township West Mineral,Kansas House of Representatives,1,Republican,"Houser, Michael",98,000290
+CHEROKEE,Salamanca Township,Kansas House of Representatives,1,Republican,"Houser, Michael",239,00030A
+CHEROKEE,Salamanca Township Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00030B
+CHEROKEE,Scammon Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",35,000310
+CHEROKEE,Scammon Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",65,000320
+CHEROKEE,Scammon Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",55,000330
+CHEROKEE,Shawnee Township,Kansas House of Representatives,1,Republican,"Houser, Michael",205,000340
+CHEROKEE,Sheridan Township,Kansas House of Representatives,1,Republican,"Houser, Michael",98,000350
+CHEROKEE,Spring Valley Township Neutral,Kansas House of Representatives,1,Republican,"Houser, Michael",257,000360
+CHEROKEE,Spring Valley Township Spring Valley,Kansas House of Representatives,1,Republican,"Houser, Michael",166,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00037C
+CHEROKEE,Weir Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",44,00039A
+CHEROKEE,Weir Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",89,000400
+CHEROKEE,Weir Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",55,000410
+CHEROKEE,West Mineral City,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas House of Representatives,1,Republican,"Houser, Michael",0,00042B
+CHEROKEE,Lyon Township,Kansas House of Representatives,1,Republican,"Houser, Michael",159,140010
+CHEROKEE,Baxter Springs Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",98,000010
+CHEROKEE,Baxter Springs Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",200,000010
+CHEROKEE,Baxter Springs Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",77,000020
+CHEROKEE,Baxter Springs Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",172,000020
+CHEROKEE,Baxter Springs Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",224,000030
+CHEROKEE,Baxter Springs Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",418,000030
+CHEROKEE,Baxter Springs Ward 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",106,00004A
+CHEROKEE,Baxter Springs Ward 4,Kansas Senate,13,Republican,"LaTurner, Jake",232,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,00004B
+CHEROKEE,Cherokee Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",77,000050
+CHEROKEE,Cherokee Township,Kansas Senate,13,Republican,"LaTurner, Jake",86,000050
+CHEROKEE,Columbus Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",83,000060
+CHEROKEE,Columbus Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",132,000060
+CHEROKEE,Columbus Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",133,000070
+CHEROKEE,Columbus Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",191,000070
+CHEROKEE,Columbus Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",126,000080
+CHEROKEE,Columbus Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",148,000080
+CHEROKEE,Columbus Ward 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",88,000090
+CHEROKEE,Columbus Ward 4,Kansas Senate,13,Republican,"LaTurner, Jake",145,000090
+CHEROKEE,Columbus Ward 5,Kansas Senate,13,Democratic,"Grant, Lynn D.",80,00010A
+CHEROKEE,Columbus Ward 5,Kansas Senate,13,Republican,"LaTurner, Jake",139,00010A
+CHEROKEE,Columbus Ward 5 Exclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,00010B
+CHEROKEE,Crawford Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",116,000110
+CHEROKEE,Crawford Township,Kansas Senate,13,Republican,"LaTurner, Jake",231,000110
+CHEROKEE,Galena Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",82,000120
+CHEROKEE,Galena Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",177,000120
+CHEROKEE,Galena Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",65,00013A
+CHEROKEE,Galena Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",144,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,Kansas Senate,13,Republican,"LaTurner, Jake",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,Kansas Senate,13,Republican,"LaTurner, Jake",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,Kansas Senate,13,Republican,"LaTurner, Jake",0,00013D
+CHEROKEE,Galena Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",125,000140
+CHEROKEE,Galena Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",216,000140
+CHEROKEE,Galena Ward 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",55,00015A
+CHEROKEE,Galena Ward 4,Kansas Senate,13,Republican,"LaTurner, Jake",120,00015A
+CHEROKEE,Galena Ward 4 Exclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,00015B
+CHEROKEE,Garden Township Lowell,Kansas Senate,13,Democratic,"Grant, Lynn D.",342,000170
+CHEROKEE,Garden Township Lowell,Kansas Senate,13,Republican,"LaTurner, Jake",630,000170
+CHEROKEE,Garden Township Stanley Mine,Kansas Senate,13,Democratic,"Grant, Lynn D.",84,00018A
+CHEROKEE,Garden Township Stanley Mine,Kansas Senate,13,Republican,"LaTurner, Jake",196,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,Kansas Senate,13,Republican,"LaTurner, Jake",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,Kansas Senate,13,Republican,"LaTurner, Jake",0,00018C
+CHEROKEE,Lola Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",45,000190
+CHEROKEE,Lola Township,Kansas Senate,13,Republican,"LaTurner, Jake",103,000190
+CHEROKEE,Lowell Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",88,000200
+CHEROKEE,Lowell Township,Kansas Senate,13,Republican,"LaTurner, Jake",221,000200
+CHEROKEE,Mineral Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",16,000220
+CHEROKEE,Mineral Township,Kansas Senate,13,Republican,"LaTurner, Jake",76,000220
+CHEROKEE,Neosho Township Faulkner,Kansas Senate,13,Democratic,"Grant, Lynn D.",10,000230
+CHEROKEE,Neosho Township Faulkner,Kansas Senate,13,Republican,"LaTurner, Jake",35,000230
+CHEROKEE,Neosho Township Melrose,Kansas Senate,13,Democratic,"Grant, Lynn D.",16,000240
+CHEROKEE,Neosho Township Melrose,Kansas Senate,13,Republican,"LaTurner, Jake",55,000240
+CHEROKEE,Pleasant View Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",87,000250
+CHEROKEE,Pleasant View Township,Kansas Senate,13,Republican,"LaTurner, Jake",215,000250
+CHEROKEE,Roseland City,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,000260
+CHEROKEE,Roseland City,Kansas Senate,13,Republican,"LaTurner, Jake",0,000260
+CHEROKEE,Ross Township Belleview,Kansas Senate,13,Democratic,"Grant, Lynn D.",26,000270
+CHEROKEE,Ross Township Belleview,Kansas Senate,13,Republican,"LaTurner, Jake",58,000270
+CHEROKEE,Ross Township Roseland,Kansas Senate,13,Democratic,"Grant, Lynn D.",58,000280
+CHEROKEE,Ross Township Roseland,Kansas Senate,13,Republican,"LaTurner, Jake",64,000280
+CHEROKEE,Ross Township West Mineral,Kansas Senate,13,Democratic,"Grant, Lynn D.",50,000290
+CHEROKEE,Ross Township West Mineral,Kansas Senate,13,Republican,"LaTurner, Jake",72,000290
+CHEROKEE,Salamanca Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",117,00030A
+CHEROKEE,Salamanca Township,Kansas Senate,13,Republican,"LaTurner, Jake",197,00030A
+CHEROKEE,Salamanca Township Enclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00030B
+CHEROKEE,Salamanca Township Enclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,00030B
+CHEROKEE,Scammon Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",30,000310
+CHEROKEE,Scammon Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",18,000310
+CHEROKEE,Scammon Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",33,000320
+CHEROKEE,Scammon Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",40,000320
+CHEROKEE,Scammon Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",31,000330
+CHEROKEE,Scammon Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",41,000330
+CHEROKEE,Shawnee Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",67,000340
+CHEROKEE,Shawnee Township,Kansas Senate,13,Republican,"LaTurner, Jake",177,000340
+CHEROKEE,Sheridan Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",41,000350
+CHEROKEE,Sheridan Township,Kansas Senate,13,Republican,"LaTurner, Jake",73,000350
+CHEROKEE,Spring Valley Township Neutral,Kansas Senate,13,Democratic,"Grant, Lynn D.",101,000360
+CHEROKEE,Spring Valley Township Neutral,Kansas Senate,13,Republican,"LaTurner, Jake",202,000360
+CHEROKEE,Spring Valley Township Spring Valley,Kansas Senate,13,Democratic,"Grant, Lynn D.",54,00037A
+CHEROKEE,Spring Valley Township Spring Valley,Kansas Senate,13,Republican,"LaTurner, Jake",138,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,00037C
+CHEROKEE,Weir Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",37,00039A
+CHEROKEE,Weir Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",25,00039A
+CHEROKEE,Weir Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",68,000400
+CHEROKEE,Weir Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",51,000400
+CHEROKEE,Weir Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",39,000410
+CHEROKEE,Weir Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",35,000410
+CHEROKEE,West Mineral City,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00042A
+CHEROKEE,West Mineral City,Kansas Senate,13,Republican,"LaTurner, Jake",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,Kansas Senate,13,Republican,"LaTurner, Jake",0,00042B
+CHEROKEE,Lyon Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",41,140010
+CHEROKEE,Lyon Township,Kansas Senate,13,Republican,"LaTurner, Jake",145,140010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,independent,"Stein, Jill",6,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000010
+CHEROKEE,Baxter Springs Ward 1,President / Vice President,,Republican,"Trump, Donald J.",205,000010
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,independent,"Stein, Jill",6,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",11,000020
+CHEROKEE,Baxter Springs Ward 2,President / Vice President,,Republican,"Trump, Donald J.",180,000020
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,independent,"Stein, Jill",9,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",149,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",24,000030
+CHEROKEE,Baxter Springs Ward 3,President / Vice President,,Republican,"Trump, Donald J.",463,000030
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,independent,"Stein, Jill",8,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Castle, Darrell L",1,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",8,00004A
+CHEROKEE,Baxter Springs Ward 4,President / Vice President,,Republican,"Trump, Donald J.",257,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00004B
+CHEROKEE,Cherokee Township,President / Vice President,,independent,"Stein, Jill",3,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"McMullin, Evan",2,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+CHEROKEE,Cherokee Township,President / Vice President,,Republican,"Trump, Donald J.",94,000050
+CHEROKEE,Columbus Ward 1,President / Vice President,,independent,"Stein, Jill",1,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000060
+CHEROKEE,Columbus Ward 1,President / Vice President,,Republican,"Trump, Donald J.",145,000060
+CHEROKEE,Columbus Ward 2,President / Vice President,,independent,"Stein, Jill",2,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",92,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000070
+CHEROKEE,Columbus Ward 2,President / Vice President,,Republican,"Trump, Donald J.",214,000070
+CHEROKEE,Columbus Ward 3,President / Vice President,,independent,"Stein, Jill",1,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",15,000080
+CHEROKEE,Columbus Ward 3,President / Vice President,,Republican,"Trump, Donald J.",185,000080
+CHEROKEE,Columbus Ward 4,President / Vice President,,independent,"Stein, Jill",2,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",14,000090
+CHEROKEE,Columbus Ward 4,President / Vice President,,Republican,"Trump, Donald J.",154,000090
+CHEROKEE,Columbus Ward 5,President / Vice President,,independent,"Stein, Jill",8,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Hedges, James A",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Smith, Mike",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",5,00010A
+CHEROKEE,Columbus Ward 5,President / Vice President,,Republican,"Trump, Donald J.",158,00010A
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,independent,"Stein, Jill",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00010B
+CHEROKEE,Crawford Township,President / Vice President,,independent,"Stein, Jill",3,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+CHEROKEE,Crawford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000110
+CHEROKEE,Crawford Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+CHEROKEE,Crawford Township,President / Vice President,,Republican,"Trump, Donald J.",282,000110
+CHEROKEE,Galena Ward 1,President / Vice President,,independent,"Stein, Jill",2,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000120
+CHEROKEE,Galena Ward 1,President / Vice President,,Republican,"Trump, Donald J.",189,000120
+CHEROKEE,Galena Ward 2,President / Vice President,,independent,"Stein, Jill",3,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",11,00013A
+CHEROKEE,Galena Ward 2,President / Vice President,,Republican,"Trump, Donald J.",155,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,independent,"Stein, Jill",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Castle, Darrell L",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Giordani, Rocky",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Hedges, James A",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Kahn, Lynn",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"La Riva, Gloria",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Levinson, Michael S.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Maturen, Michael A",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"McMullin, Evan",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Perry, Darryl",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Schriner, Joe C",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Smith, Mike",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Sood, Ajay",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Sterling, Shawna",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,President / Vice President,,Republican,"Trump, Donald J.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,independent,"Stein, Jill",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00013D
+CHEROKEE,Galena Ward 3,President / Vice President,,independent,"Stein, Jill",1,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",105,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000140
+CHEROKEE,Galena Ward 3,President / Vice President,,Republican,"Trump, Donald J.",231,000140
+CHEROKEE,Galena Ward 4,President / Vice President,,independent,"Stein, Jill",3,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",9,00015A
+CHEROKEE,Galena Ward 4,President / Vice President,,Republican,"Trump, Donald J.",123,00015A
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00015B
+CHEROKEE,Garden Township Lowell,President / Vice President,,independent,"Stein, Jill",18,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Hedges, James A",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"McMullin, Evan",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Perry, Darryl",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Smith, Mike",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Sood, Ajay",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Democratic,"Clinton, Hillary Rodham",237,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Libertarian,"Johnson, Gary",26,000170
+CHEROKEE,Garden Township Lowell,President / Vice President,,Republican,"Trump, Donald J.",680,000170
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,independent,"Stein, Jill",5,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Castle, Darrell L",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Giordani, Rocky",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Hedges, James A",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Kahn, Lynn",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"La Riva, Gloria",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Levinson, Michael S.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Maturen, Michael A",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"McMullin, Evan",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Perry, Darryl",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Schriner, Joe C",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Smith, Mike",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Sood, Ajay",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Sterling, Shawna",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Libertarian,"Johnson, Gary",11,00018A
+CHEROKEE,Garden Township Stanley Mine,President / Vice President,,Republican,"Trump, Donald J.",214,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,independent,"Stein, Jill",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,independent,"Stein, Jill",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00018C
+CHEROKEE,Lola Township,President / Vice President,,independent,"Stein, Jill",2,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+CHEROKEE,Lola Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+CHEROKEE,Lola Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000190
+CHEROKEE,Lola Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000190
+CHEROKEE,Lola Township,President / Vice President,,Republican,"Trump, Donald J.",107,000190
+CHEROKEE,Lowell Township,President / Vice President,,independent,"Stein, Jill",6,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+CHEROKEE,Lowell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000200
+CHEROKEE,Lowell Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000200
+CHEROKEE,Lowell Township,President / Vice President,,Republican,"Trump, Donald J.",251,000200
+CHEROKEE,Mineral Township,President / Vice President,,independent,"Stein, Jill",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+CHEROKEE,Mineral Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000220
+CHEROKEE,Mineral Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+CHEROKEE,Mineral Township,President / Vice President,,Republican,"Trump, Donald J.",75,000220
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,independent,"Stein, Jill",2,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Hedges, James A",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"McMullin, Evan",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Perry, Darryl",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Smith, Mike",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Sood, Ajay",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+CHEROKEE,Neosho Township Faulkner,President / Vice President,,Republican,"Trump, Donald J.",37,000230
+CHEROKEE,Neosho Township Melrose,President / Vice President,,independent,"Stein, Jill",1,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Hedges, James A",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"McMullin, Evan",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Perry, Darryl",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Smith, Mike",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Sood, Ajay",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Libertarian,"Johnson, Gary",5,000240
+CHEROKEE,Neosho Township Melrose,President / Vice President,,Republican,"Trump, Donald J.",58,000240
+CHEROKEE,Pleasant View Township,President / Vice President,,independent,"Stein, Jill",4,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000250
+CHEROKEE,Pleasant View Township,President / Vice President,,Republican,"Trump, Donald J.",222,000250
+CHEROKEE,Roseland City,President / Vice President,,independent,"Stein, Jill",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Hedges, James A",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"McMullin, Evan",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Perry, Darryl",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Smith, Mike",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Sood, Ajay",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+CHEROKEE,Roseland City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+CHEROKEE,Roseland City,President / Vice President,,Republican,"Trump, Donald J.",0,000260
+CHEROKEE,Ross Township Belleview,President / Vice President,,independent,"Stein, Jill",1,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Hedges, James A",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"McMullin, Evan",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Perry, Darryl",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Smith, Mike",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Sood, Ajay",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+CHEROKEE,Ross Township Belleview,President / Vice President,,Republican,"Trump, Donald J.",65,000270
+CHEROKEE,Ross Township Roseland,President / Vice President,,independent,"Stein, Jill",4,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Hedges, James A",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"McMullin, Evan",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Perry, Darryl",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Smith, Mike",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Sood, Ajay",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Libertarian,"Johnson, Gary",5,000280
+CHEROKEE,Ross Township Roseland,President / Vice President,,Republican,"Trump, Donald J.",66,000280
+CHEROKEE,Ross Township West Mineral,President / Vice President,,independent,"Stein, Jill",5,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Hedges, James A",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"McMullin, Evan",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Perry, Darryl",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Smith, Mike",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Sood, Ajay",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Libertarian,"Johnson, Gary",6,000290
+CHEROKEE,Ross Township West Mineral,President / Vice President,,Republican,"Trump, Donald J.",75,000290
+CHEROKEE,Salamanca Township,President / Vice President,,independent,"Stein, Jill",1,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Castle, Darrell L",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Giordani, Rocky",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Hedges, James A",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Hoefling, Tom",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Kahn, Lynn",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"La Riva, Gloria",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Maturen, Michael A",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"McMullin, Evan",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Perry, Darryl",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Schriner, Joe C",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Smith, Mike",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Sood, Ajay",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Sterling, Shawna",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Libertarian,"Johnson, Gary",8,00030A
+CHEROKEE,Salamanca Township,President / Vice President,,Republican,"Trump, Donald J.",230,00030A
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,independent,"Stein, Jill",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00030B
+CHEROKEE,Salamanca Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00030B
+CHEROKEE,Scammon Ward 1,President / Vice President,,independent,"Stein, Jill",1,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000310
+CHEROKEE,Scammon Ward 1,President / Vice President,,Republican,"Trump, Donald J.",25,000310
+CHEROKEE,Scammon Ward 2,President / Vice President,,independent,"Stein, Jill",1,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000320
+CHEROKEE,Scammon Ward 2,President / Vice President,,Republican,"Trump, Donald J.",51,000320
+CHEROKEE,Scammon Ward 3,President / Vice President,,independent,"Stein, Jill",1,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000330
+CHEROKEE,Scammon Ward 3,President / Vice President,,Republican,"Trump, Donald J.",53,000330
+CHEROKEE,Shawnee Township,President / Vice President,,independent,"Stein, Jill",5,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Hedges, James A",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"McMullin, Evan",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Perry, Darryl",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Smith, Mike",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Sood, Ajay",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000340
+CHEROKEE,Shawnee Township,President / Vice President,,Republican,"Trump, Donald J.",194,000340
+CHEROKEE,Sheridan Township,President / Vice President,,independent,"Stein, Jill",1,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Hedges, James A",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"McMullin, Evan",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Perry, Darryl",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Smith, Mike",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Sood, Ajay",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000350
+CHEROKEE,Sheridan Township,President / Vice President,,Republican,"Trump, Donald J.",86,000350
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,independent,"Stein, Jill",3,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Hedges, James A",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"McMullin, Evan",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Perry, Darryl",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Smith, Mike",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Sood, Ajay",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Libertarian,"Johnson, Gary",11,000360
+CHEROKEE,Spring Valley Township Neutral,President / Vice President,,Republican,"Trump, Donald J.",231,000360
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,independent,"Stein, Jill",4,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Basiago, Andrew D.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Castle, Darrell L",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Giordani, Rocky",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Hedges, James A",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Hoefling, Tom",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Kahn, Lynn",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"La Riva, Gloria",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Levinson, Michael S.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Maturen, Michael A",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"McMullin, Evan",1,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Moorehead, Monica G.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Perry, Darryl",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Schriner, Joe C",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Smith, Mike",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Sood, Ajay",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Sterling, Shawna",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Valdivia, Anthony J",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Libertarian,"Johnson, Gary",2,00037A
+CHEROKEE,Spring Valley Township Spring Valley,President / Vice President,,Republican,"Trump, Donald J.",144,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,independent,"Stein, Jill",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Hedges, James A",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Smith, Mike",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,independent,"Stein, Jill",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Hedges, James A",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Smith, Mike",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00037C
+CHEROKEE,Weir Ward 1,President / Vice President,,independent,"Stein, Jill",1,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",1,00039A
+CHEROKEE,Weir Ward 1,President / Vice President,,Republican,"Trump, Donald J.",34,00039A
+CHEROKEE,Weir Ward 2,President / Vice President,,independent,"Stein, Jill",4,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000400
+CHEROKEE,Weir Ward 2,President / Vice President,,Republican,"Trump, Donald J.",56,000400
+CHEROKEE,Weir Ward 3,President / Vice President,,independent,"Stein, Jill",1,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000410
+CHEROKEE,Weir Ward 3,President / Vice President,,Republican,"Trump, Donald J.",44,000410
+CHEROKEE,West Mineral City,President / Vice President,,independent,"Stein, Jill",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Basiago, Andrew D.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Castle, Darrell L",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Giordani, Rocky",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Hedges, James A",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Kahn, Lynn",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"La Riva, Gloria",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Levinson, Michael S.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Maturen, Michael A",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"McMullin, Evan",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Moorehead, Monica G.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Perry, Darryl",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Schriner, Joe C",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Smith, Mike",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Sood, Ajay",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Sterling, Shawna",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Valdivia, Anthony J",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Libertarian,"Johnson, Gary",0,00042A
+CHEROKEE,West Mineral City,President / Vice President,,Republican,"Trump, Donald J.",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,independent,"Stein, Jill",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Basiago, Andrew D.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Castle, Darrell L",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Giordani, Rocky",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Hedges, James A",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Hoefling, Tom",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Kahn, Lynn",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"La Riva, Gloria",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Levinson, Michael S.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Maturen, Michael A",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"McMullin, Evan",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Moorehead, Monica G.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Perry, Darryl",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Schriner, Joe C",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Smith, Mike",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Sood, Ajay",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Sterling, Shawna",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Valdivia, Anthony J",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Libertarian,"Johnson, Gary",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,President / Vice President,,Republican,"Trump, Donald J.",0,00042B
+CHEROKEE,Lyon Township,President / Vice President,,independent,"Stein, Jill",1,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Hedges, James A",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"McMullin, Evan",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Perry, Darryl",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Smith, Mike",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Sood, Ajay",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+CHEROKEE,Lyon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,140010
+CHEROKEE,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",6,140010
+CHEROKEE,Lyon Township,President / Vice President,,Republican,"Trump, Donald J.",149,140010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",65,000010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000010
+CHEROKEE,Baxter Springs Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000010
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",48,000020
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000020
+CHEROKEE,Baxter Springs Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000020
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",130,000030
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",36,000030
+CHEROKEE,Baxter Springs Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",476,000030
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",57,00004A
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,00004A
+CHEROKEE,Baxter Springs Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Democratic,"Potter, Britani",57,000050
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000050
+CHEROKEE,Cherokee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000050
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",43,000060
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000060
+CHEROKEE,Columbus Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",151,000060
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",72,000070
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000070
+CHEROKEE,Columbus Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",234,000070
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",72,000080
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000080
+CHEROKEE,Columbus Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,000080
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",62,000090
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000090
+CHEROKEE,Columbus Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",151,000090
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Democratic,"Potter, Britani",46,00010A
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,00010A
+CHEROKEE,Columbus Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",154,00010A
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+CHEROKEE,Crawford Township,United States House of Representatives,2,Democratic,"Potter, Britani",55,000110
+CHEROKEE,Crawford Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000110
+CHEROKEE,Crawford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",273,000110
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",47,000120
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000120
+CHEROKEE,Galena Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",192,000120
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",46,00013A
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,00013A
+CHEROKEE,Galena Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Democratic,"Potter, Britani",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Democratic,"Potter, Britani",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013D
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",92,000140
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000140
+CHEROKEE,Galena Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",232,000140
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",43,00015A
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,00015A
+CHEROKEE,Galena Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,00015A
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00015B
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Democratic,"Potter, Britani",220,000170
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Libertarian,"Bales, James Houston",48,000170
+CHEROKEE,Garden Township Lowell,United States House of Representatives,2,Republican,"Jenkins, Lynn",706,000170
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Democratic,"Potter, Britani",48,00018A
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,00018A
+CHEROKEE,Garden Township Stanley Mine,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00018C
+CHEROKEE,Lola Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000190
+CHEROKEE,Lola Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000190
+CHEROKEE,Lola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,000190
+CHEROKEE,Lowell Township,United States House of Representatives,2,Democratic,"Potter, Britani",48,000200
+CHEROKEE,Lowell Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000200
+CHEROKEE,Lowell Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",253,000200
+CHEROKEE,Mineral Township,United States House of Representatives,2,Democratic,"Potter, Britani",10,000220
+CHEROKEE,Mineral Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000220
+CHEROKEE,Mineral Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000220
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Democratic,"Potter, Britani",3,000230
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000230
+CHEROKEE,Neosho Township Faulkner,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000230
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Democratic,"Potter, Britani",12,000240
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000240
+CHEROKEE,Neosho Township Melrose,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000240
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Democratic,"Potter, Britani",60,000250
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000250
+CHEROKEE,Pleasant View Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",224,000250
+CHEROKEE,Roseland City,United States House of Representatives,2,Democratic,"Potter, Britani",0,000260
+CHEROKEE,Roseland City,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000260
+CHEROKEE,Roseland City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000260
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Democratic,"Potter, Britani",18,000270
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000270
+CHEROKEE,Ross Township Belleview,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000270
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Democratic,"Potter, Britani",43,000280
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000280
+CHEROKEE,Ross Township Roseland,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,000280
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Democratic,"Potter, Britani",39,000290
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000290
+CHEROKEE,Ross Township West Mineral,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000290
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Democratic,"Potter, Britani",64,00030A
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,00030A
+CHEROKEE,Salamanca Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",241,00030A
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00030B
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",19,000310
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000310
+CHEROKEE,Scammon Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",23,000310
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",19,000320
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000320
+CHEROKEE,Scammon Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000320
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",19,000330
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000330
+CHEROKEE,Scammon Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000330
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Democratic,"Potter, Britani",40,000340
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000340
+CHEROKEE,Shawnee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,000340
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Democratic,"Potter, Britani",29,000350
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000350
+CHEROKEE,Sheridan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000350
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Democratic,"Potter, Britani",63,000360
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000360
+CHEROKEE,Spring Valley Township Neutral,United States House of Representatives,2,Republican,"Jenkins, Lynn",219,000360
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Democratic,"Potter, Britani",39,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00037C
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",20,00039A
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,00039A
+CHEROKEE,Weir Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,00039A
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",47,000400
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000400
+CHEROKEE,Weir Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000400
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",22,000410
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000410
+CHEROKEE,Weir Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,000410
+CHEROKEE,West Mineral City,United States House of Representatives,2,Democratic,"Potter, Britani",0,00042A
+CHEROKEE,West Mineral City,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00042A
+CHEROKEE,West Mineral City,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Democratic,"Potter, Britani",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00042B
+CHEROKEE,Lyon Township,United States House of Representatives,2,Democratic,"Potter, Britani",25,140010
+CHEROKEE,Lyon Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,140010
+CHEROKEE,Lyon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,140010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,write - in,"Smith, DJ",0,000010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",86,000010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000010
+CHEROKEE,Baxter Springs Ward 1,United States Senate,,Republican,"Moran, Jerry",199,000010
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,write - in,"Smith, DJ",0,000020
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",61,000020
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,000020
+CHEROKEE,Baxter Springs Ward 2,United States Senate,,Republican,"Moran, Jerry",163,000020
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",169,000030
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",29,000030
+CHEROKEE,Baxter Springs Ward 3,United States Senate,,Republican,"Moran, Jerry",438,000030
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,write - in,"Smith, DJ",0,00004A
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",71,00004A
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",22,00004A
+CHEROKEE,Baxter Springs Ward 4,United States Senate,,Republican,"Moran, Jerry",243,00004A
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004B
+CHEROKEE,Baxter Springs Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00004B
+CHEROKEE,Cherokee Township,United States Senate,,write - in,"Smith, DJ",0,000050
+CHEROKEE,Cherokee Township,United States Senate,,Democratic,"Wiesner, Patrick",54,000050
+CHEROKEE,Cherokee Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000050
+CHEROKEE,Cherokee Township,United States Senate,,Republican,"Moran, Jerry",95,000050
+CHEROKEE,Columbus Ward 1,United States Senate,,write - in,"Smith, DJ",0,000060
+CHEROKEE,Columbus Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",51,000060
+CHEROKEE,Columbus Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,000060
+CHEROKEE,Columbus Ward 1,United States Senate,,Republican,"Moran, Jerry",148,000060
+CHEROKEE,Columbus Ward 2,United States Senate,,write - in,"Smith, DJ",0,000070
+CHEROKEE,Columbus Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",85,000070
+CHEROKEE,Columbus Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",15,000070
+CHEROKEE,Columbus Ward 2,United States Senate,,Republican,"Moran, Jerry",224,000070
+CHEROKEE,Columbus Ward 3,United States Senate,,write - in,"Smith, DJ",0,000080
+CHEROKEE,Columbus Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",83,000080
+CHEROKEE,Columbus Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",9,000080
+CHEROKEE,Columbus Ward 3,United States Senate,,Republican,"Moran, Jerry",177,000080
+CHEROKEE,Columbus Ward 4,United States Senate,,write - in,"Smith, DJ",0,000090
+CHEROKEE,Columbus Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",53,000090
+CHEROKEE,Columbus Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",16,000090
+CHEROKEE,Columbus Ward 4,United States Senate,,Republican,"Moran, Jerry",160,000090
+CHEROKEE,Columbus Ward 5,United States Senate,,write - in,"Smith, DJ",0,00010A
+CHEROKEE,Columbus Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",60,00010A
+CHEROKEE,Columbus Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",11,00010A
+CHEROKEE,Columbus Ward 5,United States Senate,,Republican,"Moran, Jerry",143,00010A
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,write - in,"Smith, DJ",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00010B
+CHEROKEE,Columbus Ward 5 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00010B
+CHEROKEE,Crawford Township,United States Senate,,write - in,"Smith, DJ",0,000110
+CHEROKEE,Crawford Township,United States Senate,,Democratic,"Wiesner, Patrick",66,000110
+CHEROKEE,Crawford Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000110
+CHEROKEE,Crawford Township,United States Senate,,Republican,"Moran, Jerry",267,000110
+CHEROKEE,Galena Ward 1,United States Senate,,write - in,"Smith, DJ",0,000120
+CHEROKEE,Galena Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",70,000120
+CHEROKEE,Galena Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,000120
+CHEROKEE,Galena Ward 1,United States Senate,,Republican,"Moran, Jerry",172,000120
+CHEROKEE,Galena Ward 2,United States Senate,,write - in,"Smith, DJ",0,00013A
+CHEROKEE,Galena Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",54,00013A
+CHEROKEE,Galena Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,00013A
+CHEROKEE,Galena Ward 2,United States Senate,,Republican,"Moran, Jerry",132,00013A
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,write - in,"Smith, DJ",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,Democratic,"Wiesner, Patrick",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,Libertarian,"Garrard, Robert D.",0,00013B
+CHEROKEE,Galena Ward 2 Exclave A City Park,United States Senate,,Republican,"Moran, Jerry",0,00013B
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00013C
+CHEROKEE,Galena Ward 2 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00013C
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,write - in,"Smith, DJ",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00013D
+CHEROKEE,Galena Ward 2 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,00013D
+CHEROKEE,Galena Ward 3,United States Senate,,write - in,"Smith, DJ",0,000140
+CHEROKEE,Galena Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",102,000140
+CHEROKEE,Galena Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",19,000140
+CHEROKEE,Galena Ward 3,United States Senate,,Republican,"Moran, Jerry",214,000140
+CHEROKEE,Galena Ward 4,United States Senate,,write - in,"Smith, DJ",0,00015A
+CHEROKEE,Galena Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",49,00015A
+CHEROKEE,Galena Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",10,00015A
+CHEROKEE,Galena Ward 4,United States Senate,,Republican,"Moran, Jerry",112,00015A
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00015B
+CHEROKEE,Galena Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00015B
+CHEROKEE,Garden Township Lowell,United States Senate,,write - in,"Smith, DJ",0,000170
+CHEROKEE,Garden Township Lowell,United States Senate,,Democratic,"Wiesner, Patrick",262,000170
+CHEROKEE,Garden Township Lowell,United States Senate,,Libertarian,"Garrard, Robert D.",49,000170
+CHEROKEE,Garden Township Lowell,United States Senate,,Republican,"Moran, Jerry",661,000170
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,write - in,"Smith, DJ",0,00018A
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,Democratic,"Wiesner, Patrick",56,00018A
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,Libertarian,"Garrard, Robert D.",17,00018A
+CHEROKEE,Garden Township Stanley Mine,United States Senate,,Republican,"Moran, Jerry",203,00018A
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,write - in,"Smith, DJ",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00018B
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,write - in,"Smith, DJ",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018C
+CHEROKEE,Garden Township Stanley Mine Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00018C
+CHEROKEE,Lola Township,United States Senate,,write - in,"Smith, DJ",0,000190
+CHEROKEE,Lola Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000190
+CHEROKEE,Lola Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000190
+CHEROKEE,Lola Township,United States Senate,,Republican,"Moran, Jerry",107,000190
+CHEROKEE,Lowell Township,United States Senate,,write - in,"Smith, DJ",0,000200
+CHEROKEE,Lowell Township,United States Senate,,Democratic,"Wiesner, Patrick",59,000200
+CHEROKEE,Lowell Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000200
+CHEROKEE,Lowell Township,United States Senate,,Republican,"Moran, Jerry",235,000200
+CHEROKEE,Mineral Township,United States Senate,,write - in,"Smith, DJ",0,000220
+CHEROKEE,Mineral Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000220
+CHEROKEE,Mineral Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000220
+CHEROKEE,Mineral Township,United States Senate,,Republican,"Moran, Jerry",74,000220
+CHEROKEE,Neosho Township Faulkner,United States Senate,,write - in,"Smith, DJ",0,000230
+CHEROKEE,Neosho Township Faulkner,United States Senate,,Democratic,"Wiesner, Patrick",5,000230
+CHEROKEE,Neosho Township Faulkner,United States Senate,,Libertarian,"Garrard, Robert D.",2,000230
+CHEROKEE,Neosho Township Faulkner,United States Senate,,Republican,"Moran, Jerry",38,000230
+CHEROKEE,Neosho Township Melrose,United States Senate,,write - in,"Smith, DJ",0,000240
+CHEROKEE,Neosho Township Melrose,United States Senate,,Democratic,"Wiesner, Patrick",14,000240
+CHEROKEE,Neosho Township Melrose,United States Senate,,Libertarian,"Garrard, Robert D.",4,000240
+CHEROKEE,Neosho Township Melrose,United States Senate,,Republican,"Moran, Jerry",49,000240
+CHEROKEE,Pleasant View Township,United States Senate,,write - in,"Smith, DJ",0,000250
+CHEROKEE,Pleasant View Township,United States Senate,,Democratic,"Wiesner, Patrick",58,000250
+CHEROKEE,Pleasant View Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000250
+CHEROKEE,Pleasant View Township,United States Senate,,Republican,"Moran, Jerry",227,000250
+CHEROKEE,Roseland City,United States Senate,,write - in,"Smith, DJ",0,000260
+CHEROKEE,Roseland City,United States Senate,,Democratic,"Wiesner, Patrick",0,000260
+CHEROKEE,Roseland City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000260
+CHEROKEE,Roseland City,United States Senate,,Republican,"Moran, Jerry",0,000260
+CHEROKEE,Ross Township Belleview,United States Senate,,write - in,"Smith, DJ",0,000270
+CHEROKEE,Ross Township Belleview,United States Senate,,Democratic,"Wiesner, Patrick",17,000270
+CHEROKEE,Ross Township Belleview,United States Senate,,Libertarian,"Garrard, Robert D.",6,000270
+CHEROKEE,Ross Township Belleview,United States Senate,,Republican,"Moran, Jerry",61,000270
+CHEROKEE,Ross Township Roseland,United States Senate,,write - in,"Smith, DJ",0,000280
+CHEROKEE,Ross Township Roseland,United States Senate,,Democratic,"Wiesner, Patrick",44,000280
+CHEROKEE,Ross Township Roseland,United States Senate,,Libertarian,"Garrard, Robert D.",9,000280
+CHEROKEE,Ross Township Roseland,United States Senate,,Republican,"Moran, Jerry",67,000280
+CHEROKEE,Ross Township West Mineral,United States Senate,,write - in,"Smith, DJ",0,000290
+CHEROKEE,Ross Township West Mineral,United States Senate,,Democratic,"Wiesner, Patrick",43,000290
+CHEROKEE,Ross Township West Mineral,United States Senate,,Libertarian,"Garrard, Robert D.",7,000290
+CHEROKEE,Ross Township West Mineral,United States Senate,,Republican,"Moran, Jerry",71,000290
+CHEROKEE,Salamanca Township,United States Senate,,write - in,"Smith, DJ",0,00030A
+CHEROKEE,Salamanca Township,United States Senate,,Democratic,"Wiesner, Patrick",75,00030A
+CHEROKEE,Salamanca Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,00030A
+CHEROKEE,Salamanca Township,United States Senate,,Republican,"Moran, Jerry",236,00030A
+CHEROKEE,Salamanca Township Enclave,United States Senate,,write - in,"Smith, DJ",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00030B
+CHEROKEE,Salamanca Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,00030B
+CHEROKEE,Scammon Ward 1,United States Senate,,write - in,"Smith, DJ",0,000310
+CHEROKEE,Scammon Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",19,000310
+CHEROKEE,Scammon Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",1,000310
+CHEROKEE,Scammon Ward 1,United States Senate,,Republican,"Moran, Jerry",24,000310
+CHEROKEE,Scammon Ward 2,United States Senate,,write - in,"Smith, DJ",0,000320
+CHEROKEE,Scammon Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",20,000320
+CHEROKEE,Scammon Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",9,000320
+CHEROKEE,Scammon Ward 2,United States Senate,,Republican,"Moran, Jerry",44,000320
+CHEROKEE,Scammon Ward 3,United States Senate,,write - in,"Smith, DJ",0,000330
+CHEROKEE,Scammon Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",20,000330
+CHEROKEE,Scammon Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",2,000330
+CHEROKEE,Scammon Ward 3,United States Senate,,Republican,"Moran, Jerry",47,000330
+CHEROKEE,Shawnee Township,United States Senate,,write - in,"Smith, DJ",0,000340
+CHEROKEE,Shawnee Township,United States Senate,,Democratic,"Wiesner, Patrick",43,000340
+CHEROKEE,Shawnee Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000340
+CHEROKEE,Shawnee Township,United States Senate,,Republican,"Moran, Jerry",189,000340
+CHEROKEE,Sheridan Township,United States Senate,,write - in,"Smith, DJ",0,000350
+CHEROKEE,Sheridan Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000350
+CHEROKEE,Sheridan Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000350
+CHEROKEE,Sheridan Township,United States Senate,,Republican,"Moran, Jerry",79,000350
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,write - in,"Smith, DJ",0,000360
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,Democratic,"Wiesner, Patrick",66,000360
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,Libertarian,"Garrard, Robert D.",17,000360
+CHEROKEE,Spring Valley Township Neutral,United States Senate,,Republican,"Moran, Jerry",218,000360
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,write - in,"Smith, DJ",0,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,Democratic,"Wiesner, Patrick",38,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,Libertarian,"Garrard, Robert D.",7,00037A
+CHEROKEE,Spring Valley Township Spring Valley,United States Senate,,Republican,"Moran, Jerry",146,00037A
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,write - in,"Smith, DJ",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Republican,"Moran, Jerry",0,00037B
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,write - in,"Smith, DJ",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00037C
+CHEROKEE,Spring Valley Township Spring Valley Enclave,United States Senate,,Republican,"Moran, Jerry",0,00037C
+CHEROKEE,Weir Ward 1,United States Senate,,write - in,"Smith, DJ",0,00039A
+CHEROKEE,Weir Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",27,00039A
+CHEROKEE,Weir Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",2,00039A
+CHEROKEE,Weir Ward 1,United States Senate,,Republican,"Moran, Jerry",33,00039A
+CHEROKEE,Weir Ward 2,United States Senate,,write - in,"Smith, DJ",0,000400
+CHEROKEE,Weir Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",58,000400
+CHEROKEE,Weir Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",4,000400
+CHEROKEE,Weir Ward 2,United States Senate,,Republican,"Moran, Jerry",54,000400
+CHEROKEE,Weir Ward 3,United States Senate,,write - in,"Smith, DJ",0,000410
+CHEROKEE,Weir Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",24,000410
+CHEROKEE,Weir Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",8,000410
+CHEROKEE,Weir Ward 3,United States Senate,,Republican,"Moran, Jerry",39,000410
+CHEROKEE,West Mineral City,United States Senate,,write - in,"Smith, DJ",0,00042A
+CHEROKEE,West Mineral City,United States Senate,,Democratic,"Wiesner, Patrick",0,00042A
+CHEROKEE,West Mineral City,United States Senate,,Libertarian,"Garrard, Robert D.",0,00042A
+CHEROKEE,West Mineral City,United States Senate,,Republican,"Moran, Jerry",0,00042A
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,write - in,"Smith, DJ",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,Democratic,"Wiesner, Patrick",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,Libertarian,"Garrard, Robert D.",0,00042B
+CHEROKEE,West Mineral City Exclave Big Brutus,United States Senate,,Republican,"Moran, Jerry",0,00042B
+CHEROKEE,Lyon Township,United States Senate,,write - in,"Smith, DJ",0,140010
+CHEROKEE,Lyon Township,United States Senate,,Democratic,"Wiesner, Patrick",34,140010
+CHEROKEE,Lyon Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,140010
+CHEROKEE,Lyon Township,United States Senate,,Republican,"Moran, Jerry",149,140010

--- a/2016/20161108__ks__general__cheyenne__precinct.csv
+++ b/2016/20161108__ks__general__cheyenne__precinct.csv
@@ -1,129 +1,297 @@
-county,precinct,office,district,party,candidate,votes
-Cheyenne,Benkelman,President,,D,Hillary Clinton,3
-Cheyenne,Bird City,President,,D,Hillary Clinton,32
-Cheyenne,Calhoun,President,,D,Hillary Clinton,0
-Cheyenne,Cleveland Run,President,,D,Hillary Clinton,3
-Cheyenne,Jaqua,President,,D,Hillary Clinton,0
-Cheyenne,Orlando,President,,D,Hillary Clinton,0
-Cheyenne,Wano I,President,,D,Hillary Clinton,27
-Cheyenne,Wano II,President,,D,Hillary Clinton,41
-Cheyenne,Advance,President,,D,Hillary Clinton,75
-Cheyenne,Benkelman,President,,LBT,Gary Johnson,0
-Cheyenne,Bird City,President,,LBT,Gary Johnson,5
-Cheyenne,Calhoun,President,,LBT,Gary Johnson,0
-Cheyenne,Cleveland Run,President,,LBT,Gary Johnson,0
-Cheyenne,Jaqua,President,,LBT,Gary Johnson,0
-Cheyenne,Orlando,President,,LBT,Gary Johnson,0
-Cheyenne,Wano I,President,,LBT,Gary Johnson,5
-Cheyenne,Wano II,President,,LBT,Gary Johnson,10
-Cheyenne,Advance,President,,LBT,Gary Johnson,9
-Cheyenne,Benkelman,President,,IND,Jill Stein,1
-Cheyenne,Bird City,President,,IND,Jill Stein,1
-Cheyenne,Calhoun,President,,IND,Jill Stein,0
-Cheyenne,Cleveland Run,President,,IND,Jill Stein,0
-Cheyenne,Jaqua,President,,IND,Jill Stein,0
-Cheyenne,Orlando,President,,IND,Jill Stein,3
-Cheyenne,Wano I,President,,IND,Jill Stein,1
-Cheyenne,Wano II,President,,IND,Jill Stein,9
-Cheyenne,Advance,President,,IND,Jill Stein,5
-Cheyenne,Benkelman,President,,R,Donald Trump,10
-Cheyenne,Bird City,President,,R,Donald Trump,223
-Cheyenne,Calhoun,President,,R,Donald Trump,16
-Cheyenne,Cleveland Run,President,,R,Donald Trump,19
-Cheyenne,Jaqua,President,,R,Donald Trump,9
-Cheyenne,Orlando,President,,R,Donald Trump,13
-Cheyenne,Wano I,President,,R,Donald Trump,229
-Cheyenne,Wano II,President,,R,Donald Trump,258
-Cheyenne,Advance,President,,R,Donald Trump,396
-Cheyenne,Calhoun,President,,wri,Evan McMullin,2
-Cheyenne,Wano I,President,,wri,Evan McMullin,2
-Cheyenne,Benkelman,U.S. Senate,,LBT,Robert Garrard,0
-Cheyenne,Bird City,U.S. Senate,,LBT,Robert Garrard,7
-Cheyenne,Calhoun,U.S. Senate,,LBT,Robert Garrard,0
-Cheyenne,Cleveland Run,U.S. Senate,,LBT,Robert Garrard,0
-Cheyenne,Jaqua,U.S. Senate,,LBT,Robert Garrard,0
-Cheyenne,Orlando,U.S. Senate,,LBT,Robert Garrard,1
-Cheyenne,Wano I,U.S. Senate,,LBT,Robert Garrard,13
-Cheyenne,Wano II,U.S. Senate,,LBT,Robert Garrard,9
-Cheyenne,Advance,U.S. Senate,,LBT,Robert Garrard,18
-Cheyenne,Benkelman,U.S. Senate,,R,Jerry Moran,12
-Cheyenne,Bird City,U.S. Senate,,R,Jerry Moran,231
-Cheyenne,Calhoun,U.S. Senate,,R,Jerry Moran,14
-Cheyenne,Cleveland Run,U.S. Senate,,R,Jerry Moran,21
-Cheyenne,Jaqua,U.S. Senate,,R,Jerry Moran,9
-Cheyenne,Orlando,U.S. Senate,,R,Jerry Moran,14
-Cheyenne,Wano I,U.S. Senate,,R,Jerry Moran,234
-Cheyenne,Wano II,U.S. Senate,,R,Jerry Moran,284
-Cheyenne,Advance,U.S. Senate,,R,Jerry Moran,408
-Cheyenne,Benkelman,U.S. Senate,,D,Patrick Wiesner,2
-Cheyenne,Bird City,U.S. Senate,,D,Patrick Wiesner,21
-Cheyenne,Calhoun,U.S. Senate,,D,Patrick Wiesner,1
-Cheyenne,Cleveland Run,U.S. Senate,,D,Patrick Wiesner,1
-Cheyenne,Jaqua,U.S. Senate,,D,Patrick Wiesner,0
-Cheyenne,Orlando,U.S. Senate,,D,Patrick Wiesner,1
-Cheyenne,Wano I,U.S. Senate,,D,Patrick Wiesner,14
-Cheyenne,Wano II,U.S. Senate,,D,Patrick Wiesner,27
-Cheyenne,Advance,U.S. Senate,,D,Patrick Wiesner,58
-Cheyenne,Benkelman,U.S. House,1,LBT,Kerry Burt,0
-Cheyenne,Bird City,U.S. House,1,LBT,Kerry Burt,11
-Cheyenne,Calhoun,U.S. House,1,LBT,Kerry Burt,0
-Cheyenne,Cleveland Run,U.S. House,1,LBT,Kerry Burt,2
-Cheyenne,Jaqua,U.S. House,1,LBT,Kerry Burt,0
-Cheyenne,Orlando,U.S. House,1,LBT,Kerry Burt,0
-Cheyenne,Wano I,U.S. House,1,LBT,Kerry Burt,16
-Cheyenne,Wano II,U.S. House,1,LBT,Kerry Burt,14
-Cheyenne,Advance,U.S. House,1,LBT,Kerry Burt,17
-Cheyenne,Benkelman,U.S. House,1,D,Alan LaPolice,1
-Cheyenne,Bird City,U.S. House,1,D,Alan LaPolice,29
-Cheyenne,Calhoun,U.S. House,1,D,Alan LaPolice,2
-Cheyenne,Cleveland Run,U.S. House,1,D,Alan LaPolice,3
-Cheyenne,Jaqua,U.S. House,1,D,Alan LaPolice,0
-Cheyenne,Orlando,U.S. House,1,D,Alan LaPolice,2
-Cheyenne,Wano I,U.S. House,1,D,Alan LaPolice,26
-Cheyenne,Wano II,U.S. House,1,D,Alan LaPolice,40
-Cheyenne,Advance,U.S. House,1,D,Alan LaPolice,65
-Cheyenne,Benkelman,U.S. House,1,R,Roger Marshall,13
-Cheyenne,Bird City,U.S. House,1,R,Roger Marshall,207
-Cheyenne,Calhoun,U.S. House,1,R,Roger Marshall,14
-Cheyenne,Cleveland Run,U.S. House,1,R,Roger Marshall,17
-Cheyenne,Jaqua,U.S. House,1,R,Roger Marshall,9
-Cheyenne,Orlando,U.S. House,1,R,Roger Marshall,14
-Cheyenne,Wano I,U.S. House,1,R,Roger Marshall,214
-Cheyenne,Wano II,U.S. House,1,R,Roger Marshall,259
-Cheyenne,Advance,U.S. House,1,R,Roger Marshall,381
-Cheyenne,Benkelman,State Senate,40,R,Rick Billinger,12
-Cheyenne,Bird City,State Senate,40,R,Rick Billinger,230
-Cheyenne,Calhoun,State Senate,40,R,Rick Billinger,14
-Cheyenne,Cleveland Run,State Senate,40,R,Rick Billinger,21
-Cheyenne,Jaqua,State Senate,40,R,Rick Billinger,8
-Cheyenne,Orlando,State Senate,40,R,Rick Billinger,14
-Cheyenne,Wano I,State Senate,40,R,Rick Billinger,237
-Cheyenne,Wano II,State Senate,40,R,Rick Billinger,278
-Cheyenne,Advance,State Senate,40,R,Rick Billinger,417
-Cheyenne,Benkelman,State Senate,40,D,Alex Herman,2
-Cheyenne,Bird City,State Senate,40,D,Alex Herman,22
-Cheyenne,Calhoun,State Senate,40,D,Alex Herman,2
-Cheyenne,Cleveland Run,State Senate,40,D,Alex Herman,1
-Cheyenne,Jaqua,State Senate,40,D,Alex Herman,1
-Cheyenne,Orlando,State Senate,40,D,Alex Herman,2
-Cheyenne,Wano I,State Senate,40,D,Alex Herman,20
-Cheyenne,Wano II,State Senate,40,D,Alex Herman,42
-Cheyenne,Advance,State Senate,40,D,Alex Herman,57
-Cheyenne,Benkelman,State House,120,D,Bonita Peterson,3
-Cheyenne,Bird City,State House,120,D,Bonita Peterson,27
-Cheyenne,Calhoun,State House,120,D,Bonita Peterson,1
-Cheyenne,Cleveland Run,State House,120,D,Bonita Peterson,2
-Cheyenne,Jaqua,State House,120,D,Bonita Peterson,0
-Cheyenne,Orlando,State House,120,D,Bonita Peterson,0
-Cheyenne,Wano I,State House,120,D,Bonita Peterson,30
-Cheyenne,Wano II,State House,120,D,Bonita Peterson,52
-Cheyenne,Advance,State House,120,D,Bonita Peterson,62
-Cheyenne,Benkelman,State House,120,R,Adam Smith,11
-Cheyenne,Bird City,State House,120,R,Adam Smith,227
-Cheyenne,Calhoun,State House,120,R,Adam Smith,14
-Cheyenne,Cleveland Run,State House,120,R,Adam Smith,20
-Cheyenne,Jaqua,State House,120,R,Adam Smith,9
-Cheyenne,Orlando,State House,120,R,Adam Smith,16
-Cheyenne,Wano I,State House,120,R,Adam Smith,222
-Cheyenne,Wano II,State House,120,R,Adam Smith,258
-Cheyenne,Advance,State House,120,R,Adam Smith,400
+county,precinct,office,district,party,candidate,votes,vtd
+CHEYENNE,Benkelman Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",3,000010
+CHEYENNE,Benkelman Township,Kansas House of Representatives,120,Republican,"Smith, Adam",20,000010
+CHEYENNE,Bird City Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",41,000020
+CHEYENNE,Bird City Township,Kansas House of Representatives,120,Republican,"Smith, Adam",281,000020
+CHEYENNE,Calhoun Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000030
+CHEYENNE,Calhoun Township,Kansas House of Representatives,120,Republican,"Smith, Adam",24,000030
+CHEYENNE,Cleveland Run Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000040
+CHEYENNE,Cleveland Run Township,Kansas House of Representatives,120,Republican,"Smith, Adam",27,000040
+CHEYENNE,Jaqua Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000050
+CHEYENNE,Jaqua Township,Kansas House of Representatives,120,Republican,"Smith, Adam",15,000050
+CHEYENNE,Orlando Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000060
+CHEYENNE,Orlando Township,Kansas House of Representatives,120,Republican,"Smith, Adam",35,000060
+CHEYENNE,Wano 1 Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",46,000070
+CHEYENNE,Wano 1 Township,Kansas House of Representatives,120,Republican,"Smith, Adam",319,000070
+CHEYENNE,Wano 2 Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",84,000080
+CHEYENNE,Wano 2 Township,Kansas House of Representatives,120,Republican,"Smith, Adam",456,000080
+CHEYENNE,Benkelman Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000010
+CHEYENNE,Benkelman Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",21,000010
+CHEYENNE,Bird City Township,Kansas Senate,40,Democratic,"Herman, Alex",33,000020
+CHEYENNE,Bird City Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",287,000020
+CHEYENNE,Calhoun Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000030
+CHEYENNE,Calhoun Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",24,000030
+CHEYENNE,Cleveland Run Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000040
+CHEYENNE,Cleveland Run Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",28,000040
+CHEYENNE,Jaqua Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000050
+CHEYENNE,Jaqua Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",14,000050
+CHEYENNE,Orlando Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000060
+CHEYENNE,Orlando Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",32,000060
+CHEYENNE,Wano 1 Township,Kansas Senate,40,Democratic,"Herman, Alex",39,000070
+CHEYENNE,Wano 1 Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",334,000070
+CHEYENNE,Wano 2 Township,Kansas Senate,40,Democratic,"Herman, Alex",68,000080
+CHEYENNE,Wano 2 Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",491,000080
+CHEYENNE,Benkelman Township,President / Vice President,,independent,"Stein, Jill",1,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CHEYENNE,Benkelman Township,President / Vice President,,Republican,"Trump, Donald J.",19,000010
+CHEYENNE,Bird City Township,President / Vice President,,independent,"Stein, Jill",1,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CHEYENNE,Bird City Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,000020
+CHEYENNE,Bird City Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+CHEYENNE,Bird City Township,President / Vice President,,Republican,"Trump, Donald J.",276,000020
+CHEYENNE,Calhoun Township,President / Vice President,,independent,"Stein, Jill",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"McMullin, Evan",2,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+CHEYENNE,Calhoun Township,President / Vice President,,Republican,"Trump, Donald J.",24,000030
+CHEYENNE,Cleveland Run Township,President / Vice President,,independent,"Stein, Jill",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CHEYENNE,Cleveland Run Township,President / Vice President,,Republican,"Trump, Donald J.",27,000040
+CHEYENNE,Jaqua Township,President / Vice President,,independent,"Stein, Jill",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+CHEYENNE,Jaqua Township,President / Vice President,,Republican,"Trump, Donald J.",15,000050
+CHEYENNE,Orlando Township,President / Vice President,,independent,"Stein, Jill",3,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+CHEYENNE,Orlando Township,President / Vice President,,Republican,"Trump, Donald J.",32,000060
+CHEYENNE,Wano 1 Township,President / Vice President,,independent,"Stein, Jill",1,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"McMullin, Evan",2,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000070
+CHEYENNE,Wano 1 Township,President / Vice President,,Republican,"Trump, Donald J.",325,000070
+CHEYENNE,Wano 2 Township,President / Vice President,,independent,"Stein, Jill",14,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000080
+CHEYENNE,Wano 2 Township,President / Vice President,,Republican,"Trump, Donald J.",455,000080
+CHEYENNE,Benkelman Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000010
+CHEYENNE,Benkelman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+CHEYENNE,Benkelman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+CHEYENNE,Benkelman Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000010
+CHEYENNE,Bird City Township,United States House of Representatives,1,independent,"LaPolice, Alan",43,000020
+CHEYENNE,Bird City Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+CHEYENNE,Bird City Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000020
+CHEYENNE,Bird City Township,United States House of Representatives,1,Republican,"Marshall, Roger",259,000020
+CHEYENNE,Calhoun Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000030
+CHEYENNE,Calhoun Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+CHEYENNE,Calhoun Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+CHEYENNE,Calhoun Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000030
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000040
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000040
+CHEYENNE,Cleveland Run Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000040
+CHEYENNE,Jaqua Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000050
+CHEYENNE,Jaqua Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+CHEYENNE,Jaqua Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+CHEYENNE,Jaqua Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000050
+CHEYENNE,Orlando Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000060
+CHEYENNE,Orlando Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+CHEYENNE,Orlando Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+CHEYENNE,Orlando Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000060
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,independent,"LaPolice, Alan",50,000070
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000070
+CHEYENNE,Wano 1 Township,United States House of Representatives,1,Republican,"Marshall, Roger",301,000070
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,independent,"LaPolice, Alan",63,000080
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000080
+CHEYENNE,Wano 2 Township,United States House of Representatives,1,Republican,"Marshall, Roger",457,000080
+CHEYENNE,Benkelman Township,United States Senate,,write - in,"Smith, DJ",0,000010
+CHEYENNE,Benkelman Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000010
+CHEYENNE,Benkelman Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+CHEYENNE,Benkelman Township,United States Senate,,Republican,"Moran, Jerry",21,000010
+CHEYENNE,Bird City Township,United States Senate,,write - in,"Smith, DJ",0,000020
+CHEYENNE,Bird City Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000020
+CHEYENNE,Bird City Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000020
+CHEYENNE,Bird City Township,United States Senate,,Republican,"Moran, Jerry",287,000020
+CHEYENNE,Calhoun Township,United States Senate,,write - in,"Smith, DJ",0,000030
+CHEYENNE,Calhoun Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000030
+CHEYENNE,Calhoun Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+CHEYENNE,Calhoun Township,United States Senate,,Republican,"Moran, Jerry",24,000030
+CHEYENNE,Cleveland Run Township,United States Senate,,write - in,"Smith, DJ",0,000040
+CHEYENNE,Cleveland Run Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+CHEYENNE,Cleveland Run Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+CHEYENNE,Cleveland Run Township,United States Senate,,Republican,"Moran, Jerry",29,000040
+CHEYENNE,Jaqua Township,United States Senate,,write - in,"Smith, DJ",0,000050
+CHEYENNE,Jaqua Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000050
+CHEYENNE,Jaqua Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+CHEYENNE,Jaqua Township,United States Senate,,Republican,"Moran, Jerry",15,000050
+CHEYENNE,Orlando Township,United States Senate,,write - in,"Smith, DJ",0,000060
+CHEYENNE,Orlando Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000060
+CHEYENNE,Orlando Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000060
+CHEYENNE,Orlando Township,United States Senate,,Republican,"Moran, Jerry",31,000060
+CHEYENNE,Wano 1 Township,United States Senate,,write - in,"Smith, DJ",0,000070
+CHEYENNE,Wano 1 Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000070
+CHEYENNE,Wano 1 Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000070
+CHEYENNE,Wano 1 Township,United States Senate,,Republican,"Moran, Jerry",331,000070
+CHEYENNE,Wano 2 Township,United States Senate,,write - in,"Smith, DJ",0,000080
+CHEYENNE,Wano 2 Township,United States Senate,,Democratic,"Wiesner, Patrick",55,000080
+CHEYENNE,Wano 2 Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000080
+CHEYENNE,Wano 2 Township,United States Senate,,Republican,"Moran, Jerry",489,000080

--- a/2016/20161108__ks__general__clark__precinct.csv
+++ b/2016/20161108__ks__general__clark__precinct.csv
@@ -1,106 +1,253 @@
-county,precinct,office,district,party,candidate,votes
-Clark,Appleton,President,,Dem,Clinton & Kaine,44
-Clark,Appleton,President,,Lib,Johnson & Weld,11
-Clark,Appleton,President,,ind,Stein & Baraka,5
-Clark,Appleton,President,,Rep,Trump & Pence,328
-Clark,Appleton,President,,,write-ins,3
-Clark,Appleton,U.S. Senate,,Lib,Robert D. Garrard,15
-Clark,Appleton,U.S. Senate,,Rep,Jerry Moran,332
-Clark,Appleton,U.S. Senate,,Dem,Patrick Wiesner,36
-Clark,Appleton,U.S. Senate,,,write-ins,2
-Clark,Appleton,U.S. House,1,Lib,Kerry Burt,23
-Clark,Appleton,U.S. House,1,ind,Alan LaPolice,94
-Clark,Appleton,U.S. House,1,Rep,Roger Marshall,261
-Clark,Appleton,U.S. House,1,,Tim Huelskamp,1
-Clark,Appleton,State Senate,38,Rep,Bud Estes,346
-Clark,Appleton,State Senate,38,Dem,Miguel Angel Rodriguez,38
-Clark,Appleton,State House,115,Rep,Boyd Orr,366
-Clark,Center I,President,,Dem,Clinton & Kaine,41
-Clark,Center I,President,,Lib,Johnson & Weld,12
-Clark,Center I,President,,ind,Stein & Baraka,6
-Clark,Center I,President,,Rep,Trump & Pence,208
-Clark,Center I,President,,,Write-ins,1
-Clark,Center I,U.S. Senate,,Lib,Robert D. Garrard,18
-Clark,Center I,U.S. Senate,,Rep,Jerry Moran,210
-Clark,Center I,U.S. Senate,,Dem,Patrick Wiesner,36
-Clark,Center I,U.S. House,1,Lib,Kerry Burt,17
-Clark,Center I,U.S. House,1,ind,Alan LaPolice,46
-Clark,Center I,U.S. House,1,Rep,Roger Marshall,191
-Clark,Center I,U.S. House,1,,Tim Huelskamp,1
-Clark,Center I,State Senate,38,Rep,Bud Estes,221
-Clark,Center I,State Senate,38,Dem,Miguel Angel Rodriguez,38
-Clark,Center I,State House,115,Rep,Boyd Orr,232
-Clark,Center I,State House,115,,write-ins,2
-Clark,Center II,President,,Dem,Clinton & Kaine,16
-Clark,Center II,President,,Lib,Johnson & Weld,9
-Clark,Center II,President,,ind,Stein & Baraka,6
-Clark,Center II,President,,Rep,Trump & Pence,167
-Clark,Center II,President,,,Write-ins,2
-Clark,Center II,U.S. Senate,,Lib,Robert D. Garrard,9
-Clark,Center II,U.S. Senate,,Rep,Jerry Moran,173
-Clark,Center II,U.S. Senate,,Dem,Patrick Wiesner,12
-Clark,Center II,U.S. Senate,,,Write-ins,1
-Clark,Center II,U.S. House,1,Lib,Kerry Burt,12
-Clark,Center II,U.S. House,1,ind,Alan LaPolice,24
-Clark,Center II,U.S. House,1,Rep,Roger Marshall,151
-Clark,Center II,State Senate,38,Rep,Bud Estes,179
-Clark,Center II,State Senate,38,Dem,Miguel Angel Rodriguez,16
-Clark,Center II,State House,115,Rep,Boyd Orr,179
-Clark,Englewood,President,,Dem,Clinton & Kaine,11
-Clark,Englewood,President,,Lib,Johnson & Weld,3
-Clark,Englewood,President,,ind,Stein & Baraka,2
-Clark,Englewood,President,,Rep,Trump & Pence,49
-Clark,Englewood,President,,,Write-ins,1
-Clark,Englewood,President,,,Evan McMullin,2
-Clark,Englewood,U.S. Senate,,Lib,Robert D. Garrard,4
-Clark,Englewood,U.S. Senate,,Rep,Jerry Moran,49
-Clark,Englewood,U.S. Senate,,Dem,Patrick Wiesner,15
-Clark,Englewood,U.S. House,1,Lib,Kerry Burt,4
-Clark,Englewood,U.S. House,1,ind,Alan LaPolice,14
-Clark,Englewood,U.S. House,1,Rep,Roger Marshall,40
-Clark,Englewood,U.S. House,1,,Tim Huelskamp  ,4
-Clark,Englewood,State Senate,38,Rep,Bud Estes,55
-Clark,Englewood,State Senate,38,Dem,Miguel Angel Rodriguez,13
-Clark,Englewood,State House,115,Rep,Boyd Orr,58
-Clark,Englewood,State House,115,,Terry Cordes,1
-Clark,Lexington,President,,Dem,Clinton & Kaine,2
-Clark,Lexington,President,,Lib,Johnson & Weld,0
-Clark,Lexington,President,,ind,Stein & Baraka,0
-Clark,Lexington,President,,Rep,Trump & Pence,19
-Clark,Lexington,President,,,Evan McMullin,1
-Clark,Lexington,U.S. Senate,,Lib,Robert D. Garrard,2
-Clark,Lexington,U.S. Senate,,Rep,Jerry Moran,19
-Clark,Lexington,U.S. Senate,,Dem,Patrick Wiesner,1
-Clark,Lexington,U.S. House,1,Lib,Kerry Burt,1
-Clark,Lexington,U.S. House,1,ind,Alan LaPolice,4
-Clark,Lexington,U.S. House,1,Rep,Roger Marshall,15
-Clark,Lexington,State Senate,38,Rep,Bud Estes,22
-Clark,Lexington,State Senate,38,Dem,Miguel Angel Rodriguez,0
-Clark,Lexington,State House,115,Rep,Boyd Orr,20
-Clark,Liberty,President,,Dem,Clinton & Kaine,1
-Clark,Liberty,President,,Lib,Johnson & Weld,0
-Clark,Liberty,President,,ind,Stein & Baraka,0
-Clark,Liberty,President,,Rep,Trump & Pence,20
-Clark,Liberty,U.S. Senate,,Lib,Robert D. Garrard,1
-Clark,Liberty,U.S. Senate,,Rep,Jerry Moran,19
-Clark,Liberty,U.S. Senate,,Dem,Patrick Wiesner,1
-Clark,Liberty,U.S. House,1,Lib,Kerry Burt,2
-Clark,Liberty,U.S. House,1,ind,Alan LaPolice,1
-Clark,Liberty,U.S. House,1,Rep,Roger Marshall,18
-Clark,Liberty,State Senate,38,Rep,Bud Estes,19
-Clark,Liberty,State Senate,38,Dem,Miguel Angel Rodriguez,2
-Clark,Liberty,State House,115,Rep,Boyd Orr,21
-Clark,Sitka,President,,Dem,Clinton & Kaine,5
-Clark,Sitka,President,,Lib,Johnson & Weld,1
-Clark,Sitka,President,,ind,Stein & Baraka,1
-Clark,Sitka,President,,Rep,Trump & Pence,34
-Clark,Sitka,President,,,Evan McMullin,1
-Clark,Sitka,U.S. Senate,,Lib,Robert D. Garrard,2
-Clark,Sitka,U.S. Senate,,Rep,Jerry Moran,38
-Clark,Sitka,U.S. Senate,,Dem,Patrick Wiesner,2
-Clark,Sitka,U.S. House,1,Lib,Kerry Burt,3
-Clark,Sitka,U.S. House,1,ind,Alan LaPolice,10
-Clark,Sitka,U.S. House,1,Rep,Roger Marshall,30
-Clark,Sitka,State Senate,38,Rep,Bud Estes,37
-Clark,Sitka,State Senate,38,Dem,Miguel Angel Rodriguez,6
-Clark,Sitka,State House,115,Rep,Boyd Orr,40
+county,precinct,office,district,party,candidate,votes,vtd
+CLARK,Appleton Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",366,000010
+CLARK,Center 1,Kansas House of Representatives,115,Republican,"Orr, Boyd",232,000020
+CLARK,Center 2,Kansas House of Representatives,115,Republican,"Orr, Boyd",179,000030
+CLARK,Englewood Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",58,000040
+CLARK,Lexington Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",20,000050
+CLARK,Liberty Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",21,000060
+CLARK,Sitka Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",40,000070
+CLARK,Appleton Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",38,000010
+CLARK,Appleton Township,Kansas Senate,38,Republican,"Estes, Bud",346,000010
+CLARK,Center 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",38,000020
+CLARK,Center 1,Kansas Senate,38,Republican,"Estes, Bud",221,000020
+CLARK,Center 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",16,000030
+CLARK,Center 2,Kansas Senate,38,Republican,"Estes, Bud",179,000030
+CLARK,Englewood Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",13,000040
+CLARK,Englewood Township,Kansas Senate,38,Republican,"Estes, Bud",55,000040
+CLARK,Lexington Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,000050
+CLARK,Lexington Township,Kansas Senate,38,Republican,"Estes, Bud",22,000050
+CLARK,Liberty Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",2,000060
+CLARK,Liberty Township,Kansas Senate,38,Republican,"Estes, Bud",19,000060
+CLARK,Sitka Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",6,000070
+CLARK,Sitka Township,Kansas Senate,38,Republican,"Estes, Bud",37,000070
+CLARK,Appleton Township,President / Vice President,,independent,"Stein, Jill",5,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CLARK,Appleton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CLARK,Appleton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000010
+CLARK,Appleton Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000010
+CLARK,Appleton Township,President / Vice President,,Republican,"Trump, Donald J.",328,000010
+CLARK,Center 1,President / Vice President,,independent,"Stein, Jill",6,000020
+CLARK,Center 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"McMullin, Evan",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CLARK,Center 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CLARK,Center 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000020
+CLARK,Center 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000020
+CLARK,Center 1,President / Vice President,,Republican,"Trump, Donald J.",208,000020
+CLARK,Center 2,President / Vice President,,independent,"Stein, Jill",6,000030
+CLARK,Center 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"McMullin, Evan",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CLARK,Center 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CLARK,Center 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000030
+CLARK,Center 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+CLARK,Center 2,President / Vice President,,Republican,"Trump, Donald J.",167,000030
+CLARK,Englewood Township,President / Vice President,,independent,"Stein, Jill",2,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"McMullin, Evan",2,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CLARK,Englewood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CLARK,Englewood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000040
+CLARK,Englewood Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+CLARK,Englewood Township,President / Vice President,,Republican,"Trump, Donald J.",49,000040
+CLARK,Lexington Township,President / Vice President,,independent,"Stein, Jill",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"McMullin, Evan",1,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CLARK,Lexington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CLARK,Lexington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000050
+CLARK,Lexington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+CLARK,Lexington Township,President / Vice President,,Republican,"Trump, Donald J.",19,000050
+CLARK,Liberty Township,President / Vice President,,independent,"Stein, Jill",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+CLARK,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+CLARK,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000060
+CLARK,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+CLARK,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",20,000060
+CLARK,Sitka Township,President / Vice President,,independent,"Stein, Jill",1,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CLARK,Sitka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CLARK,Sitka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000070
+CLARK,Sitka Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+CLARK,Sitka Township,President / Vice President,,Republican,"Trump, Donald J.",34,000070
+CLARK,Appleton Township,United States House of Representatives,1,independent,"LaPolice, Alan",94,000010
+CLARK,Appleton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+CLARK,Appleton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,000010
+CLARK,Appleton Township,United States House of Representatives,1,Republican,"Marshall, Roger",261,000010
+CLARK,Center 1,United States House of Representatives,1,independent,"LaPolice, Alan",46,000020
+CLARK,Center 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+CLARK,Center 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000020
+CLARK,Center 1,United States House of Representatives,1,Republican,"Marshall, Roger",191,000020
+CLARK,Center 2,United States House of Representatives,1,independent,"LaPolice, Alan",24,000030
+CLARK,Center 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+CLARK,Center 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000030
+CLARK,Center 2,United States House of Representatives,1,Republican,"Marshall, Roger",151,000030
+CLARK,Englewood Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000040
+CLARK,Englewood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000040
+CLARK,Englewood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000040
+CLARK,Englewood Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000040
+CLARK,Lexington Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000050
+CLARK,Lexington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+CLARK,Lexington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000050
+CLARK,Lexington Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000050
+CLARK,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000060
+CLARK,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+CLARK,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000060
+CLARK,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000060
+CLARK,Sitka Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000070
+CLARK,Sitka Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+CLARK,Sitka Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000070
+CLARK,Sitka Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000070
+CLARK,Appleton Township,United States Senate,,write - in,"Smith, DJ",0,000010
+CLARK,Appleton Township,United States Senate,,Democratic,"Wiesner, Patrick",36,000010
+CLARK,Appleton Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000010
+CLARK,Appleton Township,United States Senate,,Republican,"Moran, Jerry",332,000010
+CLARK,Center 1,United States Senate,,write - in,"Smith, DJ",0,000020
+CLARK,Center 1,United States Senate,,Democratic,"Wiesner, Patrick",36,000020
+CLARK,Center 1,United States Senate,,Libertarian,"Garrard, Robert D.",18,000020
+CLARK,Center 1,United States Senate,,Republican,"Moran, Jerry",210,000020
+CLARK,Center 2,United States Senate,,write - in,"Smith, DJ",0,000030
+CLARK,Center 2,United States Senate,,Democratic,"Wiesner, Patrick",12,000030
+CLARK,Center 2,United States Senate,,Libertarian,"Garrard, Robert D.",9,000030
+CLARK,Center 2,United States Senate,,Republican,"Moran, Jerry",173,000030
+CLARK,Englewood Township,United States Senate,,write - in,"Smith, DJ",0,000040
+CLARK,Englewood Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000040
+CLARK,Englewood Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000040
+CLARK,Englewood Township,United States Senate,,Republican,"Moran, Jerry",49,000040
+CLARK,Lexington Township,United States Senate,,write - in,"Smith, DJ",0,000050
+CLARK,Lexington Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000050
+CLARK,Lexington Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+CLARK,Lexington Township,United States Senate,,Republican,"Moran, Jerry",19,000050
+CLARK,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000060
+CLARK,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000060
+CLARK,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+CLARK,Liberty Township,United States Senate,,Republican,"Moran, Jerry",19,000060
+CLARK,Sitka Township,United States Senate,,write - in,"Smith, DJ",0,000070
+CLARK,Sitka Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000070
+CLARK,Sitka Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+CLARK,Sitka Township,United States Senate,,Republican,"Moran, Jerry",38,000070

--- a/2016/20161108__ks__general__clay__precinct.csv
+++ b/2016/20161108__ks__general__clay__precinct.csv
@@ -1,877 +1,877 @@
-county,precinct,office,district,candidate,party,votes
-Clay,Athelstane Township,President,,"Stein, Jill  ",independent,1
-Clay,Athelstane Township,President,,"Basiago, Andrew D. ",,0
-Clay,Athelstane Township,President,,"Castle, Darrell L ",,0
-Clay,Athelstane Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Athelstane Township,President,,"Giordani, Rocky  ",,0
-Clay,Athelstane Township,President,,"Hedges, James A ",,0
-Clay,Athelstane Township,President,,"Hoefling, Tom  ",,0
-Clay,Athelstane Township,President,,"Kahn, Lynn  ",,0
-Clay,Athelstane Township,President,,"La Riva, Gloria  ",,0
-Clay,Athelstane Township,President,,"Levinson, Michael S. ",,0
-Clay,Athelstane Township,President,,"Maturen, Michael A ",,0
-Clay,Athelstane Township,President,,"McMullin, Evan  ",,0
-Clay,Athelstane Township,President,,"Moorehead, Monica G. ",,0
-Clay,Athelstane Township,President,,"Perry, Darryl  ",,0
-Clay,Athelstane Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Athelstane Township,President,,"Schriner, Joe C ",,0
-Clay,Athelstane Township,President,,"Smith, Mike  ",,0
-Clay,Athelstane Township,President,,"Sood, Ajay  ",,0
-Clay,Athelstane Township,President,,"Sterling, Shawna  ",,0
-Clay,Athelstane Township,President,,"Valdivia, Anthony J ",,0
-Clay,Athelstane Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Athelstane Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Athelstane Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-Clay,Athelstane Township,President,,"Johnson, Gary  ",Libertarian,3
-Clay,Athelstane Township,President,,"Trump, Donald J. ",Republican,53
-Clay,Blaine Township,President,,"Stein, Jill  ",independent,3
-Clay,Blaine Township,President,,"Basiago, Andrew D. ",,0
-Clay,Blaine Township,President,,"Castle, Darrell L ",,0
-Clay,Blaine Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Blaine Township,President,,"Giordani, Rocky  ",,0
-Clay,Blaine Township,President,,"Hedges, James A ",,1
-Clay,Blaine Township,President,,"Hoefling, Tom  ",,0
-Clay,Blaine Township,President,,"Kahn, Lynn  ",,0
-Clay,Blaine Township,President,,"La Riva, Gloria  ",,0
-Clay,Blaine Township,President,,"Levinson, Michael S. ",,0
-Clay,Blaine Township,President,,"Maturen, Michael A ",,0
-Clay,Blaine Township,President,,"McMullin, Evan  ",,5
-Clay,Blaine Township,President,,"Moorehead, Monica G. ",,0
-Clay,Blaine Township,President,,"Perry, Darryl  ",,0
-Clay,Blaine Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Blaine Township,President,,"Schriner, Joe C ",,0
-Clay,Blaine Township,President,,"Smith, Mike  ",,0
-Clay,Blaine Township,President,,"Sood, Ajay  ",,0
-Clay,Blaine Township,President,,"Sterling, Shawna  ",,0
-Clay,Blaine Township,President,,"Valdivia, Anthony J ",,0
-Clay,Blaine Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Blaine Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Blaine Township,President,,"Clinton, Hillary Rodham ",Democratic,16
-Clay,Blaine Township,President,,"Johnson, Gary  ",Libertarian,3
-Clay,Blaine Township,President,,"Trump, Donald J. ",Republican,118
-Clay,Bloom Township,President,,"Stein, Jill  ",independent,1
-Clay,Bloom Township,President,,"Basiago, Andrew D. ",,0
-Clay,Bloom Township,President,,"Castle, Darrell L ",,0
-Clay,Bloom Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Bloom Township,President,,"Giordani, Rocky  ",,0
-Clay,Bloom Township,President,,"Hedges, James A ",,0
-Clay,Bloom Township,President,,"Hoefling, Tom  ",,0
-Clay,Bloom Township,President,,"Kahn, Lynn  ",,0
-Clay,Bloom Township,President,,"La Riva, Gloria  ",,0
-Clay,Bloom Township,President,,"Levinson, Michael S. ",,0
-Clay,Bloom Township,President,,"Maturen, Michael A ",,0
-Clay,Bloom Township,President,,"McMullin, Evan  ",,0
-Clay,Bloom Township,President,,"Moorehead, Monica G. ",,0
-Clay,Bloom Township,President,,"Perry, Darryl  ",,0
-Clay,Bloom Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Bloom Township,President,,"Schriner, Joe C ",,0
-Clay,Bloom Township,President,,"Smith, Mike  ",,0
-Clay,Bloom Township,President,,"Sood, Ajay  ",,0
-Clay,Bloom Township,President,,"Sterling, Shawna  ",,0
-Clay,Bloom Township,President,,"Valdivia, Anthony J ",,0
-Clay,Bloom Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Bloom Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Bloom Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Clay,Bloom Township,President,,"Johnson, Gary  ",Libertarian,3
-Clay,Bloom Township,President,,"Trump, Donald J. ",Republican,50
-Clay,Chapman Township,President,,"Stein, Jill  ",independent,3
-Clay,Chapman Township,President,,"Basiago, Andrew D. ",,0
-Clay,Chapman Township,President,,"Castle, Darrell L ",,0
-Clay,Chapman Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Chapman Township,President,,"Giordani, Rocky  ",,0
-Clay,Chapman Township,President,,"Hedges, James A ",,0
-Clay,Chapman Township,President,,"Hoefling, Tom  ",,0
-Clay,Chapman Township,President,,"Kahn, Lynn  ",,0
-Clay,Chapman Township,President,,"La Riva, Gloria  ",,0
-Clay,Chapman Township,President,,"Levinson, Michael S. ",,0
-Clay,Chapman Township,President,,"Maturen, Michael A ",,0
-Clay,Chapman Township,President,,"McMullin, Evan  ",,0
-Clay,Chapman Township,President,,"Moorehead, Monica G. ",,0
-Clay,Chapman Township,President,,"Perry, Darryl  ",,0
-Clay,Chapman Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Chapman Township,President,,"Schriner, Joe C ",,0
-Clay,Chapman Township,President,,"Smith, Mike  ",,0
-Clay,Chapman Township,President,,"Sood, Ajay  ",,0
-Clay,Chapman Township,President,,"Sterling, Shawna  ",,0
-Clay,Chapman Township,President,,"Valdivia, Anthony J ",,0
-Clay,Chapman Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Chapman Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Chapman Township,President,,"Clinton, Hillary Rodham ",Democratic,19
-Clay,Chapman Township,President,,"Johnson, Gary  ",Libertarian,6
-Clay,Chapman Township,President,,"Trump, Donald J. ",Republican,55
-Clay,Clay Center Township,President,,"Stein, Jill  ",independent,5
-Clay,Clay Center Township,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Township,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Township,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Township,President,,"Hedges, James A ",,0
-Clay,Clay Center Township,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Township,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Township,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Township,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Township,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Township,President,,"McMullin, Evan  ",,0
-Clay,Clay Center Township,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Township,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Township,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Township,President,,"Smith, Mike  ",,0
-Clay,Clay Center Township,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Township,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Township,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Township,President,,"Clinton, Hillary Rodham ",Democratic,34
-Clay,Clay Center Township,President,,"Johnson, Gary  ",Libertarian,11
-Clay,Clay Center Township,President,,"Trump, Donald J. ",Republican,152
-Clay,Clay Center Township Enclave,President,,"Stein, Jill  ",independent,0
-Clay,Clay Center Township Enclave,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Township Enclave,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Township Enclave,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Township Enclave,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Township Enclave,President,,"Hedges, James A ",,0
-Clay,Clay Center Township Enclave,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Township Enclave,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Township Enclave,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Township Enclave,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Township Enclave,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Township Enclave,President,,"McMullin, Evan  ",,0
-Clay,Clay Center Township Enclave,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Township Enclave,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Township Enclave,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Township Enclave,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Township Enclave,President,,"Smith, Mike  ",,0
-Clay,Clay Center Township Enclave,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Township Enclave,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Township Enclave,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Township Enclave,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Township Enclave,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Township Enclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Clay,Clay Center Township Enclave,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Clay Center Township Enclave,President,,"Trump, Donald J. ",Republican,0
-Clay,Clay Center Ward 1,President,,"Stein, Jill  ",independent,12
-Clay,Clay Center Ward 1,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Ward 1,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Ward 1,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Ward 1,President,,"Hedges, James A ",,0
-Clay,Clay Center Ward 1,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Ward 1,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Ward 1,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Ward 1,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Ward 1,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Ward 1,President,,"McMullin, Evan  ",,2
-Clay,Clay Center Ward 1,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Ward 1,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Ward 1,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Ward 1,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Ward 1,President,,"Smith, Mike  ",,0
-Clay,Clay Center Ward 1,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Ward 1,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Ward 1,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Ward 1,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Ward 1,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,124
-Clay,Clay Center Ward 1,President,,"Johnson, Gary  ",Libertarian,36
-Clay,Clay Center Ward 1,President,,"Trump, Donald J. ",Republican,367
-Clay,Clay Center Ward 1 Exclave,President,,"Stein, Jill  ",independent,0
-Clay,Clay Center Ward 1 Exclave,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Hedges, James A ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"McMullin, Evan  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Smith, Mike  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Ward 1 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Clay,Clay Center Ward 1 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Clay Center Ward 1 Exclave,President,,"Trump, Donald J. ",Republican,0
-Clay,Clay Center Ward 2,President,,"Stein, Jill  ",independent,9
-Clay,Clay Center Ward 2,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Ward 2,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Ward 2,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Ward 2,President,,"Hedges, James A ",,0
-Clay,Clay Center Ward 2,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Ward 2,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Ward 2,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Ward 2,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Ward 2,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Ward 2,President,,"McMullin, Evan  ",,2
-Clay,Clay Center Ward 2,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Ward 2,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Ward 2,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Ward 2,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Ward 2,President,,"Smith, Mike  ",,0
-Clay,Clay Center Ward 2,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Ward 2,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Ward 2,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Ward 2,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Ward 2,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,108
-Clay,Clay Center Ward 2,President,,"Johnson, Gary  ",Libertarian,30
-Clay,Clay Center Ward 2,President,,"Trump, Donald J. ",Republican,426
-Clay,Clay Center Ward 3,President,,"Stein, Jill  ",independent,13
-Clay,Clay Center Ward 3,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Ward 3,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Ward 3,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Ward 3,President,,"Hedges, James A ",,0
-Clay,Clay Center Ward 3,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Ward 3,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Ward 3,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Ward 3,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Ward 3,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Ward 3,President,,"McMullin, Evan  ",,0
-Clay,Clay Center Ward 3,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Ward 3,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Ward 3,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Ward 3,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Ward 3,President,,"Smith, Mike  ",,0
-Clay,Clay Center Ward 3,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Ward 3,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Ward 3,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Ward 3,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Ward 3,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,88
-Clay,Clay Center Ward 3,President,,"Johnson, Gary  ",Libertarian,11
-Clay,Clay Center Ward 3,President,,"Trump, Donald J. ",Republican,281
-Clay,Clay Center Ward 4,President,,"Stein, Jill  ",independent,7
-Clay,Clay Center Ward 4,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Ward 4,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Ward 4,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Ward 4,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Ward 4,President,,"Hedges, James A ",,0
-Clay,Clay Center Ward 4,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Ward 4,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Ward 4,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Ward 4,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Ward 4,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Ward 4,President,,"McMullin, Evan  ",,1
-Clay,Clay Center Ward 4,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Ward 4,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Ward 4,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Ward 4,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Ward 4,President,,"Smith, Mike  ",,0
-Clay,Clay Center Ward 4,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Ward 4,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Ward 4,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Ward 4,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Ward 4,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Ward 4,President,,"Clinton, Hillary Rodham ",Democratic,82
-Clay,Clay Center Ward 4,President,,"Johnson, Gary  ",Libertarian,15
-Clay,Clay Center Ward 4,President,,"Trump, Donald J. ",Republican,230
-Clay,Exeter Township,President,,"Stein, Jill  ",independent,1
-Clay,Exeter Township,President,,"Basiago, Andrew D. ",,0
-Clay,Exeter Township,President,,"Castle, Darrell L ",,0
-Clay,Exeter Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Exeter Township,President,,"Giordani, Rocky  ",,0
-Clay,Exeter Township,President,,"Hedges, James A ",,0
-Clay,Exeter Township,President,,"Hoefling, Tom  ",,0
-Clay,Exeter Township,President,,"Kahn, Lynn  ",,0
-Clay,Exeter Township,President,,"La Riva, Gloria  ",,0
-Clay,Exeter Township,President,,"Levinson, Michael S. ",,0
-Clay,Exeter Township,President,,"Maturen, Michael A ",,0
-Clay,Exeter Township,President,,"McMullin, Evan  ",,0
-Clay,Exeter Township,President,,"Moorehead, Monica G. ",,0
-Clay,Exeter Township,President,,"Perry, Darryl  ",,0
-Clay,Exeter Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Exeter Township,President,,"Schriner, Joe C ",,0
-Clay,Exeter Township,President,,"Smith, Mike  ",,0
-Clay,Exeter Township,President,,"Sood, Ajay  ",,0
-Clay,Exeter Township,President,,"Sterling, Shawna  ",,0
-Clay,Exeter Township,President,,"Valdivia, Anthony J ",,0
-Clay,Exeter Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Exeter Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Exeter Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Clay,Exeter Township,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Exeter Township,President,,"Trump, Donald J. ",Republican,47
-Clay,Five Creeks Township,President,,"Stein, Jill  ",independent,2
-Clay,Five Creeks Township,President,,"Basiago, Andrew D. ",,0
-Clay,Five Creeks Township,President,,"Castle, Darrell L ",,0
-Clay,Five Creeks Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Five Creeks Township,President,,"Giordani, Rocky  ",,0
-Clay,Five Creeks Township,President,,"Hedges, James A ",,0
-Clay,Five Creeks Township,President,,"Hoefling, Tom  ",,0
-Clay,Five Creeks Township,President,,"Kahn, Lynn  ",,0
-Clay,Five Creeks Township,President,,"La Riva, Gloria  ",,0
-Clay,Five Creeks Township,President,,"Levinson, Michael S. ",,0
-Clay,Five Creeks Township,President,,"Maturen, Michael A ",,0
-Clay,Five Creeks Township,President,,"McMullin, Evan  ",,0
-Clay,Five Creeks Township,President,,"Moorehead, Monica G. ",,0
-Clay,Five Creeks Township,President,,"Perry, Darryl  ",,0
-Clay,Five Creeks Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Five Creeks Township,President,,"Schriner, Joe C ",,0
-Clay,Five Creeks Township,President,,"Smith, Mike  ",,0
-Clay,Five Creeks Township,President,,"Sood, Ajay  ",,0
-Clay,Five Creeks Township,President,,"Sterling, Shawna  ",,0
-Clay,Five Creeks Township,President,,"Valdivia, Anthony J ",,0
-Clay,Five Creeks Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Five Creeks Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Five Creeks Township,President,,"Clinton, Hillary Rodham ",Democratic,10
-Clay,Five Creeks Township,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Five Creeks Township,President,,"Trump, Donald J. ",Republican,48
-Clay,Garfield Township,President,,"Stein, Jill  ",independent,0
-Clay,Garfield Township,President,,"Basiago, Andrew D. ",,0
-Clay,Garfield Township,President,,"Castle, Darrell L ",,0
-Clay,Garfield Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Garfield Township,President,,"Giordani, Rocky  ",,0
-Clay,Garfield Township,President,,"Hedges, James A ",,0
-Clay,Garfield Township,President,,"Hoefling, Tom  ",,0
-Clay,Garfield Township,President,,"Kahn, Lynn  ",,0
-Clay,Garfield Township,President,,"La Riva, Gloria  ",,0
-Clay,Garfield Township,President,,"Levinson, Michael S. ",,0
-Clay,Garfield Township,President,,"Maturen, Michael A ",,0
-Clay,Garfield Township,President,,"McMullin, Evan  ",,1
-Clay,Garfield Township,President,,"Moorehead, Monica G. ",,0
-Clay,Garfield Township,President,,"Perry, Darryl  ",,0
-Clay,Garfield Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Garfield Township,President,,"Schriner, Joe C ",,0
-Clay,Garfield Township,President,,"Smith, Mike  ",,0
-Clay,Garfield Township,President,,"Sood, Ajay  ",,0
-Clay,Garfield Township,President,,"Sterling, Shawna  ",,0
-Clay,Garfield Township,President,,"Valdivia, Anthony J ",,0
-Clay,Garfield Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Garfield Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Garfield Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-Clay,Garfield Township,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Garfield Township,President,,"Trump, Donald J. ",Republican,48
-Clay,Gill Township,President,,"Stein, Jill  ",independent,3
-Clay,Gill Township,President,,"Basiago, Andrew D. ",,0
-Clay,Gill Township,President,,"Castle, Darrell L ",,0
-Clay,Gill Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Gill Township,President,,"Giordani, Rocky  ",,0
-Clay,Gill Township,President,,"Hedges, James A ",,0
-Clay,Gill Township,President,,"Hoefling, Tom  ",,0
-Clay,Gill Township,President,,"Kahn, Lynn  ",,0
-Clay,Gill Township,President,,"La Riva, Gloria  ",,0
-Clay,Gill Township,President,,"Levinson, Michael S. ",,0
-Clay,Gill Township,President,,"Maturen, Michael A ",,0
-Clay,Gill Township,President,,"McMullin, Evan  ",,0
-Clay,Gill Township,President,,"Moorehead, Monica G. ",,0
-Clay,Gill Township,President,,"Perry, Darryl  ",,0
-Clay,Gill Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Gill Township,President,,"Schriner, Joe C ",,0
-Clay,Gill Township,President,,"Smith, Mike  ",,0
-Clay,Gill Township,President,,"Sood, Ajay  ",,0
-Clay,Gill Township,President,,"Sterling, Shawna  ",,0
-Clay,Gill Township,President,,"Valdivia, Anthony J ",,0
-Clay,Gill Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Gill Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Gill Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Clay,Gill Township,President,,"Johnson, Gary  ",Libertarian,1
-Clay,Gill Township,President,,"Trump, Donald J. ",Republican,65
-Clay,Goshen Township,President,,"Stein, Jill  ",independent,0
-Clay,Goshen Township,President,,"Basiago, Andrew D. ",,0
-Clay,Goshen Township,President,,"Castle, Darrell L ",,0
-Clay,Goshen Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Goshen Township,President,,"Giordani, Rocky  ",,0
-Clay,Goshen Township,President,,"Hedges, James A ",,0
-Clay,Goshen Township,President,,"Hoefling, Tom  ",,0
-Clay,Goshen Township,President,,"Kahn, Lynn  ",,0
-Clay,Goshen Township,President,,"La Riva, Gloria  ",,0
-Clay,Goshen Township,President,,"Levinson, Michael S. ",,0
-Clay,Goshen Township,President,,"Maturen, Michael A ",,0
-Clay,Goshen Township,President,,"McMullin, Evan  ",,0
-Clay,Goshen Township,President,,"Moorehead, Monica G. ",,0
-Clay,Goshen Township,President,,"Perry, Darryl  ",,0
-Clay,Goshen Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Goshen Township,President,,"Schriner, Joe C ",,0
-Clay,Goshen Township,President,,"Smith, Mike  ",,0
-Clay,Goshen Township,President,,"Sood, Ajay  ",,0
-Clay,Goshen Township,President,,"Sterling, Shawna  ",,0
-Clay,Goshen Township,President,,"Valdivia, Anthony J ",,0
-Clay,Goshen Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Goshen Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Goshen Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-Clay,Goshen Township,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Goshen Township,President,,"Trump, Donald J. ",Republican,25
-Clay,Grant Township,President,,"Stein, Jill  ",independent,1
-Clay,Grant Township,President,,"Basiago, Andrew D. ",,0
-Clay,Grant Township,President,,"Castle, Darrell L ",,0
-Clay,Grant Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Grant Township,President,,"Giordani, Rocky  ",,0
-Clay,Grant Township,President,,"Hedges, James A ",,0
-Clay,Grant Township,President,,"Hoefling, Tom  ",,0
-Clay,Grant Township,President,,"Kahn, Lynn  ",,0
-Clay,Grant Township,President,,"La Riva, Gloria  ",,0
-Clay,Grant Township,President,,"Levinson, Michael S. ",,0
-Clay,Grant Township,President,,"Maturen, Michael A ",,0
-Clay,Grant Township,President,,"McMullin, Evan  ",,0
-Clay,Grant Township,President,,"Moorehead, Monica G. ",,0
-Clay,Grant Township,President,,"Perry, Darryl  ",,0
-Clay,Grant Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Grant Township,President,,"Schriner, Joe C ",,0
-Clay,Grant Township,President,,"Smith, Mike  ",,0
-Clay,Grant Township,President,,"Sood, Ajay  ",,0
-Clay,Grant Township,President,,"Sterling, Shawna  ",,0
-Clay,Grant Township,President,,"Valdivia, Anthony J ",,0
-Clay,Grant Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Grant Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Grant Township,President,,"Clinton, Hillary Rodham ",Democratic,11
-Clay,Grant Township,President,,"Johnson, Gary  ",Libertarian,2
-Clay,Grant Township,President,,"Trump, Donald J. ",Republican,88
-Clay,Hayes Township,President,,"Stein, Jill  ",independent,1
-Clay,Hayes Township,President,,"Basiago, Andrew D. ",,0
-Clay,Hayes Township,President,,"Castle, Darrell L ",,0
-Clay,Hayes Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Hayes Township,President,,"Giordani, Rocky  ",,0
-Clay,Hayes Township,President,,"Hedges, James A ",,0
-Clay,Hayes Township,President,,"Hoefling, Tom  ",,0
-Clay,Hayes Township,President,,"Kahn, Lynn  ",,0
-Clay,Hayes Township,President,,"La Riva, Gloria  ",,0
-Clay,Hayes Township,President,,"Levinson, Michael S. ",,0
-Clay,Hayes Township,President,,"Maturen, Michael A ",,0
-Clay,Hayes Township,President,,"McMullin, Evan  ",,0
-Clay,Hayes Township,President,,"Moorehead, Monica G. ",,0
-Clay,Hayes Township,President,,"Perry, Darryl  ",,0
-Clay,Hayes Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Hayes Township,President,,"Schriner, Joe C ",,0
-Clay,Hayes Township,President,,"Smith, Mike  ",,0
-Clay,Hayes Township,President,,"Sood, Ajay  ",,0
-Clay,Hayes Township,President,,"Sterling, Shawna  ",,0
-Clay,Hayes Township,President,,"Valdivia, Anthony J ",,0
-Clay,Hayes Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Hayes Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Hayes Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Clay,Hayes Township,President,,"Johnson, Gary  ",Libertarian,4
-Clay,Hayes Township,President,,"Trump, Donald J. ",Republican,92
-Clay,Highland Township,President,,"Stein, Jill  ",independent,5
-Clay,Highland Township,President,,"Basiago, Andrew D. ",,0
-Clay,Highland Township,President,,"Castle, Darrell L ",,0
-Clay,Highland Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Highland Township,President,,"Giordani, Rocky  ",,0
-Clay,Highland Township,President,,"Hedges, James A ",,0
-Clay,Highland Township,President,,"Hoefling, Tom  ",,0
-Clay,Highland Township,President,,"Kahn, Lynn  ",,0
-Clay,Highland Township,President,,"La Riva, Gloria  ",,0
-Clay,Highland Township,President,,"Levinson, Michael S. ",,0
-Clay,Highland Township,President,,"Maturen, Michael A ",,0
-Clay,Highland Township,President,,"McMullin, Evan  ",,4
-Clay,Highland Township,President,,"Moorehead, Monica G. ",,0
-Clay,Highland Township,President,,"Perry, Darryl  ",,0
-Clay,Highland Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Highland Township,President,,"Schriner, Joe C ",,0
-Clay,Highland Township,President,,"Smith, Mike  ",,0
-Clay,Highland Township,President,,"Sood, Ajay  ",,0
-Clay,Highland Township,President,,"Sterling, Shawna  ",,0
-Clay,Highland Township,President,,"Valdivia, Anthony J ",,0
-Clay,Highland Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Highland Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Highland Township,President,,"Clinton, Hillary Rodham ",Democratic,29
-Clay,Highland Township,President,,"Johnson, Gary  ",Libertarian,3
-Clay,Highland Township,President,,"Trump, Donald J. ",Republican,104
-Clay,Mulberry Township,President,,"Stein, Jill  ",independent,3
-Clay,Mulberry Township,President,,"Basiago, Andrew D. ",,0
-Clay,Mulberry Township,President,,"Castle, Darrell L ",,0
-Clay,Mulberry Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Mulberry Township,President,,"Giordani, Rocky  ",,0
-Clay,Mulberry Township,President,,"Hedges, James A ",,0
-Clay,Mulberry Township,President,,"Hoefling, Tom  ",,0
-Clay,Mulberry Township,President,,"Kahn, Lynn  ",,0
-Clay,Mulberry Township,President,,"La Riva, Gloria  ",,0
-Clay,Mulberry Township,President,,"Levinson, Michael S. ",,0
-Clay,Mulberry Township,President,,"Maturen, Michael A ",,0
-Clay,Mulberry Township,President,,"McMullin, Evan  ",,0
-Clay,Mulberry Township,President,,"Moorehead, Monica G. ",,0
-Clay,Mulberry Township,President,,"Perry, Darryl  ",,0
-Clay,Mulberry Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Mulberry Township,President,,"Schriner, Joe C ",,0
-Clay,Mulberry Township,President,,"Smith, Mike  ",,0
-Clay,Mulberry Township,President,,"Sood, Ajay  ",,0
-Clay,Mulberry Township,President,,"Sterling, Shawna  ",,0
-Clay,Mulberry Township,President,,"Valdivia, Anthony J ",,0
-Clay,Mulberry Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Mulberry Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Mulberry Township,President,,"Clinton, Hillary Rodham ",Democratic,23
-Clay,Mulberry Township,President,,"Johnson, Gary  ",Libertarian,3
-Clay,Mulberry Township,President,,"Trump, Donald J. ",Republican,116
-Clay,Oakland Township,President,,"Stein, Jill  ",independent,1
-Clay,Oakland Township,President,,"Basiago, Andrew D. ",,0
-Clay,Oakland Township,President,,"Castle, Darrell L ",,0
-Clay,Oakland Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Oakland Township,President,,"Giordani, Rocky  ",,0
-Clay,Oakland Township,President,,"Hedges, James A ",,0
-Clay,Oakland Township,President,,"Hoefling, Tom  ",,0
-Clay,Oakland Township,President,,"Kahn, Lynn  ",,0
-Clay,Oakland Township,President,,"La Riva, Gloria  ",,0
-Clay,Oakland Township,President,,"Levinson, Michael S. ",,0
-Clay,Oakland Township,President,,"Maturen, Michael A ",,0
-Clay,Oakland Township,President,,"McMullin, Evan  ",,0
-Clay,Oakland Township,President,,"Moorehead, Monica G. ",,0
-Clay,Oakland Township,President,,"Perry, Darryl  ",,0
-Clay,Oakland Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Oakland Township,President,,"Schriner, Joe C ",,0
-Clay,Oakland Township,President,,"Smith, Mike  ",,0
-Clay,Oakland Township,President,,"Sood, Ajay  ",,0
-Clay,Oakland Township,President,,"Sterling, Shawna  ",,0
-Clay,Oakland Township,President,,"Valdivia, Anthony J ",,0
-Clay,Oakland Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Oakland Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Oakland Township,President,,"Clinton, Hillary Rodham ",Democratic,9
-Clay,Oakland Township,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Oakland Township,President,,"Trump, Donald J. ",Republican,33
-Clay,Republican Township,President,,"Stein, Jill  ",independent,8
-Clay,Republican Township,President,,"Basiago, Andrew D. ",,0
-Clay,Republican Township,President,,"Castle, Darrell L ",,0
-Clay,Republican Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Republican Township,President,,"Giordani, Rocky  ",,0
-Clay,Republican Township,President,,"Hedges, James A ",,0
-Clay,Republican Township,President,,"Hoefling, Tom  ",,0
-Clay,Republican Township,President,,"Kahn, Lynn  ",,0
-Clay,Republican Township,President,,"La Riva, Gloria  ",,0
-Clay,Republican Township,President,,"Levinson, Michael S. ",,0
-Clay,Republican Township,President,,"Maturen, Michael A ",,0
-Clay,Republican Township,President,,"McMullin, Evan  ",,1
-Clay,Republican Township,President,,"Moorehead, Monica G. ",,0
-Clay,Republican Township,President,,"Perry, Darryl  ",,0
-Clay,Republican Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Republican Township,President,,"Schriner, Joe C ",,0
-Clay,Republican Township,President,,"Smith, Mike  ",,0
-Clay,Republican Township,President,,"Sood, Ajay  ",,0
-Clay,Republican Township,President,,"Sterling, Shawna  ",,0
-Clay,Republican Township,President,,"Valdivia, Anthony J ",,0
-Clay,Republican Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Republican Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Republican Township,President,,"Clinton, Hillary Rodham ",Democratic,51
-Clay,Republican Township,President,,"Johnson, Gary  ",Libertarian,15
-Clay,Republican Township,President,,"Trump, Donald J. ",Republican,330
-Clay,Sherman Township,President,,"Stein, Jill  ",independent,3
-Clay,Sherman Township,President,,"Basiago, Andrew D. ",,0
-Clay,Sherman Township,President,,"Castle, Darrell L ",,0
-Clay,Sherman Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Sherman Township,President,,"Giordani, Rocky  ",,0
-Clay,Sherman Township,President,,"Hedges, James A ",,0
-Clay,Sherman Township,President,,"Hoefling, Tom  ",,0
-Clay,Sherman Township,President,,"Kahn, Lynn  ",,0
-Clay,Sherman Township,President,,"La Riva, Gloria  ",,0
-Clay,Sherman Township,President,,"Levinson, Michael S. ",,0
-Clay,Sherman Township,President,,"Maturen, Michael A ",,0
-Clay,Sherman Township,President,,"McMullin, Evan  ",,0
-Clay,Sherman Township,President,,"Moorehead, Monica G. ",,0
-Clay,Sherman Township,President,,"Perry, Darryl  ",,0
-Clay,Sherman Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Sherman Township,President,,"Schriner, Joe C ",,0
-Clay,Sherman Township,President,,"Smith, Mike  ",,0
-Clay,Sherman Township,President,,"Sood, Ajay  ",,0
-Clay,Sherman Township,President,,"Sterling, Shawna  ",,0
-Clay,Sherman Township,President,,"Valdivia, Anthony J ",,0
-Clay,Sherman Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Sherman Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Sherman Township,President,,"Clinton, Hillary Rodham ",Democratic,23
-Clay,Sherman Township,President,,"Johnson, Gary  ",Libertarian,2
-Clay,Sherman Township,President,,"Trump, Donald J. ",Republican,92
-Clay,Union Township,President,,"Stein, Jill  ",independent,3
-Clay,Union Township,President,,"Basiago, Andrew D. ",,0
-Clay,Union Township,President,,"Castle, Darrell L ",,0
-Clay,Union Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Union Township,President,,"Giordani, Rocky  ",,0
-Clay,Union Township,President,,"Hedges, James A ",,0
-Clay,Union Township,President,,"Hoefling, Tom  ",,0
-Clay,Union Township,President,,"Kahn, Lynn  ",,0
-Clay,Union Township,President,,"La Riva, Gloria  ",,0
-Clay,Union Township,President,,"Levinson, Michael S. ",,0
-Clay,Union Township,President,,"Maturen, Michael A ",,0
-Clay,Union Township,President,,"McMullin, Evan  ",,0
-Clay,Union Township,President,,"Moorehead, Monica G. ",,0
-Clay,Union Township,President,,"Perry, Darryl  ",,0
-Clay,Union Township,President,,"Schoenke, Marshall R. ",,0
-Clay,Union Township,President,,"Schriner, Joe C ",,0
-Clay,Union Township,President,,"Smith, Mike  ",,0
-Clay,Union Township,President,,"Sood, Ajay  ",,0
-Clay,Union Township,President,,"Sterling, Shawna  ",,0
-Clay,Union Township,President,,"Valdivia, Anthony J ",,0
-Clay,Union Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Union Township,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Union Township,President,,"Clinton, Hillary Rodham ",Democratic,12
-Clay,Union Township,President,,"Johnson, Gary  ",Libertarian,2
-Clay,Union Township,President,,"Trump, Donald J. ",Republican,71
-Clay,Clay Center Ward 4 Exclave,President,,"Stein, Jill  ",independent,0
-Clay,Clay Center Ward 4 Exclave,President,,"Basiago, Andrew D. ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Castle, Darrell L ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Giordani, Rocky  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Hedges, James A ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Hoefling, Tom  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Kahn, Lynn  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"La Riva, Gloria  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Levinson, Michael S. ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Maturen, Michael A ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"McMullin, Evan  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Moorehead, Monica G. ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Perry, Darryl  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Schoenke, Marshall R. ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Schriner, Joe C ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Smith, Mike  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Sood, Ajay  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Sterling, Shawna  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Valdivia, Anthony J ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Vogel-Walcutt, J.J.  ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Wysinger, Demetra Jefferson ",,0
-Clay,Clay Center Ward 4 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Clay,Clay Center Ward 4 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-Clay,Clay Center Ward 4 Exclave,President,,"Trump, Donald J. ",Republican,0
-Clay,Athelstane Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Athelstane Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Clay,Athelstane Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Clay,Athelstane Township,U.S. Senate,,"Moran, Jerry  ",Republican,52
-Clay,Blaine Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Blaine Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Clay,Blaine Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Clay,Blaine Township,U.S. Senate,,"Moran, Jerry  ",Republican,139
-Clay,Bloom Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Bloom Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Clay,Bloom Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Clay,Bloom Township,U.S. Senate,,"Moran, Jerry  ",Republican,58
-Clay,Chapman Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Chapman Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,13
-Clay,Chapman Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Clay,Chapman Township,U.S. Senate,,"Moran, Jerry  ",Republican,66
-Clay,Clay Center Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,15
-Clay,Clay Center Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,6
-Clay,Clay Center Township,U.S. Senate,,"Moran, Jerry  ",Republican,183
-Clay,Clay Center Township Enclave,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Township Enclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Clay,Clay Center Township Enclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Clay,Clay Center Township Enclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Clay,Clay Center Ward 1,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,61
-Clay,Clay Center Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,22
-Clay,Clay Center Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,458
-Clay,Clay Center Ward 1 Exclave,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Ward 1 Exclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Clay,Clay Center Ward 1 Exclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Clay,Clay Center Ward 1 Exclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Clay,Clay Center Ward 2,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,72
-Clay,Clay Center Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,21
-Clay,Clay Center Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,488
-Clay,Clay Center Ward 3,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,53
-Clay,Clay Center Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,16
-Clay,Clay Center Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,330
-Clay,Clay Center Ward 4,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Ward 4,U.S. Senate,,"Wiesner, Patrick  ",Democratic,46
-Clay,Clay Center Ward 4,U.S. Senate,,"Garrard, Robert D. ",Libertarian,20
-Clay,Clay Center Ward 4,U.S. Senate,,"Moran, Jerry  ",Republican,272
-Clay,Exeter Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Exeter Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Clay,Exeter Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Clay,Exeter Township,U.S. Senate,,"Moran, Jerry  ",Republican,48
-Clay,Five Creeks Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Five Creeks Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,6
-Clay,Five Creeks Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Clay,Five Creeks Township,U.S. Senate,,"Moran, Jerry  ",Republican,54
-Clay,Garfield Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Garfield Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Clay,Garfield Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Clay,Garfield Township,U.S. Senate,,"Moran, Jerry  ",Republican,47
-Clay,Gill Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Gill Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,6
-Clay,Gill Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Clay,Gill Township,U.S. Senate,,"Moran, Jerry  ",Republican,64
-Clay,Goshen Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Goshen Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Clay,Goshen Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Clay,Goshen Township,U.S. Senate,,"Moran, Jerry  ",Republican,27
-Clay,Grant Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Grant Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Clay,Grant Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Clay,Grant Township,U.S. Senate,,"Moran, Jerry  ",Republican,91
-Clay,Hayes Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Hayes Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Clay,Hayes Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Clay,Hayes Township,U.S. Senate,,"Moran, Jerry  ",Republican,97
-Clay,Highland Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Highland Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,19
-Clay,Highland Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Clay,Highland Township,U.S. Senate,,"Moran, Jerry  ",Republican,117
-Clay,Mulberry Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Mulberry Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,14
-Clay,Mulberry Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,10
-Clay,Mulberry Township,U.S. Senate,,"Moran, Jerry  ",Republican,118
-Clay,Oakland Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Oakland Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Clay,Oakland Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Clay,Oakland Township,U.S. Senate,,"Moran, Jerry  ",Republican,32
-Clay,Republican Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Republican Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,42
-Clay,Republican Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,27
-Clay,Republican Township,U.S. Senate,,"Moran, Jerry  ",Republican,334
-Clay,Sherman Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Sherman Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,19
-Clay,Sherman Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Clay,Sherman Township,U.S. Senate,,"Moran, Jerry  ",Republican,96
-Clay,Union Township,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Union Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Clay,Union Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Clay,Union Township,U.S. Senate,,"Moran, Jerry  ",Republican,79
-Clay,Clay Center Ward 4 Exclave,U.S. Senate,,"Smith, DJ  ",,0
-Clay,Clay Center Ward 4 Exclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Clay,Clay Center Ward 4 Exclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Clay,Clay Center Ward 4 Exclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Clay,Athelstane Township,U.S. House,1,"LaPolice, Alan  ",independent,19
-Clay,Athelstane Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Athelstane Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Athelstane Township,U.S. House,1,"Marshall, Roger  ",Republican,38
-Clay,Blaine Township,U.S. House,1,"LaPolice, Alan  ",independent,64
-Clay,Blaine Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Blaine Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Clay,Blaine Township,U.S. House,1,"Marshall, Roger  ",Republican,79
-Clay,Bloom Township,U.S. House,1,"LaPolice, Alan  ",independent,30
-Clay,Bloom Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Bloom Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Bloom Township,U.S. House,1,"Marshall, Roger  ",Republican,30
-Clay,Chapman Township,U.S. House,1,"LaPolice, Alan  ",independent,41
-Clay,Chapman Township,U.S. House,1,"Huelskamp, Tim  ",,2
-Clay,Chapman Township,U.S. House,1,"Burt, Kerry  ",Libertarian,7
-Clay,Chapman Township,U.S. House,1,"Marshall, Roger  ",Republican,31
-Clay,Clay Center Township,U.S. House,1,"LaPolice, Alan  ",independent,88
-Clay,Clay Center Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Clay Center Township,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Clay,Clay Center Township,U.S. House,1,"Marshall, Roger  ",Republican,109
-Clay,Clay Center Township Enclave,U.S. House,1,"LaPolice, Alan  ",independent,0
-Clay,Clay Center Township Enclave,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Clay Center Township Enclave,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Clay Center Township Enclave,U.S. House,1,"Marshall, Roger  ",Republican,0
-Clay,Clay Center Ward 1,U.S. House,1,"LaPolice, Alan  ",independent,261
-Clay,Clay Center Ward 1,U.S. House,1,"Huelskamp, Tim  ",,2
-Clay,Clay Center Ward 1,U.S. House,1,"Burt, Kerry  ",Libertarian,9
-Clay,Clay Center Ward 1,U.S. House,1,"Marshall, Roger  ",Republican,261
-Clay,Clay Center Ward 1 Exclave,U.S. House,1,"LaPolice, Alan  ",independent,0
-Clay,Clay Center Ward 1 Exclave,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Clay Center Ward 1 Exclave,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Clay Center Ward 1 Exclave,U.S. House,1,"Marshall, Roger  ",Republican,0
-Clay,Clay Center Ward 2,U.S. House,1,"LaPolice, Alan  ",independent,298
-Clay,Clay Center Ward 2,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Clay Center Ward 2,U.S. House,1,"Burt, Kerry  ",Libertarian,15
-Clay,Clay Center Ward 2,U.S. House,1,"Marshall, Roger  ",Republican,268
-Clay,Clay Center Ward 3,U.S. House,1,"LaPolice, Alan  ",independent,196
-Clay,Clay Center Ward 3,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Clay Center Ward 3,U.S. House,1,"Burt, Kerry  ",Libertarian,11
-Clay,Clay Center Ward 3,U.S. House,1,"Marshall, Roger  ",Republican,185
-Clay,Clay Center Ward 4,U.S. House,1,"LaPolice, Alan  ",independent,180
-Clay,Clay Center Ward 4,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Clay Center Ward 4,U.S. House,1,"Burt, Kerry  ",Libertarian,11
-Clay,Clay Center Ward 4,U.S. House,1,"Marshall, Roger  ",Republican,146
-Clay,Exeter Township,U.S. House,1,"LaPolice, Alan  ",independent,16
-Clay,Exeter Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Exeter Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Exeter Township,U.S. House,1,"Marshall, Roger  ",Republican,36
-Clay,Five Creeks Township,U.S. House,1,"LaPolice, Alan  ",independent,28
-Clay,Five Creeks Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Five Creeks Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Five Creeks Township,U.S. House,1,"Marshall, Roger  ",Republican,32
-Clay,Garfield Township,U.S. House,1,"LaPolice, Alan  ",independent,20
-Clay,Garfield Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Garfield Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Clay,Garfield Township,U.S. House,1,"Marshall, Roger  ",Republican,32
-Clay,Gill Township,U.S. House,1,"LaPolice, Alan  ",independent,33
-Clay,Gill Township,U.S. House,1,"Huelskamp, Tim  ",,2
-Clay,Gill Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Clay,Gill Township,U.S. House,1,"Marshall, Roger  ",Republican,36
-Clay,Goshen Township,U.S. House,1,"LaPolice, Alan  ",independent,11
-Clay,Goshen Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Goshen Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Goshen Township,U.S. House,1,"Marshall, Roger  ",Republican,19
-Clay,Grant Township,U.S. House,1,"LaPolice, Alan  ",independent,29
-Clay,Grant Township,U.S. House,1,"Huelskamp, Tim  ",,1
-Clay,Grant Township,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Clay,Grant Township,U.S. House,1,"Marshall, Roger  ",Republican,64
-Clay,Hayes Township,U.S. House,1,"LaPolice, Alan  ",independent,53
-Clay,Hayes Township,U.S. House,1,"Huelskamp, Tim  ",,3
-Clay,Hayes Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Clay,Hayes Township,U.S. House,1,"Marshall, Roger  ",Republican,48
-Clay,Highland Township,U.S. House,1,"LaPolice, Alan  ",independent,51
-Clay,Highland Township,U.S. House,1,"Huelskamp, Tim  ",,3
-Clay,Highland Township,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Clay,Highland Township,U.S. House,1,"Marshall, Roger  ",Republican,79
-Clay,Mulberry Township,U.S. House,1,"LaPolice, Alan  ",independent,106
-Clay,Mulberry Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Mulberry Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Clay,Mulberry Township,U.S. House,1,"Marshall, Roger  ",Republican,37
-Clay,Oakland Township,U.S. House,1,"LaPolice, Alan  ",independent,19
-Clay,Oakland Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Oakland Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Clay,Oakland Township,U.S. House,1,"Marshall, Roger  ",Republican,22
-Clay,Republican Township,U.S. House,1,"LaPolice, Alan  ",independent,120
-Clay,Republican Township,U.S. House,1,"Huelskamp, Tim  ",,6
-Clay,Republican Township,U.S. House,1,"Burt, Kerry  ",Libertarian,20
-Clay,Republican Township,U.S. House,1,"Marshall, Roger  ",Republican,245
-Clay,Sherman Township,U.S. House,1,"LaPolice, Alan  ",independent,63
-Clay,Sherman Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Sherman Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Sherman Township,U.S. House,1,"Marshall, Roger  ",Republican,57
-Clay,Union Township,U.S. House,1,"LaPolice, Alan  ",independent,32
-Clay,Union Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Union Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Union Township,U.S. House,1,"Marshall, Roger  ",Republican,55
-Clay,Clay Center Ward 4 Exclave,U.S. House,1,"LaPolice, Alan  ",independent,0
-Clay,Clay Center Ward 4 Exclave,U.S. House,1,"Huelskamp, Tim  ",,0
-Clay,Clay Center Ward 4 Exclave,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Clay,Clay Center Ward 4 Exclave,U.S. House,1,"Marshall, Roger  ",Republican,0
-Clay,Athelstane Township,State Senate,22,"Hawk, Tom  ",Democratic,43
-Clay,Blaine Township,State Senate,22,"Hawk, Tom  ",Democratic,100
-Clay,Bloom Township,State Senate,22,"Hawk, Tom  ",Democratic,43
-Clay,Chapman Township,State Senate,22,"Hawk, Tom  ",Democratic,58
-Clay,Clay Center Township,State Senate,22,"Hawk, Tom  ",Democratic,144
-Clay,Clay Center Township Enclave,State Senate,22,"Hawk, Tom  ",Democratic,0
-Clay,Clay Center Ward 1,State Senate,22,"Hawk, Tom  ",Democratic,424
-Clay,Clay Center Ward 1 Exclave,State Senate,22,"Hawk, Tom  ",Democratic,0
-Clay,Clay Center Ward 2,State Senate,22,"Hawk, Tom  ",Democratic,453
-Clay,Clay Center Ward 3,State Senate,22,"Hawk, Tom  ",Democratic,295
-Clay,Clay Center Ward 4,State Senate,22,"Hawk, Tom  ",Democratic,260
-Clay,Exeter Township,State Senate,22,"Hawk, Tom  ",Democratic,29
-Clay,Five Creeks Township,State Senate,22,"Hawk, Tom  ",Democratic,42
-Clay,Garfield Township,State Senate,22,"Hawk, Tom  ",Democratic,29
-Clay,Gill Township,State Senate,22,"Hawk, Tom  ",Democratic,50
-Clay,Goshen Township,State Senate,22,"Hawk, Tom  ",Democratic,19
-Clay,Grant Township,State Senate,22,"Hawk, Tom  ",Democratic,72
-Clay,Hayes Township,State Senate,22,"Hawk, Tom  ",Democratic,72
-Clay,Highland Township,State Senate,22,"Hawk, Tom  ",Democratic,98
-Clay,Mulberry Township,State Senate,22,"Hawk, Tom  ",Democratic,94
-Clay,Oakland Township,State Senate,22,"Hawk, Tom  ",Democratic,31
-Clay,Republican Township,State Senate,22,"Hawk, Tom  ",Democratic,274
-Clay,Sherman Township,State Senate,22,"Hawk, Tom  ",Democratic,90
-Clay,Union Township,State Senate,22,"Hawk, Tom  ",Democratic,60
-Clay,Clay Center Ward 4 Exclave,State Senate,22,"Hawk, Tom  ",Democratic,0
-Clay,Athelstane Township,State House,64,"Swanson, Susie  ",Republican,56
-Clay,Blaine Township,State House,64,"Swanson, Susie  ",Republican,128
-Clay,Bloom Township,State House,64,"Swanson, Susie  ",Republican,55
-Clay,Chapman Township,State House,70,"Schwartz, Jo  ",Democratic,29
-Clay,Chapman Township,State House,70,"Barker, John E. ",Republican,51
-Clay,Clay Center Township,State House,64,"Swanson, Susie  ",Republican,184
-Clay,Clay Center Township Enclave,State House,64,"Swanson, Susie  ",Republican,0
-Clay,Clay Center Ward 1,State House,64,"Swanson, Susie  ",Republican,500
-Clay,Clay Center Ward 1 Exclave,State House,64,"Swanson, Susie  ",Republican,0
-Clay,Clay Center Ward 2,State House,64,"Swanson, Susie  ",Republican,537
-Clay,Clay Center Ward 3,State House,64,"Swanson, Susie  ",Republican,364
-Clay,Clay Center Ward 4,State House,64,"Swanson, Susie  ",Republican,313
-Clay,Exeter Township,State House,64,"Swanson, Susie  ",Republican,42
-Clay,Five Creeks Township,State House,64,"Swanson, Susie  ",Republican,55
-Clay,Garfield Township,State House,64,"Swanson, Susie  ",Republican,49
-Clay,Gill Township,State House,64,"Swanson, Susie  ",Republican,63
-Clay,Goshen Township,State House,64,"Swanson, Susie  ",Republican,27
-Clay,Grant Township,State House,64,"Swanson, Susie  ",Republican,84
-Clay,Hayes Township,State House,64,"Swanson, Susie  ",Republican,95
-Clay,Highland Township,State House,64,"Swanson, Susie  ",Republican,112
-Clay,Mulberry Township,State House,64,"Swanson, Susie  ",Republican,127
-Clay,Oakland Township,State House,64,"Swanson, Susie  ",Republican,38
-Clay,Republican Township,State House,64,"Swanson, Susie  ",Republican,370
-Clay,Sherman Township,State House,64,"Swanson, Susie  ",Republican,108
-Clay,Union Township,State House,64,"Swanson, Susie  ",Republican,83
-Clay,Clay Center Ward 4 Exclave,State House,64,"Swanson, Susie  ",Republican,0
+county,precinct,office,district,party,candidate,votes,vtd
+CLAY,Athelstane Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",56,000010
+CLAY,Blaine Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",128,000020
+CLAY,Bloom Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",55,000030
+CLAY,Chapman Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",29,000040
+CLAY,Chapman Township,Kansas House of Representatives,70,Republican,"Barker, John E.",51,000040
+CLAY,Clay Center Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",184,00005A
+CLAY,Clay Center Township Enclave,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,00005B
+CLAY,Clay Center Ward 1,Kansas House of Representatives,64,Republican,"Swanson, Susie",500,00006A
+CLAY,Clay Center Ward 1 Exclave,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,00006B
+CLAY,Clay Center Ward 2,Kansas House of Representatives,64,Republican,"Swanson, Susie",537,000070
+CLAY,Clay Center Ward 3,Kansas House of Representatives,64,Republican,"Swanson, Susie",364,000080
+CLAY,Clay Center Ward 4,Kansas House of Representatives,64,Republican,"Swanson, Susie",313,000090
+CLAY,Exeter Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",42,000100
+CLAY,Five Creeks Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",55,000110
+CLAY,Garfield Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",49,000120
+CLAY,Gill Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",63,000130
+CLAY,Goshen Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",27,000140
+CLAY,Grant Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",84,000150
+CLAY,Hayes Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",95,000160
+CLAY,Highland Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",112,000170
+CLAY,Mulberry Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",127,000180
+CLAY,Oakland Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",38,000190
+CLAY,Republican Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",370,000200
+CLAY,Sherman Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",108,000210
+CLAY,Union Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",83,000220
+CLAY,Clay Center Ward 4 Exclave,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,900230
+CLAY,Athelstane Township,Kansas Senate,22,Democratic,"Hawk, Tom",43,000010
+CLAY,Blaine Township,Kansas Senate,22,Democratic,"Hawk, Tom",100,000020
+CLAY,Bloom Township,Kansas Senate,22,Democratic,"Hawk, Tom",43,000030
+CLAY,Chapman Township,Kansas Senate,22,Democratic,"Hawk, Tom",58,000040
+CLAY,Clay Center Township,Kansas Senate,22,Democratic,"Hawk, Tom",144,00005A
+CLAY,Clay Center Township Enclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,00005B
+CLAY,Clay Center Ward 1,Kansas Senate,22,Democratic,"Hawk, Tom",424,00006A
+CLAY,Clay Center Ward 1 Exclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,00006B
+CLAY,Clay Center Ward 2,Kansas Senate,22,Democratic,"Hawk, Tom",453,000070
+CLAY,Clay Center Ward 3,Kansas Senate,22,Democratic,"Hawk, Tom",295,000080
+CLAY,Clay Center Ward 4,Kansas Senate,22,Democratic,"Hawk, Tom",260,000090
+CLAY,Exeter Township,Kansas Senate,22,Democratic,"Hawk, Tom",29,000100
+CLAY,Five Creeks Township,Kansas Senate,22,Democratic,"Hawk, Tom",42,000110
+CLAY,Garfield Township,Kansas Senate,22,Democratic,"Hawk, Tom",29,000120
+CLAY,Gill Township,Kansas Senate,22,Democratic,"Hawk, Tom",50,000130
+CLAY,Goshen Township,Kansas Senate,22,Democratic,"Hawk, Tom",19,000140
+CLAY,Grant Township,Kansas Senate,22,Democratic,"Hawk, Tom",72,000150
+CLAY,Hayes Township,Kansas Senate,22,Democratic,"Hawk, Tom",72,000160
+CLAY,Highland Township,Kansas Senate,22,Democratic,"Hawk, Tom",98,000170
+CLAY,Mulberry Township,Kansas Senate,22,Democratic,"Hawk, Tom",94,000180
+CLAY,Oakland Township,Kansas Senate,22,Democratic,"Hawk, Tom",31,000190
+CLAY,Republican Township,Kansas Senate,22,Democratic,"Hawk, Tom",274,000200
+CLAY,Sherman Township,Kansas Senate,22,Democratic,"Hawk, Tom",90,000210
+CLAY,Union Township,Kansas Senate,22,Democratic,"Hawk, Tom",60,000220
+CLAY,Clay Center Ward 4 Exclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,900230
+CLAY,Athelstane Township,President / Vice President,,independent,"Stein, Jill",1,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CLAY,Athelstane Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CLAY,Athelstane Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+CLAY,Athelstane Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+CLAY,Athelstane Township,President / Vice President,,Republican,"Trump, Donald J.",53,000010
+CLAY,Blaine Township,President / Vice President,,independent,"Stein, Jill",3,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Hedges, James A",1,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"McMullin, Evan",5,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CLAY,Blaine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CLAY,Blaine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000020
+CLAY,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+CLAY,Blaine Township,President / Vice President,,Republican,"Trump, Donald J.",118,000020
+CLAY,Bloom Township,President / Vice President,,independent,"Stein, Jill",1,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CLAY,Bloom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CLAY,Bloom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+CLAY,Bloom Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+CLAY,Bloom Township,President / Vice President,,Republican,"Trump, Donald J.",50,000030
+CLAY,Chapman Township,President / Vice President,,independent,"Stein, Jill",3,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CLAY,Chapman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CLAY,Chapman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000040
+CLAY,Chapman Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+CLAY,Chapman Township,President / Vice President,,Republican,"Trump, Donald J.",55,000040
+CLAY,Clay Center Township,President / Vice President,,independent,"Stein, Jill",5,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Hedges, James A",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"McMullin, Evan",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Smith, Mike",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+CLAY,Clay Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+CLAY,Clay Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,00005A
+CLAY,Clay Center Township,President / Vice President,,Libertarian,"Johnson, Gary",11,00005A
+CLAY,Clay Center Township,President / Vice President,,Republican,"Trump, Donald J.",152,00005A
+CLAY,Clay Center Township Enclave,President / Vice President,,independent,"Stein, Jill",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+CLAY,Clay Center Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+CLAY,Clay Center Ward 1,President / Vice President,,independent,"Stein, Jill",12,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",36,00006A
+CLAY,Clay Center Ward 1,President / Vice President,,Republican,"Trump, Donald J.",367,00006A
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+CLAY,Clay Center Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+CLAY,Clay Center Ward 2,President / Vice President,,independent,"Stein, Jill",9,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",108,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",30,000070
+CLAY,Clay Center Ward 2,President / Vice President,,Republican,"Trump, Donald J.",426,000070
+CLAY,Clay Center Ward 3,President / Vice President,,independent,"Stein, Jill",13,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",11,000080
+CLAY,Clay Center Ward 3,President / Vice President,,Republican,"Trump, Donald J.",281,000080
+CLAY,Clay Center Ward 4,President / Vice President,,independent,"Stein, Jill",7,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",15,000090
+CLAY,Clay Center Ward 4,President / Vice President,,Republican,"Trump, Donald J.",230,000090
+CLAY,Exeter Township,President / Vice President,,independent,"Stein, Jill",1,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+CLAY,Exeter Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+CLAY,Exeter Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000100
+CLAY,Exeter Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+CLAY,Exeter Township,President / Vice President,,Republican,"Trump, Donald J.",47,000100
+CLAY,Five Creeks Township,President / Vice President,,independent,"Stein, Jill",2,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+CLAY,Five Creeks Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+CLAY,Five Creeks Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000110
+CLAY,Five Creeks Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+CLAY,Five Creeks Township,President / Vice President,,Republican,"Trump, Donald J.",48,000110
+CLAY,Garfield Township,President / Vice President,,independent,"Stein, Jill",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",1,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+CLAY,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+CLAY,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000120
+CLAY,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+CLAY,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",48,000120
+CLAY,Gill Township,President / Vice President,,independent,"Stein, Jill",3,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+CLAY,Gill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+CLAY,Gill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000130
+CLAY,Gill Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+CLAY,Gill Township,President / Vice President,,Republican,"Trump, Donald J.",65,000130
+CLAY,Goshen Township,President / Vice President,,independent,"Stein, Jill",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+CLAY,Goshen Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+CLAY,Goshen Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000140
+CLAY,Goshen Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+CLAY,Goshen Township,President / Vice President,,Republican,"Trump, Donald J.",25,000140
+CLAY,Grant Township,President / Vice President,,independent,"Stein, Jill",1,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+CLAY,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+CLAY,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000150
+CLAY,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+CLAY,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",88,000150
+CLAY,Hayes Township,President / Vice President,,independent,"Stein, Jill",1,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+CLAY,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+CLAY,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000160
+CLAY,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000160
+CLAY,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",92,000160
+CLAY,Highland Township,President / Vice President,,independent,"Stein, Jill",5,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"McMullin, Evan",4,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+CLAY,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+CLAY,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000170
+CLAY,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+CLAY,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",104,000170
+CLAY,Mulberry Township,President / Vice President,,independent,"Stein, Jill",3,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+CLAY,Mulberry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+CLAY,Mulberry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000180
+CLAY,Mulberry Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000180
+CLAY,Mulberry Township,President / Vice President,,Republican,"Trump, Donald J.",116,000180
+CLAY,Oakland Township,President / Vice President,,independent,"Stein, Jill",1,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+CLAY,Oakland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+CLAY,Oakland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000190
+CLAY,Oakland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+CLAY,Oakland Township,President / Vice President,,Republican,"Trump, Donald J.",33,000190
+CLAY,Republican Township,President / Vice President,,independent,"Stein, Jill",8,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"McMullin, Evan",1,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+CLAY,Republican Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+CLAY,Republican Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000200
+CLAY,Republican Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000200
+CLAY,Republican Township,President / Vice President,,Republican,"Trump, Donald J.",330,000200
+CLAY,Sherman Township,President / Vice President,,independent,"Stein, Jill",3,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+CLAY,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+CLAY,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000210
+CLAY,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+CLAY,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",92,000210
+CLAY,Union Township,President / Vice President,,independent,"Stein, Jill",3,000220
+CLAY,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+CLAY,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+CLAY,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000220
+CLAY,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+CLAY,Union Township,President / Vice President,,Republican,"Trump, Donald J.",71,000220
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900230
+CLAY,Clay Center Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900230
+CLAY,Athelstane Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000010
+CLAY,Athelstane Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+CLAY,Athelstane Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+CLAY,Athelstane Township,United States House of Representatives,1,Republican,"Marshall, Roger",38,000010
+CLAY,Blaine Township,United States House of Representatives,1,independent,"LaPolice, Alan",64,000020
+CLAY,Blaine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+CLAY,Blaine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000020
+CLAY,Blaine Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000020
+CLAY,Bloom Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000030
+CLAY,Bloom Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+CLAY,Bloom Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+CLAY,Bloom Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000030
+CLAY,Chapman Township,United States House of Representatives,1,independent,"LaPolice, Alan",41,000040
+CLAY,Chapman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000040
+CLAY,Chapman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000040
+CLAY,Chapman Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000040
+CLAY,Clay Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",88,00005A
+CLAY,Clay Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00005A
+CLAY,Clay Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,00005A
+CLAY,Clay Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",109,00005A
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005B
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005B
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005B
+CLAY,Clay Center Township Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005B
+CLAY,Clay Center Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",261,00006A
+CLAY,Clay Center Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00006A
+CLAY,Clay Center Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,00006A
+CLAY,Clay Center Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",261,00006A
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006B
+CLAY,Clay Center Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",298,000070
+CLAY,Clay Center Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000070
+CLAY,Clay Center Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000070
+CLAY,Clay Center Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",268,000070
+CLAY,Clay Center Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",196,000080
+CLAY,Clay Center Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000080
+CLAY,Clay Center Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000080
+CLAY,Clay Center Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",185,000080
+CLAY,Clay Center Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",180,000090
+CLAY,Clay Center Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+CLAY,Clay Center Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000090
+CLAY,Clay Center Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",146,000090
+CLAY,Exeter Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000100
+CLAY,Exeter Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+CLAY,Exeter Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+CLAY,Exeter Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000100
+CLAY,Five Creeks Township,United States House of Representatives,1,independent,"LaPolice, Alan",28,000110
+CLAY,Five Creeks Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+CLAY,Five Creeks Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+CLAY,Five Creeks Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000110
+CLAY,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000120
+CLAY,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+CLAY,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000120
+CLAY,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000120
+CLAY,Gill Township,United States House of Representatives,1,independent,"LaPolice, Alan",33,000130
+CLAY,Gill Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000130
+CLAY,Gill Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000130
+CLAY,Gill Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000130
+CLAY,Goshen Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000140
+CLAY,Goshen Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000140
+CLAY,Goshen Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+CLAY,Goshen Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000140
+CLAY,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000150
+CLAY,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000150
+CLAY,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000150
+CLAY,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",64,000150
+CLAY,Hayes Township,United States House of Representatives,1,independent,"LaPolice, Alan",53,000160
+CLAY,Hayes Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000160
+CLAY,Hayes Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000160
+CLAY,Hayes Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000160
+CLAY,Highland Township,United States House of Representatives,1,independent,"LaPolice, Alan",51,000170
+CLAY,Highland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000170
+CLAY,Highland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000170
+CLAY,Highland Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000170
+CLAY,Mulberry Township,United States House of Representatives,1,independent,"LaPolice, Alan",106,000180
+CLAY,Mulberry Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+CLAY,Mulberry Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000180
+CLAY,Mulberry Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000180
+CLAY,Oakland Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000190
+CLAY,Oakland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+CLAY,Oakland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000190
+CLAY,Oakland Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000190
+CLAY,Republican Township,United States House of Representatives,1,independent,"LaPolice, Alan",120,000200
+CLAY,Republican Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,000200
+CLAY,Republican Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000200
+CLAY,Republican Township,United States House of Representatives,1,Republican,"Marshall, Roger",245,000200
+CLAY,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",63,000210
+CLAY,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+CLAY,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000210
+CLAY,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",57,000210
+CLAY,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",32,000220
+CLAY,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+CLAY,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+CLAY,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",55,000220
+CLAY,Clay Center Ward 4 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900230
+CLAY,Athelstane Township,United States Senate,,write - in,"Smith, DJ",0,000010
+CLAY,Athelstane Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+CLAY,Athelstane Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+CLAY,Athelstane Township,United States Senate,,Republican,"Moran, Jerry",52,000010
+CLAY,Blaine Township,United States Senate,,write - in,"Smith, DJ",0,000020
+CLAY,Blaine Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000020
+CLAY,Blaine Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+CLAY,Blaine Township,United States Senate,,Republican,"Moran, Jerry",139,000020
+CLAY,Bloom Township,United States Senate,,write - in,"Smith, DJ",0,000030
+CLAY,Bloom Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000030
+CLAY,Bloom Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+CLAY,Bloom Township,United States Senate,,Republican,"Moran, Jerry",58,000030
+CLAY,Chapman Township,United States Senate,,write - in,"Smith, DJ",0,000040
+CLAY,Chapman Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000040
+CLAY,Chapman Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000040
+CLAY,Chapman Township,United States Senate,,Republican,"Moran, Jerry",66,000040
+CLAY,Clay Center Township,United States Senate,,write - in,"Smith, DJ",0,00005A
+CLAY,Clay Center Township,United States Senate,,Democratic,"Wiesner, Patrick",15,00005A
+CLAY,Clay Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,00005A
+CLAY,Clay Center Township,United States Senate,,Republican,"Moran, Jerry",183,00005A
+CLAY,Clay Center Township Enclave,United States Senate,,write - in,"Smith, DJ",0,00005B
+CLAY,Clay Center Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+CLAY,Clay Center Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+CLAY,Clay Center Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,00005B
+CLAY,Clay Center Ward 1,United States Senate,,write - in,"Smith, DJ",0,00006A
+CLAY,Clay Center Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",61,00006A
+CLAY,Clay Center Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",22,00006A
+CLAY,Clay Center Ward 1,United States Senate,,Republican,"Moran, Jerry",458,00006A
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+CLAY,Clay Center Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00006B
+CLAY,Clay Center Ward 2,United States Senate,,write - in,"Smith, DJ",0,000070
+CLAY,Clay Center Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",72,000070
+CLAY,Clay Center Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",21,000070
+CLAY,Clay Center Ward 2,United States Senate,,Republican,"Moran, Jerry",488,000070
+CLAY,Clay Center Ward 3,United States Senate,,write - in,"Smith, DJ",0,000080
+CLAY,Clay Center Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",53,000080
+CLAY,Clay Center Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",16,000080
+CLAY,Clay Center Ward 3,United States Senate,,Republican,"Moran, Jerry",330,000080
+CLAY,Clay Center Ward 4,United States Senate,,write - in,"Smith, DJ",0,000090
+CLAY,Clay Center Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",46,000090
+CLAY,Clay Center Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",20,000090
+CLAY,Clay Center Ward 4,United States Senate,,Republican,"Moran, Jerry",272,000090
+CLAY,Exeter Township,United States Senate,,write - in,"Smith, DJ",0,000100
+CLAY,Exeter Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+CLAY,Exeter Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+CLAY,Exeter Township,United States Senate,,Republican,"Moran, Jerry",48,000100
+CLAY,Five Creeks Township,United States Senate,,write - in,"Smith, DJ",0,000110
+CLAY,Five Creeks Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000110
+CLAY,Five Creeks Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+CLAY,Five Creeks Township,United States Senate,,Republican,"Moran, Jerry",54,000110
+CLAY,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000120
+CLAY,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000120
+CLAY,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000120
+CLAY,Garfield Township,United States Senate,,Republican,"Moran, Jerry",47,000120
+CLAY,Gill Township,United States Senate,,write - in,"Smith, DJ",0,000130
+CLAY,Gill Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000130
+CLAY,Gill Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000130
+CLAY,Gill Township,United States Senate,,Republican,"Moran, Jerry",64,000130
+CLAY,Goshen Township,United States Senate,,write - in,"Smith, DJ",0,000140
+CLAY,Goshen Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000140
+CLAY,Goshen Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000140
+CLAY,Goshen Township,United States Senate,,Republican,"Moran, Jerry",27,000140
+CLAY,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000150
+CLAY,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000150
+CLAY,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000150
+CLAY,Grant Township,United States Senate,,Republican,"Moran, Jerry",91,000150
+CLAY,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000160
+CLAY,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000160
+CLAY,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000160
+CLAY,Hayes Township,United States Senate,,Republican,"Moran, Jerry",97,000160
+CLAY,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000170
+CLAY,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000170
+CLAY,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000170
+CLAY,Highland Township,United States Senate,,Republican,"Moran, Jerry",117,000170
+CLAY,Mulberry Township,United States Senate,,write - in,"Smith, DJ",0,000180
+CLAY,Mulberry Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000180
+CLAY,Mulberry Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000180
+CLAY,Mulberry Township,United States Senate,,Republican,"Moran, Jerry",118,000180
+CLAY,Oakland Township,United States Senate,,write - in,"Smith, DJ",0,000190
+CLAY,Oakland Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000190
+CLAY,Oakland Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000190
+CLAY,Oakland Township,United States Senate,,Republican,"Moran, Jerry",32,000190
+CLAY,Republican Township,United States Senate,,write - in,"Smith, DJ",0,000200
+CLAY,Republican Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000200
+CLAY,Republican Township,United States Senate,,Libertarian,"Garrard, Robert D.",27,000200
+CLAY,Republican Township,United States Senate,,Republican,"Moran, Jerry",334,000200
+CLAY,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000210
+CLAY,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000210
+CLAY,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000210
+CLAY,Sherman Township,United States Senate,,Republican,"Moran, Jerry",96,000210
+CLAY,Union Township,United States Senate,,write - in,"Smith, DJ",0,000220
+CLAY,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000220
+CLAY,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000220
+CLAY,Union Township,United States Senate,,Republican,"Moran, Jerry",79,000220
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900230
+CLAY,Clay Center Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900230

--- a/2016/20161108__ks__general__cloud__precinct.csv
+++ b/2016/20161108__ks__general__cloud__precinct.csv
@@ -1,700 +1,1045 @@
-county,precinct,office,district,party,candidate,votes
-Cloud,Total,,,,Registered Voters,6003
-Cloud,1st Ward,,,,Registered Voters,520
-Cloud,2nd Ward / 1st Pct.,,,,Registered Voters,620
-Cloud,2nd Ward / 2nd Pct.,,,,Registered Voters,682
-Cloud,3rd Ward,,,,Registered Voters,929
-Cloud,4th Ward,,,,Registered Voters,463
-Cloud,Arion Township,,,,Registered Voters,76
-Cloud,Aurora Township,,,,Registered Voters,89
-Cloud,Buffalo Township,,,,Registered Voters,79
-Cloud,Center Township,,,,Registered Voters,159
-Cloud,Colfax Township,,,,Registered Voters,32
-Cloud,Elk Township,,,,Registered Voters,542
-Cloud,Grant Township,,,,Registered Voters,232
-Cloud,North Lawrence Pct,,,,Registered Voters,54
-Cloud,South Lawrence Pct,,,,Registered Voters,40
-Cloud,East Lincoln Pct.,,,,Registered Voters,165
-Cloud,West Lincoln Pct.,,,,Registered Voters,116
-Cloud,Lyon Township,,,,Registered Voters,73
-Cloud,East Meredith Pct.,,,,Registered Voters,28
-Cloud,West Meredith,,,,Registered Voters,26
-Cloud,Nelson Township,,,,Registered Voters,89
-Cloud,Oakland Township,,,,Registered Voters,33
-Cloud,Shirley Township,,,,Registered Voters,99
-Cloud,Sibley Township,,,,Registered Voters,133
-Cloud,Solomon Township,,,,Registered Voters,329
-Cloud,Starr Township,,,,Registered Voters,360
-Cloud,Summit Township,,,,Registered Voters,35
-Cloud,Total,,,,Voters,4002
-Cloud,1st Ward,,,,Voters,301
-Cloud,2nd Ward / 1st Pct.,,,,Voters,370
-Cloud,2nd Ward / 2nd Pct.,,,,Voters,473
-Cloud,3rd Ward,,,,Voters,568
-Cloud,4th Ward,,,,Voters,257
-Cloud,Arion Township,,,,Voters,57
-Cloud,Aurora Township,,,,Voters,60
-Cloud,Buffalo Township,,,,Voters,62
-Cloud,Center Township,,,,Voters,117
-Cloud,Colfax Township,,,,Voters,22
-Cloud,Elk Township,,,,Voters,374
-Cloud,Grant Township,,,,Voters,149
-Cloud,North Lawrence Pct,,,,Voters,42
-Cloud,South Lawrence Pct,,,,Voters,28
-Cloud,East Lincoln Pct.,,,,Voters,120
-Cloud,West Lincoln Pct.,,,,Voters,81
-Cloud,Lyon Township,,,,Voters,56
-Cloud,East Meredith Pct.,,,,Voters,22
-Cloud,West Meredith,,,,Voters,17
-Cloud,Nelson Township,,,,Voters,61
-Cloud,Oakland Township,,,,Voters,27
-Cloud,Shirley Township,,,,Voters,68
-Cloud,Sibley Township,,,,Voters,102
-Cloud,Solomon Township,,,,Voters,221
-Cloud,Starr Township,,,,Voters,241
-Cloud,Summit Township,,,,Voters,29
-Cloud,Total,,,,Hand Counted,7
-Cloud,1st Ward,,,,Hand Counted,1
-Cloud,2nd Ward / 1st Pct.,,,,Hand Counted,2
-Cloud,2nd Ward / 2nd Pct.,,,,Hand Counted,3
-Cloud,Solomon Township,,,,Hand Counted,1
-Cloud,Total,,,,Advance Votes,962
-Cloud,1st Ward,,,,Advance Votes,86
-Cloud,2nd Ward / 1st Pct.,,,,Advance Votes,135
-Cloud,2nd Ward / 2nd Pct.,,,,Advance Votes,143
-Cloud,3rd Ward,,,,Advance Votes,166
-Cloud,4th Ward,,,,Advance Votes,62
-Cloud,Arion Township,,,,Advance Votes,14
-Cloud,Aurora Township,,,,Advance Votes,8
-Cloud,Buffalo Township,,,,Advance Votes,14
-Cloud,Center Township,,,,Advance Votes,29
-Cloud,Colfax Township,,,,Advance Votes,2
-Cloud,Elk Township,,,,Advance Votes,60
-Cloud,Grant Township,,,,Advance Votes,20
-Cloud,North Lawrence Pct,,,,Advance Votes,17
-Cloud,South Lawrence Pct,,,,Advance Votes,8
-Cloud,East Lincoln Pct.,,,,Advance Votes,26
-Cloud,West Lincoln Pct.,,,,Advance Votes,23
-Cloud,Lyon Township,,,,Advance Votes,10
-Cloud,East Meredith Pct.,,,,Advance Votes,12
-Cloud,West Meredith,,,,Advance Votes,4
-Cloud,Nelson Township,,,,Advance Votes,12
-Cloud,Oakland Township,,,,Advance Votes,2
-Cloud,Shirley Township,,,,Advance Votes,10
-Cloud,Sibley Township,,,,Advance Votes,26
-Cloud,Solomon Township,,,,Advance Votes,32
-Cloud,Starr Township,,,,Advance Votes,33
-Cloud,Summit Township,,,,Advance Votes,8
-Cloud,Total,,,,Election Day Votes,3033
-Cloud,Provisional,,,,Election Day Votes,77
-Cloud,1st Ward,,,,Election Day Votes,214
-Cloud,2nd Ward / 1st Pct.,,,,Election Day Votes,233
-Cloud,2nd Ward / 2nd Pct.,,,,Election Day Votes,327
-Cloud,3rd Ward,,,,Election Day Votes,402
-Cloud,4th Ward,,,,Election Day Votes,195
-Cloud,Arion Township,,,,Election Day Votes,43
-Cloud,Aurora Township,,,,Election Day Votes,52
-Cloud,Buffalo Township,,,,Election Day Votes,48
-Cloud,Center Township,,,,Election Day Votes,88
-Cloud,Colfax Township,,,,Election Day Votes,20
-Cloud,Elk Township,,,,Election Day Votes,314
-Cloud,Grant Township,,,,Election Day Votes,129
-Cloud,North Lawrence Pct,,,,Election Day Votes,25
-Cloud,South Lawrence Pct,,,,Election Day Votes,20
-Cloud,East Lincoln Pct.,,,,Election Day Votes,94
-Cloud,West Lincoln Pct.,,,,Election Day Votes,58
-Cloud,Lyon Township,,,,Election Day Votes,46
-Cloud,East Meredith Pct.,,,,Election Day Votes,10
-Cloud,West Meredith,,,,Election Day Votes,13
-Cloud,Nelson Township,,,,Election Day Votes,49
-Cloud,Oakland Township,,,,Election Day Votes,25
-Cloud,Shirley Township,,,,Election Day Votes,58
-Cloud,Sibley Township,,,,Election Day Votes,76
-Cloud,Solomon Township,,,,Election Day Votes,188
-Cloud,Starr Township,,,,Election Day Votes,208
-Cloud,Summit Township,,,,Election Day Votes,21
-Cloud,Total,President,,DEM,Clinton & Kaine,761
-Cloud,Advanced,President,,DEM,Clinton & Kaine,264
-Cloud,Provisional,President,,DEM,Clinton & Kaine,15
-Cloud,1st Ward,President,,DEM,Clinton & Kaine,58
-Cloud,2nd Ward / 1st Pct.,President,,DEM,Clinton & Kaine,48
-Cloud,2nd Ward / 2nd Pct.,President,,DEM,Clinton & Kaine,69
-Cloud,3rd Ward,President,,DEM,Clinton & Kaine,57
-Cloud,4th Ward,President,,DEM,Clinton & Kaine,41
-Cloud,Arion Township,President,,DEM,Clinton & Kaine,9
-Cloud,Aurora Township,President,,DEM,Clinton & Kaine,1
-Cloud,Buffalo Township,President,,DEM,Clinton & Kaine,4
-Cloud,Center Township,President,,DEM,Clinton & Kaine,8
-Cloud,Colfax Township,President,,DEM,Clinton & Kaine,0
-Cloud,Elk Township,President,,DEM,Clinton & Kaine,53
-Cloud,Grant Township,President,,DEM,Clinton & Kaine,18
-Cloud,North Lawrence Pct,President,,DEM,Clinton & Kaine,2
-Cloud,South Lawrence Pct,President,,DEM,Clinton & Kaine,2
-Cloud,East Lincoln Pct.,President,,DEM,Clinton & Kaine,9
-Cloud,West Lincoln Pct.,President,,DEM,Clinton & Kaine,12
-Cloud,Lyon Township,President,,DEM,Clinton & Kaine,5
-Cloud,East Meredith Pct.,President,,DEM,Clinton & Kaine,3
-Cloud,West Meredith,President,,DEM,Clinton & Kaine,2
-Cloud,Nelson Township,President,,DEM,Clinton & Kaine,6
-Cloud,Oakland Township,President,,DEM,Clinton & Kaine,1
-Cloud,Shirley Township,President,,DEM,Clinton & Kaine,9
-Cloud,Sibley Township,President,,DEM,Clinton & Kaine,16
-Cloud,Solomon Township,President,,DEM,Clinton & Kaine,26
-Cloud,Starr Township,President,,DEM,Clinton & Kaine,20
-Cloud,Summit Township,President,,DEM,Clinton & Kaine,3
-Cloud,Total,President,,LBT,Johnson & Weld,161
-Cloud,Advanced,President,,LBT,Johnson & Weld,51
-Cloud,Provisional,President,,LBT,Johnson & Weld,3
-Cloud,1st Ward,President,,LBT,Johnson & Weld,9
-Cloud,2nd Ward / 1st Pct.,President,,LBT,Johnson & Weld,13
-Cloud,2nd Ward / 2nd Pct.,President,,LBT,Johnson & Weld,18
-Cloud,3rd Ward,President,,LBT,Johnson & Weld,18
-Cloud,4th Ward,President,,LBT,Johnson & Weld,6
-Cloud,Arion Township,President,,LBT,Johnson & Weld,0
-Cloud,Aurora Township,President,,LBT,Johnson & Weld,1
-Cloud,Buffalo Township,President,,LBT,Johnson & Weld,3
-Cloud,Center Township,President,,LBT,Johnson & Weld,0
-Cloud,Colfax Township,President,,LBT,Johnson & Weld,0
-Cloud,Elk Township,President,,LBT,Johnson & Weld,12
-Cloud,Grant Township,President,,LBT,Johnson & Weld,3
-Cloud,North Lawrence Pct,President,,LBT,Johnson & Weld,1
-Cloud,South Lawrence Pct,President,,LBT,Johnson & Weld,0
-Cloud,East Lincoln Pct.,President,,LBT,Johnson & Weld,3
-Cloud,West Lincoln Pct.,President,,LBT,Johnson & Weld,0
-Cloud,Lyon Township,President,,LBT,Johnson & Weld,3
-Cloud,East Meredith Pct.,President,,LBT,Johnson & Weld,0
-Cloud,West Meredith,President,,LBT,Johnson & Weld,0
-Cloud,Nelson Township,President,,LBT,Johnson & Weld,1
-Cloud,Oakland Township,President,,LBT,Johnson & Weld,0
-Cloud,Shirley Township,President,,LBT,Johnson & Weld,1
-Cloud,Sibley Township,President,,LBT,Johnson & Weld,2
-Cloud,Solomon Township,President,,LBT,Johnson & Weld,6
-Cloud,Starr Township,President,,LBT,Johnson & Weld,7
-Cloud,Summit Township,President,,LBT,Johnson & Weld,0
-Cloud,Total,President,,IND,Stein & Baraka,74
-Cloud,Advanced,President,,IND,Stein & Baraka,16
-Cloud,Provisional,President,,IND,Stein & Baraka,0
-Cloud,1st Ward,President,,IND,Stein & Baraka,5
-Cloud,2nd Ward / 1st Pct.,President,,IND,Stein & Baraka,5
-Cloud,2nd Ward / 2nd Pct.,President,,IND,Stein & Baraka,8
-Cloud,3rd Ward,President,,IND,Stein & Baraka,12
-Cloud,4th Ward,President,,IND,Stein & Baraka,3
-Cloud,Arion Township,President,,IND,Stein & Baraka,2
-Cloud,Aurora Township,President,,IND,Stein & Baraka,0
-Cloud,Buffalo Township,President,,IND,Stein & Baraka,0
-Cloud,Center Township,President,,IND,Stein & Baraka,2
-Cloud,Colfax Township,President,,IND,Stein & Baraka,1
-Cloud,Elk Township,President,,IND,Stein & Baraka,6
-Cloud,Grant Township,President,,IND,Stein & Baraka,2
-Cloud,North Lawrence Pct,President,,IND,Stein & Baraka,1
-Cloud,South Lawrence Pct,President,,IND,Stein & Baraka,1
-Cloud,East Lincoln Pct.,President,,IND,Stein & Baraka,1
-Cloud,West Lincoln Pct.,President,,IND,Stein & Baraka,0
-Cloud,Lyon Township,President,,IND,Stein & Baraka,0
-Cloud,East Meredith Pct.,President,,IND,Stein & Baraka,0
-Cloud,West Meredith,President,,IND,Stein & Baraka,0
-Cloud,Nelson Township,President,,IND,Stein & Baraka,0
-Cloud,Oakland Township,President,,IND,Stein & Baraka,0
-Cloud,Shirley Township,President,,IND,Stein & Baraka,0
-Cloud,Sibley Township,President,,IND,Stein & Baraka,2
-Cloud,Solomon Township,President,,IND,Stein & Baraka,4
-Cloud,Starr Township,President,,IND,Stein & Baraka,3
-Cloud,Summit Township,President,,IND,Stein & Baraka,0
-Cloud,Total,President,,REP,Trump & Pence,2919
-Cloud,Advanced,President,,REP,Trump & Pence,608
-Cloud,Provisional,President,,REP,Trump & Pence,59
-Cloud,1st Ward,President,,REP,Trump & Pence,139
-Cloud,2nd Ward / 1st Pct.,President,,REP,Trump & Pence,163
-Cloud,2nd Ward / 2nd Pct.,President,,REP,Trump & Pence,226
-Cloud,3rd Ward,President,,REP,Trump & Pence,309
-Cloud,4th Ward,President,,REP,Trump & Pence,139
-Cloud,Arion Township,President,,REP,Trump & Pence,32
-Cloud,Aurora Township,President,,REP,Trump & Pence,48
-Cloud,Buffalo Township,President,,REP,Trump & Pence,38
-Cloud,Center Township,President,,REP,Trump & Pence,78
-Cloud,Colfax Township,President,,REP,Trump & Pence,19
-Cloud,Elk Township,President,,REP,Trump & Pence,233
-Cloud,Grant Township,President,,REP,Trump & Pence,103
-Cloud,North Lawrence Pct,President,,REP,Trump & Pence,21
-Cloud,South Lawrence Pct,President,,REP,Trump & Pence,17
-Cloud,East Lincoln Pct.,President,,REP,Trump & Pence,78
-Cloud,West Lincoln Pct.,President,,REP,Trump & Pence,46
-Cloud,Lyon Township,President,,REP,Trump & Pence,38
-Cloud,East Meredith Pct.,President,,REP,Trump & Pence,7
-Cloud,West Meredith,President,,REP,Trump & Pence,11
-Cloud,Nelson Township,President,,REP,Trump & Pence,41
-Cloud,Oakland Township,President,,REP,Trump & Pence,23
-Cloud,Shirley Township,President,,REP,Trump & Pence,46
-Cloud,Sibley Township,President,,REP,Trump & Pence,55
-Cloud,Solomon Township,President,,REP,Trump & Pence,150
-Cloud,Starr Township,President,,REP,Trump & Pence,175
-Cloud,Summit Township,President,,REP,Trump & Pence,17
-Cloud,Total,President,,,Evan McMullin,15
-Cloud,Advanced,President,,,Evan McMullin,4
-Cloud,Provisional,President,,,Evan McMullin,0
-Cloud,1st Ward,President,,,Evan McMullin,0
-Cloud,2nd Ward / 1st Pct.,President,,,Evan McMullin,1
-Cloud,2nd Ward / 2nd Pct.,President,,,Evan McMullin,0
-Cloud,3rd Ward,President,,,Evan McMullin,0
-Cloud,4th Ward,President,,,Evan McMullin,0
-Cloud,Arion Township,President,,,Evan McMullin,0
-Cloud,Aurora Township,President,,,Evan McMullin,0
-Cloud,Buffalo Township,President,,,Evan McMullin,0
-Cloud,Center Township,President,,,Evan McMullin,0
-Cloud,Colfax Township,President,,,Evan McMullin,0
-Cloud,Elk Township,President,,,Evan McMullin,5
-Cloud,Grant Township,President,,,Evan McMullin,0
-Cloud,North Lawrence Pct,President,,,Evan McMullin,0
-Cloud,South Lawrence Pct,President,,,Evan McMullin,0
-Cloud,East Lincoln Pct.,President,,,Evan McMullin,0
-Cloud,West Lincoln Pct.,President,,,Evan McMullin,0
-Cloud,Lyon Township,President,,,Evan McMullin,0
-Cloud,East Meredith Pct.,President,,,Evan McMullin,0
-Cloud,West Meredith,President,,,Evan McMullin,0
-Cloud,Nelson Township,President,,,Evan McMullin,0
-Cloud,Oakland Township,President,,,Evan McMullin,1
-Cloud,Aurora Township,President,,,Evan McMullin,0
-Cloud,Elk Township,President,,,Evan McMullin,0
-Cloud,Grant Township,President,,,Evan McMullin,0
-Cloud,Shirley Township,President,,,Evan McMullin,1
-Cloud,Sibley Township,President,,,Evan McMullin,1
-Cloud,Solomon Township,President,,,Evan McMullin,0
-Cloud,Starr Township,President,,,Evan McMullin,0
-Cloud,Solomon Township,President,,,Evan McMullin,2
-Cloud,Starr Township,President,,,Evan McMullin,0
-Cloud,Summit Township,President,,,Evan McMullin,0
-Cloud,Total,President,,,Write-ins,22
-Cloud,Advanced,President,,,Write-ins,4
-Cloud,Provisional,President,,,Write-ins,0
-Cloud,1st Ward,President,,,Write-ins,0
-Cloud,2nd Ward / 1st Pct.,President,,,Write-ins,3
-Cloud,2nd Ward / 2nd Pct.,President,,,Write-ins,2
-Cloud,3rd Ward,President,,,Write-ins,3
-Cloud,4th Ward,President,,,Write-ins,5
-Cloud,Arion Township,President,,,Write-ins,0
-Cloud,Aurora Township,President,,,Write-ins,0
-Cloud,Buffalo Township,President,,,Write-ins,0
-Cloud,Center Township,President,,,Write-ins,0
-Cloud,Colfax Township,President,,,Write-ins,0
-Cloud,Elk Township,President,,,Write-ins,1
-Cloud,Grant Township,President,,,Write-ins,0
-Cloud,North Lawrence Pct,President,,,Write-ins,0
-Cloud,South Lawrence Pct,President,,,Write-ins,0
-Cloud,East Lincoln Pct.,President,,,Write-ins,1
-Cloud,West Lincoln Pct.,President,,,Write-ins,0
-Cloud,Lyon Township,President,,,Write-ins,0
-Cloud,East Meredith Pct.,President,,,Write-ins,0
-Cloud,West Meredith,President,,,Write-ins,0
-Cloud,Nelson Township,President,,,Write-ins,1
-Cloud,Oakland Township,President,,,Write-ins,0
-Cloud,Aurora Township,President,,,Write-ins,0
-Cloud,Elk Township,President,,,Write-ins,0
-Cloud,Grant Township,President,,,Write-ins,0
-Cloud,Shirley Township,President,,,Write-ins,0
-Cloud,Sibley Township,President,,,Write-ins,0
-Cloud,Solomon Township,President,,,Write-ins,0
-Cloud,Starr Township,President,,,Write-ins,0
-Cloud,Solomon Township,President,,,Write-ins,0
-Cloud,Starr Township,President,,,Write-ins,2
-Cloud,Summit Township,President,,,Write-ins,0
-Cloud,Total,President,,,Blanks,3
-Cloud,Advanced,President,,,Blanks,0
-Cloud,1st Ward,President,,,Blanks,1
-Cloud,Buffalo Township,President,,,Blanks,1
-Cloud,Elk Township,President,,,Blanks,1
-Cloud,Grant Township,President,,,Blanks,1
-Cloud,Starr Township,President,,,Blanks,1
-Cloud,Total,U.S. Senate,,LBT,Robert D. Garrard,219
-Cloud,Advanced,U.S. Senate,,LBT,Robert D. Garrard,46
-Cloud,Provisional,U.S. Senate,,LBT,Robert D. Garrard,7
-Cloud,1st Ward,U.S. Senate,,LBT,Robert D. Garrard,10
-Cloud,2nd Ward / 1st Pct.,U.S. Senate,,LBT,Robert D. Garrard,17
-Cloud,2nd Ward / 2nd Pct.,U.S. Senate,,LBT,Robert D. Garrard,19
-Cloud,3rd Ward,U.S. Senate,,LBT,Robert D. Garrard,38
-Cloud,4th Ward,U.S. Senate,,LBT,Robert D. Garrard,20
-Cloud,Arion Township,U.S. Senate,,LBT,Robert D. Garrard,1
-Cloud,Aurora Township,U.S. Senate,,LBT,Robert D. Garrard,3
-Cloud,Buffalo Township,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,Center Township,U.S. Senate,,LBT,Robert D. Garrard,5
-Cloud,Colfax Township,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,Elk Township,U.S. Senate,,LBT,Robert D. Garrard,12
-Cloud,Grant Township,U.S. Senate,,LBT,Robert D. Garrard,7
-Cloud,North Lawrence Pct,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,South Lawrence Pct,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,East Lincoln Pct.,U.S. Senate,,LBT,Robert D. Garrard,3
-Cloud,West Lincoln Pct.,U.S. Senate,,LBT,Robert D. Garrard,3
-Cloud,Lyon Township,U.S. Senate,,LBT,Robert D. Garrard,2
-Cloud,West Meredith,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,Nelson Township,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,Oakland Township,U.S. Senate,,LBT,Robert D. Garrard,0
-Cloud,Shirley Township,U.S. Senate,,LBT,Robert D. Garrard,2
-Cloud,Sibley Township,U.S. Senate,,LBT,Robert D. Garrard,4
-Cloud,Solomon Township,U.S. Senate,,LBT,Robert D. Garrard,11
-Cloud,Starr Township,U.S. Senate,,LBT,Robert D. Garrard,8
-Cloud,Summit Township,U.S. Senate,,LBT,Robert D. Garrard,1
-Cloud,Total,U.S. Senate,,DEM,Patrick Wiesner,597
-Cloud,Advanced,U.S. Senate,,DEM,Patrick Wiesner,204
-Cloud,Provisional,U.S. Senate,,DEM,Patrick Wiesner,14
-Cloud,1st Ward,U.S. Senate,,DEM,Patrick Wiesner,46
-Cloud,2nd Ward / 1st Pct.,U.S. Senate,,DEM,Patrick Wiesner,32
-Cloud,2nd Ward / 2nd Pct.,U.S. Senate,,DEM,Patrick Wiesner,48
-Cloud,3rd Ward,U.S. Senate,,DEM,Patrick Wiesner,57
-Cloud,4th Ward,U.S. Senate,,DEM,Patrick Wiesner,36
-Cloud,Arion Township,U.S. Senate,,DEM,Patrick Wiesner,7
-Cloud,Aurora Township,U.S. Senate,,DEM,Patrick Wiesner,2
-Cloud,Buffalo Township,U.S. Senate,,DEM,Patrick Wiesner,1
-Cloud,Center Township,U.S. Senate,,DEM,Patrick Wiesner,4
-Cloud,Colfax Township,U.S. Senate,,DEM,Patrick Wiesner,1
-Cloud,Elk Township,U.S. Senate,,DEM,Patrick Wiesner,41
-Cloud,Grant Township,U.S. Senate,,DEM,Patrick Wiesner,12
-Cloud,North Lawrence Pct,U.S. Senate,,DEM,Patrick Wiesner,0
-Cloud,South Lawrence Pct,U.S. Senate,,DEM,Patrick Wiesner,4
-Cloud,East Lincoln Pct.,U.S. Senate,,DEM,Patrick Wiesner,7
-Cloud,West Lincoln Pct.,U.S. Senate,,DEM,Patrick Wiesner,8
-Cloud,Lyon Township,U.S. Senate,,DEM,Patrick Wiesner,3
-Cloud,East Meredith Pct.,U.S. Senate,,DEM,Patrick Wiesner,1
-Cloud,West Meredith,U.S. Senate,,DEM,Patrick Wiesner,2
-Cloud,Nelson Township,U.S. Senate,,DEM,Patrick Wiesner,5
-Cloud,Shirley Township,U.S. Senate,,DEM,Patrick Wiesner,4
-Cloud,Sibley Township,U.S. Senate,,DEM,Patrick Wiesner,12
-Cloud,Solomon Township,U.S. Senate,,DEM,Patrick Wiesner,23
-Cloud,Starr Township,U.S. Senate,,DEM,Patrick Wiesner,21
-Cloud,Summit Township,U.S. Senate,,DEM,Patrick Wiesner,2
-Cloud,Total,U.S. Senate,,,Write-ins,3
-Cloud,Advanced,U.S. Senate,,,Write-ins,1
-Cloud,Provisional,U.S. Senate,,,Write-ins,0
-Cloud,1st Ward,U.S. Senate,,,Write-ins,1
-Cloud,2nd Ward / 1st Pct.,U.S. Senate,,,Write-ins,0
-Cloud,2nd Ward / 2nd Pct.,U.S. Senate,,,Write-ins,0
-Cloud,3rd Ward,U.S. Senate,,,Write-ins,0
-Cloud,4th Ward,U.S. Senate,,,Write-ins,0
-Cloud,Arion Township,U.S. Senate,,,Write-ins,0
-Cloud,Aurora Township,U.S. Senate,,,Write-ins,0
-Cloud,Buffalo Township,U.S. Senate,,,Write-ins,0
-Cloud,Center Township,U.S. Senate,,,Write-ins,0
-Cloud,Colfax Township,U.S. Senate,,,Write-ins,0
-Cloud,Elk Township,U.S. Senate,,,Write-ins,0
-Cloud,Grant Township,U.S. Senate,,,Write-ins,0
-Cloud,North Lawrence Pct,U.S. Senate,,,Write-ins,0
-Cloud,South Lawrence Pct,U.S. Senate,,,Write-ins,0
-Cloud,East Lincoln Pct.,U.S. Senate,,,Write-ins,0
-Cloud,West Lincoln Pct.,U.S. Senate,,,Write-ins,0
-Cloud,Lyon Township,U.S. Senate,,,Write-ins,0
-Cloud,East Meredith Pct.,U.S. Senate,,,Write-ins,0
-Cloud,West Meredith,U.S. Senate,,,Write-ins,0
-Cloud,Nelson Township,U.S. Senate,,,Write-ins,0
-Cloud,Oakland Township,U.S. Senate,,,Write-ins,0
-Cloud,Aurora Township,U.S. Senate,,,Write-ins,0
-Cloud,Elk Township,U.S. Senate,,,Write-ins,0
-Cloud,Grant Township,U.S. Senate,,,Write-ins,0
-Cloud,Shirley Township,U.S. Senate,,,Write-ins,0
-Cloud,Sibley Township,U.S. Senate,,,Write-ins,0
-Cloud,Solomon Township,U.S. Senate,,,Write-ins,0
-Cloud,Starr Township,U.S. Senate,,,Write-ins,0
-Cloud,Solomon Township,U.S. Senate,,,Write-ins,0
-Cloud,Starr Township,U.S. Senate,,,Write-ins,0
-Cloud,Summit Township,U.S. Senate,,,Write-ins,0
-Cloud,Total,U.S. Senate,,,Blanks,6
-Cloud,Advanced,U.S. Senate,,,Blanks,3
-Cloud,1st Ward,U.S. Senate,,,Blanks,1
-Cloud,2nd Ward / 2nd Pct.,U.S. Senate,,,Blanks,1
-Cloud,Aurora Township,U.S. Senate,,,Blanks,1
-Cloud,East Meredith Pct.,U.S. Senate,,,Blanks,1
-Cloud,Starr Township,U.S. Senate,,,Blanks,1
-Cloud,Total,U.S. House,1,LBT,Kerry Burt,85
-Cloud,Advanced,U.S. House,1,LBT,Kerry Burt,20
-Cloud,Provisional,U.S. House,1,LBT,Kerry Burt,2
-Cloud,1st Ward,U.S. House,1,LBT,Kerry Burt,4
-Cloud,2nd Ward / 1st Pct.,U.S. House,1,LBT,Kerry Burt,9
-Cloud,2nd Ward / 2nd Pct.,U.S. House,1,LBT,Kerry Burt,9
-Cloud,3rd Ward,U.S. House,1,LBT,Kerry Burt,10
-Cloud,4th Ward,U.S. House,1,LBT,Kerry Burt,8
-Cloud,Arion Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Aurora Township,U.S. House,1,LBT,Kerry Burt,1
-Cloud,Buffalo Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Center Township,U.S. House,1,LBT,Kerry Burt,2
-Cloud,Colfax Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Elk Township,U.S. House,1,LBT,Kerry Burt,2
-Cloud,Grant Township,U.S. House,1,LBT,Kerry Burt,2
-Cloud,North Lawrence Pct,U.S. House,1,LBT,Kerry Burt,0
-Cloud,South Lawrence Pct,U.S. House,1,LBT,Kerry Burt,0
-Cloud,East Lincoln Pct.,U.S. House,1,LBT,Kerry Burt,4
-Cloud,West Lincoln Pct.,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Lyon Township,U.S. House,1,LBT,Kerry Burt,1
-Cloud,East Meredith Pct.,U.S. House,1,LBT,Kerry Burt,1
-Cloud,West Meredith,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Nelson Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Oakland Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Shirley Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Sibley Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Solomon Township,U.S. House,1,LBT,Kerry Burt,4
-Cloud,Starr Township,U.S. House,1,LBT,Kerry Burt,6
-Cloud,Summit Township,U.S. House,1,LBT,Kerry Burt,0
-Cloud,Total,U.S. House,1,IND,Alan LaPolice,2359
-Cloud,Advanced,U.S. House,1,IND,Alan LaPolice,586
-Cloud,Provisional,U.S. House,1,IND,Alan LaPolice,43
-Cloud,1st Ward,U.S. House,1,IND,Alan LaPolice,138
-Cloud,2nd Ward / 1st Pct.,U.S. House,1,IND,Alan LaPolice,132
-Cloud,2nd Ward / 2nd Pct.,U.S. House,1,IND,Alan LaPolice,186
-Cloud,3rd Ward,U.S. House,1,IND,Alan LaPolice,249
-Cloud,4th Ward,U.S. House,1,IND,Alan LaPolice,119
-Cloud,Arion Township,U.S. House,1,IND,Alan LaPolice,21
-Cloud,Aurora Township,U.S. House,1,IND,Alan LaPolice,31
-Cloud,Buffalo Township,U.S. House,1,IND,Alan LaPolice,25
-Cloud,Center Township,U.S. House,1,IND,Alan LaPolice,52
-Cloud,Colfax Township,U.S. House,1,IND,Alan LaPolice,11
-Cloud,Elk Township,U.S. House,1,IND,Alan LaPolice,208
-Cloud,Grant Township,U.S. House,1,IND,Alan LaPolice,65
-Cloud,North Lawrence Pct,U.S. House,1,IND,Alan LaPolice,19
-Cloud,South Lawrence Pct,U.S. House,1,IND,Alan LaPolice,16
-Cloud,East Lincoln Pct.,U.S. House,1,IND,Alan LaPolice,40
-Cloud,West Lincoln Pct.,U.S. House,1,IND,Alan LaPolice,44
-Cloud,Lyon Township,U.S. House,1,IND,Alan LaPolice,27
-Cloud,East Meredith Pct.,U.S. House,1,IND,Alan LaPolice,5
-Cloud,West Meredith,U.S. House,1,IND,Alan LaPolice,4
-Cloud,Nelson Township,U.S. House,1,IND,Alan LaPolice,24
-Cloud,Oakland Township,U.S. House,1,IND,Alan LaPolice,14
-Cloud,Shirley Township,U.S. House,1,IND,Alan LaPolice,26
-Cloud,Sibley Township,U.S. House,1,IND,Alan LaPolice,45
-Cloud,Solomon Township,U.S. House,1,IND,Alan LaPolice,100
-Cloud,Starr Township,U.S. House,1,IND,Alan LaPolice,117
-Cloud,Summit Township,U.S. House,1,IND,Alan LaPolice,12
-Cloud,Total,U.S. House,1,REP,Roger Marshall,1459
-Cloud,Advanced,U.S. House,1,REP,Roger Marshall,325
-Cloud,Provisional,U.S. House,1,REP,Roger Marshall,29
-Cloud,1st Ward,U.S. House,1,REP,Roger Marshall,66
-Cloud,2nd Ward / 1st Pct.,U.S. House,1,REP,Roger Marshall,90
-Cloud,2nd Ward / 2nd Pct.,U.S. House,1,REP,Roger Marshall,124
-Cloud,3rd Ward,U.S. House,1,REP,Roger Marshall,135
-Cloud,4th Ward,U.S. House,1,REP,Roger Marshall,67
-Cloud,Arion Township,U.S. House,1,REP,Roger Marshall,22
-Cloud,Aurora Township,U.S. House,1,REP,Roger Marshall,19
-Cloud,Buffalo Township,U.S. House,1,REP,Roger Marshall,19
-Cloud,Center Township,U.S. House,1,REP,Roger Marshall,33
-Cloud,Colfax Township,U.S. House,1,REP,Roger Marshall,9
-Cloud,Elk Township,U.S. House,1,REP,Roger Marshall,99
-Cloud,Grant Township,U.S. House,1,REP,Roger Marshall,62
-Cloud,North Lawrence Pct,U.S. House,1,REP,Roger Marshall,5
-Cloud,South Lawrence Pct,U.S. House,1,REP,Roger Marshall,4
-Cloud,East Lincoln Pct.,U.S. House,1,REP,Roger Marshall,49
-Cloud,West Lincoln Pct.,U.S. House,1,REP,Roger Marshall,11
-Cloud,Lyon Township,U.S. House,1,REP,Roger Marshall,18
-Cloud,East Meredith Pct.,U.S. House,1,REP,Roger Marshall,4
-Cloud,West Meredith,U.S. House,1,REP,Roger Marshall,8
-Cloud,Nelson Township,U.S. House,1,REP,Roger Marshall,24
-Cloud,Oakland Township,U.S. House,1,REP,Roger Marshall,10
-Cloud,Shirley Township,U.S. House,1,REP,Roger Marshall,32
-Cloud,Sibley Township,U.S. House,1,REP,Roger Marshall,29
-Cloud,Solomon Township,U.S. House,1,REP,Roger Marshall,79
-Cloud,Starr Township,U.S. House,1,REP,Roger Marshall,80
-Cloud,Summit Township,U.S. House,1,REP,Roger Marshall,7
-Cloud,Total,U.S. House,1,,Tim Huelskamp,5
-Cloud,Advanced,U.S. House,1,,Tim Huelskamp,2
-Cloud,2nd Ward / 2nd Pct.,U.S. House,1,,Tim Huelskamp,1
-Cloud,4th Ward,U.S. House,1,,Tim Huelskamp,1
-Cloud,Oakland Township,U.S. House,1,,Tim Huelskamp,1
-Cloud,Total,U.S. House,1,,Write-ins,3
-Cloud,Advanced,U.S. House,1,,Write-ins,1
-Cloud,Provisional,U.S. House,1,,Write-ins,0
-Cloud,1st Ward,U.S. House,1,,Write-ins,1
-Cloud,2nd Ward / 1st Pct.,U.S. House,1,,Write-ins,0
-Cloud,2nd Ward / 2nd Pct.,U.S. House,1,,Write-ins,0
-Cloud,3rd Ward,U.S. House,1,,Write-ins,0
-Cloud,4th Ward,U.S. House,1,,Write-ins,0
-Cloud,Arion Township,U.S. House,1,,Write-ins,0
-Cloud,Aurora Township,U.S. House,1,,Write-ins,0
-Cloud,Buffalo Township,U.S. House,1,,Write-ins,0
-Cloud,Center Township,U.S. House,1,,Write-ins,0
-Cloud,Colfax Township,U.S. House,1,,Write-ins,0
-Cloud,Elk Township,U.S. House,1,,Write-ins,0
-Cloud,Grant Township,U.S. House,1,,Write-ins,0
-Cloud,North Lawrence Pct,U.S. House,1,,Write-ins,0
-Cloud,South Lawrence Pct,U.S. House,1,,Write-ins,0
-Cloud,East Lincoln Pct.,U.S. House,1,,Write-ins,0
-Cloud,West Lincoln Pct.,U.S. House,1,,Write-ins,0
-Cloud,Lyon Township,U.S. House,1,,Write-ins,0
-Cloud,East Meredith Pct.,U.S. House,1,,Write-ins,0
-Cloud,West Meredith,U.S. House,1,,Write-ins,0
-Cloud,Nelson Township,U.S. House,1,,Write-ins,0
-Cloud,Oakland Township,U.S. House,1,,Write-ins,0
-Cloud,Aurora Township,U.S. House,1,,Write-ins,0
-Cloud,Elk Township,U.S. House,1,,Write-ins,0
-Cloud,Grant Township,U.S. House,1,,Write-ins,0
-Cloud,Shirley Township,U.S. House,1,,Write-ins,0
-Cloud,Sibley Township,U.S. House,1,,Write-ins,0
-Cloud,Solomon Township,U.S. House,1,,Write-ins,0
-Cloud,Starr Township,U.S. House,1,,Write-ins,0
-Cloud,Solomon Township,U.S. House,1,,Write-ins,1
-Cloud,Starr Township,U.S. House,1,,Write-ins,0
-Cloud,Summit Township,U.S. House,1,,Write-ins,0
-Cloud,Total,U.S. House,1,,Blanks,9
-Cloud,Advanced,U.S. House,1,,Blanks,2
-Cloud,2nd Ward / 2nd Pct.,U.S. House,1,,Blanks,2
-Cloud,3rd Ward,U.S. House,1,,Blanks,1
-Cloud,Aurora Township,U.S. House,1,,Blanks,1
-Cloud,West Lincoln Pct.,U.S. House,1,,Blanks,1
-Cloud,Solomon Township,U.S. House,1,,Blanks,1
-Cloud,Starr Township,U.S. House,1,,Blanks,1
-Cloud,Total,State Senate,36,DEM,Brian G. Angevine,605
-Cloud,Advanced,State Senate,36,DEM,Brian G. Angevine,203
-Cloud,Provisional,State Senate,36,DEM,Brian G. Angevine,9
-Cloud,1st Ward,State Senate,36,DEM,Brian G. Angevine,40
-Cloud,2nd Ward / 1st Pct.,State Senate,36,DEM,Brian G. Angevine,42
-Cloud,2nd Ward / 2nd Pct.,State Senate,36,DEM,Brian G. Angevine,52
-Cloud,3rd Ward,State Senate,36,DEM,Brian G. Angevine,51
-Cloud,4th Ward,State Senate,36,DEM,Brian G. Angevine,33
-Cloud,Arion Township,State Senate,36,DEM,Brian G. Angevine,5
-Cloud,Aurora Township,State Senate,36,DEM,Brian G. Angevine,4
-Cloud,Buffalo Township,State Senate,36,DEM,Brian G. Angevine,3
-Cloud,Center Township,State Senate,36,DEM,Brian G. Angevine,5
-Cloud,Colfax Township,State Senate,36,DEM,Brian G. Angevine,0
-Cloud,Elk Township,State Senate,36,DEM,Brian G. Angevine,40
-Cloud,Grant Township,State Senate,36,DEM,Brian G. Angevine,13
-Cloud,North Lawrence Pct,State Senate,36,DEM,Brian G. Angevine,1
-Cloud,South Lawrence Pct,State Senate,36,DEM,Brian G. Angevine,5
-Cloud,East Lincoln Pct.,State Senate,36,DEM,Brian G. Angevine,12
-Cloud,West Lincoln Pct.,State Senate,36,DEM,Brian G. Angevine,10
-Cloud,Lyon Township,State Senate,36,DEM,Brian G. Angevine,5
-Cloud,East Meredith Pct.,State Senate,36,DEM,Brian G. Angevine,1
-Cloud,West Meredith,State Senate,36,DEM,Brian G. Angevine,1
-Cloud,Nelson Township,State Senate,36,DEM,Brian G. Angevine,1
-Cloud,Oakland Township,State Senate,36,DEM,Brian G. Angevine,2
-Cloud,Shirley Township,State Senate,36,DEM,Brian G. Angevine,6
-Cloud,Sibley Township,State Senate,36,DEM,Brian G. Angevine,14
-Cloud,Solomon Township,State Senate,36,DEM,Brian G. Angevine,23
-Cloud,Starr Township,State Senate,36,DEM,Brian G. Angevine,24
-Cloud,Total,State Senate,36,REP,Elaine S. Bowers,3341
-Cloud,Advanced,State Senate,36,REP,Elaine S. Bowers,748
-Cloud,Provisional,State Senate,36,REP,Elaine S. Bowers,65
-Cloud,1st Ward,State Senate,36,REP,Elaine S. Bowers,170
-Cloud,2nd Ward / 1st Pct.,State Senate,36,REP,Elaine S. Bowers,188
-Cloud,2nd Ward / 2nd Pct.,State Senate,36,REP,Elaine S. Bowers,274
-Cloud,3rd Ward,State Senate,36,REP,Elaine S. Bowers,347
-Cloud,4th Ward,State Senate,36,REP,Elaine S. Bowers,159
-Cloud,Arion Township,State Senate,36,REP,Elaine S. Bowers,38
-Cloud,Aurora Township,State Senate,36,REP,Elaine S. Bowers,48
-Cloud,Buffalo Township,State Senate,36,REP,Elaine S. Bowers,43
-Cloud,Center Township,State Senate,36,REP,Elaine S. Bowers,81
-Cloud,Colfax Township,State Senate,36,REP,Elaine S. Bowers,20
-Cloud,Elk Township,State Senate,36,REP,Elaine S. Bowers,269
-Cloud,Grant Township,State Senate,36,REP,Elaine S. Bowers,115
-Cloud,North Lawrence Pct,State Senate,36,REP,Elaine S. Bowers,23
-Cloud,South Lawrence Pct,State Senate,36,REP,Elaine S. Bowers,15
-Cloud,East Lincoln Pct.,State Senate,36,REP,Elaine S. Bowers,81
-Cloud,West Lincoln Pct.,State Senate,36,REP,Elaine S. Bowers,48
-Cloud,Lyon Township,State Senate,36,REP,Elaine S. Bowers,41
-Cloud,East Meredith Pct.,State Senate,36,REP,Elaine S. Bowers,9
-Cloud,West Meredith,State Senate,36,REP,Elaine S. Bowers,12
-Cloud,Nelson Township,State Senate,36,REP,Elaine S. Bowers,48
-Cloud,Oakland Township,State Senate,36,REP,Elaine S. Bowers,23
-Cloud,Shirley Township,State Senate,36,REP,Elaine S. Bowers,51
-Cloud,Sibley Township,State Senate,36,REP,Elaine S. Bowers,61
-Cloud,Solomon Township,State Senate,36,REP,Elaine S. Bowers,161
-Cloud,Starr Township,State Senate,36,REP,Elaine S. Bowers,182
-Cloud,Summit Township,State Senate,36,REP,Elaine S. Bowers,21
-Cloud,Total,State Senate,36,,Write-ins,2
-Cloud,Advanced,State Senate,36,,Write-ins,1
-Cloud,Provisional,State Senate,36,,Write-ins,0
-Cloud,1st Ward,State Senate,36,,Write-ins,0
-Cloud,2nd Ward / 1st Pct.,State Senate,36,,Write-ins,0
-Cloud,2nd Ward / 2nd Pct.,State Senate,36,,Write-ins,0
-Cloud,3rd Ward,State Senate,36,,Write-ins,0
-Cloud,4th Ward,State Senate,36,,Write-ins,1
-Cloud,Arion Township,State Senate,36,,Write-ins,0
-Cloud,Aurora Township,State Senate,36,,Write-ins,0
-Cloud,Buffalo Township,State Senate,36,,Write-ins,0
-Cloud,Center Township,State Senate,36,,Write-ins,0
-Cloud,Colfax Township,State Senate,36,,Write-ins,0
-Cloud,Elk Township,State Senate,36,,Write-ins,0
-Cloud,Grant Township,State Senate,36,,Write-ins,0
-Cloud,North Lawrence Pct,State Senate,36,,Write-ins,0
-Cloud,South Lawrence Pct,State Senate,36,,Write-ins,0
-Cloud,East Lincoln Pct.,State Senate,36,,Write-ins,0
-Cloud,West Lincoln Pct.,State Senate,36,,Write-ins,0
-Cloud,Lyon Township,State Senate,36,,Write-ins,0
-Cloud,East Meredith Pct.,State Senate,36,,Write-ins,0
-Cloud,West Meredith,State Senate,36,,Write-ins,0
-Cloud,Nelson Township,State Senate,36,,Write-ins,0
-Cloud,Oakland Township,State Senate,36,,Write-ins,0
-Cloud,Aurora Township,State Senate,36,,Write-ins,0
-Cloud,Elk Township,State Senate,36,,Write-ins,0
-Cloud,Grant Township,State Senate,36,,Write-ins,0
-Cloud,Shirley Township,State Senate,36,,Write-ins,0
-Cloud,Sibley Township,State Senate,36,,Write-ins,0
-Cloud,Solomon Township,State Senate,36,,Write-ins,0
-Cloud,Starr Township,State Senate,36,,Write-ins,0
-Cloud,Solomon Township,State Senate,36,,Write-ins,0
-Cloud,Starr Township,State Senate,36,,Write-ins,0
-Cloud,Summit Township,State Senate,36,,Write-ins,0
-Cloud,Total,State House,107,REP,Susan L. Concannon,3383
-Cloud,Advanced,State House,107,REP,Susan L. Concannon,811
-Cloud,Provisional,State House,107,REP,Susan L. Concannon,59
-Cloud,1st Ward,State House,107,REP,Susan L. Concannon,186
-Cloud,2nd Ward / 1st Pct.,State House,107,REP,Susan L. Concannon,203
-Cloud,2nd Ward / 2nd Pct.,State House,107,REP,Susan L. Concannon,285
-Cloud,3rd Ward,State House,107,REP,Susan L. Concannon,344
-Cloud,4th Ward,State House,107,REP,Susan L. Concannon,158
-Cloud,Arion Township,State House,107,REP,Susan L. Concannon,36
-Cloud,Aurora Township,State House,107,REP,Susan L. Concannon,46
-Cloud,Buffalo Township,State House,107,REP,Susan L. Concannon,38
-Cloud,Center Township,State House,107,REP,Susan L. Concannon,72
-Cloud,Colfax Township,State House,107,REP,Susan L. Concannon,16
-Cloud,Elk Township,State House,107,REP,Susan L. Concannon,254
-Cloud,Grant Township,State House,107,REP,Susan L. Concannon,109
-Cloud,North Lawrence Pct,State House,107,REP,Susan L. Concannon,21
-Cloud,South Lawrence Pct,State House,107,REP,Susan L. Concannon,17
-Cloud,East Lincoln Pct.,State House,107,REP,Susan L. Concannon,78
-Cloud,West Lincoln Pct.,State House,107,REP,Susan L. Concannon,49
-Cloud,Lyon Township,State House,107,REP,Susan L. Concannon,38
-Cloud,East Meredith Pct.,State House,107,REP,Susan L. Concannon,8
-Cloud,West Meredith,State House,107,REP,Susan L. Concannon,11
-Cloud,Nelson Township,State House,107,REP,Susan L. Concannon,45
-Cloud,Oakland Township,State House,107,REP,Susan L. Concannon,20
-Cloud,Shirley Township,State House,107,REP,Susan L. Concannon,50
-Cloud,Sibley Township,State House,107,REP,Susan L. Concannon,65
-Cloud,Solomon Township,State House,107,REP,Susan L. Concannon,168
-Cloud,Starr Township,State House,107,REP,Susan L. Concannon,181
-Cloud,Summit Township,State House,107,REP,Susan L. Concannon,15
-Cloud,Total,State House,107,,Write-ins,27
-Cloud,Advanced,State House,107,,Write-ins,4
-Cloud,Provisional,State House,107,,Write-ins,0
-Cloud,1st Ward,State House,107,,Write-ins,1
-Cloud,2nd Ward / 1st Pct.,State House,107,,Write-ins,0
-Cloud,2nd Ward / 2nd Pct.,State House,107,,Write-ins,0
-Cloud,3rd Ward,State House,107,,Write-ins,0
-Cloud,4th Ward,State House,107,,Write-ins,5
-Cloud,Arion Township,State House,107,,Write-ins,1
-Cloud,Aurora Township,State House,107,,Write-ins,1
-Cloud,Buffalo Township,State House,107,,Write-ins,0
-Cloud,Center Township,State House,107,,Write-ins,0
-Cloud,Colfax Township,State House,107,,Write-ins,1
-Cloud,Elk Township,State House,107,,Write-ins,3
-Cloud,Grant Township,State House,107,,Write-ins,4
-Cloud,North Lawrence Pct,State House,107,,Write-ins,0
-Cloud,South Lawrence Pct,State House,107,,Write-ins,0
-Cloud,East Lincoln Pct.,State House,107,,Write-ins,0
-Cloud,West Lincoln Pct.,State House,107,,Write-ins,0
-Cloud,Lyon Township,State House,107,,Write-ins,1
-Cloud,East Meredith Pct.,State House,107,,Write-ins,0
-Cloud,West Meredith,State House,107,,Write-ins,0
-Cloud,Nelson Township,State House,107,,Write-ins,0
-Cloud,Oakland Township,State House,107,,Write-ins,0
-Cloud,Aurora Township,State House,107,,Write-ins,0
-Cloud,Elk Township,State House,107,,Write-ins,0
-Cloud,Grant Township,State House,107,,Write-ins,0
-Cloud,Shirley Township,State House,107,,Write-ins,0
-Cloud,Sibley Township,State House,107,,Write-ins,0
-Cloud,Solomon Township,State House,107,,Write-ins,0
-Cloud,Starr Township,State House,107,,Write-ins,0
-Cloud,Solomon Township,State House,107,,Write-ins,3
-Cloud,Starr Township,State House,107,,Write-ins,2
-Cloud,Summit Township,State House,107,,Write-ins,1
-Cloud,Total,State House,107,,Blanks,13
-Cloud,Advanced,State House,107,,Blanks,2
-Cloud,1st Ward,State House,107,,Blanks,1
-Cloud,2nd Ward / 1st Pct.,State House,107,,Blanks,2
-Cloud,2nd Ward / 2nd Pct.,State House,107,,Blanks,1
-Cloud,3rd Ward,State House,107,,Blanks,1
-Cloud,4th Ward,State House,107,,Blanks,4
-Cloud,Lyon Township,State House,107,,Blanks,1
-Cloud,Sibley Township,State House,107,,Blanks,1
+county,precinct,office,district,party,candidate,votes,vtd
+CLOUD,Arion Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",47,000010
+CLOUD,Aurora Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",55,000020
+CLOUD,Buffalo Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",50,000030
+CLOUD,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",94,000040
+CLOUD,Colfax Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",17,000050
+CLOUD,Concordia Ward 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",262,00006A
+CLOUD,Concordia Ward 1 Exclave A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",324,000070
+CLOUD,Concordia Ward 2 Precinct 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",417,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00008B
+CLOUD,Concordia Ward 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",490,000090
+CLOUD,Concordia Ward 4,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",218,000100
+CLOUD,East Lincoln,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",102,00011A
+CLOUD,East Lincoln Enclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00011B
+CLOUD,East Meredith,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",20,000120
+CLOUD,Elk Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",307,000130
+CLOUD,Grant Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",131,000140
+CLOUD,Lyon Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",48,000150
+CLOUD,Nelson Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",56,000160
+CLOUD,North Lawrence,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",31,000170
+CLOUD,Oakland Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",21,000180
+CLOUD,Shirley Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",60,000190
+CLOUD,Sibley Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",84,000200
+CLOUD,Solomon Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",205,000210
+CLOUD,South Lawrence,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",24,000220
+CLOUD,Starr Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",213,000230
+CLOUD,Summit Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",23,000240
+CLOUD,West Lincoln,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",70,000250
+CLOUD,West Meredith,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",14,000260
+CLOUD,Arion Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000010
+CLOUD,Arion Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",49,000010
+CLOUD,Aurora Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000020
+CLOUD,Aurora Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",60,000020
+CLOUD,Buffalo Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000030
+CLOUD,Buffalo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000030
+CLOUD,Center Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000040
+CLOUD,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",108,000040
+CLOUD,Colfax Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000050
+CLOUD,Colfax Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",22,000050
+CLOUD,Concordia Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",66,00006A
+CLOUD,Concordia Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",232,00006A
+CLOUD,Concordia Ward 1 Exclave A,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",72,000070
+CLOUD,Concordia Ward 2 Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",295,000070
+CLOUD,Concordia Ward 2 Precinct 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",82,00008A
+CLOUD,Concordia Ward 2 Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",401,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00008B
+CLOUD,Concordia Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",91,000090
+CLOUD,Concordia Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",483,000090
+CLOUD,Concordia Ward 4,Kansas Senate,36,Democratic,"Angevine, Brian G.",48,000100
+CLOUD,Concordia Ward 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",214,000100
+CLOUD,East Lincoln,Kansas Senate,36,Democratic,"Angevine, Brian G.",18,00011A
+CLOUD,East Lincoln,Kansas Senate,36,Republican,"Bowers, Elaine S.",105,00011A
+CLOUD,East Lincoln Enclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00011B
+CLOUD,East Lincoln Enclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00011B
+CLOUD,East Meredith,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000120
+CLOUD,East Meredith,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000120
+CLOUD,Elk Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",51,000130
+CLOUD,Elk Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",321,000130
+CLOUD,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",17,000140
+CLOUD,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",134,000140
+CLOUD,Lyon Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000150
+CLOUD,Lyon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000150
+CLOUD,Nelson Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000160
+CLOUD,Nelson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",57,000160
+CLOUD,North Lawrence,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000170
+CLOUD,North Lawrence,Kansas Senate,36,Republican,"Bowers, Elaine S.",37,000170
+CLOUD,Oakland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000180
+CLOUD,Oakland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000180
+CLOUD,Shirley Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000190
+CLOUD,Shirley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",62,000190
+CLOUD,Sibley Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000200
+CLOUD,Sibley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",80,000200
+CLOUD,Solomon Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",36,000210
+CLOUD,Solomon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",185,000210
+CLOUD,South Lawrence,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000220
+CLOUD,South Lawrence,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000220
+CLOUD,Starr Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",31,000230
+CLOUD,Starr Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",213,000230
+CLOUD,Summit Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000240
+CLOUD,Summit Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000240
+CLOUD,West Lincoln,Kansas Senate,36,Democratic,"Angevine, Brian G.",12,000250
+CLOUD,West Lincoln,Kansas Senate,36,Republican,"Bowers, Elaine S.",69,000250
+CLOUD,West Meredith,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000260
+CLOUD,West Meredith,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000260
+CLOUD,Arion Township,President / Vice President,,independent,"Stein, Jill",4,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CLOUD,Arion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CLOUD,Arion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000010
+CLOUD,Arion Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+CLOUD,Arion Township,President / Vice President,,Republican,"Trump, Donald J.",42,000010
+CLOUD,Aurora Township,President / Vice President,,independent,"Stein, Jill",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CLOUD,Aurora Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CLOUD,Aurora Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+CLOUD,Aurora Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+CLOUD,Aurora Township,President / Vice President,,Republican,"Trump, Donald J.",58,000020
+CLOUD,Buffalo Township,President / Vice President,,independent,"Stein, Jill",1,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CLOUD,Buffalo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CLOUD,Buffalo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+CLOUD,Buffalo Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+CLOUD,Buffalo Township,President / Vice President,,Republican,"Trump, Donald J.",49,000030
+CLOUD,Center Township,President / Vice President,,independent,"Stein, Jill",2,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CLOUD,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CLOUD,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000040
+CLOUD,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CLOUD,Center Township,President / Vice President,,Republican,"Trump, Donald J.",104,000040
+CLOUD,Colfax Township,President / Vice President,,independent,"Stein, Jill",1,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CLOUD,Colfax Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CLOUD,Colfax Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000050
+CLOUD,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+CLOUD,Colfax Township,President / Vice President,,Republican,"Trump, Donald J.",21,000050
+CLOUD,Concordia Ward 1,President / Vice President,,independent,"Stein, Jill",6,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"McMullin, Evan",4,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",87,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",17,00006A
+CLOUD,Concordia Ward 1,President / Vice President,,Republican,"Trump, Donald J.",190,00006A
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",8,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",20,000070
+CLOUD,Concordia Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",236,000070
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",9,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",31,00008A
+CLOUD,Concordia Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",322,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00008B
+CLOUD,Concordia Ward 3,President / Vice President,,independent,"Stein, Jill",13,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",24,000090
+CLOUD,Concordia Ward 3,President / Vice President,,Republican,"Trump, Donald J.",427,000090
+CLOUD,Concordia Ward 4,President / Vice President,,independent,"Stein, Jill",4,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",7,000100
+CLOUD,Concordia Ward 4,President / Vice President,,Republican,"Trump, Donald J.",187,000100
+CLOUD,East Lincoln,President / Vice President,,independent,"Stein, Jill",1,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Castle, Darrell L",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Giordani, Rocky",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Hedges, James A",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Kahn, Lynn",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"La Riva, Gloria",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Levinson, Michael S.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Maturen, Michael A",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"McMullin, Evan",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Perry, Darryl",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Schriner, Joe C",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Smith, Mike",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Sood, Ajay",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Sterling, Shawna",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011A
+CLOUD,East Lincoln,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011A
+CLOUD,East Lincoln,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,00011A
+CLOUD,East Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",6,00011A
+CLOUD,East Lincoln,President / Vice President,,Republican,"Trump, Donald J.",98,00011A
+CLOUD,East Lincoln Enclave,President / Vice President,,independent,"Stein, Jill",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Hedges, James A",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Smith, Mike",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00011B
+CLOUD,East Lincoln Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00011B
+CLOUD,East Meredith,President / Vice President,,independent,"Stein, Jill",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Hedges, James A",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"McMullin, Evan",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Perry, Darryl",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Smith, Mike",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Sood, Ajay",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+CLOUD,East Meredith,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+CLOUD,East Meredith,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000120
+CLOUD,East Meredith,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+CLOUD,East Meredith,President / Vice President,,Republican,"Trump, Donald J.",15,000120
+CLOUD,Elk Township,President / Vice President,,independent,"Stein, Jill",8,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"McMullin, Evan",5,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+CLOUD,Elk Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+CLOUD,Elk Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000130
+CLOUD,Elk Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000130
+CLOUD,Elk Township,President / Vice President,,Republican,"Trump, Donald J.",273,000130
+CLOUD,Grant Township,President / Vice President,,independent,"Stein, Jill",2,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+CLOUD,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+CLOUD,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000140
+CLOUD,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+CLOUD,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",122,000140
+CLOUD,Lyon Township,President / Vice President,,independent,"Stein, Jill",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+CLOUD,Lyon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+CLOUD,Lyon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000150
+CLOUD,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000150
+CLOUD,Lyon Township,President / Vice President,,Republican,"Trump, Donald J.",45,000150
+CLOUD,Nelson Township,President / Vice President,,independent,"Stein, Jill",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+CLOUD,Nelson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+CLOUD,Nelson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000160
+CLOUD,Nelson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+CLOUD,Nelson Township,President / Vice President,,Republican,"Trump, Donald J.",50,000160
+CLOUD,North Lawrence,President / Vice President,,independent,"Stein, Jill",1,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Hedges, James A",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"McMullin, Evan",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Perry, Darryl",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Smith, Mike",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Sood, Ajay",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+CLOUD,North Lawrence,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+CLOUD,North Lawrence,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000170
+CLOUD,North Lawrence,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+CLOUD,North Lawrence,President / Vice President,,Republican,"Trump, Donald J.",36,000170
+CLOUD,Oakland Township,President / Vice President,,independent,"Stein, Jill",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"McMullin, Evan",1,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+CLOUD,Oakland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+CLOUD,Oakland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000180
+CLOUD,Oakland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+CLOUD,Oakland Township,President / Vice President,,Republican,"Trump, Donald J.",24,000180
+CLOUD,Shirley Township,President / Vice President,,independent,"Stein, Jill",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"McMullin, Evan",1,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+CLOUD,Shirley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+CLOUD,Shirley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000190
+CLOUD,Shirley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+CLOUD,Shirley Township,President / Vice President,,Republican,"Trump, Donald J.",54,000190
+CLOUD,Sibley Township,President / Vice President,,independent,"Stein, Jill",2,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"McMullin, Evan",1,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+CLOUD,Sibley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+CLOUD,Sibley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000200
+CLOUD,Sibley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+CLOUD,Sibley Township,President / Vice President,,Republican,"Trump, Donald J.",73,000200
+CLOUD,Solomon Township,President / Vice President,,independent,"Stein, Jill",6,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"McMullin, Evan",2,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+CLOUD,Solomon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+CLOUD,Solomon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000210
+CLOUD,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000210
+CLOUD,Solomon Township,President / Vice President,,Republican,"Trump, Donald J.",168,000210
+CLOUD,South Lawrence,President / Vice President,,independent,"Stein, Jill",1,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Hedges, James A",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"McMullin, Evan",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Perry, Darryl",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Smith, Mike",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Sood, Ajay",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+CLOUD,South Lawrence,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+CLOUD,South Lawrence,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000220
+CLOUD,South Lawrence,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+CLOUD,South Lawrence,President / Vice President,,Republican,"Trump, Donald J.",21,000220
+CLOUD,Starr Township,President / Vice President,,independent,"Stein, Jill",3,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+CLOUD,Starr Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+CLOUD,Starr Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000230
+CLOUD,Starr Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000230
+CLOUD,Starr Township,President / Vice President,,Republican,"Trump, Donald J.",202,000230
+CLOUD,Summit Township,President / Vice President,,independent,"Stein, Jill",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+CLOUD,Summit Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+CLOUD,Summit Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000240
+CLOUD,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+CLOUD,Summit Township,President / Vice President,,Republican,"Trump, Donald J.",24,000240
+CLOUD,West Lincoln,President / Vice President,,independent,"Stein, Jill",2,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Hedges, James A",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"McMullin, Evan",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Perry, Darryl",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Smith, Mike",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Sood, Ajay",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+CLOUD,West Lincoln,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+CLOUD,West Lincoln,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000250
+CLOUD,West Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",4,000250
+CLOUD,West Lincoln,President / Vice President,,Republican,"Trump, Donald J.",64,000250
+CLOUD,West Meredith,President / Vice President,,independent,"Stein, Jill",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Hedges, James A",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"McMullin, Evan",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Perry, Darryl",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Smith, Mike",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Sood, Ajay",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+CLOUD,West Meredith,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+CLOUD,West Meredith,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000260
+CLOUD,West Meredith,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+CLOUD,West Meredith,President / Vice President,,Republican,"Trump, Donald J.",14,000260
+CLOUD,Arion Township,United States House of Representatives,1,independent,"LaPolice, Alan",32,000010
+CLOUD,Arion Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+CLOUD,Arion Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+CLOUD,Arion Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000010
+CLOUD,Aurora Township,United States House of Representatives,1,independent,"LaPolice, Alan",35,000020
+CLOUD,Aurora Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+CLOUD,Aurora Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000020
+CLOUD,Aurora Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000020
+CLOUD,Buffalo Township,United States House of Representatives,1,independent,"LaPolice, Alan",32,000030
+CLOUD,Buffalo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+CLOUD,Buffalo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+CLOUD,Buffalo Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000030
+CLOUD,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",63,000040
+CLOUD,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+CLOUD,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000040
+CLOUD,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000040
+CLOUD,Colfax Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000050
+CLOUD,Colfax Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+CLOUD,Colfax Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+CLOUD,Colfax Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000050
+CLOUD,Concordia Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",183,00006A
+CLOUD,Concordia Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00006A
+CLOUD,Concordia Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,00006A
+CLOUD,Concordia Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",105,00006A
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",223,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",132,000070
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",284,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",176,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00008B
+CLOUD,Concordia Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",356,000090
+CLOUD,Concordia Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+CLOUD,Concordia Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000090
+CLOUD,Concordia Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",195,000090
+CLOUD,Concordia Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",169,000100
+CLOUD,Concordia Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+CLOUD,Concordia Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000100
+CLOUD,Concordia Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",87,000100
+CLOUD,East Lincoln,United States House of Representatives,1,independent,"LaPolice, Alan",60,00011A
+CLOUD,East Lincoln,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011A
+CLOUD,East Lincoln,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,00011A
+CLOUD,East Lincoln,United States House of Representatives,1,Republican,"Marshall, Roger",57,00011A
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00011B
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011B
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00011B
+CLOUD,East Lincoln Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00011B
+CLOUD,East Meredith,United States House of Representatives,1,independent,"LaPolice, Alan",8,000120
+CLOUD,East Meredith,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+CLOUD,East Meredith,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000120
+CLOUD,East Meredith,United States House of Representatives,1,Republican,"Marshall, Roger",12,000120
+CLOUD,Elk Township,United States House of Representatives,1,independent,"LaPolice, Alan",258,000130
+CLOUD,Elk Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+CLOUD,Elk Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000130
+CLOUD,Elk Township,United States House of Representatives,1,Republican,"Marshall, Roger",112,000130
+CLOUD,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",75,000140
+CLOUD,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+CLOUD,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000140
+CLOUD,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",75,000140
+CLOUD,Lyon Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000150
+CLOUD,Lyon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+CLOUD,Lyon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000150
+CLOUD,Lyon Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000150
+CLOUD,Nelson Township,United States House of Representatives,1,independent,"LaPolice, Alan",35,000160
+CLOUD,Nelson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+CLOUD,Nelson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+CLOUD,Nelson Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000160
+CLOUD,North Lawrence,United States House of Representatives,1,independent,"LaPolice, Alan",23,000170
+CLOUD,North Lawrence,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+CLOUD,North Lawrence,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000170
+CLOUD,North Lawrence,United States House of Representatives,1,Republican,"Marshall, Roger",16,000170
+CLOUD,Oakland Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000180
+CLOUD,Oakland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000180
+CLOUD,Oakland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000180
+CLOUD,Oakland Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000180
+CLOUD,Shirley Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000190
+CLOUD,Shirley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+CLOUD,Shirley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000190
+CLOUD,Shirley Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000190
+CLOUD,Sibley Township,United States House of Representatives,1,independent,"LaPolice, Alan",61,000200
+CLOUD,Sibley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+CLOUD,Sibley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000200
+CLOUD,Sibley Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000200
+CLOUD,Solomon Township,United States House of Representatives,1,independent,"LaPolice, Alan",122,000210
+CLOUD,Solomon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+CLOUD,Solomon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000210
+CLOUD,Solomon Township,United States House of Representatives,1,Republican,"Marshall, Roger",90,000210
+CLOUD,South Lawrence,United States House of Representatives,1,independent,"LaPolice, Alan",22,000220
+CLOUD,South Lawrence,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+CLOUD,South Lawrence,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+CLOUD,South Lawrence,United States House of Representatives,1,Republican,"Marshall, Roger",6,000220
+CLOUD,Starr Township,United States House of Representatives,1,independent,"LaPolice, Alan",141,000230
+CLOUD,Starr Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+CLOUD,Starr Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000230
+CLOUD,Starr Township,United States House of Representatives,1,Republican,"Marshall, Roger",91,000230
+CLOUD,Summit Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000240
+CLOUD,Summit Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+CLOUD,Summit Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000240
+CLOUD,Summit Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000240
+CLOUD,West Lincoln,United States House of Representatives,1,independent,"LaPolice, Alan",58,000250
+CLOUD,West Lincoln,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+CLOUD,West Lincoln,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000250
+CLOUD,West Lincoln,United States House of Representatives,1,Republican,"Marshall, Roger",21,000250
+CLOUD,West Meredith,United States House of Representatives,1,independent,"LaPolice, Alan",8,000260
+CLOUD,West Meredith,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+CLOUD,West Meredith,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000260
+CLOUD,West Meredith,United States House of Representatives,1,Republican,"Marshall, Roger",8,000260
+CLOUD,Arion Township,United States Senate,,write - in,"Smith, DJ",0,000010
+CLOUD,Arion Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000010
+CLOUD,Arion Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+CLOUD,Arion Township,United States Senate,,Republican,"Moran, Jerry",46,000010
+CLOUD,Aurora Township,United States Senate,,write - in,"Smith, DJ",0,000020
+CLOUD,Aurora Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+CLOUD,Aurora Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000020
+CLOUD,Aurora Township,United States Senate,,Republican,"Moran, Jerry",57,000020
+CLOUD,Buffalo Township,United States Senate,,write - in,"Smith, DJ",0,000030
+CLOUD,Buffalo Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+CLOUD,Buffalo Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+CLOUD,Buffalo Township,United States Senate,,Republican,"Moran, Jerry",56,000030
+CLOUD,Center Township,United States Senate,,write - in,"Smith, DJ",0,000040
+CLOUD,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000040
+CLOUD,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000040
+CLOUD,Center Township,United States Senate,,Republican,"Moran, Jerry",102,000040
+CLOUD,Colfax Township,United States Senate,,write - in,"Smith, DJ",0,000050
+CLOUD,Colfax Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000050
+CLOUD,Colfax Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+CLOUD,Colfax Township,United States Senate,,Republican,"Moran, Jerry",21,000050
+CLOUD,Concordia Ward 1,United States Senate,,write - in,"Smith, DJ",0,00006A
+CLOUD,Concordia Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",71,00006A
+CLOUD,Concordia Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,00006A
+CLOUD,Concordia Ward 1,United States Senate,,Republican,"Moran, Jerry",209,00006A
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+CLOUD,Concordia Ward 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00006B
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",75,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",22,000070
+CLOUD,Concordia Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",267,000070
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",81,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",27,00008A
+CLOUD,Concordia Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",370,00008A
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008B
+CLOUD,Concordia Ward 2 Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00008B
+CLOUD,Concordia Ward 3,United States Senate,,write - in,"Smith, DJ",0,000090
+CLOUD,Concordia Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",87,000090
+CLOUD,Concordia Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",46,000090
+CLOUD,Concordia Ward 3,United States Senate,,Republican,"Moran, Jerry",428,000090
+CLOUD,Concordia Ward 4,United States Senate,,write - in,"Smith, DJ",0,000100
+CLOUD,Concordia Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",50,000100
+CLOUD,Concordia Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",22,000100
+CLOUD,Concordia Ward 4,United States Senate,,Republican,"Moran, Jerry",188,000100
+CLOUD,East Lincoln,United States Senate,,write - in,"Smith, DJ",0,00011A
+CLOUD,East Lincoln,United States Senate,,Democratic,"Wiesner, Patrick",11,00011A
+CLOUD,East Lincoln,United States Senate,,Libertarian,"Garrard, Robert D.",6,00011A
+CLOUD,East Lincoln,United States Senate,,Republican,"Moran, Jerry",103,00011A
+CLOUD,East Lincoln Enclave,United States Senate,,write - in,"Smith, DJ",0,00011B
+CLOUD,East Lincoln Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00011B
+CLOUD,East Lincoln Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00011B
+CLOUD,East Lincoln Enclave,United States Senate,,Republican,"Moran, Jerry",0,00011B
+CLOUD,East Meredith,United States Senate,,write - in,"Smith, DJ",0,000120
+CLOUD,East Meredith,United States Senate,,Democratic,"Wiesner, Patrick",2,000120
+CLOUD,East Meredith,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+CLOUD,East Meredith,United States Senate,,Republican,"Moran, Jerry",19,000120
+CLOUD,Elk Township,United States Senate,,write - in,"Smith, DJ",0,000130
+CLOUD,Elk Township,United States Senate,,Democratic,"Wiesner, Patrick",51,000130
+CLOUD,Elk Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000130
+CLOUD,Elk Township,United States Senate,,Republican,"Moran, Jerry",304,000130
+CLOUD,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000140
+CLOUD,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000140
+CLOUD,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000140
+CLOUD,Grant Township,United States Senate,,Republican,"Moran, Jerry",126,000140
+CLOUD,Lyon Township,United States Senate,,write - in,"Smith, DJ",0,000150
+CLOUD,Lyon Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000150
+CLOUD,Lyon Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000150
+CLOUD,Lyon Township,United States Senate,,Republican,"Moran, Jerry",48,000150
+CLOUD,Nelson Township,United States Senate,,write - in,"Smith, DJ",0,000160
+CLOUD,Nelson Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000160
+CLOUD,Nelson Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+CLOUD,Nelson Township,United States Senate,,Republican,"Moran, Jerry",53,000160
+CLOUD,North Lawrence,United States Senate,,write - in,"Smith, DJ",0,000170
+CLOUD,North Lawrence,United States Senate,,Democratic,"Wiesner, Patrick",1,000170
+CLOUD,North Lawrence,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+CLOUD,North Lawrence,United States Senate,,Republican,"Moran, Jerry",36,000170
+CLOUD,Oakland Township,United States Senate,,write - in,"Smith, DJ",0,000180
+CLOUD,Oakland Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000180
+CLOUD,Oakland Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+CLOUD,Oakland Township,United States Senate,,Republican,"Moran, Jerry",25,000180
+CLOUD,Shirley Township,United States Senate,,write - in,"Smith, DJ",0,000190
+CLOUD,Shirley Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000190
+CLOUD,Shirley Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000190
+CLOUD,Shirley Township,United States Senate,,Republican,"Moran, Jerry",61,000190
+CLOUD,Sibley Township,United States Senate,,write - in,"Smith, DJ",0,000200
+CLOUD,Sibley Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000200
+CLOUD,Sibley Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000200
+CLOUD,Sibley Township,United States Senate,,Republican,"Moran, Jerry",75,000200
+CLOUD,Solomon Township,United States Senate,,write - in,"Smith, DJ",0,000210
+CLOUD,Solomon Township,United States Senate,,Democratic,"Wiesner, Patrick",40,000210
+CLOUD,Solomon Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000210
+CLOUD,Solomon Township,United States Senate,,Republican,"Moran, Jerry",169,000210
+CLOUD,South Lawrence,United States Senate,,write - in,"Smith, DJ",0,000220
+CLOUD,South Lawrence,United States Senate,,Democratic,"Wiesner, Patrick",7,000220
+CLOUD,South Lawrence,United States Senate,,Libertarian,"Garrard, Robert D.",1,000220
+CLOUD,South Lawrence,United States Senate,,Republican,"Moran, Jerry",20,000220
+CLOUD,Starr Township,United States Senate,,write - in,"Smith, DJ",0,000230
+CLOUD,Starr Township,United States Senate,,Democratic,"Wiesner, Patrick",27,000230
+CLOUD,Starr Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000230
+CLOUD,Starr Township,United States Senate,,Republican,"Moran, Jerry",206,000230
+CLOUD,Summit Township,United States Senate,,write - in,"Smith, DJ",0,000240
+CLOUD,Summit Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000240
+CLOUD,Summit Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+CLOUD,Summit Township,United States Senate,,Republican,"Moran, Jerry",24,000240
+CLOUD,West Lincoln,United States Senate,,write - in,"Smith, DJ",0,000250
+CLOUD,West Lincoln,United States Senate,,Democratic,"Wiesner, Patrick",11,000250
+CLOUD,West Lincoln,United States Senate,,Libertarian,"Garrard, Robert D.",6,000250
+CLOUD,West Lincoln,United States Senate,,Republican,"Moran, Jerry",62,000250
+CLOUD,West Meredith,United States Senate,,write - in,"Smith, DJ",0,000260
+CLOUD,West Meredith,United States Senate,,Democratic,"Wiesner, Patrick",3,000260
+CLOUD,West Meredith,United States Senate,,Libertarian,"Garrard, Robert D.",0,000260
+CLOUD,West Meredith,United States Senate,,Republican,"Moran, Jerry",14,000260

--- a/2016/20161108__ks__general__coffey__precinct.csv
+++ b/2016/20161108__ks__general__coffey__precinct.csv
@@ -1,765 +1,765 @@
-county,precinct,office,district,candidate,party,votes
-Coffey,Avon Township,State House,76,"Briggs, Teresa  ",Democratic,16
-Coffey,Avon Township,State House,76,"Smith, Eric L. ",Republican,79
-Coffey,Burlington Township,State House,76,"Briggs, Teresa  ",Democratic,26
-Coffey,Burlington Township,State House,76,"Smith, Eric L. ",Republican,179
-Coffey,Burlington Ward 1,State House,76,"Briggs, Teresa  ",Democratic,85
-Coffey,Burlington Ward 1,State House,76,"Smith, Eric L. ",Republican,338
-Coffey,Burlington Ward 2,State House,76,"Briggs, Teresa  ",Democratic,61
-Coffey,Burlington Ward 2,State House,76,"Smith, Eric L. ",Republican,283
-Coffey,Burlington Ward 2 Country Club Heights,State House,76,"Briggs, Teresa  ",Democratic,0
-Coffey,Burlington Ward 2 Country Club Heights,State House,76,"Smith, Eric L. ",Republican,0
-Coffey,Burlington Ward 3,State House,76,"Briggs, Teresa  ",Democratic,60
-Coffey,Burlington Ward 3,State House,76,"Smith, Eric L. ",Republican,326
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,State House,76,"Briggs, Teresa  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,State House,76,"Smith, Eric L. ",Republican,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,State House,76,"Briggs, Teresa  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,State House,76,"Smith, Eric L. ",Republican,0
-Coffey,Hampden Township,State House,76,"Briggs, Teresa  ",Democratic,15
-Coffey,Hampden Township,State House,76,"Smith, Eric L. ",Republican,68
-Coffey,Key West Township,State House,76,"Briggs, Teresa  ",Democratic,42
-Coffey,Key West Township,State House,76,"Smith, Eric L. ",Republican,95
-Coffey,Leroy Township,State House,76,"Briggs, Teresa  ",Democratic,58
-Coffey,Leroy Township,State House,76,"Smith, Eric L. ",Republican,232
-Coffey,Liberty Township,State House,76,"Briggs, Teresa  ",Democratic,95
-Coffey,Liberty Township,State House,76,"Smith, Eric L. ",Republican,197
-Coffey,Lincoln Township,State House,76,"Briggs, Teresa  ",Democratic,206
-Coffey,Lincoln Township,State House,76,"Smith, Eric L. ",Republican,328
-Coffey,Neosho Township,State House,76,"Briggs, Teresa  ",Democratic,19
-Coffey,Neosho Township,State House,76,"Smith, Eric L. ",Republican,50
-Coffey,Ottumwa Township,State House,76,"Briggs, Teresa  ",Democratic,77
-Coffey,Ottumwa Township,State House,76,"Smith, Eric L. ",Republican,319
-Coffey,Pleasant Township,State House,76,"Briggs, Teresa  ",Democratic,33
-Coffey,Pleasant Township,State House,76,"Smith, Eric L. ",Republican,89
-Coffey,Pottawatomie Township,State House,76,"Briggs, Teresa  ",Democratic,12
-Coffey,Pottawatomie Township,State House,76,"Smith, Eric L. ",Republican,87
-Coffey,Rock Creek Township,State House,76,"Briggs, Teresa  ",Democratic,104
-Coffey,Rock Creek Township,State House,76,"Smith, Eric L. ",Republican,300
-Coffey,Spring Creek Township,State House,76,"Briggs, Teresa  ",Democratic,7
-Coffey,Spring Creek Township,State House,76,"Smith, Eric L. ",Republican,68
-Coffey,Star Township,State House,76,"Briggs, Teresa  ",Democratic,14
-Coffey,Star Township,State House,76,"Smith, Eric L. ",Republican,73
-Coffey,Burlington Township Enclave 1,State House,76,"Briggs, Teresa  ",Democratic,0
-Coffey,Burlington Township Enclave 1,State House,76,"Smith, Eric L. ",Republican,0
-Coffey,Burlington Township Enclave 2,State House,76,"Briggs, Teresa  ",Democratic,0
-Coffey,Burlington Township Enclave 2,State House,76,"Smith, Eric L. ",Republican,0
-Coffey,Avon Township,State Senate,14,"Pringle, Mark  ",Democratic,33
-Coffey,Avon Township,State Senate,14,"Givens, Bruce  ",Republican,58
-Coffey,Burlington Township,State Senate,14,"Pringle, Mark  ",Democratic,60
-Coffey,Burlington Township,State Senate,14,"Givens, Bruce  ",Republican,133
-Coffey,Burlington Ward 1,State Senate,14,"Pringle, Mark  ",Democratic,136
-Coffey,Burlington Ward 1,State Senate,14,"Givens, Bruce  ",Republican,278
-Coffey,Burlington Ward 2,State Senate,14,"Pringle, Mark  ",Democratic,96
-Coffey,Burlington Ward 2,State Senate,14,"Givens, Bruce  ",Republican,235
-Coffey,Burlington Ward 2 Country Club Heights,State Senate,14,"Pringle, Mark  ",Democratic,0
-Coffey,Burlington Ward 2 Country Club Heights,State Senate,14,"Givens, Bruce  ",Republican,0
-Coffey,Burlington Ward 3,State Senate,14,"Pringle, Mark  ",Democratic,117
-Coffey,Burlington Ward 3,State Senate,14,"Givens, Bruce  ",Republican,259
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,State Senate,14,"Pringle, Mark  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,State Senate,14,"Givens, Bruce  ",Republican,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,State Senate,14,"Pringle, Mark  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,State Senate,14,"Givens, Bruce  ",Republican,0
-Coffey,Hampden Township,State Senate,14,"Pringle, Mark  ",Democratic,19
-Coffey,Hampden Township,State Senate,14,"Givens, Bruce  ",Republican,62
-Coffey,Key West Township,State Senate,14,"Pringle, Mark  ",Democratic,46
-Coffey,Key West Township,State Senate,14,"Givens, Bruce  ",Republican,84
-Coffey,Leroy Township,State Senate,14,"Pringle, Mark  ",Democratic,107
-Coffey,Leroy Township,State Senate,14,"Givens, Bruce  ",Republican,178
-Coffey,Liberty Township,State Senate,14,"Pringle, Mark  ",Democratic,92
-Coffey,Liberty Township,State Senate,14,"Givens, Bruce  ",Republican,194
-Coffey,Lincoln Township,State Senate,14,"Pringle, Mark  ",Democratic,191
-Coffey,Lincoln Township,State Senate,14,"Givens, Bruce  ",Republican,329
-Coffey,Neosho Township,State Senate,14,"Pringle, Mark  ",Democratic,26
-Coffey,Neosho Township,State Senate,14,"Givens, Bruce  ",Republican,42
-Coffey,Ottumwa Township,State Senate,14,"Pringle, Mark  ",Democratic,129
-Coffey,Ottumwa Township,State Senate,14,"Givens, Bruce  ",Republican,262
-Coffey,Pleasant Township,State Senate,14,"Pringle, Mark  ",Democratic,42
-Coffey,Pleasant Township,State Senate,14,"Givens, Bruce  ",Republican,78
-Coffey,Pottawatomie Township,State Senate,14,"Pringle, Mark  ",Democratic,24
-Coffey,Pottawatomie Township,State Senate,14,"Givens, Bruce  ",Republican,71
-Coffey,Rock Creek Township,State Senate,14,"Pringle, Mark  ",Democratic,149
-Coffey,Rock Creek Township,State Senate,14,"Givens, Bruce  ",Republican,247
-Coffey,Spring Creek Township,State Senate,14,"Pringle, Mark  ",Democratic,29
-Coffey,Spring Creek Township,State Senate,14,"Givens, Bruce  ",Republican,42
-Coffey,Star Township,State Senate,14,"Pringle, Mark  ",Democratic,22
-Coffey,Star Township,State Senate,14,"Givens, Bruce  ",Republican,59
-Coffey,Burlington Township Enclave 1,State Senate,14,"Pringle, Mark  ",Democratic,0
-Coffey,Burlington Township Enclave 1,State Senate,14,"Givens, Bruce  ",Republican,0
-Coffey,Burlington Township Enclave 2,State Senate,14,"Pringle, Mark  ",Democratic,0
-Coffey,Burlington Township Enclave 2,State Senate,14,"Givens, Bruce  ",Republican,0
-Coffey,Avon Township,U.S. House,2,"Potter, Britani  ",Democratic,14
-Coffey,Avon Township,U.S. House,2,"Bales, James Houston ",Libertarian,3
-Coffey,Avon Township,U.S. House,2,"Jenkins, Lynn  ",Republican,77
-Coffey,Burlington Township,U.S. House,2,"Potter, Britani  ",Democratic,19
-Coffey,Burlington Township,U.S. House,2,"Bales, James Houston ",Libertarian,13
-Coffey,Burlington Township,U.S. House,2,"Jenkins, Lynn  ",Republican,171
-Coffey,Burlington Ward 1,U.S. House,2,"Potter, Britani  ",Democratic,78
-Coffey,Burlington Ward 1,U.S. House,2,"Bales, James Houston ",Libertarian,25
-Coffey,Burlington Ward 1,U.S. House,2,"Jenkins, Lynn  ",Republican,324
-Coffey,Burlington Ward 2,U.S. House,2,"Potter, Britani  ",Democratic,49
-Coffey,Burlington Ward 2,U.S. House,2,"Bales, James Houston ",Libertarian,19
-Coffey,Burlington Ward 2,U.S. House,2,"Jenkins, Lynn  ",Republican,272
-Coffey,Burlington Ward 2 Country Club Heights,U.S. House,2,"Potter, Britani  ",Democratic,0
-Coffey,Burlington Ward 2 Country Club Heights,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Coffey,Burlington Ward 2 Country Club Heights,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Coffey,Burlington Ward 3,U.S. House,2,"Potter, Britani  ",Democratic,59
-Coffey,Burlington Ward 3,U.S. House,2,"Bales, James Houston ",Libertarian,30
-Coffey,Burlington Ward 3,U.S. House,2,"Jenkins, Lynn  ",Republican,299
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. House,2,"Potter, Britani  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. House,2,"Potter, Britani  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Coffey,Hampden Township,U.S. House,2,"Potter, Britani  ",Democratic,14
-Coffey,Hampden Township,U.S. House,2,"Bales, James Houston ",Libertarian,2
-Coffey,Hampden Township,U.S. House,2,"Jenkins, Lynn  ",Republican,67
-Coffey,Key West Township,U.S. House,2,"Potter, Britani  ",Democratic,25
-Coffey,Key West Township,U.S. House,2,"Bales, James Houston ",Libertarian,9
-Coffey,Key West Township,U.S. House,2,"Jenkins, Lynn  ",Republican,104
-Coffey,Leroy Township,U.S. House,2,"Potter, Britani  ",Democratic,45
-Coffey,Leroy Township,U.S. House,2,"Bales, James Houston ",Libertarian,23
-Coffey,Leroy Township,U.S. House,2,"Jenkins, Lynn  ",Republican,226
-Coffey,Liberty Township,U.S. House,2,"Potter, Britani  ",Democratic,45
-Coffey,Liberty Township,U.S. House,2,"Bales, James Houston ",Libertarian,17
-Coffey,Liberty Township,U.S. House,2,"Jenkins, Lynn  ",Republican,226
-Coffey,Lincoln Township,U.S. House,2,"Potter, Britani  ",Democratic,122
-Coffey,Lincoln Township,U.S. House,2,"Bales, James Houston ",Libertarian,27
-Coffey,Lincoln Township,U.S. House,2,"Jenkins, Lynn  ",Republican,388
-Coffey,Neosho Township,U.S. House,2,"Potter, Britani  ",Democratic,9
-Coffey,Neosho Township,U.S. House,2,"Bales, James Houston ",Libertarian,2
-Coffey,Neosho Township,U.S. House,2,"Jenkins, Lynn  ",Republican,57
-Coffey,Ottumwa Township,U.S. House,2,"Potter, Britani  ",Democratic,66
-Coffey,Ottumwa Township,U.S. House,2,"Bales, James Houston ",Libertarian,31
-Coffey,Ottumwa Township,U.S. House,2,"Jenkins, Lynn  ",Republican,302
-Coffey,Pleasant Township,U.S. House,2,"Potter, Britani  ",Democratic,25
-Coffey,Pleasant Township,U.S. House,2,"Bales, James Houston ",Libertarian,10
-Coffey,Pleasant Township,U.S. House,2,"Jenkins, Lynn  ",Republican,87
-Coffey,Pottawatomie Township,U.S. House,2,"Potter, Britani  ",Democratic,14
-Coffey,Pottawatomie Township,U.S. House,2,"Bales, James Houston ",Libertarian,4
-Coffey,Pottawatomie Township,U.S. House,2,"Jenkins, Lynn  ",Republican,81
-Coffey,Rock Creek Township,U.S. House,2,"Potter, Britani  ",Democratic,85
-Coffey,Rock Creek Township,U.S. House,2,"Bales, James Houston ",Libertarian,26
-Coffey,Rock Creek Township,U.S. House,2,"Jenkins, Lynn  ",Republican,295
-Coffey,Spring Creek Township,U.S. House,2,"Potter, Britani  ",Democratic,7
-Coffey,Spring Creek Township,U.S. House,2,"Bales, James Houston ",Libertarian,2
-Coffey,Spring Creek Township,U.S. House,2,"Jenkins, Lynn  ",Republican,67
-Coffey,Star Township,U.S. House,2,"Potter, Britani  ",Democratic,10
-Coffey,Star Township,U.S. House,2,"Bales, James Houston ",Libertarian,4
-Coffey,Star Township,U.S. House,2,"Jenkins, Lynn  ",Republican,72
-Coffey,Burlington Township Enclave 1,U.S. House,2,"Potter, Britani  ",Democratic,0
-Coffey,Burlington Township Enclave 1,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Coffey,Burlington Township Enclave 1,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Coffey,Avon Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Avon Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,10
-Coffey,Avon Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Coffey,Avon Township,U.S. Senate,,"Moran, Jerry  ",Republican,84
-Coffey,Burlington Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,23
-Coffey,Burlington Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Coffey,Burlington Township,U.S. Senate,,"Moran, Jerry  ",Republican,168
-Coffey,Burlington Ward 1,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,70
-Coffey,Burlington Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,20
-Coffey,Burlington Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,328
-Coffey,Burlington Ward 2,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,50
-Coffey,Burlington Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,28
-Coffey,Burlington Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,264
-Coffey,Burlington Ward 2 Country Club Heights,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Coffey,Burlington Ward 2 Country Club Heights,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Coffey,Burlington Ward 2 Country Club Heights,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Coffey,Burlington Ward 3,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,58
-Coffey,Burlington Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,30
-Coffey,Burlington Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,297
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Coffey,Hampden Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Hampden Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,13
-Coffey,Hampden Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Coffey,Hampden Township,U.S. Senate,,"Moran, Jerry  ",Republican,67
-Coffey,Key West Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Key West Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,21
-Coffey,Key West Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Coffey,Key West Township,U.S. Senate,,"Moran, Jerry  ",Republican,104
-Coffey,Leroy Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Leroy Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,33
-Coffey,Leroy Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,24
-Coffey,Leroy Township,U.S. Senate,,"Moran, Jerry  ",Republican,232
-Coffey,Liberty Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Liberty Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,38
-Coffey,Liberty Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,17
-Coffey,Liberty Township,U.S. Senate,,"Moran, Jerry  ",Republican,235
-Coffey,Lincoln Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Lincoln Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,91
-Coffey,Lincoln Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,31
-Coffey,Lincoln Township,U.S. Senate,,"Moran, Jerry  ",Republican,415
-Coffey,Neosho Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Neosho Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Coffey,Neosho Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Coffey,Neosho Township,U.S. Senate,,"Moran, Jerry  ",Republican,59
-Coffey,Ottumwa Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Ottumwa Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,64
-Coffey,Ottumwa Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,31
-Coffey,Ottumwa Township,U.S. Senate,,"Moran, Jerry  ",Republican,302
-Coffey,Pleasant Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Pleasant Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,22
-Coffey,Pleasant Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Coffey,Pleasant Township,U.S. Senate,,"Moran, Jerry  ",Republican,89
-Coffey,Pottawatomie Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Pottawatomie Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,8
-Coffey,Pottawatomie Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,6
-Coffey,Pottawatomie Township,U.S. Senate,,"Moran, Jerry  ",Republican,84
-Coffey,Rock Creek Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Rock Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,76
-Coffey,Rock Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,39
-Coffey,Rock Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,289
-Coffey,Spring Creek Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Spring Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Coffey,Spring Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Coffey,Spring Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,61
-Coffey,Star Township,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Star Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,11
-Coffey,Star Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,7
-Coffey,Star Township,U.S. Senate,,"Moran, Jerry  ",Republican,68
-Coffey,Burlington Township Enclave 1,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Township Enclave 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Coffey,Burlington Township Enclave 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Coffey,Burlington Township Enclave 1,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Coffey,Burlington Township Enclave 2,U.S. Senate,,"Smith, DJ  ",,0
-Coffey,Burlington Township Enclave 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Coffey,Burlington Township Enclave 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Coffey,Burlington Township Enclave 2,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Coffey,Avon Township,President,,"Stein, Jill  ",independent,5
-Coffey,Avon Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Avon Township,President,,"Castle, Darrell L ",,0
-Coffey,Avon Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Avon Township,President,,"Giordani, Rocky  ",,0
-Coffey,Avon Township,President,,"Hedges, James A ",,0
-Coffey,Avon Township,President,,"Hoefling, Tom  ",,0
-Coffey,Avon Township,President,,"Kahn, Lynn  ",,0
-Coffey,Avon Township,President,,"La Riva, Gloria  ",,0
-Coffey,Avon Township,President,,"Levinson, Michael S. ",,0
-Coffey,Avon Township,President,,"Maturen, Michael A ",,0
-Coffey,Avon Township,President,,"McMullin, Evan  ",,1
-Coffey,Avon Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Avon Township,President,,"Perry, Darryl  ",,0
-Coffey,Avon Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Avon Township,President,,"Schriner, Joe C ",,0
-Coffey,Avon Township,President,,"Smith, Mike  ",,0
-Coffey,Avon Township,President,,"Sood, Ajay  ",,0
-Coffey,Avon Township,President,,"Sterling, Shawna  ",,0
-Coffey,Avon Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Avon Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Avon Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Avon Township,President,,"Clinton, Hillary Rodham ",Democratic,9
-Coffey,Avon Township,President,,"Johnson, Gary  ",Libertarian,2
-Coffey,Avon Township,President,,"Trump, Donald J. ",Republican,78
-Coffey,Burlington Township,President,,"Stein, Jill  ",independent,0
-Coffey,Burlington Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Township,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Township,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Township,President,,"Hedges, James A ",,0
-Coffey,Burlington Township,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Township,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Township,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Township,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Township,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Township,President,,"McMullin, Evan  ",,4
-Coffey,Burlington Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Township,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Township,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Township,President,,"Smith, Mike  ",,0
-Coffey,Burlington Township,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Township,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Township,President,,"Clinton, Hillary Rodham ",Democratic,34
-Coffey,Burlington Township,President,,"Johnson, Gary  ",Libertarian,4
-Coffey,Burlington Township,President,,"Trump, Donald J. ",Republican,161
-Coffey,Burlington Ward 1,President,,"Stein, Jill  ",independent,8
-Coffey,Burlington Ward 1,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Ward 1,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Ward 1,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Ward 1,President,,"Hedges, James A ",,0
-Coffey,Burlington Ward 1,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Ward 1,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Ward 1,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Ward 1,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Ward 1,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Ward 1,President,,"McMullin, Evan  ",,2
-Coffey,Burlington Ward 1,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Ward 1,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Ward 1,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Ward 1,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Ward 1,President,,"Smith, Mike  ",,0
-Coffey,Burlington Ward 1,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Ward 1,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Ward 1,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Ward 1,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Ward 1,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,92
-Coffey,Burlington Ward 1,President,,"Johnson, Gary  ",Libertarian,30
-Coffey,Burlington Ward 1,President,,"Trump, Donald J. ",Republican,294
-Coffey,Burlington Ward 2,President,,"Stein, Jill  ",independent,2
-Coffey,Burlington Ward 2,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Ward 2,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Ward 2,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Ward 2,President,,"Hedges, James A ",,0
-Coffey,Burlington Ward 2,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Ward 2,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Ward 2,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Ward 2,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Ward 2,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Ward 2,President,,"McMullin, Evan  ",,5
-Coffey,Burlington Ward 2,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Ward 2,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Ward 2,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Ward 2,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Ward 2,President,,"Smith, Mike  ",,0
-Coffey,Burlington Ward 2,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Ward 2,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Ward 2,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Ward 2,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Ward 2,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,68
-Coffey,Burlington Ward 2,President,,"Johnson, Gary  ",Libertarian,19
-Coffey,Burlington Ward 2,President,,"Trump, Donald J. ",Republican,256
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Stein, Jill  ",independent,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Hedges, James A ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"McMullin, Evan  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Smith, Mike  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Clinton, Hillary Rodham ",Democratic,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Johnson, Gary  ",Libertarian,0
-Coffey,Burlington Ward 2 Country Club Heights,President,,"Trump, Donald J. ",Republican,0
-Coffey,Burlington Ward 3,President,,"Stein, Jill  ",independent,6
-Coffey,Burlington Ward 3,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Ward 3,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Ward 3,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Ward 3,President,,"Hedges, James A ",,0
-Coffey,Burlington Ward 3,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Ward 3,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Ward 3,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Ward 3,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Ward 3,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Ward 3,President,,"McMullin, Evan  ",,2
-Coffey,Burlington Ward 3,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Ward 3,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Ward 3,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Ward 3,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Ward 3,President,,"Smith, Mike  ",,0
-Coffey,Burlington Ward 3,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Ward 3,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Ward 3,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Ward 3,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Ward 3,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,62
-Coffey,Burlington Ward 3,President,,"Johnson, Gary  ",Libertarian,23
-Coffey,Burlington Ward 3,President,,"Trump, Donald J. ",Republican,298
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Stein, Jill  ",independent,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Hedges, James A ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"McMullin, Evan  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Smith, Mike  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Clinton, Hillary Rodham ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Johnson, Gary  ",Libertarian,0
-Coffey,Burlington Ward 3 Exclave Caldwell's Add.,President,,"Trump, Donald J. ",Republican,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Stein, Jill  ",independent,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Hedges, James A ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"McMullin, Evan  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Smith, Mike  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Clinton, Hillary Rodham ",Democratic,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Johnson, Gary  ",Libertarian,0
-Coffey,Burlington Ward 3 Exclave Indust. Park #2 & 3,President,,"Trump, Donald J. ",Republican,0
-Coffey,Hampden Township,President,,"Stein, Jill  ",independent,0
-Coffey,Hampden Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Hampden Township,President,,"Castle, Darrell L ",,0
-Coffey,Hampden Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Hampden Township,President,,"Giordani, Rocky  ",,0
-Coffey,Hampden Township,President,,"Hedges, James A ",,0
-Coffey,Hampden Township,President,,"Hoefling, Tom  ",,0
-Coffey,Hampden Township,President,,"Kahn, Lynn  ",,0
-Coffey,Hampden Township,President,,"La Riva, Gloria  ",,0
-Coffey,Hampden Township,President,,"Levinson, Michael S. ",,0
-Coffey,Hampden Township,President,,"Maturen, Michael A ",,0
-Coffey,Hampden Township,President,,"McMullin, Evan  ",,1
-Coffey,Hampden Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Hampden Township,President,,"Perry, Darryl  ",,0
-Coffey,Hampden Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Hampden Township,President,,"Schriner, Joe C ",,0
-Coffey,Hampden Township,President,,"Smith, Mike  ",,0
-Coffey,Hampden Township,President,,"Sood, Ajay  ",,0
-Coffey,Hampden Township,President,,"Sterling, Shawna  ",,0
-Coffey,Hampden Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Hampden Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Hampden Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Hampden Township,President,,"Clinton, Hillary Rodham ",Democratic,14
-Coffey,Hampden Township,President,,"Johnson, Gary  ",Libertarian,1
-Coffey,Hampden Township,President,,"Trump, Donald J. ",Republican,66
-Coffey,Key West Township,President,,"Stein, Jill  ",independent,7
-Coffey,Key West Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Key West Township,President,,"Castle, Darrell L ",,1
-Coffey,Key West Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Key West Township,President,,"Giordani, Rocky  ",,0
-Coffey,Key West Township,President,,"Hedges, James A ",,0
-Coffey,Key West Township,President,,"Hoefling, Tom  ",,0
-Coffey,Key West Township,President,,"Kahn, Lynn  ",,0
-Coffey,Key West Township,President,,"La Riva, Gloria  ",,0
-Coffey,Key West Township,President,,"Levinson, Michael S. ",,0
-Coffey,Key West Township,President,,"Maturen, Michael A ",,0
-Coffey,Key West Township,President,,"McMullin, Evan  ",,2
-Coffey,Key West Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Key West Township,President,,"Perry, Darryl  ",,0
-Coffey,Key West Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Key West Township,President,,"Schriner, Joe C ",,0
-Coffey,Key West Township,President,,"Smith, Mike  ",,0
-Coffey,Key West Township,President,,"Sood, Ajay  ",,0
-Coffey,Key West Township,President,,"Sterling, Shawna  ",,0
-Coffey,Key West Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Key West Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Key West Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Key West Township,President,,"Clinton, Hillary Rodham ",Democratic,23
-Coffey,Key West Township,President,,"Johnson, Gary  ",Libertarian,5
-Coffey,Key West Township,President,,"Trump, Donald J. ",Republican,99
-Coffey,Leroy Township,President,,"Stein, Jill  ",independent,5
-Coffey,Leroy Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Leroy Township,President,,"Castle, Darrell L ",,0
-Coffey,Leroy Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Leroy Township,President,,"Giordani, Rocky  ",,0
-Coffey,Leroy Township,President,,"Hedges, James A ",,0
-Coffey,Leroy Township,President,,"Hoefling, Tom  ",,0
-Coffey,Leroy Township,President,,"Kahn, Lynn  ",,0
-Coffey,Leroy Township,President,,"La Riva, Gloria  ",,0
-Coffey,Leroy Township,President,,"Levinson, Michael S. ",,0
-Coffey,Leroy Township,President,,"Maturen, Michael A ",,0
-Coffey,Leroy Township,President,,"McMullin, Evan  ",,0
-Coffey,Leroy Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Leroy Township,President,,"Perry, Darryl  ",,0
-Coffey,Leroy Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Leroy Township,President,,"Schriner, Joe C ",,0
-Coffey,Leroy Township,President,,"Smith, Mike  ",,0
-Coffey,Leroy Township,President,,"Sood, Ajay  ",,0
-Coffey,Leroy Township,President,,"Sterling, Shawna  ",,0
-Coffey,Leroy Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Leroy Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Leroy Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Leroy Township,President,,"Clinton, Hillary Rodham ",Democratic,41
-Coffey,Leroy Township,President,,"Johnson, Gary  ",Libertarian,13
-Coffey,Leroy Township,President,,"Trump, Donald J. ",Republican,241
-Coffey,Liberty Township,President,,"Stein, Jill  ",independent,4
-Coffey,Liberty Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Liberty Township,President,,"Castle, Darrell L ",,0
-Coffey,Liberty Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Liberty Township,President,,"Giordani, Rocky  ",,0
-Coffey,Liberty Township,President,,"Hedges, James A ",,0
-Coffey,Liberty Township,President,,"Hoefling, Tom  ",,0
-Coffey,Liberty Township,President,,"Kahn, Lynn  ",,0
-Coffey,Liberty Township,President,,"La Riva, Gloria  ",,0
-Coffey,Liberty Township,President,,"Levinson, Michael S. ",,0
-Coffey,Liberty Township,President,,"Maturen, Michael A ",,0
-Coffey,Liberty Township,President,,"McMullin, Evan  ",,4
-Coffey,Liberty Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Liberty Township,President,,"Perry, Darryl  ",,0
-Coffey,Liberty Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Liberty Township,President,,"Schriner, Joe C ",,0
-Coffey,Liberty Township,President,,"Smith, Mike  ",,0
-Coffey,Liberty Township,President,,"Sood, Ajay  ",,0
-Coffey,Liberty Township,President,,"Sterling, Shawna  ",,0
-Coffey,Liberty Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Liberty Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Liberty Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Liberty Township,President,,"Clinton, Hillary Rodham ",Democratic,45
-Coffey,Liberty Township,President,,"Johnson, Gary  ",Libertarian,9
-Coffey,Liberty Township,President,,"Trump, Donald J. ",Republican,229
-Coffey,Lincoln Township,President,,"Stein, Jill  ",independent,14
-Coffey,Lincoln Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Lincoln Township,President,,"Castle, Darrell L ",,0
-Coffey,Lincoln Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Lincoln Township,President,,"Giordani, Rocky  ",,0
-Coffey,Lincoln Township,President,,"Hedges, James A ",,0
-Coffey,Lincoln Township,President,,"Hoefling, Tom  ",,0
-Coffey,Lincoln Township,President,,"Kahn, Lynn  ",,0
-Coffey,Lincoln Township,President,,"La Riva, Gloria  ",,0
-Coffey,Lincoln Township,President,,"Levinson, Michael S. ",,0
-Coffey,Lincoln Township,President,,"Maturen, Michael A ",,0
-Coffey,Lincoln Township,President,,"McMullin, Evan  ",,1
-Coffey,Lincoln Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Lincoln Township,President,,"Perry, Darryl  ",,0
-Coffey,Lincoln Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Lincoln Township,President,,"Schriner, Joe C ",,0
-Coffey,Lincoln Township,President,,"Smith, Mike  ",,0
-Coffey,Lincoln Township,President,,"Sood, Ajay  ",,0
-Coffey,Lincoln Township,President,,"Sterling, Shawna  ",,0
-Coffey,Lincoln Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Lincoln Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Lincoln Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Lincoln Township,President,,"Clinton, Hillary Rodham ",Democratic,116
-Coffey,Lincoln Township,President,,"Johnson, Gary  ",Libertarian,18
-Coffey,Lincoln Township,President,,"Trump, Donald J. ",Republican,385
-Coffey,Neosho Township,President,,"Stein, Jill  ",independent,2
-Coffey,Neosho Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Neosho Township,President,,"Castle, Darrell L ",,0
-Coffey,Neosho Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Neosho Township,President,,"Giordani, Rocky  ",,0
-Coffey,Neosho Township,President,,"Hedges, James A ",,0
-Coffey,Neosho Township,President,,"Hoefling, Tom  ",,0
-Coffey,Neosho Township,President,,"Kahn, Lynn  ",,0
-Coffey,Neosho Township,President,,"La Riva, Gloria  ",,0
-Coffey,Neosho Township,President,,"Levinson, Michael S. ",,0
-Coffey,Neosho Township,President,,"Maturen, Michael A ",,0
-Coffey,Neosho Township,President,,"McMullin, Evan  ",,1
-Coffey,Neosho Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Neosho Township,President,,"Perry, Darryl  ",,0
-Coffey,Neosho Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Neosho Township,President,,"Schriner, Joe C ",,0
-Coffey,Neosho Township,President,,"Smith, Mike  ",,0
-Coffey,Neosho Township,President,,"Sood, Ajay  ",,0
-Coffey,Neosho Township,President,,"Sterling, Shawna  ",,0
-Coffey,Neosho Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Neosho Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Neosho Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Neosho Township,President,,"Clinton, Hillary Rodham ",Democratic,9
-Coffey,Neosho Township,President,,"Johnson, Gary  ",Libertarian,3
-Coffey,Neosho Township,President,,"Trump, Donald J. ",Republican,52
-Coffey,Ottumwa Township,President,,"Stein, Jill  ",independent,6
-Coffey,Ottumwa Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Ottumwa Township,President,,"Castle, Darrell L ",,0
-Coffey,Ottumwa Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Ottumwa Township,President,,"Giordani, Rocky  ",,0
-Coffey,Ottumwa Township,President,,"Hedges, James A ",,0
-Coffey,Ottumwa Township,President,,"Hoefling, Tom  ",,0
-Coffey,Ottumwa Township,President,,"Kahn, Lynn  ",,0
-Coffey,Ottumwa Township,President,,"La Riva, Gloria  ",,0
-Coffey,Ottumwa Township,President,,"Levinson, Michael S. ",,0
-Coffey,Ottumwa Township,President,,"Maturen, Michael A ",,0
-Coffey,Ottumwa Township,President,,"McMullin, Evan  ",,4
-Coffey,Ottumwa Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Ottumwa Township,President,,"Perry, Darryl  ",,0
-Coffey,Ottumwa Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Ottumwa Township,President,,"Schriner, Joe C ",,0
-Coffey,Ottumwa Township,President,,"Smith, Mike  ",,0
-Coffey,Ottumwa Township,President,,"Sood, Ajay  ",,0
-Coffey,Ottumwa Township,President,,"Sterling, Shawna  ",,0
-Coffey,Ottumwa Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Ottumwa Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Ottumwa Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Ottumwa Township,President,,"Clinton, Hillary Rodham ",Democratic,71
-Coffey,Ottumwa Township,President,,"Johnson, Gary  ",Libertarian,23
-Coffey,Ottumwa Township,President,,"Trump, Donald J. ",Republican,297
-Coffey,Pleasant Township,President,,"Stein, Jill  ",independent,4
-Coffey,Pleasant Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Pleasant Township,President,,"Castle, Darrell L ",,0
-Coffey,Pleasant Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Pleasant Township,President,,"Giordani, Rocky  ",,0
-Coffey,Pleasant Township,President,,"Hedges, James A ",,0
-Coffey,Pleasant Township,President,,"Hoefling, Tom  ",,0
-Coffey,Pleasant Township,President,,"Kahn, Lynn  ",,0
-Coffey,Pleasant Township,President,,"La Riva, Gloria  ",,0
-Coffey,Pleasant Township,President,,"Levinson, Michael S. ",,0
-Coffey,Pleasant Township,President,,"Maturen, Michael A ",,0
-Coffey,Pleasant Township,President,,"McMullin, Evan  ",,0
-Coffey,Pleasant Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Pleasant Township,President,,"Perry, Darryl  ",,0
-Coffey,Pleasant Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Pleasant Township,President,,"Schriner, Joe C ",,0
-Coffey,Pleasant Township,President,,"Smith, Mike  ",,0
-Coffey,Pleasant Township,President,,"Sood, Ajay  ",,0
-Coffey,Pleasant Township,President,,"Sterling, Shawna  ",,0
-Coffey,Pleasant Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Pleasant Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Pleasant Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Pleasant Township,President,,"Clinton, Hillary Rodham ",Democratic,24
-Coffey,Pleasant Township,President,,"Johnson, Gary  ",Libertarian,7
-Coffey,Pleasant Township,President,,"Trump, Donald J. ",Republican,86
-Coffey,Pottawatomie Township,President,,"Stein, Jill  ",independent,0
-Coffey,Pottawatomie Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Pottawatomie Township,President,,"Castle, Darrell L ",,0
-Coffey,Pottawatomie Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Pottawatomie Township,President,,"Giordani, Rocky  ",,0
-Coffey,Pottawatomie Township,President,,"Hedges, James A ",,0
-Coffey,Pottawatomie Township,President,,"Hoefling, Tom  ",,0
-Coffey,Pottawatomie Township,President,,"Kahn, Lynn  ",,0
-Coffey,Pottawatomie Township,President,,"La Riva, Gloria  ",,0
-Coffey,Pottawatomie Township,President,,"Levinson, Michael S. ",,0
-Coffey,Pottawatomie Township,President,,"Maturen, Michael A ",,0
-Coffey,Pottawatomie Township,President,,"McMullin, Evan  ",,1
-Coffey,Pottawatomie Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Pottawatomie Township,President,,"Perry, Darryl  ",,0
-Coffey,Pottawatomie Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Pottawatomie Township,President,,"Schriner, Joe C ",,0
-Coffey,Pottawatomie Township,President,,"Smith, Mike  ",,0
-Coffey,Pottawatomie Township,President,,"Sood, Ajay  ",,0
-Coffey,Pottawatomie Township,President,,"Sterling, Shawna  ",,0
-Coffey,Pottawatomie Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Pottawatomie Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Pottawatomie Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Pottawatomie Township,President,,"Clinton, Hillary Rodham ",Democratic,10
-Coffey,Pottawatomie Township,President,,"Johnson, Gary  ",Libertarian,3
-Coffey,Pottawatomie Township,President,,"Trump, Donald J. ",Republican,86
-Coffey,Rock Creek Township,President,,"Stein, Jill  ",independent,4
-Coffey,Rock Creek Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Rock Creek Township,President,,"Castle, Darrell L ",,0
-Coffey,Rock Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Rock Creek Township,President,,"Giordani, Rocky  ",,0
-Coffey,Rock Creek Township,President,,"Hedges, James A ",,0
-Coffey,Rock Creek Township,President,,"Hoefling, Tom  ",,0
-Coffey,Rock Creek Township,President,,"Kahn, Lynn  ",,0
-Coffey,Rock Creek Township,President,,"La Riva, Gloria  ",,0
-Coffey,Rock Creek Township,President,,"Levinson, Michael S. ",,0
-Coffey,Rock Creek Township,President,,"Maturen, Michael A ",,1
-Coffey,Rock Creek Township,President,,"McMullin, Evan  ",,1
-Coffey,Rock Creek Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Rock Creek Township,President,,"Perry, Darryl  ",,0
-Coffey,Rock Creek Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Rock Creek Township,President,,"Schriner, Joe C ",,0
-Coffey,Rock Creek Township,President,,"Smith, Mike  ",,0
-Coffey,Rock Creek Township,President,,"Sood, Ajay  ",,0
-Coffey,Rock Creek Township,President,,"Sterling, Shawna  ",,0
-Coffey,Rock Creek Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Rock Creek Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Rock Creek Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Rock Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,94
-Coffey,Rock Creek Township,President,,"Johnson, Gary  ",Libertarian,23
-Coffey,Rock Creek Township,President,,"Trump, Donald J. ",Republican,288
-Coffey,Spring Creek Township,President,,"Stein, Jill  ",independent,2
-Coffey,Spring Creek Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Spring Creek Township,President,,"Castle, Darrell L ",,0
-Coffey,Spring Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Spring Creek Township,President,,"Giordani, Rocky  ",,0
-Coffey,Spring Creek Township,President,,"Hedges, James A ",,0
-Coffey,Spring Creek Township,President,,"Hoefling, Tom  ",,0
-Coffey,Spring Creek Township,President,,"Kahn, Lynn  ",,0
-Coffey,Spring Creek Township,President,,"La Riva, Gloria  ",,0
-Coffey,Spring Creek Township,President,,"Levinson, Michael S. ",,0
-Coffey,Spring Creek Township,President,,"Maturen, Michael A ",,0
-Coffey,Spring Creek Township,President,,"McMullin, Evan  ",,0
-Coffey,Spring Creek Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Spring Creek Township,President,,"Perry, Darryl  ",,0
-Coffey,Spring Creek Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Spring Creek Township,President,,"Schriner, Joe C ",,0
-Coffey,Spring Creek Township,President,,"Smith, Mike  ",,0
-Coffey,Spring Creek Township,President,,"Sood, Ajay  ",,0
-Coffey,Spring Creek Township,President,,"Sterling, Shawna  ",,0
-Coffey,Spring Creek Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Spring Creek Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Spring Creek Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Spring Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Coffey,Spring Creek Township,President,,"Johnson, Gary  ",Libertarian,2
-Coffey,Spring Creek Township,President,,"Trump, Donald J. ",Republican,64
-Coffey,Star Township,President,,"Stein, Jill  ",independent,1
-Coffey,Star Township,President,,"Basiago, Andrew D. ",,0
-Coffey,Star Township,President,,"Castle, Darrell L ",,0
-Coffey,Star Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Star Township,President,,"Giordani, Rocky  ",,0
-Coffey,Star Township,President,,"Hedges, James A ",,0
-Coffey,Star Township,President,,"Hoefling, Tom  ",,0
-Coffey,Star Township,President,,"Kahn, Lynn  ",,0
-Coffey,Star Township,President,,"La Riva, Gloria  ",,0
-Coffey,Star Township,President,,"Levinson, Michael S. ",,0
-Coffey,Star Township,President,,"Maturen, Michael A ",,0
-Coffey,Star Township,President,,"McMullin, Evan  ",,1
-Coffey,Star Township,President,,"Moorehead, Monica G. ",,0
-Coffey,Star Township,President,,"Perry, Darryl  ",,0
-Coffey,Star Township,President,,"Schoenke, Marshall R. ",,0
-Coffey,Star Township,President,,"Schriner, Joe C ",,0
-Coffey,Star Township,President,,"Smith, Mike  ",,0
-Coffey,Star Township,President,,"Sood, Ajay  ",,0
-Coffey,Star Township,President,,"Sterling, Shawna  ",,0
-Coffey,Star Township,President,,"Valdivia, Anthony J ",,0
-Coffey,Star Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Star Township,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Star Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Coffey,Star Township,President,,"Johnson, Gary  ",Libertarian,4
-Coffey,Star Township,President,,"Trump, Donald J. ",Republican,70
-Coffey,Burlington Township Enclave 2,President,,"Stein, Jill  ",independent,0
-Coffey,Burlington Township Enclave 2,President,,"Basiago, Andrew D. ",,0
-Coffey,Burlington Township Enclave 2,President,,"Castle, Darrell L ",,0
-Coffey,Burlington Township Enclave 2,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Giordani, Rocky  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Hedges, James A ",,0
-Coffey,Burlington Township Enclave 2,President,,"Hoefling, Tom  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Kahn, Lynn  ",,0
-Coffey,Burlington Township Enclave 2,President,,"La Riva, Gloria  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Levinson, Michael S. ",,0
-Coffey,Burlington Township Enclave 2,President,,"Maturen, Michael A ",,0
-Coffey,Burlington Township Enclave 2,President,,"McMullin, Evan  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Moorehead, Monica G. ",,0
-Coffey,Burlington Township Enclave 2,President,,"Perry, Darryl  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Schoenke, Marshall R. ",,0
-Coffey,Burlington Township Enclave 2,President,,"Schriner, Joe C ",,0
-Coffey,Burlington Township Enclave 2,President,,"Smith, Mike  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Sood, Ajay  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Sterling, Shawna  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Valdivia, Anthony J ",,0
-Coffey,Burlington Township Enclave 2,President,,"Vogel-Walcutt, J.J.  ",,0
-Coffey,Burlington Township Enclave 2,President,,"Wysinger, Demetra Jefferson ",,0
-Coffey,Burlington Township Enclave 2,President,,"Clinton, Hillary Rodham ",Democratic,0
-Coffey,Burlington Township Enclave 2,President,,"Johnson, Gary  ",Libertarian,0
-Coffey,Burlington Township Enclave 2,President,,"Trump, Donald J. ",Republican,0
+county,precinct,office,district,party,candidate,votes,vtd
+COFFEY,Avon Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",16,000010
+COFFEY,Avon Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",79,000010
+COFFEY,Burlington Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",26,000020
+COFFEY,Burlington Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",179,000020
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",85,000030
+COFFEY,Burlington Ward 1,Kansas House of Representatives,76,Republican,"Smith, Eric L.",338,000030
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",61,00004A
+COFFEY,Burlington Ward 2,Kansas House of Representatives,76,Republican,"Smith, Eric L.",283,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,00004B
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",60,00005A
+COFFEY,Burlington Ward 3,Kansas House of Representatives,76,Republican,"Smith, Eric L.",326,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,00005C
+COFFEY,Hampden Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",15,000060
+COFFEY,Hampden Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",68,000060
+COFFEY,Key West Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",42,000070
+COFFEY,Key West Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",95,000070
+COFFEY,Leroy Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",58,000080
+COFFEY,Leroy Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",232,000080
+COFFEY,Liberty Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",95,000090
+COFFEY,Liberty Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",197,000090
+COFFEY,Lincoln Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",206,000100
+COFFEY,Lincoln Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",328,000100
+COFFEY,Neosho Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",19,000110
+COFFEY,Neosho Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",50,000110
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",77,000120
+COFFEY,Ottumwa Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",319,000120
+COFFEY,Pleasant Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",33,000130
+COFFEY,Pleasant Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",89,000130
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",12,000140
+COFFEY,Pottawatomie Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",87,000140
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",104,000150
+COFFEY,Rock Creek Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",300,000150
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",7,000160
+COFFEY,Spring Creek Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",68,000160
+COFFEY,Star Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",14,000170
+COFFEY,Star Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",73,000170
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900020
+COFFEY,Burlington Township Enclave 1,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900020
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900030
+COFFEY,Burlington Township Enclave 2,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900030
+COFFEY,Avon Township,Kansas Senate,14,Democratic,"Pringle, Mark",33,000010
+COFFEY,Avon Township,Kansas Senate,14,Republican,"Givens, Bruce",58,000010
+COFFEY,Burlington Township,Kansas Senate,14,Democratic,"Pringle, Mark",60,000020
+COFFEY,Burlington Township,Kansas Senate,14,Republican,"Givens, Bruce",133,000020
+COFFEY,Burlington Ward 1,Kansas Senate,14,Democratic,"Pringle, Mark",136,000030
+COFFEY,Burlington Ward 1,Kansas Senate,14,Republican,"Givens, Bruce",278,000030
+COFFEY,Burlington Ward 2,Kansas Senate,14,Democratic,"Pringle, Mark",96,00004A
+COFFEY,Burlington Ward 2,Kansas Senate,14,Republican,"Givens, Bruce",235,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas Senate,14,Democratic,"Pringle, Mark",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,Kansas Senate,14,Republican,"Givens, Bruce",0,00004B
+COFFEY,Burlington Ward 3,Kansas Senate,14,Democratic,"Pringle, Mark",117,00005A
+COFFEY,Burlington Ward 3,Kansas Senate,14,Republican,"Givens, Bruce",259,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas Senate,14,Democratic,"Pringle, Mark",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,Kansas Senate,14,Republican,"Givens, Bruce",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas Senate,14,Democratic,"Pringle, Mark",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,Kansas Senate,14,Republican,"Givens, Bruce",0,00005C
+COFFEY,Hampden Township,Kansas Senate,14,Democratic,"Pringle, Mark",19,000060
+COFFEY,Hampden Township,Kansas Senate,14,Republican,"Givens, Bruce",62,000060
+COFFEY,Key West Township,Kansas Senate,14,Democratic,"Pringle, Mark",46,000070
+COFFEY,Key West Township,Kansas Senate,14,Republican,"Givens, Bruce",84,000070
+COFFEY,Leroy Township,Kansas Senate,14,Democratic,"Pringle, Mark",107,000080
+COFFEY,Leroy Township,Kansas Senate,14,Republican,"Givens, Bruce",178,000080
+COFFEY,Liberty Township,Kansas Senate,14,Democratic,"Pringle, Mark",92,000090
+COFFEY,Liberty Township,Kansas Senate,14,Republican,"Givens, Bruce",194,000090
+COFFEY,Lincoln Township,Kansas Senate,14,Democratic,"Pringle, Mark",191,000100
+COFFEY,Lincoln Township,Kansas Senate,14,Republican,"Givens, Bruce",329,000100
+COFFEY,Neosho Township,Kansas Senate,14,Democratic,"Pringle, Mark",26,000110
+COFFEY,Neosho Township,Kansas Senate,14,Republican,"Givens, Bruce",42,000110
+COFFEY,Ottumwa Township,Kansas Senate,14,Democratic,"Pringle, Mark",129,000120
+COFFEY,Ottumwa Township,Kansas Senate,14,Republican,"Givens, Bruce",262,000120
+COFFEY,Pleasant Township,Kansas Senate,14,Democratic,"Pringle, Mark",42,000130
+COFFEY,Pleasant Township,Kansas Senate,14,Republican,"Givens, Bruce",78,000130
+COFFEY,Pottawatomie Township,Kansas Senate,14,Democratic,"Pringle, Mark",24,000140
+COFFEY,Pottawatomie Township,Kansas Senate,14,Republican,"Givens, Bruce",71,000140
+COFFEY,Rock Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",149,000150
+COFFEY,Rock Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",247,000150
+COFFEY,Spring Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",29,000160
+COFFEY,Spring Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",42,000160
+COFFEY,Star Township,Kansas Senate,14,Democratic,"Pringle, Mark",22,000170
+COFFEY,Star Township,Kansas Senate,14,Republican,"Givens, Bruce",59,000170
+COFFEY,Burlington Township Enclave 1,Kansas Senate,14,Democratic,"Pringle, Mark",0,900020
+COFFEY,Burlington Township Enclave 1,Kansas Senate,14,Republican,"Givens, Bruce",0,900020
+COFFEY,Burlington Township Enclave 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,900030
+COFFEY,Burlington Township Enclave 2,Kansas Senate,14,Republican,"Givens, Bruce",0,900030
+COFFEY,Avon Township,President / Vice President,,independent,"Stein, Jill",5,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"McMullin, Evan",1,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+COFFEY,Avon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+COFFEY,Avon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000010
+COFFEY,Avon Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+COFFEY,Avon Township,President / Vice President,,Republican,"Trump, Donald J.",78,000010
+COFFEY,Burlington Township,President / Vice President,,independent,"Stein, Jill",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"McMullin, Evan",4,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+COFFEY,Burlington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+COFFEY,Burlington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000020
+COFFEY,Burlington Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+COFFEY,Burlington Township,President / Vice President,,Republican,"Trump, Donald J.",161,000020
+COFFEY,Burlington Ward 1,President / Vice President,,independent,"Stein, Jill",8,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",92,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",30,000030
+COFFEY,Burlington Ward 1,President / Vice President,,Republican,"Trump, Donald J.",294,000030
+COFFEY,Burlington Ward 2,President / Vice President,,independent,"Stein, Jill",2,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"McMullin, Evan",5,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",19,00004A
+COFFEY,Burlington Ward 2,President / Vice President,,Republican,"Trump, Donald J.",256,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,independent,"Stein, Jill",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Castle, Darrell L",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Giordani, Rocky",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Hedges, James A",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Kahn, Lynn",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"La Riva, Gloria",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Levinson, Michael S.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Maturen, Michael A",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"McMullin, Evan",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Perry, Darryl",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Schriner, Joe C",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Smith, Mike",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Sood, Ajay",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Sterling, Shawna",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,President / Vice President,,Republican,"Trump, Donald J.",0,00004B
+COFFEY,Burlington Ward 3,President / Vice President,,independent,"Stein, Jill",6,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"McMullin, Evan",2,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",23,00005A
+COFFEY,Burlington Ward 3,President / Vice President,,Republican,"Trump, Donald J.",298,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,independent,"Stein, Jill",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Hedges, James A",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Smith, Mike",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,independent,"Stein, Jill",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Castle, Darrell L",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Giordani, Rocky",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Hedges, James A",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Kahn, Lynn",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"La Riva, Gloria",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Maturen, Michael A",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"McMullin, Evan",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Perry, Darryl",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Schriner, Joe C",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Smith, Mike",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Sood, Ajay",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Sterling, Shawna",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,President / Vice President,,Republican,"Trump, Donald J.",0,00005C
+COFFEY,Hampden Township,President / Vice President,,independent,"Stein, Jill",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"McMullin, Evan",1,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+COFFEY,Hampden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+COFFEY,Hampden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000060
+COFFEY,Hampden Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+COFFEY,Hampden Township,President / Vice President,,Republican,"Trump, Donald J.",66,000060
+COFFEY,Key West Township,President / Vice President,,independent,"Stein, Jill",7,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Castle, Darrell L",1,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"McMullin, Evan",2,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+COFFEY,Key West Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+COFFEY,Key West Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000070
+COFFEY,Key West Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+COFFEY,Key West Township,President / Vice President,,Republican,"Trump, Donald J.",99,000070
+COFFEY,Leroy Township,President / Vice President,,independent,"Stein, Jill",5,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+COFFEY,Leroy Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+COFFEY,Leroy Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000080
+COFFEY,Leroy Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+COFFEY,Leroy Township,President / Vice President,,Republican,"Trump, Donald J.",241,000080
+COFFEY,Liberty Township,President / Vice President,,independent,"Stein, Jill",4,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",4,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+COFFEY,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+COFFEY,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000090
+COFFEY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000090
+COFFEY,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",229,000090
+COFFEY,Lincoln Township,President / Vice President,,independent,"Stein, Jill",14,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",1,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+COFFEY,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+COFFEY,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",116,000100
+COFFEY,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000100
+COFFEY,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",385,000100
+COFFEY,Neosho Township,President / Vice President,,independent,"Stein, Jill",2,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"McMullin, Evan",1,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+COFFEY,Neosho Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+COFFEY,Neosho Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000110
+COFFEY,Neosho Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+COFFEY,Neosho Township,President / Vice President,,Republican,"Trump, Donald J.",52,000110
+COFFEY,Ottumwa Township,President / Vice President,,independent,"Stein, Jill",6,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"McMullin, Evan",4,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+COFFEY,Ottumwa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000120
+COFFEY,Ottumwa Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000120
+COFFEY,Ottumwa Township,President / Vice President,,Republican,"Trump, Donald J.",297,000120
+COFFEY,Pleasant Township,President / Vice President,,independent,"Stein, Jill",4,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+COFFEY,Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+COFFEY,Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000130
+COFFEY,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000130
+COFFEY,Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",86,000130
+COFFEY,Pottawatomie Township,President / Vice President,,independent,"Stein, Jill",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"McMullin, Evan",1,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+COFFEY,Pottawatomie Township,President / Vice President,,Republican,"Trump, Donald J.",86,000140
+COFFEY,Rock Creek Township,President / Vice President,,independent,"Stein, Jill",4,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Maturen, Michael A",1,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+COFFEY,Rock Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",94,000150
+COFFEY,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000150
+COFFEY,Rock Creek Township,President / Vice President,,Republican,"Trump, Donald J.",288,000150
+COFFEY,Spring Creek Township,President / Vice President,,independent,"Stein, Jill",2,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+COFFEY,Spring Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000160
+COFFEY,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+COFFEY,Spring Creek Township,President / Vice President,,Republican,"Trump, Donald J.",64,000160
+COFFEY,Star Township,President / Vice President,,independent,"Stein, Jill",1,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"McMullin, Evan",1,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+COFFEY,Star Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+COFFEY,Star Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000170
+COFFEY,Star Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000170
+COFFEY,Star Township,President / Vice President,,Republican,"Trump, Donald J.",70,000170
+COFFEY,Burlington Township Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+COFFEY,Burlington Township Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+COFFEY,Avon Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000010
+COFFEY,Avon Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000010
+COFFEY,Avon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000010
+COFFEY,Burlington Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,000020
+COFFEY,Burlington Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000020
+COFFEY,Burlington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",171,000020
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",78,000030
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000030
+COFFEY,Burlington Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",324,000030
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",49,00004A
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,00004A
+COFFEY,Burlington Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",272,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Democratic,"Potter, Britani",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00004B
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",59,00005A
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",30,00005A
+COFFEY,Burlington Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",299,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+COFFEY,Hampden Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000060
+COFFEY,Hampden Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000060
+COFFEY,Hampden Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000060
+COFFEY,Key West Township,United States House of Representatives,2,Democratic,"Potter, Britani",25,000070
+COFFEY,Key West Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000070
+COFFEY,Key West Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,000070
+COFFEY,Leroy Township,United States House of Representatives,2,Democratic,"Potter, Britani",45,000080
+COFFEY,Leroy Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000080
+COFFEY,Leroy Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,000080
+COFFEY,Liberty Township,United States House of Representatives,2,Democratic,"Potter, Britani",45,000090
+COFFEY,Liberty Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000090
+COFFEY,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,000090
+COFFEY,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",122,000100
+COFFEY,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",27,000100
+COFFEY,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",388,000100
+COFFEY,Neosho Township,United States House of Representatives,2,Democratic,"Potter, Britani",9,000110
+COFFEY,Neosho Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000110
+COFFEY,Neosho Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000110
+COFFEY,Ottumwa Township,United States House of Representatives,2,Democratic,"Potter, Britani",66,000120
+COFFEY,Ottumwa Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",31,000120
+COFFEY,Ottumwa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",302,000120
+COFFEY,Pleasant Township,United States House of Representatives,2,Democratic,"Potter, Britani",25,000130
+COFFEY,Pleasant Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000130
+COFFEY,Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",87,000130
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000140
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000140
+COFFEY,Pottawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",81,000140
+COFFEY,Rock Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",85,000150
+COFFEY,Rock Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",26,000150
+COFFEY,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",295,000150
+COFFEY,Spring Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",7,000160
+COFFEY,Spring Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000160
+COFFEY,Spring Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000160
+COFFEY,Star Township,United States House of Representatives,2,Democratic,"Potter, Britani",10,000170
+COFFEY,Star Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000170
+COFFEY,Star Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000170
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+COFFEY,Burlington Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+COFFEY,Avon Township,United States Senate,,write - in,"Smith, DJ",0,000010
+COFFEY,Avon Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000010
+COFFEY,Avon Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+COFFEY,Avon Township,United States Senate,,Republican,"Moran, Jerry",84,000010
+COFFEY,Burlington Township,United States Senate,,write - in,"Smith, DJ",0,000020
+COFFEY,Burlington Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000020
+COFFEY,Burlington Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000020
+COFFEY,Burlington Township,United States Senate,,Republican,"Moran, Jerry",168,000020
+COFFEY,Burlington Ward 1,United States Senate,,write - in,"Smith, DJ",0,000030
+COFFEY,Burlington Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",70,000030
+COFFEY,Burlington Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",20,000030
+COFFEY,Burlington Ward 1,United States Senate,,Republican,"Moran, Jerry",328,000030
+COFFEY,Burlington Ward 2,United States Senate,,write - in,"Smith, DJ",0,00004A
+COFFEY,Burlington Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",50,00004A
+COFFEY,Burlington Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",28,00004A
+COFFEY,Burlington Ward 2,United States Senate,,Republican,"Moran, Jerry",264,00004A
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,write - in,"Smith, DJ",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,Democratic,"Wiesner, Patrick",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004B
+COFFEY,Burlington Ward 2 Country Club Heights,United States Senate,,Republican,"Moran, Jerry",0,00004B
+COFFEY,Burlington Ward 3,United States Senate,,write - in,"Smith, DJ",0,00005A
+COFFEY,Burlington Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",58,00005A
+COFFEY,Burlington Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",30,00005A
+COFFEY,Burlington Ward 3,United States Senate,,Republican,"Moran, Jerry",297,00005A
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,write - in,"Smith, DJ",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+COFFEY,Burlington Ward 3 Exclave Caldwell's Add.,United States Senate,,Republican,"Moran, Jerry",0,00005B
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,write - in,"Smith, DJ",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,Democratic,"Wiesner, Patrick",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005C
+COFFEY,Burlington Ward 3 Exclave Indust. Park #2 & 3,United States Senate,,Republican,"Moran, Jerry",0,00005C
+COFFEY,Hampden Township,United States Senate,,write - in,"Smith, DJ",0,000060
+COFFEY,Hampden Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000060
+COFFEY,Hampden Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000060
+COFFEY,Hampden Township,United States Senate,,Republican,"Moran, Jerry",67,000060
+COFFEY,Key West Township,United States Senate,,write - in,"Smith, DJ",0,000070
+COFFEY,Key West Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000070
+COFFEY,Key West Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000070
+COFFEY,Key West Township,United States Senate,,Republican,"Moran, Jerry",104,000070
+COFFEY,Leroy Township,United States Senate,,write - in,"Smith, DJ",0,000080
+COFFEY,Leroy Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000080
+COFFEY,Leroy Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000080
+COFFEY,Leroy Township,United States Senate,,Republican,"Moran, Jerry",232,000080
+COFFEY,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000090
+COFFEY,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",38,000090
+COFFEY,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000090
+COFFEY,Liberty Township,United States Senate,,Republican,"Moran, Jerry",235,000090
+COFFEY,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000100
+COFFEY,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",91,000100
+COFFEY,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",31,000100
+COFFEY,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",415,000100
+COFFEY,Neosho Township,United States Senate,,write - in,"Smith, DJ",0,000110
+COFFEY,Neosho Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000110
+COFFEY,Neosho Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+COFFEY,Neosho Township,United States Senate,,Republican,"Moran, Jerry",59,000110
+COFFEY,Ottumwa Township,United States Senate,,write - in,"Smith, DJ",0,000120
+COFFEY,Ottumwa Township,United States Senate,,Democratic,"Wiesner, Patrick",64,000120
+COFFEY,Ottumwa Township,United States Senate,,Libertarian,"Garrard, Robert D.",31,000120
+COFFEY,Ottumwa Township,United States Senate,,Republican,"Moran, Jerry",302,000120
+COFFEY,Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,000130
+COFFEY,Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000130
+COFFEY,Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000130
+COFFEY,Pleasant Township,United States Senate,,Republican,"Moran, Jerry",89,000130
+COFFEY,Pottawatomie Township,United States Senate,,write - in,"Smith, DJ",0,000140
+COFFEY,Pottawatomie Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000140
+COFFEY,Pottawatomie Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000140
+COFFEY,Pottawatomie Township,United States Senate,,Republican,"Moran, Jerry",84,000140
+COFFEY,Rock Creek Township,United States Senate,,write - in,"Smith, DJ",0,000150
+COFFEY,Rock Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",76,000150
+COFFEY,Rock Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",39,000150
+COFFEY,Rock Creek Township,United States Senate,,Republican,"Moran, Jerry",289,000150
+COFFEY,Spring Creek Township,United States Senate,,write - in,"Smith, DJ",0,000160
+COFFEY,Spring Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000160
+COFFEY,Spring Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000160
+COFFEY,Spring Creek Township,United States Senate,,Republican,"Moran, Jerry",61,000160
+COFFEY,Star Township,United States Senate,,write - in,"Smith, DJ",0,000170
+COFFEY,Star Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000170
+COFFEY,Star Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000170
+COFFEY,Star Township,United States Senate,,Republican,"Moran, Jerry",68,000170
+COFFEY,Burlington Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900020
+COFFEY,Burlington Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+COFFEY,Burlington Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+COFFEY,Burlington Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900020
+COFFEY,Burlington Township Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900030
+COFFEY,Burlington Township Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+COFFEY,Burlington Township Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+COFFEY,Burlington Township Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900030

--- a/2016/20161108__ks__general__comanche__precinct.csv
+++ b/2016/20161108__ks__general__comanche__precinct.csv
@@ -1,185 +1,185 @@
-county,precinct,office,district,candidate,party,votes
-Comanche,Avilla Township,State House,116,"Roitman, Jolene E. ",Democratic,19
-Comanche,Avilla Township,State House,116,"Hoffman, Kyle D. ",Republican,23
-Comanche,Coldwater Township,State House,116,"Roitman, Jolene E. ",Democratic,283
-Comanche,Coldwater Township,State House,116,"Hoffman, Kyle D. ",Republican,206
-Comanche,Powell Township,State House,116,"Roitman, Jolene E. ",Democratic,25
-Comanche,Powell Township,State House,116,"Hoffman, Kyle D. ",Republican,26
-Comanche,Protection Township H115,State House,115,"Orr, Boyd  ",Republican,210
-Comanche,Protection Township H116,State House,116,"Roitman, Jolene E. ",Democratic,18
-Comanche,Protection Township H116,State House,116,"Hoffman, Kyle D. ",Republican,42
-Comanche,Avilla Township,State Senate,32,"Shimkus, Don  ",Democratic,4
-Comanche,Avilla Township,State Senate,32,"Alley, Larry W. ",Republican,37
-Comanche,Coldwater Township,State Senate,32,"Shimkus, Don  ",Democratic,119
-Comanche,Coldwater Township,State Senate,32,"Alley, Larry W. ",Republican,342
-Comanche,Powell Township,State Senate,32,"Shimkus, Don  ",Democratic,15
-Comanche,Powell Township,State Senate,32,"Alley, Larry W. ",Republican,35
-Comanche,Protection Township H115,State Senate,32,"Shimkus, Don  ",Democratic,41
-Comanche,Protection Township H115,State Senate,32,"Alley, Larry W. ",Republican,177
-Comanche,Protection Township H116,State Senate,32,"Shimkus, Don  ",Democratic,8
-Comanche,Protection Township H116,State Senate,32,"Alley, Larry W. ",Republican,54
-Comanche,Avilla Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Comanche,Avilla Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,1
-Comanche,Avilla Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Comanche,Avilla Township,U.S. House,4,"Pompeo, Michael  ",Republican,40
-Comanche,Coldwater Township,U.S. House,4,"Allen, Miranda  ",independent,48
-Comanche,Coldwater Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,58
-Comanche,Coldwater Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,14
-Comanche,Coldwater Township,U.S. House,4,"Pompeo, Michael  ",Republican,370
-Comanche,Powell Township,U.S. House,4,"Allen, Miranda  ",independent,5
-Comanche,Powell Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,5
-Comanche,Powell Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Comanche,Powell Township,U.S. House,4,"Pompeo, Michael  ",Republican,42
-Comanche,Protection Township H115,U.S. House,4,"Allen, Miranda  ",independent,20
-Comanche,Protection Township H115,U.S. House,4,"Giroux, Daniel B. ",Democratic,18
-Comanche,Protection Township H115,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Comanche,Protection Township H115,U.S. House,4,"Pompeo, Michael  ",Republican,192
-Comanche,Protection Township H116,U.S. House,4,"Allen, Miranda  ",independent,4
-Comanche,Protection Township H116,U.S. House,4,"Giroux, Daniel B. ",Democratic,6
-Comanche,Protection Township H116,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Comanche,Protection Township H116,U.S. House,4,"Pompeo, Michael  ",Republican,51
-Comanche,Avilla Township,U.S. Senate,,"Smith, DJ  ",,0
-Comanche,Avilla Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Comanche,Avilla Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Comanche,Avilla Township,U.S. Senate,,"Moran, Jerry  ",Republican,41
-Comanche,Coldwater Township,U.S. Senate,,"Smith, DJ  ",,0
-Comanche,Coldwater Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,63
-Comanche,Coldwater Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,25
-Comanche,Coldwater Township,U.S. Senate,,"Moran, Jerry  ",Republican,394
-Comanche,Powell Township,U.S. Senate,,"Smith, DJ  ",,0
-Comanche,Powell Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,6
-Comanche,Powell Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Comanche,Powell Township,U.S. Senate,,"Moran, Jerry  ",Republican,43
-Comanche,Protection Township H115,U.S. Senate,,"Smith, DJ  ",,0
-Comanche,Protection Township H115,U.S. Senate,,"Wiesner, Patrick  ",Democratic,21
-Comanche,Protection Township H115,U.S. Senate,,"Garrard, Robert D. ",Libertarian,7
-Comanche,Protection Township H115,U.S. Senate,,"Moran, Jerry  ",Republican,203
-Comanche,Protection Township H116,U.S. Senate,,"Smith, DJ  ",,0
-Comanche,Protection Township H116,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Comanche,Protection Township H116,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Comanche,Protection Township H116,U.S. Senate,,"Moran, Jerry  ",Republican,51
-Comanche,Avilla Township,President,,"Stein, Jill  ",independent,0
-Comanche,Avilla Township,President,,"Basiago, Andrew D. ",,0
-Comanche,Avilla Township,President,,"Castle, Darrell L ",,0
-Comanche,Avilla Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Comanche,Avilla Township,President,,"Giordani, Rocky  ",,0
-Comanche,Avilla Township,President,,"Hedges, James A ",,0
-Comanche,Avilla Township,President,,"Hoefling, Tom  ",,0
-Comanche,Avilla Township,President,,"Kahn, Lynn  ",,0
-Comanche,Avilla Township,President,,"La Riva, Gloria  ",,0
-Comanche,Avilla Township,President,,"Levinson, Michael S. ",,0
-Comanche,Avilla Township,President,,"Maturen, Michael A ",,0
-Comanche,Avilla Township,President,,"McMullin, Evan  ",,0
-Comanche,Avilla Township,President,,"Moorehead, Monica G. ",,0
-Comanche,Avilla Township,President,,"Perry, Darryl  ",,0
-Comanche,Avilla Township,President,,"Schoenke, Marshall R. ",,0
-Comanche,Avilla Township,President,,"Schriner, Joe C ",,0
-Comanche,Avilla Township,President,,"Smith, Mike  ",,0
-Comanche,Avilla Township,President,,"Sood, Ajay  ",,0
-Comanche,Avilla Township,President,,"Sterling, Shawna  ",,0
-Comanche,Avilla Township,President,,"Valdivia, Anthony J ",,0
-Comanche,Avilla Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Comanche,Avilla Township,President,,"Wysinger, Demetra Jefferson ",,0
-Comanche,Avilla Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Comanche,Avilla Township,President,,"Johnson, Gary  ",Libertarian,1
-Comanche,Avilla Township,President,,"Trump, Donald J. ",Republican,44
-Comanche,Coldwater Township,President,,"Stein, Jill  ",independent,9
-Comanche,Coldwater Township,President,,"Basiago, Andrew D. ",,0
-Comanche,Coldwater Township,President,,"Castle, Darrell L ",,0
-Comanche,Coldwater Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Comanche,Coldwater Township,President,,"Giordani, Rocky  ",,0
-Comanche,Coldwater Township,President,,"Hedges, James A ",,0
-Comanche,Coldwater Township,President,,"Hoefling, Tom  ",,0
-Comanche,Coldwater Township,President,,"Kahn, Lynn  ",,0
-Comanche,Coldwater Township,President,,"La Riva, Gloria  ",,0
-Comanche,Coldwater Township,President,,"Levinson, Michael S. ",,0
-Comanche,Coldwater Township,President,,"Maturen, Michael A ",,0
-Comanche,Coldwater Township,President,,"McMullin, Evan  ",,0
-Comanche,Coldwater Township,President,,"Moorehead, Monica G. ",,0
-Comanche,Coldwater Township,President,,"Perry, Darryl  ",,0
-Comanche,Coldwater Township,President,,"Schoenke, Marshall R. ",,0
-Comanche,Coldwater Township,President,,"Schriner, Joe C ",,0
-Comanche,Coldwater Township,President,,"Smith, Mike  ",,0
-Comanche,Coldwater Township,President,,"Sood, Ajay  ",,0
-Comanche,Coldwater Township,President,,"Sterling, Shawna  ",,0
-Comanche,Coldwater Township,President,,"Valdivia, Anthony J ",,0
-Comanche,Coldwater Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Comanche,Coldwater Township,President,,"Wysinger, Demetra Jefferson ",,0
-Comanche,Coldwater Township,President,,"Clinton, Hillary Rodham ",Democratic,69
-Comanche,Coldwater Township,President,,"Johnson, Gary  ",Libertarian,30
-Comanche,Coldwater Township,President,,"Trump, Donald J. ",Republican,371
-Comanche,Powell Township,President,,"Stein, Jill  ",independent,0
-Comanche,Powell Township,President,,"Basiago, Andrew D. ",,0
-Comanche,Powell Township,President,,"Castle, Darrell L ",,0
-Comanche,Powell Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Comanche,Powell Township,President,,"Giordani, Rocky  ",,0
-Comanche,Powell Township,President,,"Hedges, James A ",,0
-Comanche,Powell Township,President,,"Hoefling, Tom  ",,0
-Comanche,Powell Township,President,,"Kahn, Lynn  ",,0
-Comanche,Powell Township,President,,"La Riva, Gloria  ",,0
-Comanche,Powell Township,President,,"Levinson, Michael S. ",,0
-Comanche,Powell Township,President,,"Maturen, Michael A ",,0
-Comanche,Powell Township,President,,"McMullin, Evan  ",,0
-Comanche,Powell Township,President,,"Moorehead, Monica G. ",,0
-Comanche,Powell Township,President,,"Perry, Darryl  ",,0
-Comanche,Powell Township,President,,"Schoenke, Marshall R. ",,0
-Comanche,Powell Township,President,,"Schriner, Joe C ",,0
-Comanche,Powell Township,President,,"Smith, Mike  ",,0
-Comanche,Powell Township,President,,"Sood, Ajay  ",,0
-Comanche,Powell Township,President,,"Sterling, Shawna  ",,0
-Comanche,Powell Township,President,,"Valdivia, Anthony J ",,0
-Comanche,Powell Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Comanche,Powell Township,President,,"Wysinger, Demetra Jefferson ",,0
-Comanche,Powell Township,President,,"Clinton, Hillary Rodham ",Democratic,9
-Comanche,Powell Township,President,,"Johnson, Gary  ",Libertarian,1
-Comanche,Powell Township,President,,"Trump, Donald J. ",Republican,40
-Comanche,Protection Township H115,President,,"Stein, Jill  ",independent,1
-Comanche,Protection Township H115,President,,"Basiago, Andrew D. ",,0
-Comanche,Protection Township H115,President,,"Castle, Darrell L ",,0
-Comanche,Protection Township H115,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Comanche,Protection Township H115,President,,"Giordani, Rocky  ",,0
-Comanche,Protection Township H115,President,,"Hedges, James A ",,0
-Comanche,Protection Township H115,President,,"Hoefling, Tom  ",,0
-Comanche,Protection Township H115,President,,"Kahn, Lynn  ",,0
-Comanche,Protection Township H115,President,,"La Riva, Gloria  ",,0
-Comanche,Protection Township H115,President,,"Levinson, Michael S. ",,0
-Comanche,Protection Township H115,President,,"Maturen, Michael A ",,0
-Comanche,Protection Township H115,President,,"McMullin, Evan  ",,0
-Comanche,Protection Township H115,President,,"Moorehead, Monica G. ",,0
-Comanche,Protection Township H115,President,,"Perry, Darryl  ",,0
-Comanche,Protection Township H115,President,,"Schoenke, Marshall R. ",,0
-Comanche,Protection Township H115,President,,"Schriner, Joe C ",,0
-Comanche,Protection Township H115,President,,"Smith, Mike  ",,0
-Comanche,Protection Township H115,President,,"Sood, Ajay  ",,0
-Comanche,Protection Township H115,President,,"Sterling, Shawna  ",,0
-Comanche,Protection Township H115,President,,"Valdivia, Anthony J ",,0
-Comanche,Protection Township H115,President,,"Vogel-Walcutt, J.J.  ",,0
-Comanche,Protection Township H115,President,,"Wysinger, Demetra Jefferson ",,0
-Comanche,Protection Township H115,President,,"Clinton, Hillary Rodham ",Democratic,18
-Comanche,Protection Township H115,President,,"Johnson, Gary  ",Libertarian,6
-Comanche,Protection Township H115,President,,"Trump, Donald J. ",Republican,207
-Comanche,Protection Township H116,President,,"Stein, Jill  ",independent,0
-Comanche,Protection Township H116,President,,"Basiago, Andrew D. ",,0
-Comanche,Protection Township H116,President,,"Castle, Darrell L ",,0
-Comanche,Protection Township H116,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Comanche,Protection Township H116,President,,"Giordani, Rocky  ",,0
-Comanche,Protection Township H116,President,,"Hedges, James A ",,0
-Comanche,Protection Township H116,President,,"Hoefling, Tom  ",,0
-Comanche,Protection Township H116,President,,"Kahn, Lynn  ",,0
-Comanche,Protection Township H116,President,,"La Riva, Gloria  ",,0
-Comanche,Protection Township H116,President,,"Levinson, Michael S. ",,0
-Comanche,Protection Township H116,President,,"Maturen, Michael A ",,0
-Comanche,Protection Township H116,President,,"McMullin, Evan  ",,0
-Comanche,Protection Township H116,President,,"Moorehead, Monica G. ",,0
-Comanche,Protection Township H116,President,,"Perry, Darryl  ",,0
-Comanche,Protection Township H116,President,,"Schoenke, Marshall R. ",,0
-Comanche,Protection Township H116,President,,"Schriner, Joe C ",,0
-Comanche,Protection Township H116,President,,"Smith, Mike  ",,0
-Comanche,Protection Township H116,President,,"Sood, Ajay  ",,0
-Comanche,Protection Township H116,President,,"Sterling, Shawna  ",,0
-Comanche,Protection Township H116,President,,"Valdivia, Anthony J ",,0
-Comanche,Protection Township H116,President,,"Vogel-Walcutt, J.J.  ",,0
-Comanche,Protection Township H116,President,,"Wysinger, Demetra Jefferson ",,0
-Comanche,Protection Township H116,President,,"Clinton, Hillary Rodham ",Democratic,6
-Comanche,Protection Township H116,President,,"Johnson, Gary  ",Libertarian,2
-Comanche,Protection Township H116,President,,"Trump, Donald J. ",Republican,53
+county,precinct,office,district,party,candidate,votes,vtd
+COMANCHE,Avilla Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",19,000010
+COMANCHE,Avilla Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",23,000010
+COMANCHE,Coldwater Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",283,000020
+COMANCHE,Coldwater Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",206,000020
+COMANCHE,Powell Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",25,000030
+COMANCHE,Powell Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",26,000030
+COMANCHE,Protection Township H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",210,120020
+COMANCHE,Protection Township H116,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",18,120030
+COMANCHE,Protection Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",42,120030
+COMANCHE,Avilla Township,Kansas Senate,32,Democratic,"Shimkus, Don",4,000010
+COMANCHE,Avilla Township,Kansas Senate,32,Republican,"Alley, Larry W.",37,000010
+COMANCHE,Coldwater Township,Kansas Senate,32,Democratic,"Shimkus, Don",119,000020
+COMANCHE,Coldwater Township,Kansas Senate,32,Republican,"Alley, Larry W.",342,000020
+COMANCHE,Powell Township,Kansas Senate,32,Democratic,"Shimkus, Don",15,000030
+COMANCHE,Powell Township,Kansas Senate,32,Republican,"Alley, Larry W.",35,000030
+COMANCHE,Protection Township H115,Kansas Senate,32,Democratic,"Shimkus, Don",41,120020
+COMANCHE,Protection Township H115,Kansas Senate,32,Republican,"Alley, Larry W.",177,120020
+COMANCHE,Protection Township H116,Kansas Senate,32,Democratic,"Shimkus, Don",8,120030
+COMANCHE,Protection Township H116,Kansas Senate,32,Republican,"Alley, Larry W.",54,120030
+COMANCHE,Avilla Township,President / Vice President,,independent,"Stein, Jill",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+COMANCHE,Avilla Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+COMANCHE,Avilla Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+COMANCHE,Avilla Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+COMANCHE,Avilla Township,President / Vice President,,Republican,"Trump, Donald J.",44,000010
+COMANCHE,Coldwater Township,President / Vice President,,independent,"Stein, Jill",9,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+COMANCHE,Coldwater Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,000020
+COMANCHE,Coldwater Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000020
+COMANCHE,Coldwater Township,President / Vice President,,Republican,"Trump, Donald J.",371,000020
+COMANCHE,Powell Township,President / Vice President,,independent,"Stein, Jill",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+COMANCHE,Powell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+COMANCHE,Powell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000030
+COMANCHE,Powell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+COMANCHE,Powell Township,President / Vice President,,Republican,"Trump, Donald J.",40,000030
+COMANCHE,Protection Township H115,President / Vice President,,independent,"Stein, Jill",1,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Hedges, James A",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"McMullin, Evan",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Perry, Darryl",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Smith, Mike",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Sood, Ajay",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+COMANCHE,Protection Township H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,120020
+COMANCHE,Protection Township H115,President / Vice President,,Libertarian,"Johnson, Gary",6,120020
+COMANCHE,Protection Township H115,President / Vice President,,Republican,"Trump, Donald J.",207,120020
+COMANCHE,Protection Township H116,President / Vice President,,independent,"Stein, Jill",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Hedges, James A",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"McMullin, Evan",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Perry, Darryl",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Smith, Mike",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Sood, Ajay",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+COMANCHE,Protection Township H116,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,120030
+COMANCHE,Protection Township H116,President / Vice President,,Libertarian,"Johnson, Gary",2,120030
+COMANCHE,Protection Township H116,President / Vice President,,Republican,"Trump, Donald J.",53,120030
+COMANCHE,Avilla Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000010
+COMANCHE,Avilla Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000010
+COMANCHE,Avilla Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000010
+COMANCHE,Avilla Township,United States House of Representatives,4,Republican,"Pompeo, Michael",40,000010
+COMANCHE,Coldwater Township,United States House of Representatives,4,independent,"Allen, Miranda",48,000020
+COMANCHE,Coldwater Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",58,000020
+COMANCHE,Coldwater Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,000020
+COMANCHE,Coldwater Township,United States House of Representatives,4,Republican,"Pompeo, Michael",370,000020
+COMANCHE,Powell Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000030
+COMANCHE,Powell Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000030
+COMANCHE,Powell Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000030
+COMANCHE,Powell Township,United States House of Representatives,4,Republican,"Pompeo, Michael",42,000030
+COMANCHE,Protection Township H115,United States House of Representatives,4,independent,"Allen, Miranda",20,120020
+COMANCHE,Protection Township H115,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",18,120020
+COMANCHE,Protection Township H115,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,120020
+COMANCHE,Protection Township H115,United States House of Representatives,4,Republican,"Pompeo, Michael",192,120020
+COMANCHE,Protection Township H116,United States House of Representatives,4,independent,"Allen, Miranda",4,120030
+COMANCHE,Protection Township H116,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,120030
+COMANCHE,Protection Township H116,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,120030
+COMANCHE,Protection Township H116,United States House of Representatives,4,Republican,"Pompeo, Michael",51,120030
+COMANCHE,Avilla Township,United States Senate,,write - in,"Smith, DJ",0,000010
+COMANCHE,Avilla Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000010
+COMANCHE,Avilla Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+COMANCHE,Avilla Township,United States Senate,,Republican,"Moran, Jerry",41,000010
+COMANCHE,Coldwater Township,United States Senate,,write - in,"Smith, DJ",0,000020
+COMANCHE,Coldwater Township,United States Senate,,Democratic,"Wiesner, Patrick",63,000020
+COMANCHE,Coldwater Township,United States Senate,,Libertarian,"Garrard, Robert D.",25,000020
+COMANCHE,Coldwater Township,United States Senate,,Republican,"Moran, Jerry",394,000020
+COMANCHE,Powell Township,United States Senate,,write - in,"Smith, DJ",0,000030
+COMANCHE,Powell Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000030
+COMANCHE,Powell Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+COMANCHE,Powell Township,United States Senate,,Republican,"Moran, Jerry",43,000030
+COMANCHE,Protection Township H115,United States Senate,,write - in,"Smith, DJ",0,120020
+COMANCHE,Protection Township H115,United States Senate,,Democratic,"Wiesner, Patrick",21,120020
+COMANCHE,Protection Township H115,United States Senate,,Libertarian,"Garrard, Robert D.",7,120020
+COMANCHE,Protection Township H115,United States Senate,,Republican,"Moran, Jerry",203,120020
+COMANCHE,Protection Township H116,United States Senate,,write - in,"Smith, DJ",0,120030
+COMANCHE,Protection Township H116,United States Senate,,Democratic,"Wiesner, Patrick",7,120030
+COMANCHE,Protection Township H116,United States Senate,,Libertarian,"Garrard, Robert D.",2,120030
+COMANCHE,Protection Township H116,United States Senate,,Republican,"Moran, Jerry",51,120030

--- a/2016/20161108__ks__general__cowley__precinct.csv
+++ b/2016/20161108__ks__general__cowley__precinct.csv
@@ -1,848 +1,2519 @@
-county,precinct,office,district,party,candidate,votes
-Cowley,AC1A,President,,D,Clinton and Kaine,51
-Cowley,AC1A,President,,L,Johnson and Weld,7
-Cowley,AC1A,President,,I,Stein and Baraka,2
-Cowley,AC1A,President,,R,Trump and Pence,92
-Cowley,AC1A,U.S. Senate,,L,Robert D. Gerrard,11
-Cowley,AC1A,U.S. Senate,,R,Jerry Moran,95
-Cowley,AC1A,U.S. Senate,,D,Patrick Wiesner,45
-Cowley,AC1A,U.S. House,4,I,Miranda Allen,22
-Cowley,AC1A,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,AC1A,U.S. House,4,D,Daniel B. Giroux,45
-Cowley,AC1A,U.S. House,4,R,Michael Pompeo,82
-Cowley,AC1A,State Senate,32,R,Larry W. Alley,82
-Cowley,AC1A,State Senate,32,D,Don Shimkus,68
-Cowley,AC1A,State House,80,R,Anita Judd-Jenkins,100
-Cowley,AC1A,State House,80,D,Michelle Schiltz,28
-Cowley,AC1A-A,President,,D,Clinton and Kaine,2
-Cowley,AC1A-A,President,,L,Johnson and Weld,0
-Cowley,AC1A-A,President,,I,Stein and Baraka,0
-Cowley,AC1A-A,President,,R,Trump and Pence,11
-Cowley,AC1A-A,U.S. Senate,,L,Robert D. Gerrard,0
-Cowley,AC1A-A,U.S. Senate,,R,Jerry Moran,11
-Cowley,AC1A-A,U.S. Senate,,D,Patrick Wiesner,2
-Cowley,AC1A-A,U.S. House,4,I,Miranda Allen,1
-Cowley,AC1A-A,U.S. House,4,L,Goraden J. Bakken,0
-Cowley,AC1A-A,U.S. House,4,D,Daniel B. Giroux,1
-Cowley,AC1A-A,U.S. House,4,R,Michael Pompeo,11
-Cowley,AC1A-A,State Senate,32,R,Larry W. Alley,11
-Cowley,AC1A-A,State Senate,32,D,Don Shimkus,2
-Cowley,AC1A-A,State House,80,R,Anita Judd-Jenkins,7
-Cowley,AC1A-A,State House,80,D,Michelle Schiltz,0
-Cowley,AC1B,President,,D,Clinton and Kaine,39
-Cowley,AC1B,President,,L,Johnson and Weld,9
-Cowley,AC1B,President,,I,Stein and Baraka,3
-Cowley,AC1B,President,,R,Trump and Pence,104
-Cowley,AC1B,U.S. Senate,,L,Robert D. Gerrard,15
-Cowley,AC1B,U.S. Senate,,R,Jerry Moran,99
-Cowley,AC1B,U.S. Senate,,D,Patrick Wiesner,38
-Cowley,AC1B,U.S. House,4,I,Miranda Allen,19
-Cowley,AC1B,U.S. House,4,L,Goraden J. Bakken,4
-Cowley,AC1B,U.S. House,4,D,Daniel B. Giroux,34
-Cowley,AC1B,U.S. House,4,R,Michael Pompeo,95
-Cowley,AC1B,State Senate,32,R,Larry W. Alley,93
-Cowley,AC1B,State Senate,32,D,Don Shimkus,58
-Cowley,AC1B,State House,80,R,Anita Judd-Jenkins,98
-Cowley,AC1B,State House,80,D,Michelle Schiltz,34
-Cowley,AC1C,President,,D,Clinton and Kaine,99
-Cowley,AC1C,President,,L,Johnson and Weld,9
-Cowley,AC1C,President,,I,Stein and Baraka,5
-Cowley,AC1C,President,,R,Trump and Pence,191
-Cowley,AC1C,U.S. Senate,,L,Robert D. Gerrard,15
-Cowley,AC1C,U.S. Senate,,R,Jerry Moran,192
-Cowley,AC1C,U.S. Senate,,D,Patrick Wiesner,101
-Cowley,AC1C,U.S. House,4,I,Miranda Allen,42
-Cowley,AC1C,U.S. House,4,L,Goraden J. Bakken,4
-Cowley,AC1C,U.S. House,4,D,Daniel B. Giroux,89
-Cowley,AC1C,U.S. House,4,R,Michael Pompeo,172
-Cowley,AC1C,State Senate,32,R,Larry W. Alley,159
-Cowley,AC1C,State Senate,32,D,Don Shimkus,145
-Cowley,AC1C,State House,80,R,Anita Judd-Jenkins,221
-Cowley,AC1C,State House,80,D,Michelle Schiltz,74
-Cowley,AC1D,President,,D,Clinton and Kaine,82
-Cowley,AC1D,President,,L,Johnson and Weld,14
-Cowley,AC1D,President,,I,Stein and Baraka,3
-Cowley,AC1D,President,,R,Trump and Pence,136
-Cowley,AC1D,U.S. Senate,,L,Robert D. Gerrard,20
-Cowley,AC1D,U.S. Senate,,R,Jerry Moran,147
-Cowley,AC1D,U.S. Senate,,D,Patrick Wiesner,72
-Cowley,AC1D,U.S. House,4,I,Miranda Allen,25
-Cowley,AC1D,U.S. House,4,L,Goraden J. Bakken,5
-Cowley,AC1D,U.S. House,4,D,Daniel B. Giroux,70
-Cowley,AC1D,U.S. House,4,R,Michael Pompeo,137
-Cowley,AC1D,State Senate,32,R,Larry W. Alley,122
-Cowley,AC1D,State Senate,32,D,Don Shimkus,117
-Cowley,AC1D,State House,80,R,Anita Judd-Jenkins,180
-Cowley,AC1D,State House,80,D,Michelle Schiltz,43
-Cowley,AC2A,President,,D,Clinton and Kaine,93
-Cowley,AC2A,President,,L,Johnson and Weld,12
-Cowley,AC2A,President,,I,Stein and Baraka,7
-Cowley,AC2A,President,,R,Trump and Pence,228
-Cowley,AC2A,U.S. Senate,,L,Robert D. Gerrard,26
-Cowley,AC2A,U.S. Senate,,R,Jerry Moran,237
-Cowley,AC2A,U.S. Senate,,D,Patrick Wiesner,75
-Cowley,AC2A,U.S. House,4,I,Miranda Allen,38
-Cowley,AC2A,U.S. House,4,L,Goraden J. Bakken,8
-Cowley,AC2A,U.S. House,4,D,Daniel B. Giroux,66
-Cowley,AC2A,U.S. House,4,R,Michael Pompeo,222
-Cowley,AC2A,State Senate,32,R,Larry W. Alley,193
-Cowley,AC2A,State Senate,32,D,Don Shimkus,140
-Cowley,AC2A,State House,80,R,Anita Judd-Jenkins,236
-Cowley,AC2A,State House,80,D,Michelle Schiltz,55
-Cowley,AC2B,President,,D,Clinton and Kaine,37
-Cowley,AC2B,President,,L,Johnson and Weld,2
-Cowley,AC2B,President,,I,Stein and Baraka,3
-Cowley,AC2B,President,,R,Trump and Pence,89
-Cowley,AC2B,U.S. Senate,,L,Robert D. Gerrard,14
-Cowley,AC2B,U.S. Senate,,R,Jerry Moran,78
-Cowley,AC2B,U.S. Senate,,D,Patrick Wiesner,41
-Cowley,AC2B,U.S. House,4,I,Miranda Allen,27
-Cowley,AC2B,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,AC2B,U.S. House,4,D,Daniel B. Giroux,34
-Cowley,AC2B,U.S. House,4,R,Michael Pompeo,68
-Cowley,AC2B,State Senate,32,R,Larry W. Alley,75
-Cowley,AC2B,State Senate,32,D,Don Shimkus,58
-Cowley,AC2B,State House,80,R,Anita Judd-Jenkins,88
-Cowley,AC2B,State House,80,D,Michelle Schiltz,38
-Cowley,AC2B-2,President,,D,Clinton and Kaine,25
-Cowley,AC2B-2,President,,L,Johnson and Weld,2
-Cowley,AC2B-2,President,,I,Stein and Baraka,1
-Cowley,AC2B-2,President,,R,Trump and Pence,55
-Cowley,AC2B-2,U.S. Senate,,L,Robert D. Gerrard,3
-Cowley,AC2B-2,U.S. Senate,,R,Jerry Moran,56
-Cowley,AC2B-2,U.S. Senate,,D,Patrick Wiesner,22
-Cowley,AC2B-2,U.S. House,4,I,Miranda Allen,6
-Cowley,AC2B-2,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,AC2B-2,U.S. House,4,D,Daniel B. Giroux,18
-Cowley,AC2B-2,U.S. House,4,R,Michael Pompeo,56
-Cowley,AC2B-2,State Senate,32,R,Larry W. Alley,43
-Cowley,AC2B-2,State Senate,32,D,Don Shimkus,37
-Cowley,AC2B-2,State House,80,R,Anita Judd-Jenkins,62
-Cowley,AC2B-2,State House,80,D,Michelle Schiltz,7
-Cowley,AC2C,President,,D,Clinton and Kaine,8
-Cowley,AC2C,President,,L,Johnson and Weld,1
-Cowley,AC2C,President,,I,Stein and Baraka,2
-Cowley,AC2C,President,,R,Trump and Pence,24
-Cowley,AC2C,U.S. Senate,,L,Robert D. Gerrard,4
-Cowley,AC2C,U.S. Senate,,R,Jerry Moran,22
-Cowley,AC2C,U.S. Senate,,D,Patrick Wiesner,10
-Cowley,AC2C,U.S. House,4,I,Miranda Allen,2
-Cowley,AC2C,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,AC2C,U.S. House,4,D,Daniel B. Giroux,11
-Cowley,AC2C,U.S. House,4,R,Michael Pompeo,22
-Cowley,AC2C,State Senate,32,R,Larry W. Alley,23
-Cowley,AC2C,State Senate,32,D,Don Shimkus,13
-Cowley,AC2C,State House,80,R,Anita Judd-Jenkins,29
-Cowley,AC2C,State House,80,D,Michelle Schiltz,7
-Cowley,AC2D,President,,D,Clinton and Kaine,18
-Cowley,AC2D,President,,L,Johnson and Weld,0
-Cowley,AC2D,President,,I,Stein and Baraka,2
-Cowley,AC2D,President,,R,Trump and Pence,40
-Cowley,AC2D,U.S. Senate,,L,Robert D. Gerrard,4
-Cowley,AC2D,U.S. Senate,,R,Jerry Moran,37
-Cowley,AC2D,U.S. Senate,,D,Patrick Wiesner,17
-Cowley,AC2D,U.S. House,4,I,Miranda Allen,5
-Cowley,AC2D,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,AC2D,U.S. House,4,D,Daniel B. Giroux,18
-Cowley,AC2D,U.S. House,4,R,Michael Pompeo,35
-Cowley,AC2D,State Senate,32,R,Larry W. Alley,36
-Cowley,AC2D,State Senate,32,D,Don Shimkus,22
-Cowley,AC2D,State House,80,R,Anita Judd-Jenkins,35
-Cowley,AC2D,State House,80,D,Michelle Schiltz,16
-Cowley,AC3A,President,,D,Clinton and Kaine,16
-Cowley,AC3A,President,,L,Johnson and Weld,3
-Cowley,AC3A,President,,I,Stein and Baraka,4
-Cowley,AC3A,President,,R,Trump and Pence,35
-Cowley,AC3A,U.S. Senate,,L,Robert D. Gerrard,5
-Cowley,AC3A,U.S. Senate,,R,Jerry Moran,41
-Cowley,AC3A,U.S. Senate,,D,Patrick Wiesner,13
-Cowley,AC3A,U.S. House,4,I,Miranda Allen,7
-Cowley,AC3A,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,AC3A,U.S. House,4,D,Daniel B. Giroux,15
-Cowley,AC3A,U.S. House,4,R,Michael Pompeo,33
-Cowley,AC3A,State Senate,32,R,Larry W. Alley,40
-Cowley,AC3A,State Senate,32,D,Don Shimkus,19
-Cowley,AC3A,State House,80,R,Anita Judd-Jenkins,46
-Cowley,AC3A,State House,80,D,Michelle Schiltz,11
-Cowley,AC3B,President,,D,Clinton and Kaine,25
-Cowley,AC3B,President,,L,Johnson and Weld,4
-Cowley,AC3B,President,,I,Stein and Baraka,1
-Cowley,AC3B,President,,R,Trump and Pence,58
-Cowley,AC3B,U.S. Senate,,L,Robert D. Gerrard,9
-Cowley,AC3B,U.S. Senate,,R,Jerry Moran,54
-Cowley,AC3B,U.S. Senate,,D,Patrick Wiesner,25
-Cowley,AC3B,U.S. House,4,I,Miranda Allen,13
-Cowley,AC3B,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,AC3B,U.S. House,4,D,Daniel B. Giroux,21
-Cowley,AC3B,U.S. House,4,R,Michael Pompeo,50
-Cowley,AC3B,State Senate,32,R,Larry W. Alley,45
-Cowley,AC3B,State Senate,32,D,Don Shimkus,38
-Cowley,AC3B,State House,80,R,Anita Judd-Jenkins,63
-Cowley,AC3B,State House,80,D,Michelle Schiltz,17
-Cowley,AC3C,President,,D,Clinton and Kaine,27
-Cowley,AC3C,President,,L,Johnson and Weld,5
-Cowley,AC3C,President,,I,Stein and Baraka,2
-Cowley,AC3C,President,,R,Trump and Pence,58
-Cowley,AC3C,U.S. Senate,,L,Robert D. Gerrard,9
-Cowley,AC3C,U.S. Senate,,R,Jerry Moran,49
-Cowley,AC3C,U.S. Senate,,D,Patrick Wiesner,34
-Cowley,AC3C,U.S. House,4,I,Miranda Allen,12
-Cowley,AC3C,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,AC3C,U.S. House,4,D,Daniel B. Giroux,26
-Cowley,AC3C,U.S. House,4,R,Michael Pompeo,51
-Cowley,AC3C,State Senate,32,R,Larry W. Alley,51
-Cowley,AC3C,State Senate,32,D,Don Shimkus,41
-Cowley,AC3C,State House,80,R,Anita Judd-Jenkins,50
-Cowley,AC3C,State House,80,D,Michelle Schiltz,32
-Cowley,AC4A,President,,D,Clinton and Kaine,103
-Cowley,AC4A,President,,L,Johnson and Weld,14
-Cowley,AC4A,President,,I,Stein and Baraka,4
-Cowley,AC4A,President,,R,Trump and Pence,152
-Cowley,AC4A,U.S. Senate,,L,Robert D. Gerrard,23
-Cowley,AC4A,U.S. Senate,,R,Jerry Moran,155
-Cowley,AC4A,U.S. Senate,,D,Patrick Wiesner,97
-Cowley,AC4A,U.S. House,4,I,Miranda Allen,37
-Cowley,AC4A,U.S. House,4,L,Goraden J. Bakken,5
-Cowley,AC4A,U.S. House,4,D,Daniel B. Giroux,89
-Cowley,AC4A,U.S. House,4,R,Michael Pompeo,145
-Cowley,AC4A,State Senate,32,R,Larry W. Alley,143
-Cowley,AC4A,State Senate,32,D,Don Shimkus,131
-Cowley,AC4A,State House,80,R,Anita Judd-Jenkins,181
-Cowley,AC4A,State House,80,D,Michelle Schiltz,70
-Cowley,AC4B,President,,D,Clinton and Kaine,193
-Cowley,AC4B,President,,L,Johnson and Weld,27
-Cowley,AC4B,President,,I,Stein and Baraka,20
-Cowley,AC4B,President,,R,Trump and Pence,339
-Cowley,AC4B,U.S. Senate,,L,Robert D. Gerrard,39
-Cowley,AC4B,U.S. Senate,,R,Jerry Moran,345
-Cowley,AC4B,U.S. Senate,,D,Patrick Wiesner,190
-Cowley,AC4B,U.S. House,4,I,Miranda Allen,84
-Cowley,AC4B,U.S. House,4,L,Goraden J. Bakken,18
-Cowley,AC4B,U.S. House,4,D,Daniel B. Giroux,158
-Cowley,AC4B,U.S. House,4,R,Michael Pompeo,315
-Cowley,AC4B,State Senate,32,R,Larry W. Alley,296
-Cowley,AC4B,State Senate,32,D,Don Shimkus,271
-Cowley,AC4B,State House,80,R,Anita Judd-Jenkins,409
-Cowley,AC4B,State House,80,D,Michelle Schiltz,119
-Cowley,AC4C,President,,D,Clinton and Kaine,94
-Cowley,AC4C,President,,L,Johnson and Weld,13
-Cowley,AC4C,President,,I,Stein and Baraka,4
-Cowley,AC4C,President,,R,Trump and Pence,133
-Cowley,AC4C,U.S. Senate,,L,Robert D. Gerrard,11
-Cowley,AC4C,U.S. Senate,,R,Jerry Moran,139
-Cowley,AC4C,U.S. Senate,,D,Patrick Wiesner,92
-Cowley,AC4C,U.S. House,4,I,Miranda Allen,34
-Cowley,AC4C,U.S. House,4,L,Goraden J. Bakken,6
-Cowley,AC4C,U.S. House,4,D,Daniel B. Giroux,67
-Cowley,AC4C,U.S. House,4,R,Michael Pompeo,138
-Cowley,AC4C,State Senate,32,R,Larry W. Alley,117
-Cowley,AC4C,State Senate,32,D,Don Shimkus,127
-Cowley,AC4C,State House,80,R,Anita Judd-Jenkins,171
-Cowley,AC4C,State House,80,D,Michelle Schiltz,55
-Cowley,AC4D,President,,D,Clinton and Kaine,162
-Cowley,AC4D,President,,L,Johnson and Weld,15
-Cowley,AC4D,President,,I,Stein and Baraka,15
-Cowley,AC4D,President,,R,Trump and Pence,234
-Cowley,AC4D,U.S. Senate,,L,Robert D. Gerrard,23
-Cowley,AC4D,U.S. Senate,,R,Jerry Moran,261
-Cowley,AC4D,U.S. Senate,,D,Patrick Wiesner,141
-Cowley,AC4D,U.S. House,4,I,Miranda Allen,52
-Cowley,AC4D,U.S. House,4,L,Goraden J. Bakken,7
-Cowley,AC4D,U.S. House,4,D,Daniel B. Giroux,127
-Cowley,AC4D,U.S. House,4,R,Michael Pompeo,243
-Cowley,AC4D,State Senate,32,R,Larry W. Alley,223
-Cowley,AC4D,State Senate,32,D,Don Shimkus,207
-Cowley,AC4D,State House,80,R,Anita Judd-Jenkins,292
-Cowley,AC4D,State House,80,D,Michelle Schiltz,104
-Cowley,Beaver,President,,D,Clinton and Kaine,28
-Cowley,Beaver,President,,L,Johnson and Weld,2
-Cowley,Beaver,President,,I,Stein and Baraka,2
-Cowley,Beaver,President,,R,Trump and Pence,73
-Cowley,Beaver,U.S. Senate,,L,Robert D. Gerrard,2
-Cowley,Beaver,U.S. Senate,,R,Jerry Moran,73
-Cowley,Beaver,U.S. Senate,,D,Patrick Wiesner,31
-Cowley,Beaver,U.S. House,4,I,Miranda Allen,7
-Cowley,Beaver,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,Beaver,U.S. House,4,D,Daniel B. Giroux,24
-Cowley,Beaver,U.S. House,4,R,Michael Pompeo,73
-Cowley,Beaver,State Senate,32,R,Larry W. Alley,61
-Cowley,Beaver,State Senate,32,D,Don Shimkus,44
-Cowley,Beaver,State House,79,D,Ed Trimmer,82
-Cowley,Bolton,President,,D,Clinton and Kaine,114
-Cowley,Bolton,President,,L,Johnson and Weld,17
-Cowley,Bolton,President,,I,Stein and Baraka,6
-Cowley,Bolton,President,,R,Trump and Pence,511
-Cowley,Bolton,U.S. Senate,,L,Robert D. Gerrard,40
-Cowley,Bolton,U.S. Senate,,R,Jerry Moran,486
-Cowley,Bolton,U.S. Senate,,D,Patrick Wiesner,126
-Cowley,Bolton,U.S. House,4,I,Miranda Allen,70
-Cowley,Bolton,U.S. House,4,L,Goraden J. Bakken,17
-Cowley,Bolton,U.S. House,4,D,Daniel B. Giroux,113
-Cowley,Bolton,U.S. House,4,R,Michael Pompeo,447
-Cowley,Bolton,State Senate,32,R,Larry W. Alley,415
-Cowley,Bolton,State Senate,32,D,Don Shimkus,226
-Cowley,Bolton,State House,80,R,Anita Judd-Jenkins,434
-Cowley,Bolton,State House,80,D,Michelle Schiltz,129
-Cowley,Cedar,President,,D,Clinton and Kaine,3
-Cowley,Cedar,President,,L,Johnson and Weld,0
-Cowley,Cedar,President,,I,Stein and Baraka,0
-Cowley,Cedar,President,,R,Trump and Pence,16
-Cowley,Cedar,U.S. Senate,,L,Robert D. Gerrard,1
-Cowley,Cedar,U.S. Senate,,R,Jerry Moran,16
-Cowley,Cedar,U.S. Senate,,D,Patrick Wiesner,2
-Cowley,Cedar,U.S. House,4,I,Miranda Allen,2
-Cowley,Cedar,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,Cedar,U.S. House,4,D,Daniel B. Giroux,1
-Cowley,Cedar,U.S. House,4,R,Michael Pompeo,14
-Cowley,Cedar,State Senate,14,D,Mark Pringle,4
-Cowley,Cedar,State Senate,14,R,Bruce Givens,15
-Cowley,Cedar,State House,12,R,Doug Blex,14
-Cowley,Cedar,State House,12,D,Jean Kurtis Schodorf,4
-Cowley,E Creswell,President,,D,Clinton and Kaine,132
-Cowley,E Creswell,President,,L,Johnson and Weld,13
-Cowley,E Creswell,President,,I,Stein and Baraka,14
-Cowley,E Creswell,President,,R,Trump and Pence,464
-Cowley,E Creswell,U.S. Senate,,L,Robert D. Gerrard,32
-Cowley,E Creswell,U.S. Senate,,R,Jerry Moran,463
-Cowley,E Creswell,U.S. Senate,,D,Patrick Wiesner,128
-Cowley,E Creswell,U.S. House,4,I,Miranda Allen,62
-Cowley,E Creswell,U.S. House,4,L,Goraden J. Bakken,6
-Cowley,E Creswell,U.S. House,4,D,Daniel B. Giroux,118
-Cowley,E Creswell,U.S. House,4,R,Michael Pompeo,438
-Cowley,E Creswell,State Senate,32,R,Larry W. Alley,390
-Cowley,E Creswell,State Senate,32,D,Don Shimkus,231
-Cowley,E Creswell,State House,80,R,Anita Judd-Jenkins,458
-Cowley,E Creswell,State House,80,D,Michelle Schiltz,84
-Cowley,W Creswell,President,,D,Clinton and Kaine,55
-Cowley,W Creswell,President,,L,Johnson and Weld,14
-Cowley,W Creswell,President,,I,Stein and Baraka,5
-Cowley,W Creswell,President,,R,Trump and Pence,200
-Cowley,W Creswell,U.S. Senate,,L,Robert D. Gerrard,11
-Cowley,W Creswell,U.S. Senate,,R,Jerry Moran,204
-Cowley,W Creswell,U.S. Senate,,D,Patrick Wiesner,59
-Cowley,W Creswell,U.S. House,4,I,Miranda Allen,26
-Cowley,W Creswell,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,W Creswell,U.S. House,4,D,Daniel B. Giroux,54
-Cowley,W Creswell,U.S. House,4,R,Michael Pompeo,190
-Cowley,W Creswell,State Senate,32,R,Larry W. Alley,172
-Cowley,W Creswell,State Senate,32,D,Don Shimkus,95
-Cowley,W Creswell,State House,80,R,Anita Judd-Jenkins,175
-Cowley,W Creswell,State House,80,D,Michelle Schiltz,51
-Cowley,Dexter,President,,D,Clinton and Kaine,28
-Cowley,Dexter,President,,L,Johnson and Weld,2
-Cowley,Dexter,President,,I,Stein and Baraka,3
-Cowley,Dexter,President,,R,Trump and Pence,154
-Cowley,Dexter,U.S. Senate,,L,Robert D. Gerrard,7
-Cowley,Dexter,U.S. Senate,,R,Jerry Moran,156
-Cowley,Dexter,U.S. Senate,,D,Patrick Wiesner,25
-Cowley,Dexter,U.S. House,4,I,Miranda Allen,17
-Cowley,Dexter,U.S. House,4,L,Goraden J. Bakken,5
-Cowley,Dexter,U.S. House,4,D,Daniel B. Giroux,25
-Cowley,Dexter,U.S. House,4,R,Michael Pompeo,142
-Cowley,Dexter,State Senate,14,D,Mark Pringle,54
-Cowley,Dexter,State Senate,14,R,Bruce Givens,126
-Cowley,Dexter,State House,12,R,Doug Blex,116
-Cowley,Dexter,State House,12,D,Jean Kurtis Schodorf,66
-Cowley,Fairview,President,,D,Clinton and Kaine,26
-Cowley,Fairview,President,,L,Johnson and Weld,7
-Cowley,Fairview,President,,I,Stein and Baraka,1
-Cowley,Fairview,President,,R,Trump and Pence,98
-Cowley,Fairview,U.S. Senate,,L,Robert D. Gerrard,9
-Cowley,Fairview,U.S. Senate,,R,Jerry Moran,99
-Cowley,Fairview,U.S. Senate,,D,Patrick Wiesner,23
-Cowley,Fairview,U.S. House,4,I,Miranda Allen,14
-Cowley,Fairview,U.S. House,4,L,Goraden J. Bakken,0
-Cowley,Fairview,U.S. House,4,D,Daniel B. Giroux,25
-Cowley,Fairview,U.S. House,4,R,Michael Pompeo,94
-Cowley,Fairview,State Senate,14,D,Mark Pringle,45
-Cowley,Fairview,State Senate,14,R,Bruce Givens,83
-Cowley,Fairview,State House,79,D,Ed Trimmer,105
-Cowley,Grant,President,,D,Clinton and Kaine,6
-Cowley,Grant,President,,L,Johnson and Weld,2
-Cowley,Grant,President,,I,Stein and Baraka,0
-Cowley,Grant,President,,R,Trump and Pence,33
-Cowley,Grant,U.S. Senate,,L,Robert D. Gerrard,0
-Cowley,Grant,U.S. Senate,,R,Jerry Moran,37
-Cowley,Grant,U.S. Senate,,D,Patrick Wiesner,4
-Cowley,Grant,U.S. House,4,I,Miranda Allen,2
-Cowley,Grant,U.S. House,4,L,Goraden J. Bakken,0
-Cowley,Grant,U.S. House,4,D,Daniel B. Giroux,3
-Cowley,Grant,U.S. House,4,R,Michael Pompeo,36
-Cowley,Grant,State Senate,14,D,Mark Pringle,5
-Cowley,Grant,State Senate,14,R,Bruce Givens,35
-Cowley,Grant,State House,12,R,Doug Blex,33
-Cowley,Grant,State House,12,D,Jean Kurtis Schodorf,7
-Cowley,Harvey,President,,D,Clinton and Kaine,11
-Cowley,Harvey,President,,L,Johnson and Weld,0
-Cowley,Harvey,President,,I,Stein and Baraka,0
-Cowley,Harvey,President,,R,Trump and Pence,47
-Cowley,Harvey,U.S. Senate,,L,Robert D. Gerrard,1
-Cowley,Harvey,U.S. Senate,,R,Jerry Moran,43
-Cowley,Harvey,U.S. Senate,,D,Patrick Wiesner,10
-Cowley,Harvey,U.S. House,4,I,Miranda Allen,7
-Cowley,Harvey,U.S. House,4,L,Goraden J. Bakken,0
-Cowley,Harvey,U.S. House,4,D,Daniel B. Giroux,8
-Cowley,Harvey,U.S. House,4,R,Michael Pompeo,41
-Cowley,Harvey,State Senate,14,D,Mark Pringle,14
-Cowley,Harvey,State Senate,14,R,Bruce Givens,42
-Cowley,Harvey,State House,12,R,Doug Blex,35
-Cowley,Harvey,State House,12,D,Jean Kurtis Schodorf,21
-Cowley,Liberty,President,,D,Clinton and Kaine,11
-Cowley,Liberty,President,,L,Johnson and Weld,1
-Cowley,Liberty,President,,I,Stein and Baraka,1
-Cowley,Liberty,President,,R,Trump and Pence,69
-Cowley,Liberty,U.S. Senate,,L,Robert D. Gerrard,5
-Cowley,Liberty,U.S. Senate,,R,Jerry Moran,68
-Cowley,Liberty,U.S. Senate,,D,Patrick Wiesner,12
-Cowley,Liberty,U.S. House,4,I,Miranda Allen,8
-Cowley,Liberty,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,Liberty,U.S. House,4,D,Daniel B. Giroux,11
-Cowley,Liberty,U.S. House,4,R,Michael Pompeo,64
-Cowley,Liberty,State Senate,14,D,Mark Pringle,16
-Cowley,Liberty,State Senate,14,R,Bruce Givens,66
-Cowley,Liberty,State House,12,R,Doug Blex,64
-Cowley,Liberty,State House,12,D,Jean Kurtis Schodorf,18
-Cowley,Maple,President,,D,Clinton and Kaine,56
-Cowley,Maple,President,,L,Johnson and Weld,19
-Cowley,Maple,President,,I,Stein and Baraka,15
-Cowley,Maple,President,,R,Trump and Pence,279
-Cowley,Maple,U.S. Senate,,L,Robert D. Gerrard,30
-Cowley,Maple,U.S. Senate,,R,Jerry Moran,268
-Cowley,Maple,U.S. Senate,,D,Patrick Wiesner,74
-Cowley,Maple,U.S. House,4,I,Miranda Allen,44
-Cowley,Maple,U.S. House,4,L,Goraden J. Bakken,9
-Cowley,Maple,U.S. House,4,D,Daniel B. Giroux,66
-Cowley,Maple,U.S. House,4,R,Michael Pompeo,253
-Cowley,Maple,State Senate,14,D,Mark Pringle,95
-Cowley,Maple,State Senate,14,R,Bruce Givens,272
-Cowley,Maple,State House,79,D,Ed Trimmer,270
-Cowley,Ninnescah,President,,D,Clinton and Kaine,95
-Cowley,Ninnescah,President,,L,Johnson and Weld,19
-Cowley,Ninnescah,President,,I,Stein and Baraka,3
-Cowley,Ninnescah,President,,R,Trump and Pence,329
-Cowley,Ninnescah,U.S. Senate,,L,Robert D. Gerrard,28
-Cowley,Ninnescah,U.S. Senate,,R,Jerry Moran,316
-Cowley,Ninnescah,U.S. Senate,,D,Patrick Wiesner,104
-Cowley,Ninnescah,U.S. House,4,I,Miranda Allen,34
-Cowley,Ninnescah,U.S. House,4,L,Goraden J. Bakken,13
-Cowley,Ninnescah,U.S. House,4,D,Daniel B. Giroux,96
-Cowley,Ninnescah,U.S. House,4,R,Michael Pompeo,306
-Cowley,Ninnescah,State Senate,14,D,Mark Pringle,136
-Cowley,Ninnescah,State Senate,14,R,Bruce Givens,306
-Cowley,Ninnescah,State House,79,D,Ed Trimmer,340
-Cowley,Omnia,President,,D,Clinton and Kaine,12
-Cowley,Omnia,President,,L,Johnson and Weld,3
-Cowley,Omnia,President,,I,Stein and Baraka,4
-Cowley,Omnia,President,,R,Trump and Pence,117
-Cowley,Omnia,U.S. Senate,,L,Robert D. Gerrard,7
-Cowley,Omnia,U.S. Senate,,R,Jerry Moran,116
-Cowley,Omnia,U.S. Senate,,D,Patrick Wiesner,14
-Cowley,Omnia,U.S. House,4,I,Miranda Allen,8
-Cowley,Omnia,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,Omnia,U.S. House,4,D,Daniel B. Giroux,13
-Cowley,Omnia,U.S. House,4,R,Michael Pompeo,116
-Cowley,Omnia,State Senate,14,D,Mark Pringle,24
-Cowley,Omnia,State Senate,14,R,Bruce Givens,109
-Cowley,Omnia,State House,12,R,Doug Blex,108
-Cowley,Omnia,State House,12,D,Jean Kurtis Schodorf,31
-Cowley,Otter,President,,D,Clinton and Kaine,2
-Cowley,Otter,President,,L,Johnson and Weld,2
-Cowley,Otter,President,,I,Stein and Baraka,0
-Cowley,Otter,President,,R,Trump and Pence,16
-Cowley,Otter,U.S. Senate,,L,Robert D. Gerrard,0
-Cowley,Otter,U.S. Senate,,R,Jerry Moran,17
-Cowley,Otter,U.S. Senate,,D,Patrick Wiesner,3
-Cowley,Otter,U.S. House,4,I,Miranda Allen,0
-Cowley,Otter,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,Otter,U.S. House,4,D,Daniel B. Giroux,4
-Cowley,Otter,U.S. House,4,R,Michael Pompeo,16
-Cowley,Otter,State Senate,14,D,Mark Pringle,5
-Cowley,Otter,State Senate,14,R,Bruce Givens,14
-Cowley,Otter,State House,12,R,Doug Blex,13
-Cowley,Otter,State House,12,D,Jean Kurtis Schodorf,7
-Cowley,Pleasant Valley,President,,D,Clinton and Kaine,97
-Cowley,Pleasant Valley,President,,L,Johnson and Weld,14
-Cowley,Pleasant Valley,President,,I,Stein and Baraka,8
-Cowley,Pleasant Valley,President,,R,Trump and Pence,298
-Cowley,Pleasant Valley,U.S. Senate,,L,Robert D. Gerrard,20
-Cowley,Pleasant Valley,U.S. Senate,,R,Jerry Moran,315
-Cowley,Pleasant Valley,U.S. Senate,,D,Patrick Wiesner,86
-Cowley,Pleasant Valley,U.S. House,4,I,Miranda Allen,62
-Cowley,Pleasant Valley,U.S. House,4,L,Goraden J. Bakken,8
-Cowley,Pleasant Valley,U.S. House,4,D,Daniel B. Giroux,78
-Cowley,Pleasant Valley,U.S. House,4,R,Michael Pompeo,274
-Cowley,Pleasant Valley,State Senate,32,R,Larry W. Alley,259
-Cowley,Pleasant Valley,State Senate,32,D,Don Shimkus,157
-Cowley,Pleasant Valley,State House,79,D,Ed Trimmer,337
-Cowley,Richland,President,,D,Clinton and Kaine,14
-Cowley,Richland,President,,L,Johnson and Weld,3
-Cowley,Richland,President,,I,Stein and Baraka,1
-Cowley,Richland,President,,R,Trump and Pence,77
-Cowley,Richland,U.S. Senate,,L,Robert D. Gerrard,7
-Cowley,Richland,U.S. Senate,,R,Jerry Moran,74
-Cowley,Richland,U.S. Senate,,D,Patrick Wiesner,14
-Cowley,Richland,U.S. House,4,I,Miranda Allen,8
-Cowley,Richland,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,Richland,U.S. House,4,D,Daniel B. Giroux,11
-Cowley,Richland,U.S. House,4,R,Michael Pompeo,75
-Cowley,Richland,State Senate,14,D,Mark Pringle,22
-Cowley,Richland,State Senate,14,R,Bruce Givens,73
-Cowley,Richland,State House,12,R,Doug Blex,69
-Cowley,Richland,State House,12,D,Jean Kurtis Schodorf,26
-Cowley,Rock Creek,President,,D,Clinton and Kaine,22
-Cowley,Rock Creek,President,,L,Johnson and Weld,3
-Cowley,Rock Creek,President,,I,Stein and Baraka,6
-Cowley,Rock Creek,President,,R,Trump and Pence,70
-Cowley,Rock Creek,U.S. Senate,,L,Robert D. Gerrard,8
-Cowley,Rock Creek,U.S. Senate,,R,Jerry Moran,72
-Cowley,Rock Creek,U.S. Senate,,D,Patrick Wiesner,20
-Cowley,Rock Creek,U.S. House,4,I,Miranda Allen,5
-Cowley,Rock Creek,U.S. House,4,L,Goraden J. Bakken,5
-Cowley,Rock Creek,U.S. House,4,D,Daniel B. Giroux,22
-Cowley,Rock Creek,U.S. House,4,R,Michael Pompeo,68
-Cowley,Rock Creek,State Senate,14,D,Mark Pringle,33
-Cowley,Rock Creek,State Senate,14,R,Bruce Givens,65
-Cowley,Rock Creek,State House,79,D,Ed Trimmer,81
-Cowley,Salem,President,,D,Clinton and Kaine,26
-Cowley,Salem,President,,L,Johnson and Weld,2
-Cowley,Salem,President,,I,Stein and Baraka,2
-Cowley,Salem,President,,R,Trump and Pence,121
-Cowley,Salem,U.S. Senate,,L,Robert D. Gerrard,8
-Cowley,Salem,U.S. Senate,,R,Jerry Moran,123
-Cowley,Salem,U.S. Senate,,D,Patrick Wiesner,20
-Cowley,Salem,U.S. House,4,I,Miranda Allen,15
-Cowley,Salem,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,Salem,U.S. House,4,D,Daniel B. Giroux,19
-Cowley,Salem,U.S. House,4,R,Michael Pompeo,114
-Cowley,Salem,State Senate,14,D,Mark Pringle,38
-Cowley,Salem,State Senate,14,R,Bruce Givens,111
-Cowley,Salem,State House,12,R,Doug Blex,89
-Cowley,Salem,State House,12,D,Jean Kurtis Schodorf,58
-Cowley,Sheridan,President,,D,Clinton and Kaine,15
-Cowley,Sheridan,President,,L,Johnson and Weld,2
-Cowley,Sheridan,President,,I,Stein and Baraka,0
-Cowley,Sheridan,President,,R,Trump and Pence,61
-Cowley,Sheridan,U.S. Senate,,L,Robert D. Gerrard,3
-Cowley,Sheridan,U.S. Senate,,R,Jerry Moran,60
-Cowley,Sheridan,U.S. Senate,,D,Patrick Wiesner,17
-Cowley,Sheridan,U.S. House,4,I,Miranda Allen,6
-Cowley,Sheridan,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,Sheridan,U.S. House,4,D,Daniel B. Giroux,13
-Cowley,Sheridan,U.S. House,4,R,Michael Pompeo,60
-Cowley,Sheridan,State Senate,14,D,Mark Pringle,20
-Cowley,Sheridan,State Senate,14,R,Bruce Givens,58
-Cowley,Sheridan,State House,12,R,Doug Blex,46
-Cowley,Sheridan,State House,12,D,Jean Kurtis Schodorf,32
-Cowley,Silver Creek,President,,D,Clinton and Kaine,53
-Cowley,Silver Creek,President,,L,Johnson and Weld,6
-Cowley,Silver Creek,President,,I,Stein and Baraka,3
-Cowley,Silver Creek,President,,R,Trump and Pence,245
-Cowley,Silver Creek,U.S. Senate,,L,Robert D. Gerrard,20
-Cowley,Silver Creek,U.S. Senate,,R,Jerry Moran,238
-Cowley,Silver Creek,U.S. Senate,,D,Patrick Wiesner,46
-Cowley,Silver Creek,U.S. House,4,I,Miranda Allen,21
-Cowley,Silver Creek,U.S. House,4,L,Goraden J. Bakken,5
-Cowley,Silver Creek,U.S. House,4,D,Daniel B. Giroux,37
-Cowley,Silver Creek,U.S. House,4,R,Michael Pompeo,241
-Cowley,Silver Creek,State Senate,14,D,Mark Pringle,86
-Cowley,Silver Creek,State Senate,14,R,Bruce Givens,212
-Cowley,Silver Creek,State House,12,R,Doug Blex,209
-Cowley,Silver Creek,State House,12,D,Jean Kurtis Schodorf,95
-Cowley,Silverdale,President,,D,Clinton and Kaine,24
-Cowley,Silverdale,President,,L,Johnson and Weld,4
-Cowley,Silverdale,President,,I,Stein and Baraka,4
-Cowley,Silverdale,President,,R,Trump and Pence,135
-Cowley,Silverdale,U.S. Senate,,L,Robert D. Gerrard,12
-Cowley,Silverdale,U.S. Senate,,R,Jerry Moran,124
-Cowley,Silverdale,U.S. Senate,,D,Patrick Wiesner,28
-Cowley,Silverdale,U.S. House,4,I,Miranda Allen,13
-Cowley,Silverdale,U.S. House,4,L,Goraden J. Bakken,7
-Cowley,Silverdale,U.S. House,4,D,Daniel B. Giroux,24
-Cowley,Silverdale,U.S. House,4,R,Michael Pompeo,120
-Cowley,Silverdale,State Senate,14,D,Mark Pringle,44
-Cowley,Silverdale,State Senate,14,R,Bruce Givens,115
-Cowley,Silverdale,State House,12,R,Doug Blex,105
-Cowley,Silverdale,State House,12,D,Jean Kurtis Schodorf,58
-Cowley,Spring Creek,President,,D,Clinton and Kaine,2
-Cowley,Spring Creek,President,,L,Johnson and Weld,2
-Cowley,Spring Creek,President,,I,Stein and Baraka,1
-Cowley,Spring Creek,President,,R,Trump and Pence,28
-Cowley,Spring Creek,U.S. Senate,,L,Robert D. Gerrard,3
-Cowley,Spring Creek,U.S. Senate,,R,Jerry Moran,25
-Cowley,Spring Creek,U.S. Senate,,D,Patrick Wiesner,3
-Cowley,Spring Creek,U.S. House,4,I,Miranda Allen,3
-Cowley,Spring Creek,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,Spring Creek,U.S. House,4,D,Daniel B. Giroux,3
-Cowley,Spring Creek,U.S. House,4,R,Michael Pompeo,24
-Cowley,Spring Creek,State Senate,14,D,Mark Pringle,5
-Cowley,Spring Creek,State Senate,14,R,Bruce Givens,26
-Cowley,Spring Creek,State House,12,R,Doug Blex,25
-Cowley,Spring Creek,State House,12,D,Jean Kurtis Schodorf,6
-Cowley,Tisdale,President,,D,Clinton and Kaine,29
-Cowley,Tisdale,President,,L,Johnson and Weld,8
-Cowley,Tisdale,President,,I,Stein and Baraka,5
-Cowley,Tisdale,President,,R,Trump and Pence,130
-Cowley,Tisdale,U.S. Senate,,L,Robert D. Gerrard,12
-Cowley,Tisdale,U.S. Senate,,R,Jerry Moran,122
-Cowley,Tisdale,U.S. Senate,,D,Patrick Wiesner,39
-Cowley,Tisdale,U.S. House,4,I,Miranda Allen,30
-Cowley,Tisdale,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,Tisdale,U.S. House,4,D,Daniel B. Giroux,26
-Cowley,Tisdale,U.S. House,4,R,Michael Pompeo,116
-Cowley,Tisdale,State Senate,14,D,Mark Pringle,60
-Cowley,Tisdale,State Senate,14,R,Bruce Givens,110
-Cowley,Tisdale,State House,12,R,Doug Blex,93
-Cowley,Tisdale,State House,12,D,Jean Kurtis Schodorf,75
-Cowley,Vernon,President,,D,Clinton and Kaine,40
-Cowley,Vernon,President,,L,Johnson and Weld,9
-Cowley,Vernon,President,,I,Stein and Baraka,2
-Cowley,Vernon,President,,R,Trump and Pence,189
-Cowley,Vernon,U.S. Senate,,L,Robert D. Gerrard,10
-Cowley,Vernon,U.S. Senate,,R,Jerry Moran,189
-Cowley,Vernon,U.S. Senate,,D,Patrick Wiesner,38
-Cowley,Vernon,U.S. House,4,I,Miranda Allen,23
-Cowley,Vernon,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,Vernon,U.S. House,4,D,Daniel B. Giroux,37
-Cowley,Vernon,U.S. House,4,R,Michael Pompeo,176
-Cowley,Vernon,State Senate,32,R,Larry W. Alley,160
-Cowley,Vernon,State Senate,32,D,Don Shimkus,75
-Cowley,Vernon,State House,79,D,Ed Trimmer,172
-Cowley,Walnut,President,,D,Clinton and Kaine,75
-Cowley,Walnut,President,,L,Johnson and Weld,11
-Cowley,Walnut,President,,I,Stein and Baraka,5
-Cowley,Walnut,President,,R,Trump and Pence,252
-Cowley,Walnut,U.S. Senate,,L,Robert D. Gerrard,24
-Cowley,Walnut,U.S. Senate,,R,Jerry Moran,263
-Cowley,Walnut,U.S. Senate,,D,Patrick Wiesner,58
-Cowley,Walnut,U.S. House,4,I,Miranda Allen,34
-Cowley,Walnut,U.S. House,4,L,Goraden J. Bakken,8
-Cowley,Walnut,U.S. House,4,D,Daniel B. Giroux,55
-Cowley,Walnut,U.S. House,4,R,Michael Pompeo,248
-Cowley,Walnut,State Senate,32,R,Larry W. Alley,219
-Cowley,Walnut,State Senate,32,D,Don Shimkus,123
-Cowley,Walnut,State House,79,D,Ed Trimmer,279
-Cowley,Windsor,President,,D,Clinton and Kaine,18
-Cowley,Windsor,President,,L,Johnson and Weld,2
-Cowley,Windsor,President,,I,Stein and Baraka,2
-Cowley,Windsor,President,,R,Trump and Pence,64
-Cowley,Windsor,U.S. Senate,,L,Robert D. Gerrard,6
-Cowley,Windsor,U.S. Senate,,R,Jerry Moran,65
-Cowley,Windsor,U.S. Senate,,D,Patrick Wiesner,17
-Cowley,Windsor,U.S. House,4,I,Miranda Allen,13
-Cowley,Windsor,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,Windsor,U.S. House,4,D,Daniel B. Giroux,13
-Cowley,Windsor,U.S. House,4,R,Michael Pompeo,58
-Cowley,Windsor,State Senate,14,D,Mark Pringle,24
-Cowley,Windsor,State Senate,14,R,Bruce Givens,59
-Cowley,Windsor,State House,12,R,Doug Blex,50
-Cowley,Windsor,State House,12,D,Jean Kurtis Schodorf,35
-Cowley,WD1E,President,,D,Clinton and Kaine,135
-Cowley,WD1E,President,,L,Johnson and Weld,15
-Cowley,WD1E,President,,I,Stein and Baraka,5
-Cowley,WD1E,President,,R,Trump and Pence,139
-Cowley,WD1E,U.S. Senate,,L,Robert D. Gerrard,11
-Cowley,WD1E,U.S. Senate,,R,Jerry Moran,171
-Cowley,WD1E,U.S. Senate,,D,Patrick Wiesner,113
-Cowley,WD1E,U.S. House,4,I,Miranda Allen,41
-Cowley,WD1E,U.S. House,4,L,Goraden J. Bakken,5
-Cowley,WD1E,U.S. House,4,D,Daniel B. Giroux,104
-Cowley,WD1E,U.S. House,4,R,Michael Pompeo,146
-Cowley,WD1E,State Senate,32,R,Larry W. Alley,134
-Cowley,WD1E,State Senate,32,D,Don Shimkus,163
-Cowley,WD1E,State House,79,D,Ed Trimmer,256
-Cowley,WD1W,President,,D,Clinton and Kaine,65
-Cowley,WD1W,President,,L,Johnson and Weld,4
-Cowley,WD1W,President,,I,Stein and Baraka,6
-Cowley,WD1W,President,,R,Trump and Pence,106
-Cowley,WD1W,U.S. Senate,,L,Robert D. Gerrard,13
-Cowley,WD1W,U.S. Senate,,R,Jerry Moran,117
-Cowley,WD1W,U.S. Senate,,D,Patrick Wiesner,55
-Cowley,WD1W,U.S. House,4,I,Miranda Allen,24
-Cowley,WD1W,U.S. House,4,L,Goraden J. Bakken,9
-Cowley,WD1W,U.S. House,4,D,Daniel B. Giroux,52
-Cowley,WD1W,U.S. House,4,R,Michael Pompeo,104
-Cowley,WD1W,State Senate,32,R,Larry W. Alley,99
-Cowley,WD1W,State Senate,32,D,Don Shimkus,90
-Cowley,WD1W,State House,79,D,Ed Trimmer,152
-Cowley,WD2C,President,,D,Clinton and Kaine,77
-Cowley,WD2C,President,,L,Johnson and Weld,10
-Cowley,WD2C,President,,I,Stein and Baraka,9
-Cowley,WD2C,President,,R,Trump and Pence,142
-Cowley,WD2C,U.S. Senate,,L,Robert D. Gerrard,15
-Cowley,WD2C,U.S. Senate,,R,Jerry Moran,150
-Cowley,WD2C,U.S. Senate,,D,Patrick Wiesner,74
-Cowley,WD2C,U.S. House,4,I,Miranda Allen,34
-Cowley,WD2C,U.S. House,4,L,Goraden J. Bakken,4
-Cowley,WD2C,U.S. House,4,D,Daniel B. Giroux,60
-Cowley,WD2C,U.S. House,4,R,Michael Pompeo,143
-Cowley,WD2C,State Senate,32,R,Larry W. Alley,137
-Cowley,WD2C,State Senate,32,D,Don Shimkus,106
-Cowley,WD2C,State House,79,D,Ed Trimmer,206
-Cowley,WD2E,President,,D,Clinton and Kaine,102
-Cowley,WD2E,President,,L,Johnson and Weld,12
-Cowley,WD2E,President,,I,Stein and Baraka,10
-Cowley,WD2E,President,,R,Trump and Pence,163
-Cowley,WD2E,U.S. Senate,,L,Robert D. Gerrard,19
-Cowley,WD2E,U.S. Senate,,R,Jerry Moran,171
-Cowley,WD2E,U.S. Senate,,D,Patrick Wiesner,97
-Cowley,WD2E,U.S. House,4,I,Miranda Allen,30
-Cowley,WD2E,U.S. House,4,L,Goraden J. Bakken,10
-Cowley,WD2E,U.S. House,4,D,Daniel B. Giroux,84
-Cowley,WD2E,U.S. House,4,R,Michael Pompeo,166
-Cowley,WD2E,State Senate,32,R,Larry W. Alley,132
-Cowley,WD2E,State Senate,32,D,Don Shimkus,160
-Cowley,WD2E,State House,79,D,Ed Trimmer,238
-Cowley,WD2S,President,,D,Clinton and Kaine,129
-Cowley,WD2S,President,,L,Johnson and Weld,23
-Cowley,WD2S,President,,I,Stein and Baraka,5
-Cowley,WD2S,President,,R,Trump and Pence,237
-Cowley,WD2S,U.S. Senate,,L,Robert D. Gerrard,25
-Cowley,WD2S,U.S. Senate,,R,Jerry Moran,266
-Cowley,WD2S,U.S. Senate,,D,Patrick Wiesner,103
-Cowley,WD2S,U.S. House,4,I,Miranda Allen,60
-Cowley,WD2S,U.S. House,4,L,Goraden J. Bakken,11
-Cowley,WD2S,U.S. House,4,D,Daniel B. Giroux,87
-Cowley,WD2S,U.S. House,4,R,Michael Pompeo,235
-Cowley,WD2S,State Senate,32,R,Larry W. Alley,219
-Cowley,WD2S,State Senate,32,D,Don Shimkus,179
-Cowley,WD2S,State House,79,D,Ed Trimmer,317
-Cowley,WD2W,President,,D,Clinton and Kaine,89
-Cowley,WD2W,President,,L,Johnson and Weld,7
-Cowley,WD2W,President,,I,Stein and Baraka,4
-Cowley,WD2W,President,,R,Trump and Pence,129
-Cowley,WD2W,U.S. Senate,,L,Robert D. Gerrard,14
-Cowley,WD2W,U.S. Senate,,R,Jerry Moran,134
-Cowley,WD2W,U.S. Senate,,D,Patrick Wiesner,78
-Cowley,WD2W,U.S. House,4,I,Miranda Allen,47
-Cowley,WD2W,U.S. House,4,L,Goraden J. Bakken,2
-Cowley,WD2W,U.S. House,4,D,Daniel B. Giroux,58
-Cowley,WD2W,U.S. House,4,R,Michael Pompeo,127
-Cowley,WD2W,State Senate,32,R,Larry W. Alley,125
-Cowley,WD2W,State Senate,32,D,Don Shimkus,110
-Cowley,WD2W,State House,79,D,Ed Trimmer,205
-Cowley,WD3,President,,D,Clinton and Kaine,122
-Cowley,WD3,President,,L,Johnson and Weld,16
-Cowley,WD3,President,,I,Stein and Baraka,7
-Cowley,WD3,President,,R,Trump and Pence,197
-Cowley,WD3,U.S. Senate,,L,Robert D. Gerrard,22
-Cowley,WD3,U.S. Senate,,R,Jerry Moran,211
-Cowley,WD3,U.S. Senate,,D,Patrick Wiesner,107
-Cowley,WD3,U.S. House,4,I,Miranda Allen,36
-Cowley,WD3,U.S. House,4,L,Goraden J. Bakken,8
-Cowley,WD3,U.S. House,4,D,Daniel B. Giroux,99
-Cowley,WD3,U.S. House,4,R,Michael Pompeo,199
-Cowley,WD3,State Senate,32,R,Larry W. Alley,176
-Cowley,WD3,State Senate,32,D,Don Shimkus,159
-Cowley,WD3,State House,79,D,Ed Trimmer,293
-Cowley,WD3S,President,,D,Clinton and Kaine,36
-Cowley,WD3S,President,,L,Johnson and Weld,1
-Cowley,WD3S,President,,I,Stein and Baraka,1
-Cowley,WD3S,President,,R,Trump and Pence,78
-Cowley,WD3S,U.S. Senate,,L,Robert D. Gerrard,0
-Cowley,WD3S,U.S. Senate,,R,Jerry Moran,96
-Cowley,WD3S,U.S. Senate,,D,Patrick Wiesner,21
-Cowley,WD3S,U.S. House,4,I,Miranda Allen,13
-Cowley,WD3S,U.S. House,4,L,Goraden J. Bakken,0
-Cowley,WD3S,U.S. House,4,D,Daniel B. Giroux,19
-Cowley,WD3S,U.S. House,4,R,Michael Pompeo,86
-Cowley,WD3S,State Senate,32,R,Larry W. Alley,80
-Cowley,WD3S,State Senate,32,D,Don Shimkus,37
-Cowley,WD3S,State House,79,D,Ed Trimmer,81
-Cowley,WD8,President,,D,Clinton and Kaine,8
-Cowley,WD8,President,,L,Johnson and Weld,2
-Cowley,WD8,President,,I,Stein and Baraka,0
-Cowley,WD8,President,,R,Trump and Pence,24
-Cowley,WD8,U.S. Senate,,L,Robert D. Gerrard,2
-Cowley,WD8,U.S. Senate,,R,Jerry Moran,26
-Cowley,WD8,U.S. Senate,,D,Patrick Wiesner,7
-Cowley,WD8,U.S. House,4,I,Miranda Allen,2
-Cowley,WD8,U.S. House,4,L,Goraden J. Bakken,0
-Cowley,WD8,U.S. House,4,D,Daniel B. Giroux,6
-Cowley,WD8,U.S. House,4,R,Michael Pompeo,27
-Cowley,WD8,State Senate,32,R,Larry W. Alley,22
-Cowley,WD8,State Senate,32,D,Don Shimkus,12
-Cowley,WD8,State House,79,D,Ed Trimmer,25
-Cowley,WD4,President,,D,Clinton and Kaine,34
-Cowley,WD4,President,,L,Johnson and Weld,1
-Cowley,WD4,President,,I,Stein and Baraka,6
-Cowley,WD4,President,,R,Trump and Pence,70
-Cowley,WD4,U.S. Senate,,L,Robert D. Gerrard,8
-Cowley,WD4,U.S. Senate,,R,Jerry Moran,72
-Cowley,WD4,U.S. Senate,,D,Patrick Wiesner,32
-Cowley,WD4,U.S. House,4,I,Miranda Allen,20
-Cowley,WD4,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,WD4,U.S. House,4,D,Daniel B. Giroux,28
-Cowley,WD4,U.S. House,4,R,Michael Pompeo,65
-Cowley,WD4,State Senate,32,R,Larry W. Alley,66
-Cowley,WD4,State Senate,32,D,Don Shimkus,48
-Cowley,WD4,State House,79,D,Ed Trimmer,95
-Cowley,WD5E,President,,D,Clinton and Kaine,239
-Cowley,WD5E,President,,L,Johnson and Weld,31
-Cowley,WD5E,President,,I,Stein and Baraka,19
-Cowley,WD5E,President,,R,Trump and Pence,246
-Cowley,WD5E,U.S. Senate,,L,Robert D. Gerrard,29
-Cowley,WD5E,U.S. Senate,,R,Jerry Moran,300
-Cowley,WD5E,U.S. Senate,,D,Patrick Wiesner,202
-Cowley,WD5E,U.S. House,4,I,Miranda Allen,83
-Cowley,WD5E,U.S. House,4,L,Goraden J. Bakken,14
-Cowley,WD5E,U.S. House,4,D,Daniel B. Giroux,165
-Cowley,WD5E,U.S. House,4,R,Michael Pompeo,271
-Cowley,WD5E,State Senate,32,R,Larry W. Alley,240
-Cowley,WD5E,State Senate,32,D,Don Shimkus,296
-Cowley,WD5E,State House,79,D,Ed Trimmer,456
-Cowley,WD5W,President,,D,Clinton and Kaine,94
-Cowley,WD5W,President,,L,Johnson and Weld,13
-Cowley,WD5W,President,,I,Stein and Baraka,7
-Cowley,WD5W,President,,R,Trump and Pence,100
-Cowley,WD5W,U.S. Senate,,L,Robert D. Gerrard,11
-Cowley,WD5W,U.S. Senate,,R,Jerry Moran,114
-Cowley,WD5W,U.S. Senate,,D,Patrick Wiesner,85
-Cowley,WD5W,U.S. House,4,I,Miranda Allen,26
-Cowley,WD5W,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,WD5W,U.S. House,4,D,Daniel B. Giroux,70
-Cowley,WD5W,U.S. House,4,R,Michael Pompeo,110
-Cowley,WD5W,State Senate,32,R,Larry W. Alley,104
-Cowley,WD5W,State Senate,32,D,Don Shimkus,108
-Cowley,WD5W,State House,79,D,Ed Trimmer,182
-Cowley,WD6,President,,D,Clinton and Kaine,159
-Cowley,WD6,President,,L,Johnson and Weld,22
-Cowley,WD6,President,,I,Stein and Baraka,18
-Cowley,WD6,President,,R,Trump and Pence,288
-Cowley,WD6,U.S. Senate,,L,Robert D. Gerrard,26
-Cowley,WD6,U.S. Senate,,R,Jerry Moran,320
-Cowley,WD6,U.S. Senate,,D,Patrick Wiesner,140
-Cowley,WD6,U.S. House,4,I,Miranda Allen,69
-Cowley,WD6,U.S. House,4,L,Goraden J. Bakken,12
-Cowley,WD6,U.S. House,4,D,Daniel B. Giroux,115
-Cowley,WD6,U.S. House,4,R,Michael Pompeo,295
-Cowley,WD6,State Senate,32,R,Larry W. Alley,270
-Cowley,WD6,State Senate,32,D,Don Shimkus,222
-Cowley,WD6,State House,79,D,Ed Trimmer,424
-Cowley,WD6A,President,,D,Clinton and Kaine,69
-Cowley,WD6A,President,,L,Johnson and Weld,3
-Cowley,WD6A,President,,I,Stein and Baraka,1
-Cowley,WD6A,President,,R,Trump and Pence,123
-Cowley,WD6A,U.S. Senate,,L,Robert D. Gerrard,4
-Cowley,WD6A,U.S. Senate,,R,Jerry Moran,135
-Cowley,WD6A,U.S. Senate,,D,Patrick Wiesner,59
-Cowley,WD6A,U.S. House,4,I,Miranda Allen,27
-Cowley,WD6A,U.S. House,4,L,Goraden J. Bakken,1
-Cowley,WD6A,U.S. House,4,D,Daniel B. Giroux,48
-Cowley,WD6A,U.S. House,4,R,Michael Pompeo,122
-Cowley,WD6A,State Senate,32,R,Larry W. Alley,109
-Cowley,WD6A,State Senate,32,D,Don Shimkus,87
-Cowley,WD6A,State House,79,D,Ed Trimmer,148
-Cowley,WD7,President,,D,Clinton and Kaine,124
-Cowley,WD7,President,,L,Johnson and Weld,15
-Cowley,WD7,President,,I,Stein and Baraka,6
-Cowley,WD7,President,,R,Trump and Pence,172
-Cowley,WD7,U.S. Senate,,L,Robert D. Gerrard,18
-Cowley,WD7,U.S. Senate,,R,Jerry Moran,196
-Cowley,WD7,U.S. Senate,,D,Patrick Wiesner,97
-Cowley,WD7,U.S. House,4,I,Miranda Allen,41
-Cowley,WD7,U.S. House,4,L,Goraden J. Bakken,3
-Cowley,WD7,U.S. House,4,D,Daniel B. Giroux,93
-Cowley,WD7,U.S. House,4,R,Michael Pompeo,180
-Cowley,WD7,State Senate,32,R,Larry W. Alley,153
-Cowley,WD7,State Senate,32,D,Don Shimkus,167
-Cowley,WD7,State House,79,D,Ed Trimmer,266
+county,precinct,office,district,party,candidate,votes,vtd
+COWLEY,Arkansas City Ward 1 A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",24,00001A
+COWLEY,Arkansas City Ward 1 A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",28,00001A
+COWLEY,Arkansas City Ward 1 A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",100,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",4,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",7,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",2,00001C
+COWLEY,Arkansas City Ward 1 B,Kansas House of Representatives,80,write - in,"Kelley, Kasha",19,000020
+COWLEY,Arkansas City Ward 1 B,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",34,000020
+COWLEY,Arkansas City Ward 1 B,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",98,000020
+COWLEY,Arkansas City Ward 1 C,Kansas House of Representatives,80,write - in,"Kelley, Kasha",11,000030
+COWLEY,Arkansas City Ward 1 C,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",74,000030
+COWLEY,Arkansas City Ward 1 C,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",221,000030
+COWLEY,Arkansas City Ward 1 D,Kansas House of Representatives,80,write - in,"Kelley, Kasha",15,000040
+COWLEY,Arkansas City Ward 1 D,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",43,000040
+COWLEY,Arkansas City Ward 1 D,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",180,000040
+COWLEY,Arkansas City Ward 2 A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",44,000050
+COWLEY,Arkansas City Ward 2 A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",55,000050
+COWLEY,Arkansas City Ward 2 A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",236,000050
+COWLEY,Arkansas City Ward 2 B - 1,Kansas House of Representatives,80,write - in,"Kelley, Kasha",6,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",38,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",88,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Kansas House of Representatives,80,write - in,"Kelley, Kasha",11,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",7,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",62,00006B
+COWLEY,Arkansas City Ward 2 C,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000070
+COWLEY,Arkansas City Ward 2 C,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",7,000070
+COWLEY,Arkansas City Ward 2 C,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",29,000070
+COWLEY,Arkansas City Ward 2 D,Kansas House of Representatives,80,write - in,"Kelley, Kasha",10,000080
+COWLEY,Arkansas City Ward 2 D,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",16,000080
+COWLEY,Arkansas City Ward 2 D,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",35,000080
+COWLEY,Arkansas City Ward 3 A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",3,000090
+COWLEY,Arkansas City Ward 3 A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",11,000090
+COWLEY,Arkansas City Ward 3 A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",46,000090
+COWLEY,Arkansas City Ward 3 B,Kansas House of Representatives,80,write - in,"Kelley, Kasha",5,000100
+COWLEY,Arkansas City Ward 3 B,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",17,000100
+COWLEY,Arkansas City Ward 3 B,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",63,000100
+COWLEY,Arkansas City Ward 3 C,Kansas House of Representatives,80,write - in,"Kelley, Kasha",9,000110
+COWLEY,Arkansas City Ward 3 C,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",32,000110
+COWLEY,Arkansas City Ward 3 C,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",50,000110
+COWLEY,Arkansas City Ward 4 A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",25,000120
+COWLEY,Arkansas City Ward 4 A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",70,000120
+COWLEY,Arkansas City Ward 4 A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",181,000120
+COWLEY,Arkansas City Ward 4 B,Kansas House of Representatives,80,write - in,"Kelley, Kasha",47,00013A
+COWLEY,Arkansas City Ward 4 B,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",119,00013A
+COWLEY,Arkansas City Ward 4 B,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",409,00013A
+COWLEY,Arkansas City Ward 4 C,Kansas House of Representatives,80,write - in,"Kelley, Kasha",17,000140
+COWLEY,Arkansas City Ward 4 C,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",55,000140
+COWLEY,Arkansas City Ward 4 C,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",171,000140
+COWLEY,Arkansas City Ward 4 D,Kansas House of Representatives,80,write - in,"Kelley, Kasha",33,000150
+COWLEY,Arkansas City Ward 4 D,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",104,000150
+COWLEY,Arkansas City Ward 4 D,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",292,000150
+COWLEY,Beaver Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",82,000170
+COWLEY,Cedar Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",4,000180
+COWLEY,Cedar Township,Kansas House of Representatives,12,Republican,"Blex, Doug",14,000180
+COWLEY,Dexter Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",66,000190
+COWLEY,Dexter Township,Kansas House of Representatives,12,Republican,"Blex, Doug",116,000190
+COWLEY,East Creswell,Kansas House of Representatives,80,write - in,"Kelley, Kasha",76,000210
+COWLEY,East Creswell,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",84,000210
+COWLEY,East Creswell,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",458,000210
+COWLEY,Fairview Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",105,000220
+COWLEY,Grant Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",7,000230
+COWLEY,Grant Township,Kansas House of Representatives,12,Republican,"Blex, Doug",33,000230
+COWLEY,Harvey Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",21,000240
+COWLEY,Harvey Township,Kansas House of Representatives,12,Republican,"Blex, Doug",35,000240
+COWLEY,Liberty Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",18,000250
+COWLEY,Liberty Township,Kansas House of Representatives,12,Republican,"Blex, Doug",64,000250
+COWLEY,Maple Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",270,000260
+COWLEY,Ninnescah Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",340,000270
+COWLEY,Omnia Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",31,000280
+COWLEY,Omnia Township,Kansas House of Representatives,12,Republican,"Blex, Doug",108,000280
+COWLEY,Otter Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",7,000290
+COWLEY,Otter Township,Kansas House of Representatives,12,Republican,"Blex, Doug",13,000290
+COWLEY,Pleasant Valley Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",337,000300
+COWLEY,Richland Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",26,000310
+COWLEY,Richland Township,Kansas House of Representatives,12,Republican,"Blex, Doug",69,000310
+COWLEY,Rock Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",81,000320
+COWLEY,Salem Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",58,000330
+COWLEY,Salem Township,Kansas House of Representatives,12,Republican,"Blex, Doug",89,000330
+COWLEY,Sheridan Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",32,000340
+COWLEY,Sheridan Township,Kansas House of Representatives,12,Republican,"Blex, Doug",46,000340
+COWLEY,Silver Creek Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",95,000350
+COWLEY,Silver Creek Township,Kansas House of Representatives,12,Republican,"Blex, Doug",209,000350
+COWLEY,Silverdale Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",58,000360
+COWLEY,Silverdale Township,Kansas House of Representatives,12,Republican,"Blex, Doug",105,000360
+COWLEY,Spring Creek Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",6,000370
+COWLEY,Spring Creek Township,Kansas House of Representatives,12,Republican,"Blex, Doug",25,000370
+COWLEY,Tisdale Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",75,000380
+COWLEY,Tisdale Township,Kansas House of Representatives,12,Republican,"Blex, Doug",93,000380
+COWLEY,Vernon Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",172,000390
+COWLEY,Walnut Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",279,000400
+COWLEY,West Bolton Enclave A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,00041B
+COWLEY,West Bolton Enclave A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,00041B
+COWLEY,West Bolton Enclave A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,00041B
+COWLEY,West Creswell,Kansas House of Representatives,80,write - in,"Kelley, Kasha",41,00042A
+COWLEY,West Creswell,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",51,00042A
+COWLEY,West Creswell,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",175,00042A
+COWLEY,Windsor Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",35,000430
+COWLEY,Windsor Township,Kansas House of Representatives,12,Republican,"Blex, Doug",50,000430
+COWLEY,Winfield Ward 1 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",256,000440
+COWLEY,Winfield Ward 1 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",152,000450
+COWLEY,Winfield Ward 2 Central,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",206,000460
+COWLEY,Winfield Ward 2 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",238,000470
+COWLEY,Winfield Ward 2 South,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",317,000480
+COWLEY,Winfield Ward 2 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",205,000490
+COWLEY,Winfield Ward 3,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",293,000500
+COWLEY,Winfield Ward 3 South,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",81,00051A
+COWLEY,Winfield Ward 8,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",25,00051B
+COWLEY,Winfield Ward 4,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",95,000520
+COWLEY,Winfield Ward 5 East,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",456,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas House of Representatives,12,Republican,"Blex, Doug",0,00053B
+COWLEY,Winfield Ward 5 West,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",182,000540
+COWLEY,Winfield Ward 6,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",424,000550
+COWLEY,Winfield Ward 6 A,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",148,000560
+COWLEY,Winfield Ward 7,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",266,000570
+COWLEY,Bolton,Kansas House of Representatives,80,write - in,"Kelley, Kasha",87,130010
+COWLEY,Bolton,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",129,130010
+COWLEY,Bolton,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",434,130010
+COWLEY,Arkansas City Ward 5,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900010
+COWLEY,West Creswell Enclave A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,900020
+COWLEY,West Creswell Enclave A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,900020
+COWLEY,West Creswell Enclave A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,900020
+COWLEY,West Creswell Enclave B,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,900030
+COWLEY,West Creswell Enclave B,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,900030
+COWLEY,West Creswell Enclave B,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,900030
+COWLEY,West Creswell Enclave C,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,900040
+COWLEY,West Creswell Enclave C,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,900040
+COWLEY,West Creswell Enclave C,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,900060
+COWLEY,Winfield Ward 9,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",0,900070
+COWLEY,Arkansas City Ward 1 A,Kansas Senate,32,Democratic,"Shimkus, Don",68,00001A
+COWLEY,Arkansas City Ward 1 A,Kansas Senate,32,Republican,"Alley, Larry W.",82,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas Senate,32,Democratic,"Shimkus, Don",2,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,Kansas Senate,32,Republican,"Alley, Larry W.",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas Senate,32,Democratic,"Shimkus, Don",1,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,Kansas Senate,32,Republican,"Alley, Larry W.",1,00001C
+COWLEY,Arkansas City Ward 1 B,Kansas Senate,32,Democratic,"Shimkus, Don",58,000020
+COWLEY,Arkansas City Ward 1 B,Kansas Senate,32,Republican,"Alley, Larry W.",93,000020
+COWLEY,Arkansas City Ward 1 C,Kansas Senate,32,Democratic,"Shimkus, Don",145,000030
+COWLEY,Arkansas City Ward 1 C,Kansas Senate,32,Republican,"Alley, Larry W.",159,000030
+COWLEY,Arkansas City Ward 1 D,Kansas Senate,32,Democratic,"Shimkus, Don",117,000040
+COWLEY,Arkansas City Ward 1 D,Kansas Senate,32,Republican,"Alley, Larry W.",122,000040
+COWLEY,Arkansas City Ward 2 A,Kansas Senate,32,Democratic,"Shimkus, Don",140,000050
+COWLEY,Arkansas City Ward 2 A,Kansas Senate,32,Republican,"Alley, Larry W.",193,000050
+COWLEY,Arkansas City Ward 2 B - 1,Kansas Senate,32,Democratic,"Shimkus, Don",58,00006A
+COWLEY,Arkansas City Ward 2 B - 1,Kansas Senate,32,Republican,"Alley, Larry W.",75,00006A
+COWLEY,Arkansas City Ward 2 B - 2,Kansas Senate,32,Democratic,"Shimkus, Don",37,00006B
+COWLEY,Arkansas City Ward 2 B - 2,Kansas Senate,32,Republican,"Alley, Larry W.",43,00006B
+COWLEY,Arkansas City Ward 2 C,Kansas Senate,32,Democratic,"Shimkus, Don",13,000070
+COWLEY,Arkansas City Ward 2 C,Kansas Senate,32,Republican,"Alley, Larry W.",23,000070
+COWLEY,Arkansas City Ward 2 D,Kansas Senate,32,Democratic,"Shimkus, Don",22,000080
+COWLEY,Arkansas City Ward 2 D,Kansas Senate,32,Republican,"Alley, Larry W.",36,000080
+COWLEY,Arkansas City Ward 3 A,Kansas Senate,32,Democratic,"Shimkus, Don",19,000090
+COWLEY,Arkansas City Ward 3 A,Kansas Senate,32,Republican,"Alley, Larry W.",40,000090
+COWLEY,Arkansas City Ward 3 B,Kansas Senate,32,Democratic,"Shimkus, Don",38,000100
+COWLEY,Arkansas City Ward 3 B,Kansas Senate,32,Republican,"Alley, Larry W.",45,000100
+COWLEY,Arkansas City Ward 3 C,Kansas Senate,32,Democratic,"Shimkus, Don",41,000110
+COWLEY,Arkansas City Ward 3 C,Kansas Senate,32,Republican,"Alley, Larry W.",51,000110
+COWLEY,Arkansas City Ward 4 A,Kansas Senate,32,Democratic,"Shimkus, Don",131,000120
+COWLEY,Arkansas City Ward 4 A,Kansas Senate,32,Republican,"Alley, Larry W.",143,000120
+COWLEY,Arkansas City Ward 4 B,Kansas Senate,32,Democratic,"Shimkus, Don",271,00013A
+COWLEY,Arkansas City Ward 4 B,Kansas Senate,32,Republican,"Alley, Larry W.",296,00013A
+COWLEY,Arkansas City Ward 4 C,Kansas Senate,32,Democratic,"Shimkus, Don",127,000140
+COWLEY,Arkansas City Ward 4 C,Kansas Senate,32,Republican,"Alley, Larry W.",117,000140
+COWLEY,Arkansas City Ward 4 D,Kansas Senate,32,Democratic,"Shimkus, Don",207,000150
+COWLEY,Arkansas City Ward 4 D,Kansas Senate,32,Republican,"Alley, Larry W.",223,000150
+COWLEY,Beaver Township,Kansas Senate,32,Democratic,"Shimkus, Don",44,000170
+COWLEY,Beaver Township,Kansas Senate,32,Republican,"Alley, Larry W.",61,000170
+COWLEY,Cedar Township,Kansas Senate,14,Democratic,"Pringle, Mark",4,000180
+COWLEY,Cedar Township,Kansas Senate,14,Republican,"Givens, Bruce",15,000180
+COWLEY,Dexter Township,Kansas Senate,14,Democratic,"Pringle, Mark",54,000190
+COWLEY,Dexter Township,Kansas Senate,14,Republican,"Givens, Bruce",126,000190
+COWLEY,East Creswell,Kansas Senate,32,Democratic,"Shimkus, Don",231,000210
+COWLEY,East Creswell,Kansas Senate,32,Republican,"Alley, Larry W.",390,000210
+COWLEY,Fairview Township,Kansas Senate,14,Democratic,"Pringle, Mark",45,000220
+COWLEY,Fairview Township,Kansas Senate,14,Republican,"Givens, Bruce",83,000220
+COWLEY,Grant Township,Kansas Senate,14,Democratic,"Pringle, Mark",5,000230
+COWLEY,Grant Township,Kansas Senate,14,Republican,"Givens, Bruce",35,000230
+COWLEY,Harvey Township,Kansas Senate,14,Democratic,"Pringle, Mark",14,000240
+COWLEY,Harvey Township,Kansas Senate,14,Republican,"Givens, Bruce",42,000240
+COWLEY,Liberty Township,Kansas Senate,14,Democratic,"Pringle, Mark",16,000250
+COWLEY,Liberty Township,Kansas Senate,14,Republican,"Givens, Bruce",66,000250
+COWLEY,Maple Township,Kansas Senate,14,Democratic,"Pringle, Mark",95,000260
+COWLEY,Maple Township,Kansas Senate,14,Republican,"Givens, Bruce",272,000260
+COWLEY,Ninnescah Township,Kansas Senate,14,Democratic,"Pringle, Mark",136,000270
+COWLEY,Ninnescah Township,Kansas Senate,14,Republican,"Givens, Bruce",306,000270
+COWLEY,Omnia Township,Kansas Senate,14,Democratic,"Pringle, Mark",24,000280
+COWLEY,Omnia Township,Kansas Senate,14,Republican,"Givens, Bruce",109,000280
+COWLEY,Otter Township,Kansas Senate,14,Democratic,"Pringle, Mark",5,000290
+COWLEY,Otter Township,Kansas Senate,14,Republican,"Givens, Bruce",14,000290
+COWLEY,Pleasant Valley Township,Kansas Senate,32,Democratic,"Shimkus, Don",157,000300
+COWLEY,Pleasant Valley Township,Kansas Senate,32,Republican,"Alley, Larry W.",259,000300
+COWLEY,Richland Township,Kansas Senate,14,Democratic,"Pringle, Mark",22,000310
+COWLEY,Richland Township,Kansas Senate,14,Republican,"Givens, Bruce",73,000310
+COWLEY,Rock Township,Kansas Senate,14,Democratic,"Pringle, Mark",33,000320
+COWLEY,Rock Township,Kansas Senate,14,Republican,"Givens, Bruce",65,000320
+COWLEY,Salem Township,Kansas Senate,14,Democratic,"Pringle, Mark",38,000330
+COWLEY,Salem Township,Kansas Senate,14,Republican,"Givens, Bruce",111,000330
+COWLEY,Sheridan Township,Kansas Senate,14,Democratic,"Pringle, Mark",20,000340
+COWLEY,Sheridan Township,Kansas Senate,14,Republican,"Givens, Bruce",58,000340
+COWLEY,Silver Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",86,000350
+COWLEY,Silver Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",212,000350
+COWLEY,Silverdale Township,Kansas Senate,14,Democratic,"Pringle, Mark",44,000360
+COWLEY,Silverdale Township,Kansas Senate,14,Republican,"Givens, Bruce",115,000360
+COWLEY,Spring Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",5,000370
+COWLEY,Spring Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",26,000370
+COWLEY,Tisdale Township,Kansas Senate,14,Democratic,"Pringle, Mark",60,000380
+COWLEY,Tisdale Township,Kansas Senate,14,Republican,"Givens, Bruce",110,000380
+COWLEY,Vernon Township,Kansas Senate,32,Democratic,"Shimkus, Don",75,000390
+COWLEY,Vernon Township,Kansas Senate,32,Republican,"Alley, Larry W.",160,000390
+COWLEY,Walnut Township,Kansas Senate,32,Democratic,"Shimkus, Don",123,000400
+COWLEY,Walnut Township,Kansas Senate,32,Republican,"Alley, Larry W.",219,000400
+COWLEY,West Bolton Enclave A,Kansas Senate,32,Democratic,"Shimkus, Don",0,00041B
+COWLEY,West Bolton Enclave A,Kansas Senate,32,Republican,"Alley, Larry W.",0,00041B
+COWLEY,West Creswell,Kansas Senate,32,Democratic,"Shimkus, Don",95,00042A
+COWLEY,West Creswell,Kansas Senate,32,Republican,"Alley, Larry W.",172,00042A
+COWLEY,Windsor Township,Kansas Senate,14,Democratic,"Pringle, Mark",24,000430
+COWLEY,Windsor Township,Kansas Senate,14,Republican,"Givens, Bruce",59,000430
+COWLEY,Winfield Ward 1 East,Kansas Senate,32,Democratic,"Shimkus, Don",163,000440
+COWLEY,Winfield Ward 1 East,Kansas Senate,32,Republican,"Alley, Larry W.",134,000440
+COWLEY,Winfield Ward 1 West,Kansas Senate,32,Democratic,"Shimkus, Don",90,000450
+COWLEY,Winfield Ward 1 West,Kansas Senate,32,Republican,"Alley, Larry W.",99,000450
+COWLEY,Winfield Ward 2 Central,Kansas Senate,32,Democratic,"Shimkus, Don",106,000460
+COWLEY,Winfield Ward 2 Central,Kansas Senate,32,Republican,"Alley, Larry W.",137,000460
+COWLEY,Winfield Ward 2 East,Kansas Senate,32,Democratic,"Shimkus, Don",160,000470
+COWLEY,Winfield Ward 2 East,Kansas Senate,32,Republican,"Alley, Larry W.",132,000470
+COWLEY,Winfield Ward 2 South,Kansas Senate,32,Democratic,"Shimkus, Don",179,000480
+COWLEY,Winfield Ward 2 South,Kansas Senate,32,Republican,"Alley, Larry W.",219,000480
+COWLEY,Winfield Ward 2 West,Kansas Senate,32,Democratic,"Shimkus, Don",110,000490
+COWLEY,Winfield Ward 2 West,Kansas Senate,32,Republican,"Alley, Larry W.",125,000490
+COWLEY,Winfield Ward 3,Kansas Senate,32,Democratic,"Shimkus, Don",159,000500
+COWLEY,Winfield Ward 3,Kansas Senate,32,Republican,"Alley, Larry W.",176,000500
+COWLEY,Winfield Ward 3 South,Kansas Senate,32,Democratic,"Shimkus, Don",37,00051A
+COWLEY,Winfield Ward 3 South,Kansas Senate,32,Republican,"Alley, Larry W.",80,00051A
+COWLEY,Winfield Ward 8,Kansas Senate,32,Democratic,"Shimkus, Don",12,00051B
+COWLEY,Winfield Ward 8,Kansas Senate,32,Republican,"Alley, Larry W.",22,00051B
+COWLEY,Winfield Ward 4,Kansas Senate,32,Democratic,"Shimkus, Don",48,000520
+COWLEY,Winfield Ward 4,Kansas Senate,32,Republican,"Alley, Larry W.",66,000520
+COWLEY,Winfield Ward 5 East,Kansas Senate,32,Democratic,"Shimkus, Don",296,00053A
+COWLEY,Winfield Ward 5 East,Kansas Senate,32,Republican,"Alley, Larry W.",240,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas Senate,14,Democratic,"Pringle, Mark",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,Kansas Senate,14,Republican,"Givens, Bruce",0,00053B
+COWLEY,Winfield Ward 5 West,Kansas Senate,32,Democratic,"Shimkus, Don",108,000540
+COWLEY,Winfield Ward 5 West,Kansas Senate,32,Republican,"Alley, Larry W.",104,000540
+COWLEY,Winfield Ward 6,Kansas Senate,32,Democratic,"Shimkus, Don",222,000550
+COWLEY,Winfield Ward 6,Kansas Senate,32,Republican,"Alley, Larry W.",270,000550
+COWLEY,Winfield Ward 6 A,Kansas Senate,32,Democratic,"Shimkus, Don",87,000560
+COWLEY,Winfield Ward 6 A,Kansas Senate,32,Republican,"Alley, Larry W.",109,000560
+COWLEY,Winfield Ward 7,Kansas Senate,32,Democratic,"Shimkus, Don",167,000570
+COWLEY,Winfield Ward 7,Kansas Senate,32,Republican,"Alley, Larry W.",153,000570
+COWLEY,Bolton,Kansas Senate,32,Democratic,"Shimkus, Don",226,130010
+COWLEY,Bolton,Kansas Senate,32,Republican,"Alley, Larry W.",415,130010
+COWLEY,Arkansas City Ward 5,Kansas Senate,32,Democratic,"Shimkus, Don",0,900010
+COWLEY,Arkansas City Ward 5,Kansas Senate,32,Republican,"Alley, Larry W.",0,900010
+COWLEY,West Creswell Enclave A,Kansas Senate,32,Democratic,"Shimkus, Don",0,900020
+COWLEY,West Creswell Enclave A,Kansas Senate,32,Republican,"Alley, Larry W.",0,900020
+COWLEY,West Creswell Enclave B,Kansas Senate,32,Democratic,"Shimkus, Don",0,900030
+COWLEY,West Creswell Enclave B,Kansas Senate,32,Republican,"Alley, Larry W.",0,900030
+COWLEY,West Creswell Enclave C,Kansas Senate,32,Democratic,"Shimkus, Don",0,900040
+COWLEY,West Creswell Enclave C,Kansas Senate,32,Republican,"Alley, Larry W.",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas Senate,32,Democratic,"Shimkus, Don",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,Kansas Senate,32,Republican,"Alley, Larry W.",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas Senate,32,Democratic,"Shimkus, Don",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,Kansas Senate,32,Republican,"Alley, Larry W.",0,900060
+COWLEY,Winfield Ward 9,Kansas Senate,32,Democratic,"Shimkus, Don",0,900070
+COWLEY,Winfield Ward 9,Kansas Senate,32,Republican,"Alley, Larry W.",0,900070
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,independent,"Stein, Jill",2,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Castle, Darrell L",2,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Giordani, Rocky",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Hedges, James A",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Kahn, Lynn",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"La Riva, Gloria",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Levinson, Michael S.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Maturen, Michael A",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"McMullin, Evan",3,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Perry, Darryl",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Schriner, Joe C",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Smith, Mike",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Sood, Ajay",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Sterling, Shawna",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Libertarian,"Johnson, Gary",7,00001A
+COWLEY,Arkansas City Ward 1 A,President / Vice President,,Republican,"Trump, Donald J.",92,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,independent,"Stein, Jill",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,President / Vice President,,Republican,"Trump, Donald J.",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,independent,"Stein, Jill",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,President / Vice President,,Republican,"Trump, Donald J.",1,00001C
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,independent,"Stein, Jill",3,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Hedges, James A",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"McMullin, Evan",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Perry, Darryl",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Smith, Mike",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Sood, Ajay",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Libertarian,"Johnson, Gary",9,000020
+COWLEY,Arkansas City Ward 1 B,President / Vice President,,Republican,"Trump, Donald J.",104,000020
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,independent,"Stein, Jill",5,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Hedges, James A",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"McMullin, Evan",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Perry, Darryl",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Smith, Mike",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Sood, Ajay",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",99,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+COWLEY,Arkansas City Ward 1 C,President / Vice President,,Republican,"Trump, Donald J.",191,000030
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,independent,"Stein, Jill",3,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Hedges, James A",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"McMullin, Evan",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Perry, Darryl",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Smith, Mike",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Sood, Ajay",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Libertarian,"Johnson, Gary",14,000040
+COWLEY,Arkansas City Ward 1 D,President / Vice President,,Republican,"Trump, Donald J.",136,000040
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,independent,"Stein, Jill",7,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Hedges, James A",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"McMullin, Evan",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Perry, Darryl",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Smith, Mike",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Sood, Ajay",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",93,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Libertarian,"Johnson, Gary",12,000050
+COWLEY,Arkansas City Ward 2 A,President / Vice President,,Republican,"Trump, Donald J.",228,000050
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,independent,"Stein, Jill",3,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Hedges, James A",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"McMullin, Evan",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Smith, Mike",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Libertarian,"Johnson, Gary",2,00006A
+COWLEY,Arkansas City Ward 2 B - 1,President / Vice President,,Republican,"Trump, Donald J.",89,00006A
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,independent,"Stein, Jill",1,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Hedges, James A",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Smith, Mike",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Libertarian,"Johnson, Gary",2,00006B
+COWLEY,Arkansas City Ward 2 B - 2,President / Vice President,,Republican,"Trump, Donald J.",55,00006B
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,independent,"Stein, Jill",2,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Hedges, James A",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"McMullin, Evan",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Perry, Darryl",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Smith, Mike",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Sood, Ajay",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+COWLEY,Arkansas City Ward 2 C,President / Vice President,,Republican,"Trump, Donald J.",24,000070
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,independent,"Stein, Jill",2,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Hedges, James A",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"McMullin, Evan",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Perry, Darryl",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Smith, Mike",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Sood, Ajay",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+COWLEY,Arkansas City Ward 2 D,President / Vice President,,Republican,"Trump, Donald J.",40,000080
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,independent,"Stein, Jill",4,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Hedges, James A",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"McMullin, Evan",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Perry, Darryl",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Smith, Mike",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Sood, Ajay",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+COWLEY,Arkansas City Ward 3 A,President / Vice President,,Republican,"Trump, Donald J.",35,000090
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,independent,"Stein, Jill",1,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Hedges, James A",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"McMullin, Evan",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Perry, Darryl",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Smith, Mike",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Sood, Ajay",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+COWLEY,Arkansas City Ward 3 B,President / Vice President,,Republican,"Trump, Donald J.",58,000100
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,independent,"Stein, Jill",2,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Hedges, James A",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"McMullin, Evan",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Perry, Darryl",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Smith, Mike",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Sood, Ajay",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+COWLEY,Arkansas City Ward 3 C,President / Vice President,,Republican,"Trump, Donald J.",58,000110
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,independent,"Stein, Jill",4,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Hedges, James A",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"McMullin, Evan",7,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Perry, Darryl",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Smith, Mike",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Sood, Ajay",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Libertarian,"Johnson, Gary",14,000120
+COWLEY,Arkansas City Ward 4 A,President / Vice President,,Republican,"Trump, Donald J.",152,000120
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,independent,"Stein, Jill",20,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Hedges, James A",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"McMullin, Evan",5,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Smith, Mike",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",193,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Libertarian,"Johnson, Gary",27,00013A
+COWLEY,Arkansas City Ward 4 B,President / Vice President,,Republican,"Trump, Donald J.",339,00013A
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,independent,"Stein, Jill",4,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Hedges, James A",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"McMullin, Evan",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Perry, Darryl",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Smith, Mike",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Sood, Ajay",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",94,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Libertarian,"Johnson, Gary",13,000140
+COWLEY,Arkansas City Ward 4 C,President / Vice President,,Republican,"Trump, Donald J.",133,000140
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,independent,"Stein, Jill",15,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Hedges, James A",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"McMullin, Evan",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Perry, Darryl",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Smith, Mike",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Sood, Ajay",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",162,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Libertarian,"Johnson, Gary",15,000150
+COWLEY,Arkansas City Ward 4 D,President / Vice President,,Republican,"Trump, Donald J.",234,000150
+COWLEY,Beaver Township,President / Vice President,,independent,"Stein, Jill",2,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+COWLEY,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+COWLEY,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000170
+COWLEY,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+COWLEY,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",73,000170
+COWLEY,Cedar Township,President / Vice President,,independent,"Stein, Jill",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+COWLEY,Cedar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+COWLEY,Cedar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000180
+COWLEY,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+COWLEY,Cedar Township,President / Vice President,,Republican,"Trump, Donald J.",16,000180
+COWLEY,Dexter Township,President / Vice President,,independent,"Stein, Jill",3,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+COWLEY,Dexter Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+COWLEY,Dexter Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000190
+COWLEY,Dexter Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+COWLEY,Dexter Township,President / Vice President,,Republican,"Trump, Donald J.",154,000190
+COWLEY,East Creswell,President / Vice President,,independent,"Stein, Jill",14,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Hedges, James A",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"McMullin, Evan",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Perry, Darryl",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Smith, Mike",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Sood, Ajay",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+COWLEY,East Creswell,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+COWLEY,East Creswell,President / Vice President,,Democratic,"Clinton, Hillary Rodham",132,000210
+COWLEY,East Creswell,President / Vice President,,Libertarian,"Johnson, Gary",13,000210
+COWLEY,East Creswell,President / Vice President,,Republican,"Trump, Donald J.",464,000210
+COWLEY,Fairview Township,President / Vice President,,independent,"Stein, Jill",1,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+COWLEY,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+COWLEY,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000220
+COWLEY,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000220
+COWLEY,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",98,000220
+COWLEY,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+COWLEY,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+COWLEY,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000230
+COWLEY,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000230
+COWLEY,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",33,000230
+COWLEY,Harvey Township,President / Vice President,,independent,"Stein, Jill",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+COWLEY,Harvey Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+COWLEY,Harvey Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000240
+COWLEY,Harvey Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+COWLEY,Harvey Township,President / Vice President,,Republican,"Trump, Donald J.",47,000240
+COWLEY,Liberty Township,President / Vice President,,independent,"Stein, Jill",1,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+COWLEY,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+COWLEY,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000250
+COWLEY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+COWLEY,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",69,000250
+COWLEY,Maple Township,President / Vice President,,independent,"Stein, Jill",15,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"McMullin, Evan",1,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+COWLEY,Maple Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+COWLEY,Maple Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000260
+COWLEY,Maple Township,President / Vice President,,Libertarian,"Johnson, Gary",19,000260
+COWLEY,Maple Township,President / Vice President,,Republican,"Trump, Donald J.",279,000260
+COWLEY,Ninnescah Township,President / Vice President,,independent,"Stein, Jill",3,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Castle, Darrell L",1,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"McMullin, Evan",3,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+COWLEY,Ninnescah Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,000270
+COWLEY,Ninnescah Township,President / Vice President,,Libertarian,"Johnson, Gary",19,000270
+COWLEY,Ninnescah Township,President / Vice President,,Republican,"Trump, Donald J.",329,000270
+COWLEY,Omnia Township,President / Vice President,,independent,"Stein, Jill",4,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+COWLEY,Omnia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+COWLEY,Omnia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000280
+COWLEY,Omnia Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000280
+COWLEY,Omnia Township,President / Vice President,,Republican,"Trump, Donald J.",117,000280
+COWLEY,Otter Township,President / Vice President,,independent,"Stein, Jill",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+COWLEY,Otter Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+COWLEY,Otter Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000290
+COWLEY,Otter Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000290
+COWLEY,Otter Township,President / Vice President,,Republican,"Trump, Donald J.",16,000290
+COWLEY,Pleasant Valley Township,President / Vice President,,independent,"Stein, Jill",8,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000300
+COWLEY,Pleasant Valley Township,President / Vice President,,Republican,"Trump, Donald J.",298,000300
+COWLEY,Richland Township,President / Vice President,,independent,"Stein, Jill",1,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+COWLEY,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+COWLEY,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000310
+COWLEY,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000310
+COWLEY,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",77,000310
+COWLEY,Rock Township,President / Vice President,,independent,"Stein, Jill",6,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+COWLEY,Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+COWLEY,Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000320
+COWLEY,Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000320
+COWLEY,Rock Township,President / Vice President,,Republican,"Trump, Donald J.",70,000320
+COWLEY,Salem Township,President / Vice President,,independent,"Stein, Jill",2,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Hedges, James A",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"McMullin, Evan",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Perry, Darryl",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Smith, Mike",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Sood, Ajay",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+COWLEY,Salem Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+COWLEY,Salem Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000330
+COWLEY,Salem Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000330
+COWLEY,Salem Township,President / Vice President,,Republican,"Trump, Donald J.",121,000330
+COWLEY,Sheridan Township,President / Vice President,,independent,"Stein, Jill",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Hedges, James A",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",2,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"McMullin, Evan",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Perry, Darryl",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Smith, Mike",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Sood, Ajay",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+COWLEY,Sheridan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+COWLEY,Sheridan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000340
+COWLEY,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000340
+COWLEY,Sheridan Township,President / Vice President,,Republican,"Trump, Donald J.",61,000340
+COWLEY,Silver Creek Township,President / Vice President,,independent,"Stein, Jill",3,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+COWLEY,Silver Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000350
+COWLEY,Silver Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000350
+COWLEY,Silver Creek Township,President / Vice President,,Republican,"Trump, Donald J.",245,000350
+COWLEY,Silverdale Township,President / Vice President,,independent,"Stein, Jill",4,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Hedges, James A",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"McMullin, Evan",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Perry, Darryl",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Smith, Mike",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Sood, Ajay",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+COWLEY,Silverdale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+COWLEY,Silverdale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000360
+COWLEY,Silverdale Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000360
+COWLEY,Silverdale Township,President / Vice President,,Republican,"Trump, Donald J.",135,000360
+COWLEY,Spring Creek Township,President / Vice President,,independent,"Stein, Jill",1,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+COWLEY,Spring Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000370
+COWLEY,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000370
+COWLEY,Spring Creek Township,President / Vice President,,Republican,"Trump, Donald J.",28,000370
+COWLEY,Tisdale Township,President / Vice President,,independent,"Stein, Jill",5,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Hedges, James A",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"McMullin, Evan",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Perry, Darryl",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Smith, Mike",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Sood, Ajay",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+COWLEY,Tisdale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+COWLEY,Tisdale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000380
+COWLEY,Tisdale Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000380
+COWLEY,Tisdale Township,President / Vice President,,Republican,"Trump, Donald J.",130,000380
+COWLEY,Vernon Township,President / Vice President,,independent,"Stein, Jill",2,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Hedges, James A",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"McMullin, Evan",1,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Perry, Darryl",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Smith, Mike",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Sood, Ajay",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000390
+COWLEY,Vernon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000390
+COWLEY,Vernon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000390
+COWLEY,Vernon Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000390
+COWLEY,Vernon Township,President / Vice President,,Republican,"Trump, Donald J.",189,000390
+COWLEY,Walnut Township,President / Vice President,,independent,"Stein, Jill",5,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+COWLEY,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+COWLEY,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,000400
+COWLEY,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000400
+COWLEY,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",252,000400
+COWLEY,West Bolton Enclave A,President / Vice President,,independent,"Stein, Jill",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00041B
+COWLEY,West Bolton Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00041B
+COWLEY,West Creswell,President / Vice President,,independent,"Stein, Jill",5,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Basiago, Andrew D.",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Castle, Darrell L",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Giordani, Rocky",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Hedges, James A",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Kahn, Lynn",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"La Riva, Gloria",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Levinson, Michael S.",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Maturen, Michael A",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"McMullin, Evan",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Moorehead, Monica G.",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Perry, Darryl",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Schriner, Joe C",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Smith, Mike",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Sood, Ajay",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Sterling, Shawna",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Valdivia, Anthony J",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00042A
+COWLEY,West Creswell,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00042A
+COWLEY,West Creswell,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,00042A
+COWLEY,West Creswell,President / Vice President,,Libertarian,"Johnson, Gary",14,00042A
+COWLEY,West Creswell,President / Vice President,,Republican,"Trump, Donald J.",200,00042A
+COWLEY,Windsor Township,President / Vice President,,independent,"Stein, Jill",2,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Hedges, James A",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"McMullin, Evan",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Perry, Darryl",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Smith, Mike",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Sood, Ajay",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+COWLEY,Windsor Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+COWLEY,Windsor Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000430
+COWLEY,Windsor Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000430
+COWLEY,Windsor Township,President / Vice President,,Republican,"Trump, Donald J.",64,000430
+COWLEY,Winfield Ward 1 East,President / Vice President,,independent,"Stein, Jill",5,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Castle, Darrell L",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Giordani, Rocky",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Hedges, James A",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Kahn, Lynn",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"La Riva, Gloria",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Levinson, Michael S.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Maturen, Michael A",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"McMullin, Evan",2,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Perry, Darryl",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Schriner, Joe C",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Smith, Mike",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Sood, Ajay",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Sterling, Shawna",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",135,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Libertarian,"Johnson, Gary",15,000440
+COWLEY,Winfield Ward 1 East,President / Vice President,,Republican,"Trump, Donald J.",139,000440
+COWLEY,Winfield Ward 1 West,President / Vice President,,independent,"Stein, Jill",6,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Castle, Darrell L",3,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Hedges, James A",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"McMullin, Evan",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Perry, Darryl",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Smith, Mike",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Sood, Ajay",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Libertarian,"Johnson, Gary",4,000450
+COWLEY,Winfield Ward 1 West,President / Vice President,,Republican,"Trump, Donald J.",106,000450
+COWLEY,Winfield Ward 2 Central,President / Vice President,,independent,"Stein, Jill",9,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Basiago, Andrew D.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Castle, Darrell L",1,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Giordani, Rocky",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Hedges, James A",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Kahn, Lynn",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"La Riva, Gloria",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Levinson, Michael S.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Maturen, Michael A",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"McMullin, Evan",1,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Moorehead, Monica G.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Perry, Darryl",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Schriner, Joe C",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Smith, Mike",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Sood, Ajay",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Sterling, Shawna",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Valdivia, Anthony J",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Libertarian,"Johnson, Gary",10,000460
+COWLEY,Winfield Ward 2 Central,President / Vice President,,Republican,"Trump, Donald J.",142,000460
+COWLEY,Winfield Ward 2 East,President / Vice President,,independent,"Stein, Jill",10,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Castle, Darrell L",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Giordani, Rocky",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Hedges, James A",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Kahn, Lynn",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"La Riva, Gloria",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Levinson, Michael S.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Maturen, Michael A",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"McMullin, Evan",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Perry, Darryl",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Schriner, Joe C",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Smith, Mike",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Sood, Ajay",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Sterling, Shawna",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",102,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Libertarian,"Johnson, Gary",12,000470
+COWLEY,Winfield Ward 2 East,President / Vice President,,Republican,"Trump, Donald J.",163,000470
+COWLEY,Winfield Ward 2 South,President / Vice President,,independent,"Stein, Jill",5,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Basiago, Andrew D.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Castle, Darrell L",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Giordani, Rocky",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Hedges, James A",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Kahn, Lynn",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"La Riva, Gloria",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Levinson, Michael S.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Maturen, Michael A",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"McMullin, Evan",1,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Moorehead, Monica G.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Perry, Darryl",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Schriner, Joe C",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Smith, Mike",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Sood, Ajay",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Sterling, Shawna",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Valdivia, Anthony J",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Democratic,"Clinton, Hillary Rodham",129,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Libertarian,"Johnson, Gary",23,000480
+COWLEY,Winfield Ward 2 South,President / Vice President,,Republican,"Trump, Donald J.",237,000480
+COWLEY,Winfield Ward 2 West,President / Vice President,,independent,"Stein, Jill",4,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Castle, Darrell L",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Giordani, Rocky",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Hedges, James A",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Kahn, Lynn",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"La Riva, Gloria",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Levinson, Michael S.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Maturen, Michael A",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"McMullin, Evan",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Perry, Darryl",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Schriner, Joe C",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Smith, Mike",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Sood, Ajay",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Sterling, Shawna",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",89,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Libertarian,"Johnson, Gary",7,000490
+COWLEY,Winfield Ward 2 West,President / Vice President,,Republican,"Trump, Donald J.",129,000490
+COWLEY,Winfield Ward 3,President / Vice President,,independent,"Stein, Jill",7,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Castle, Darrell L",3,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",16,000500
+COWLEY,Winfield Ward 3,President / Vice President,,Republican,"Trump, Donald J.",197,000500
+COWLEY,Winfield Ward 3 South,President / Vice President,,independent,"Stein, Jill",1,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Basiago, Andrew D.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Castle, Darrell L",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Giordani, Rocky",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Hedges, James A",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Hoefling, Tom",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Kahn, Lynn",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"La Riva, Gloria",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Levinson, Michael S.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Maturen, Michael A",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"McMullin, Evan",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Moorehead, Monica G.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Perry, Darryl",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Schriner, Joe C",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Smith, Mike",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Sood, Ajay",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Sterling, Shawna",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Valdivia, Anthony J",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Libertarian,"Johnson, Gary",1,00051A
+COWLEY,Winfield Ward 3 South,President / Vice President,,Republican,"Trump, Donald J.",78,00051A
+COWLEY,Winfield Ward 8,President / Vice President,,independent,"Stein, Jill",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Basiago, Andrew D.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Castle, Darrell L",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Giordani, Rocky",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Hedges, James A",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Hoefling, Tom",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Kahn, Lynn",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"La Riva, Gloria",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Levinson, Michael S.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Maturen, Michael A",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"McMullin, Evan",1,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Moorehead, Monica G.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Perry, Darryl",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Schriner, Joe C",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Smith, Mike",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Sood, Ajay",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Sterling, Shawna",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Valdivia, Anthony J",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Libertarian,"Johnson, Gary",2,00051B
+COWLEY,Winfield Ward 8,President / Vice President,,Republican,"Trump, Donald J.",24,00051B
+COWLEY,Winfield Ward 4,President / Vice President,,independent,"Stein, Jill",6,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Castle, Darrell L",1,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",1,000520
+COWLEY,Winfield Ward 4,President / Vice President,,Republican,"Trump, Donald J.",70,000520
+COWLEY,Winfield Ward 5 East,President / Vice President,,independent,"Stein, Jill",19,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Castle, Darrell L",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Giordani, Rocky",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Hedges, James A",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Hoefling, Tom",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Kahn, Lynn",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"La Riva, Gloria",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Levinson, Michael S.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Maturen, Michael A",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"McMullin, Evan",1,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Perry, Darryl",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Schriner, Joe C",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Smith, Mike",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Sood, Ajay",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Sterling, Shawna",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",239,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Libertarian,"Johnson, Gary",31,00053A
+COWLEY,Winfield Ward 5 East,President / Vice President,,Republican,"Trump, Donald J.",246,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,independent,"Stein, Jill",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Basiago, Andrew D.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Castle, Darrell L",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Giordani, Rocky",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Hedges, James A",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Hoefling, Tom",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Kahn, Lynn",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"La Riva, Gloria",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Levinson, Michael S.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Maturen, Michael A",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"McMullin, Evan",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Moorehead, Monica G.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Perry, Darryl",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Schriner, Joe C",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Smith, Mike",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Sood, Ajay",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Sterling, Shawna",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Valdivia, Anthony J",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Libertarian,"Johnson, Gary",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,President / Vice President,,Republican,"Trump, Donald J.",0,00053B
+COWLEY,Winfield Ward 5 West,President / Vice President,,independent,"Stein, Jill",7,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Castle, Darrell L",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Giordani, Rocky",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Hedges, James A",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Hoefling, Tom",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Kahn, Lynn",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"La Riva, Gloria",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Levinson, Michael S.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Maturen, Michael A",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"McMullin, Evan",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Perry, Darryl",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Schriner, Joe C",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Smith, Mike",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Sood, Ajay",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Sterling, Shawna",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",94,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Libertarian,"Johnson, Gary",13,000540
+COWLEY,Winfield Ward 5 West,President / Vice President,,Republican,"Trump, Donald J.",100,000540
+COWLEY,Winfield Ward 6,President / Vice President,,independent,"Stein, Jill",18,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Castle, Darrell L",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Giordani, Rocky",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Hedges, James A",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Hoefling, Tom",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Kahn, Lynn",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"La Riva, Gloria",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Levinson, Michael S.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Maturen, Michael A",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"McMullin, Evan",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Perry, Darryl",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Schriner, Joe C",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Smith, Mike",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Sood, Ajay",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Sterling, Shawna",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",159,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Libertarian,"Johnson, Gary",22,000550
+COWLEY,Winfield Ward 6,President / Vice President,,Republican,"Trump, Donald J.",288,000550
+COWLEY,Winfield Ward 6 A,President / Vice President,,independent,"Stein, Jill",1,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Castle, Darrell L",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Giordani, Rocky",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Hedges, James A",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Hoefling, Tom",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Kahn, Lynn",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"La Riva, Gloria",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Levinson, Michael S.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Maturen, Michael A",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"McMullin, Evan",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Perry, Darryl",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Schriner, Joe C",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Smith, Mike",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Sood, Ajay",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Sterling, Shawna",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Libertarian,"Johnson, Gary",3,000560
+COWLEY,Winfield Ward 6 A,President / Vice President,,Republican,"Trump, Donald J.",123,000560
+COWLEY,Winfield Ward 7,President / Vice President,,independent,"Stein, Jill",6,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Castle, Darrell L",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Giordani, Rocky",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Hedges, James A",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Hoefling, Tom",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Kahn, Lynn",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"La Riva, Gloria",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Levinson, Michael S.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Maturen, Michael A",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"McMullin, Evan",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Perry, Darryl",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Schriner, Joe C",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Smith, Mike",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Sood, Ajay",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Sterling, Shawna",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Libertarian,"Johnson, Gary",15,000570
+COWLEY,Winfield Ward 7,President / Vice President,,Republican,"Trump, Donald J.",172,000570
+COWLEY,Bolton,President / Vice President,,independent,"Stein, Jill",6,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Castle, Darrell L",1,130010
+COWLEY,Bolton,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Hedges, James A",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Maturen, Michael A",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"McMullin, Evan",2,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Perry, Darryl",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Smith, Mike",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Sood, Ajay",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+COWLEY,Bolton,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+COWLEY,Bolton,President / Vice President,,Democratic,"Clinton, Hillary Rodham",114,130010
+COWLEY,Bolton,President / Vice President,,Libertarian,"Johnson, Gary",17,130010
+COWLEY,Bolton,President / Vice President,,Republican,"Trump, Donald J.",511,130010
+COWLEY,Arkansas City Ward 5,President / Vice President,,independent,"Stein, Jill",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Hedges, James A",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Smith, Mike",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+COWLEY,Arkansas City Ward 5,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+COWLEY,West Creswell Enclave A,President / Vice President,,independent,"Stein, Jill",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Hedges, James A",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Smith, Mike",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+COWLEY,West Creswell Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+COWLEY,West Creswell Enclave B,President / Vice President,,independent,"Stein, Jill",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Hedges, James A",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Smith, Mike",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+COWLEY,West Creswell Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+COWLEY,West Creswell Enclave C,President / Vice President,,independent,"Stein, Jill",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Hedges, James A",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"McMullin, Evan",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Perry, Darryl",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Smith, Mike",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Sood, Ajay",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+COWLEY,West Creswell Enclave C,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,independent,"Stein, Jill",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Hedges, James A",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Smith, Mike",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900060
+COWLEY,Winfield Ward 9,President / Vice President,,independent,"Stein, Jill",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Basiago, Andrew D.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Castle, Darrell L",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Giordani, Rocky",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Hedges, James A",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Kahn, Lynn",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"La Riva, Gloria",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Levinson, Michael S.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Maturen, Michael A",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"McMullin, Evan",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Moorehead, Monica G.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Perry, Darryl",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Schriner, Joe C",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Smith, Mike",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Sood, Ajay",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Sterling, Shawna",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Valdivia, Anthony J",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+COWLEY,Winfield Ward 9,President / Vice President,,Republican,"Trump, Donald J.",0,900070
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,independent,"Allen, Miranda",22,00001A
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",45,00001A
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,00001A
+COWLEY,Arkansas City Ward 1 A,United States House of Representatives,4,Republican,"Pompeo, Michael",82,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",1,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",1,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",1,00001C
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,independent,"Allen, Miranda",19,000020
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",34,000020
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000020
+COWLEY,Arkansas City Ward 1 B,United States House of Representatives,4,Republican,"Pompeo, Michael",95,000020
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,independent,"Allen, Miranda",42,000030
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",89,000030
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000030
+COWLEY,Arkansas City Ward 1 C,United States House of Representatives,4,Republican,"Pompeo, Michael",172,000030
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,independent,"Allen, Miranda",25,000040
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",70,000040
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000040
+COWLEY,Arkansas City Ward 1 D,United States House of Representatives,4,Republican,"Pompeo, Michael",137,000040
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,independent,"Allen, Miranda",38,000050
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",66,000050
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000050
+COWLEY,Arkansas City Ward 2 A,United States House of Representatives,4,Republican,"Pompeo, Michael",222,000050
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,independent,"Allen, Miranda",27,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",34,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States House of Representatives,4,Republican,"Pompeo, Michael",68,00006A
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,independent,"Allen, Miranda",6,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",18,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States House of Representatives,4,Republican,"Pompeo, Michael",56,00006B
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,independent,"Allen, Miranda",2,000070
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000070
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000070
+COWLEY,Arkansas City Ward 2 C,United States House of Representatives,4,Republican,"Pompeo, Michael",22,000070
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,independent,"Allen, Miranda",5,000080
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",18,000080
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000080
+COWLEY,Arkansas City Ward 2 D,United States House of Representatives,4,Republican,"Pompeo, Michael",35,000080
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,independent,"Allen, Miranda",7,000090
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",15,000090
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000090
+COWLEY,Arkansas City Ward 3 A,United States House of Representatives,4,Republican,"Pompeo, Michael",33,000090
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,independent,"Allen, Miranda",13,000100
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",21,000100
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000100
+COWLEY,Arkansas City Ward 3 B,United States House of Representatives,4,Republican,"Pompeo, Michael",50,000100
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,independent,"Allen, Miranda",12,000110
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",26,000110
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000110
+COWLEY,Arkansas City Ward 3 C,United States House of Representatives,4,Republican,"Pompeo, Michael",51,000110
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,independent,"Allen, Miranda",37,000120
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",89,000120
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000120
+COWLEY,Arkansas City Ward 4 A,United States House of Representatives,4,Republican,"Pompeo, Michael",145,000120
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,independent,"Allen, Miranda",84,00013A
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",158,00013A
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",18,00013A
+COWLEY,Arkansas City Ward 4 B,United States House of Representatives,4,Republican,"Pompeo, Michael",315,00013A
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,independent,"Allen, Miranda",34,000140
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",67,000140
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000140
+COWLEY,Arkansas City Ward 4 C,United States House of Representatives,4,Republican,"Pompeo, Michael",138,000140
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,independent,"Allen, Miranda",52,000150
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",127,000150
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,000150
+COWLEY,Arkansas City Ward 4 D,United States House of Representatives,4,Republican,"Pompeo, Michael",243,000150
+COWLEY,Beaver Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000170
+COWLEY,Beaver Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,000170
+COWLEY,Beaver Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000170
+COWLEY,Beaver Township,United States House of Representatives,4,Republican,"Pompeo, Michael",73,000170
+COWLEY,Cedar Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000180
+COWLEY,Cedar Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000180
+COWLEY,Cedar Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000180
+COWLEY,Cedar Township,United States House of Representatives,4,Republican,"Pompeo, Michael",14,000180
+COWLEY,Dexter Township,United States House of Representatives,4,independent,"Allen, Miranda",17,000190
+COWLEY,Dexter Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",25,000190
+COWLEY,Dexter Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000190
+COWLEY,Dexter Township,United States House of Representatives,4,Republican,"Pompeo, Michael",142,000190
+COWLEY,East Creswell,United States House of Representatives,4,independent,"Allen, Miranda",62,000210
+COWLEY,East Creswell,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",118,000210
+COWLEY,East Creswell,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000210
+COWLEY,East Creswell,United States House of Representatives,4,Republican,"Pompeo, Michael",438,000210
+COWLEY,Fairview Township,United States House of Representatives,4,independent,"Allen, Miranda",14,000220
+COWLEY,Fairview Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",25,000220
+COWLEY,Fairview Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000220
+COWLEY,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Michael",94,000220
+COWLEY,Grant Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000230
+COWLEY,Grant Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000230
+COWLEY,Grant Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000230
+COWLEY,Grant Township,United States House of Representatives,4,Republican,"Pompeo, Michael",36,000230
+COWLEY,Harvey Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000240
+COWLEY,Harvey Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000240
+COWLEY,Harvey Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000240
+COWLEY,Harvey Township,United States House of Representatives,4,Republican,"Pompeo, Michael",41,000240
+COWLEY,Liberty Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000250
+COWLEY,Liberty Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000250
+COWLEY,Liberty Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000250
+COWLEY,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Michael",64,000250
+COWLEY,Maple Township,United States House of Representatives,4,independent,"Allen, Miranda",44,000260
+COWLEY,Maple Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",66,000260
+COWLEY,Maple Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",9,000260
+COWLEY,Maple Township,United States House of Representatives,4,Republican,"Pompeo, Michael",253,000260
+COWLEY,Ninnescah Township,United States House of Representatives,4,independent,"Allen, Miranda",34,000270
+COWLEY,Ninnescah Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",96,000270
+COWLEY,Ninnescah Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,000270
+COWLEY,Ninnescah Township,United States House of Representatives,4,Republican,"Pompeo, Michael",306,000270
+COWLEY,Omnia Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000280
+COWLEY,Omnia Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000280
+COWLEY,Omnia Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000280
+COWLEY,Omnia Township,United States House of Representatives,4,Republican,"Pompeo, Michael",116,000280
+COWLEY,Otter Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000290
+COWLEY,Otter Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000290
+COWLEY,Otter Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000290
+COWLEY,Otter Township,United States House of Representatives,4,Republican,"Pompeo, Michael",16,000290
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,independent,"Allen, Miranda",62,000300
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",78,000300
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000300
+COWLEY,Pleasant Valley Township,United States House of Representatives,4,Republican,"Pompeo, Michael",274,000300
+COWLEY,Richland Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000310
+COWLEY,Richland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000310
+COWLEY,Richland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000310
+COWLEY,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",75,000310
+COWLEY,Rock Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000320
+COWLEY,Rock Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",22,000320
+COWLEY,Rock Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000320
+COWLEY,Rock Township,United States House of Representatives,4,Republican,"Pompeo, Michael",68,000320
+COWLEY,Salem Township,United States House of Representatives,4,independent,"Allen, Miranda",15,000330
+COWLEY,Salem Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,000330
+COWLEY,Salem Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000330
+COWLEY,Salem Township,United States House of Representatives,4,Republican,"Pompeo, Michael",114,000330
+COWLEY,Sheridan Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000340
+COWLEY,Sheridan Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000340
+COWLEY,Sheridan Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000340
+COWLEY,Sheridan Township,United States House of Representatives,4,Republican,"Pompeo, Michael",60,000340
+COWLEY,Silver Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",21,000350
+COWLEY,Silver Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",37,000350
+COWLEY,Silver Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000350
+COWLEY,Silver Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",241,000350
+COWLEY,Silverdale Township,United States House of Representatives,4,independent,"Allen, Miranda",13,000360
+COWLEY,Silverdale Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,000360
+COWLEY,Silverdale Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,000360
+COWLEY,Silverdale Township,United States House of Representatives,4,Republican,"Pompeo, Michael",120,000360
+COWLEY,Spring Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000370
+COWLEY,Spring Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000370
+COWLEY,Spring Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000370
+COWLEY,Spring Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",24,000370
+COWLEY,Tisdale Township,United States House of Representatives,4,independent,"Allen, Miranda",30,000380
+COWLEY,Tisdale Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",26,000380
+COWLEY,Tisdale Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000380
+COWLEY,Tisdale Township,United States House of Representatives,4,Republican,"Pompeo, Michael",116,000380
+COWLEY,Vernon Township,United States House of Representatives,4,independent,"Allen, Miranda",23,000390
+COWLEY,Vernon Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",37,000390
+COWLEY,Vernon Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000390
+COWLEY,Vernon Township,United States House of Representatives,4,Republican,"Pompeo, Michael",176,000390
+COWLEY,Walnut Township,United States House of Representatives,4,independent,"Allen, Miranda",34,000400
+COWLEY,Walnut Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",55,000400
+COWLEY,Walnut Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000400
+COWLEY,Walnut Township,United States House of Representatives,4,Republican,"Pompeo, Michael",248,000400
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,00041B
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00041B
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00041B
+COWLEY,West Bolton Enclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00041B
+COWLEY,West Creswell,United States House of Representatives,4,independent,"Allen, Miranda",26,00042A
+COWLEY,West Creswell,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",54,00042A
+COWLEY,West Creswell,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,00042A
+COWLEY,West Creswell,United States House of Representatives,4,Republican,"Pompeo, Michael",190,00042A
+COWLEY,Windsor Township,United States House of Representatives,4,independent,"Allen, Miranda",13,000430
+COWLEY,Windsor Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000430
+COWLEY,Windsor Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000430
+COWLEY,Windsor Township,United States House of Representatives,4,Republican,"Pompeo, Michael",58,000430
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,independent,"Allen, Miranda",41,000440
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",104,000440
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000440
+COWLEY,Winfield Ward 1 East,United States House of Representatives,4,Republican,"Pompeo, Michael",146,000440
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,independent,"Allen, Miranda",24,000450
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",52,000450
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",9,000450
+COWLEY,Winfield Ward 1 West,United States House of Representatives,4,Republican,"Pompeo, Michael",104,000450
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,independent,"Allen, Miranda",34,000460
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",60,000460
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000460
+COWLEY,Winfield Ward 2 Central,United States House of Representatives,4,Republican,"Pompeo, Michael",143,000460
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,independent,"Allen, Miranda",30,000470
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",84,000470
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000470
+COWLEY,Winfield Ward 2 East,United States House of Representatives,4,Republican,"Pompeo, Michael",166,000470
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,independent,"Allen, Miranda",60,000480
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",87,000480
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",11,000480
+COWLEY,Winfield Ward 2 South,United States House of Representatives,4,Republican,"Pompeo, Michael",235,000480
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,independent,"Allen, Miranda",47,000490
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",58,000490
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000490
+COWLEY,Winfield Ward 2 West,United States House of Representatives,4,Republican,"Pompeo, Michael",127,000490
+COWLEY,Winfield Ward 3,United States House of Representatives,4,independent,"Allen, Miranda",36,000500
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",99,000500
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000500
+COWLEY,Winfield Ward 3,United States House of Representatives,4,Republican,"Pompeo, Michael",199,000500
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,independent,"Allen, Miranda",13,00051A
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,00051A
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00051A
+COWLEY,Winfield Ward 3 South,United States House of Representatives,4,Republican,"Pompeo, Michael",86,00051A
+COWLEY,Winfield Ward 8,United States House of Representatives,4,independent,"Allen, Miranda",2,00051B
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,00051B
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00051B
+COWLEY,Winfield Ward 8,United States House of Representatives,4,Republican,"Pompeo, Michael",27,00051B
+COWLEY,Winfield Ward 4,United States House of Representatives,4,independent,"Allen, Miranda",20,000520
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",28,000520
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000520
+COWLEY,Winfield Ward 4,United States House of Representatives,4,Republican,"Pompeo, Michael",65,000520
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,independent,"Allen, Miranda",83,00053A
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",165,00053A
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,00053A
+COWLEY,Winfield Ward 5 East,United States House of Representatives,4,Republican,"Pompeo, Michael",271,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,independent,"Allen, Miranda",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00053B
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,independent,"Allen, Miranda",26,000540
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",70,000540
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000540
+COWLEY,Winfield Ward 5 West,United States House of Representatives,4,Republican,"Pompeo, Michael",110,000540
+COWLEY,Winfield Ward 6,United States House of Representatives,4,independent,"Allen, Miranda",69,000550
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",115,000550
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,000550
+COWLEY,Winfield Ward 6,United States House of Representatives,4,Republican,"Pompeo, Michael",295,000550
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,independent,"Allen, Miranda",27,000560
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",48,000560
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000560
+COWLEY,Winfield Ward 6 A,United States House of Representatives,4,Republican,"Pompeo, Michael",122,000560
+COWLEY,Winfield Ward 7,United States House of Representatives,4,independent,"Allen, Miranda",41,000570
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",93,000570
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000570
+COWLEY,Winfield Ward 7,United States House of Representatives,4,Republican,"Pompeo, Michael",180,000570
+COWLEY,Bolton,United States House of Representatives,4,independent,"Allen, Miranda",70,130010
+COWLEY,Bolton,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",113,130010
+COWLEY,Bolton,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",17,130010
+COWLEY,Bolton,United States House of Representatives,4,Republican,"Pompeo, Michael",447,130010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,independent,"Allen, Miranda",0,900010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900010
+COWLEY,Arkansas City Ward 5,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900010
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,900020
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900020
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900020
+COWLEY,West Creswell Enclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900020
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,900030
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900030
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900030
+COWLEY,West Creswell Enclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900030
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,independent,"Allen, Miranda",0,900040
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900040
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900040
+COWLEY,West Creswell Enclave C,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,independent,"Allen, Miranda",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900060
+COWLEY,Winfield Ward 9,United States House of Representatives,4,independent,"Allen, Miranda",0,900070
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900070
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900070
+COWLEY,Winfield Ward 9,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900070
+COWLEY,Arkansas City Ward 1 A,United States Senate,,write - in,"Smith, DJ",0,00001A
+COWLEY,Arkansas City Ward 1 A,United States Senate,,Democratic,"Wiesner, Patrick",45,00001A
+COWLEY,Arkansas City Ward 1 A,United States Senate,,Libertarian,"Garrard, Robert D.",11,00001A
+COWLEY,Arkansas City Ward 1 A,United States Senate,,Republican,"Moran, Jerry",95,00001A
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,write - in,"Smith, DJ",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",2,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00001B
+COWLEY,Arkansas City Ward 1 A Exclave A,United States Senate,,Republican,"Moran, Jerry",11,00001B
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,write - in,"Smith, DJ",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",1,00001C
+COWLEY,Arkansas City Ward 1 A Exclave B,United States Senate,,Republican,"Moran, Jerry",1,00001C
+COWLEY,Arkansas City Ward 1 B,United States Senate,,write - in,"Smith, DJ",0,000020
+COWLEY,Arkansas City Ward 1 B,United States Senate,,Democratic,"Wiesner, Patrick",38,000020
+COWLEY,Arkansas City Ward 1 B,United States Senate,,Libertarian,"Garrard, Robert D.",15,000020
+COWLEY,Arkansas City Ward 1 B,United States Senate,,Republican,"Moran, Jerry",99,000020
+COWLEY,Arkansas City Ward 1 C,United States Senate,,write - in,"Smith, DJ",0,000030
+COWLEY,Arkansas City Ward 1 C,United States Senate,,Democratic,"Wiesner, Patrick",101,000030
+COWLEY,Arkansas City Ward 1 C,United States Senate,,Libertarian,"Garrard, Robert D.",15,000030
+COWLEY,Arkansas City Ward 1 C,United States Senate,,Republican,"Moran, Jerry",192,000030
+COWLEY,Arkansas City Ward 1 D,United States Senate,,write - in,"Smith, DJ",0,000040
+COWLEY,Arkansas City Ward 1 D,United States Senate,,Democratic,"Wiesner, Patrick",72,000040
+COWLEY,Arkansas City Ward 1 D,United States Senate,,Libertarian,"Garrard, Robert D.",20,000040
+COWLEY,Arkansas City Ward 1 D,United States Senate,,Republican,"Moran, Jerry",147,000040
+COWLEY,Arkansas City Ward 2 A,United States Senate,,write - in,"Smith, DJ",0,000050
+COWLEY,Arkansas City Ward 2 A,United States Senate,,Democratic,"Wiesner, Patrick",75,000050
+COWLEY,Arkansas City Ward 2 A,United States Senate,,Libertarian,"Garrard, Robert D.",26,000050
+COWLEY,Arkansas City Ward 2 A,United States Senate,,Republican,"Moran, Jerry",237,000050
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,write - in,"Smith, DJ",0,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,Democratic,"Wiesner, Patrick",41,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,00006A
+COWLEY,Arkansas City Ward 2 B - 1,United States Senate,,Republican,"Moran, Jerry",78,00006A
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,write - in,"Smith, DJ",0,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,Democratic,"Wiesner, Patrick",22,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,Libertarian,"Garrard, Robert D.",3,00006B
+COWLEY,Arkansas City Ward 2 B - 2,United States Senate,,Republican,"Moran, Jerry",56,00006B
+COWLEY,Arkansas City Ward 2 C,United States Senate,,write - in,"Smith, DJ",0,000070
+COWLEY,Arkansas City Ward 2 C,United States Senate,,Democratic,"Wiesner, Patrick",10,000070
+COWLEY,Arkansas City Ward 2 C,United States Senate,,Libertarian,"Garrard, Robert D.",4,000070
+COWLEY,Arkansas City Ward 2 C,United States Senate,,Republican,"Moran, Jerry",22,000070
+COWLEY,Arkansas City Ward 2 D,United States Senate,,write - in,"Smith, DJ",0,000080
+COWLEY,Arkansas City Ward 2 D,United States Senate,,Democratic,"Wiesner, Patrick",17,000080
+COWLEY,Arkansas City Ward 2 D,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+COWLEY,Arkansas City Ward 2 D,United States Senate,,Republican,"Moran, Jerry",37,000080
+COWLEY,Arkansas City Ward 3 A,United States Senate,,write - in,"Smith, DJ",0,000090
+COWLEY,Arkansas City Ward 3 A,United States Senate,,Democratic,"Wiesner, Patrick",13,000090
+COWLEY,Arkansas City Ward 3 A,United States Senate,,Libertarian,"Garrard, Robert D.",5,000090
+COWLEY,Arkansas City Ward 3 A,United States Senate,,Republican,"Moran, Jerry",41,000090
+COWLEY,Arkansas City Ward 3 B,United States Senate,,write - in,"Smith, DJ",0,000100
+COWLEY,Arkansas City Ward 3 B,United States Senate,,Democratic,"Wiesner, Patrick",25,000100
+COWLEY,Arkansas City Ward 3 B,United States Senate,,Libertarian,"Garrard, Robert D.",9,000100
+COWLEY,Arkansas City Ward 3 B,United States Senate,,Republican,"Moran, Jerry",54,000100
+COWLEY,Arkansas City Ward 3 C,United States Senate,,write - in,"Smith, DJ",0,000110
+COWLEY,Arkansas City Ward 3 C,United States Senate,,Democratic,"Wiesner, Patrick",34,000110
+COWLEY,Arkansas City Ward 3 C,United States Senate,,Libertarian,"Garrard, Robert D.",9,000110
+COWLEY,Arkansas City Ward 3 C,United States Senate,,Republican,"Moran, Jerry",49,000110
+COWLEY,Arkansas City Ward 4 A,United States Senate,,write - in,"Smith, DJ",0,000120
+COWLEY,Arkansas City Ward 4 A,United States Senate,,Democratic,"Wiesner, Patrick",97,000120
+COWLEY,Arkansas City Ward 4 A,United States Senate,,Libertarian,"Garrard, Robert D.",23,000120
+COWLEY,Arkansas City Ward 4 A,United States Senate,,Republican,"Moran, Jerry",155,000120
+COWLEY,Arkansas City Ward 4 B,United States Senate,,write - in,"Smith, DJ",0,00013A
+COWLEY,Arkansas City Ward 4 B,United States Senate,,Democratic,"Wiesner, Patrick",190,00013A
+COWLEY,Arkansas City Ward 4 B,United States Senate,,Libertarian,"Garrard, Robert D.",39,00013A
+COWLEY,Arkansas City Ward 4 B,United States Senate,,Republican,"Moran, Jerry",345,00013A
+COWLEY,Arkansas City Ward 4 C,United States Senate,,write - in,"Smith, DJ",0,000140
+COWLEY,Arkansas City Ward 4 C,United States Senate,,Democratic,"Wiesner, Patrick",92,000140
+COWLEY,Arkansas City Ward 4 C,United States Senate,,Libertarian,"Garrard, Robert D.",11,000140
+COWLEY,Arkansas City Ward 4 C,United States Senate,,Republican,"Moran, Jerry",139,000140
+COWLEY,Arkansas City Ward 4 D,United States Senate,,write - in,"Smith, DJ",0,000150
+COWLEY,Arkansas City Ward 4 D,United States Senate,,Democratic,"Wiesner, Patrick",141,000150
+COWLEY,Arkansas City Ward 4 D,United States Senate,,Libertarian,"Garrard, Robert D.",23,000150
+COWLEY,Arkansas City Ward 4 D,United States Senate,,Republican,"Moran, Jerry",261,000150
+COWLEY,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000170
+COWLEY,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000170
+COWLEY,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000170
+COWLEY,Beaver Township,United States Senate,,Republican,"Moran, Jerry",73,000170
+COWLEY,Cedar Township,United States Senate,,write - in,"Smith, DJ",0,000180
+COWLEY,Cedar Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000180
+COWLEY,Cedar Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000180
+COWLEY,Cedar Township,United States Senate,,Republican,"Moran, Jerry",16,000180
+COWLEY,Dexter Township,United States Senate,,write - in,"Smith, DJ",0,000190
+COWLEY,Dexter Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000190
+COWLEY,Dexter Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000190
+COWLEY,Dexter Township,United States Senate,,Republican,"Moran, Jerry",156,000190
+COWLEY,East Creswell,United States Senate,,write - in,"Smith, DJ",0,000210
+COWLEY,East Creswell,United States Senate,,Democratic,"Wiesner, Patrick",128,000210
+COWLEY,East Creswell,United States Senate,,Libertarian,"Garrard, Robert D.",32,000210
+COWLEY,East Creswell,United States Senate,,Republican,"Moran, Jerry",463,000210
+COWLEY,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000220
+COWLEY,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000220
+COWLEY,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000220
+COWLEY,Fairview Township,United States Senate,,Republican,"Moran, Jerry",99,000220
+COWLEY,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000230
+COWLEY,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000230
+COWLEY,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000230
+COWLEY,Grant Township,United States Senate,,Republican,"Moran, Jerry",37,000230
+COWLEY,Harvey Township,United States Senate,,write - in,"Smith, DJ",0,000240
+COWLEY,Harvey Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000240
+COWLEY,Harvey Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+COWLEY,Harvey Township,United States Senate,,Republican,"Moran, Jerry",43,000240
+COWLEY,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000250
+COWLEY,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000250
+COWLEY,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000250
+COWLEY,Liberty Township,United States Senate,,Republican,"Moran, Jerry",68,000250
+COWLEY,Maple Township,United States Senate,,write - in,"Smith, DJ",0,000260
+COWLEY,Maple Township,United States Senate,,Democratic,"Wiesner, Patrick",74,000260
+COWLEY,Maple Township,United States Senate,,Libertarian,"Garrard, Robert D.",30,000260
+COWLEY,Maple Township,United States Senate,,Republican,"Moran, Jerry",268,000260
+COWLEY,Ninnescah Township,United States Senate,,write - in,"Smith, DJ",0,000270
+COWLEY,Ninnescah Township,United States Senate,,Democratic,"Wiesner, Patrick",104,000270
+COWLEY,Ninnescah Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,000270
+COWLEY,Ninnescah Township,United States Senate,,Republican,"Moran, Jerry",316,000270
+COWLEY,Omnia Township,United States Senate,,write - in,"Smith, DJ",0,000280
+COWLEY,Omnia Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000280
+COWLEY,Omnia Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000280
+COWLEY,Omnia Township,United States Senate,,Republican,"Moran, Jerry",116,000280
+COWLEY,Otter Township,United States Senate,,write - in,"Smith, DJ",0,000290
+COWLEY,Otter Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000290
+COWLEY,Otter Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000290
+COWLEY,Otter Township,United States Senate,,Republican,"Moran, Jerry",17,000290
+COWLEY,Pleasant Valley Township,United States Senate,,write - in,"Smith, DJ",0,000300
+COWLEY,Pleasant Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",86,000300
+COWLEY,Pleasant Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000300
+COWLEY,Pleasant Valley Township,United States Senate,,Republican,"Moran, Jerry",315,000300
+COWLEY,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000310
+COWLEY,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000310
+COWLEY,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000310
+COWLEY,Richland Township,United States Senate,,Republican,"Moran, Jerry",74,000310
+COWLEY,Rock Township,United States Senate,,write - in,"Smith, DJ",0,000320
+COWLEY,Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000320
+COWLEY,Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000320
+COWLEY,Rock Township,United States Senate,,Republican,"Moran, Jerry",72,000320
+COWLEY,Salem Township,United States Senate,,write - in,"Smith, DJ",0,000330
+COWLEY,Salem Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000330
+COWLEY,Salem Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000330
+COWLEY,Salem Township,United States Senate,,Republican,"Moran, Jerry",123,000330
+COWLEY,Sheridan Township,United States Senate,,write - in,"Smith, DJ",0,000340
+COWLEY,Sheridan Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000340
+COWLEY,Sheridan Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000340
+COWLEY,Sheridan Township,United States Senate,,Republican,"Moran, Jerry",60,000340
+COWLEY,Silver Creek Township,United States Senate,,write - in,"Smith, DJ",0,000350
+COWLEY,Silver Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",46,000350
+COWLEY,Silver Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000350
+COWLEY,Silver Creek Township,United States Senate,,Republican,"Moran, Jerry",238,000350
+COWLEY,Silverdale Township,United States Senate,,write - in,"Smith, DJ",0,000360
+COWLEY,Silverdale Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000360
+COWLEY,Silverdale Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000360
+COWLEY,Silverdale Township,United States Senate,,Republican,"Moran, Jerry",124,000360
+COWLEY,Spring Creek Township,United States Senate,,write - in,"Smith, DJ",0,000370
+COWLEY,Spring Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000370
+COWLEY,Spring Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000370
+COWLEY,Spring Creek Township,United States Senate,,Republican,"Moran, Jerry",25,000370
+COWLEY,Tisdale Township,United States Senate,,write - in,"Smith, DJ",0,000380
+COWLEY,Tisdale Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000380
+COWLEY,Tisdale Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000380
+COWLEY,Tisdale Township,United States Senate,,Republican,"Moran, Jerry",122,000380
+COWLEY,Vernon Township,United States Senate,,write - in,"Smith, DJ",0,000390
+COWLEY,Vernon Township,United States Senate,,Democratic,"Wiesner, Patrick",38,000390
+COWLEY,Vernon Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000390
+COWLEY,Vernon Township,United States Senate,,Republican,"Moran, Jerry",189,000390
+COWLEY,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000400
+COWLEY,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",58,000400
+COWLEY,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000400
+COWLEY,Walnut Township,United States Senate,,Republican,"Moran, Jerry",263,000400
+COWLEY,West Bolton Enclave A,United States Senate,,write - in,"Smith, DJ",0,00041B
+COWLEY,West Bolton Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00041B
+COWLEY,West Bolton Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00041B
+COWLEY,West Bolton Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00041B
+COWLEY,West Creswell,United States Senate,,write - in,"Smith, DJ",0,00042A
+COWLEY,West Creswell,United States Senate,,Democratic,"Wiesner, Patrick",59,00042A
+COWLEY,West Creswell,United States Senate,,Libertarian,"Garrard, Robert D.",11,00042A
+COWLEY,West Creswell,United States Senate,,Republican,"Moran, Jerry",204,00042A
+COWLEY,Windsor Township,United States Senate,,write - in,"Smith, DJ",0,000430
+COWLEY,Windsor Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000430
+COWLEY,Windsor Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000430
+COWLEY,Windsor Township,United States Senate,,Republican,"Moran, Jerry",65,000430
+COWLEY,Winfield Ward 1 East,United States Senate,,write - in,"Smith, DJ",0,000440
+COWLEY,Winfield Ward 1 East,United States Senate,,Democratic,"Wiesner, Patrick",113,000440
+COWLEY,Winfield Ward 1 East,United States Senate,,Libertarian,"Garrard, Robert D.",11,000440
+COWLEY,Winfield Ward 1 East,United States Senate,,Republican,"Moran, Jerry",171,000440
+COWLEY,Winfield Ward 1 West,United States Senate,,write - in,"Smith, DJ",0,000450
+COWLEY,Winfield Ward 1 West,United States Senate,,Democratic,"Wiesner, Patrick",55,000450
+COWLEY,Winfield Ward 1 West,United States Senate,,Libertarian,"Garrard, Robert D.",13,000450
+COWLEY,Winfield Ward 1 West,United States Senate,,Republican,"Moran, Jerry",117,000450
+COWLEY,Winfield Ward 2 Central,United States Senate,,write - in,"Smith, DJ",0,000460
+COWLEY,Winfield Ward 2 Central,United States Senate,,Democratic,"Wiesner, Patrick",74,000460
+COWLEY,Winfield Ward 2 Central,United States Senate,,Libertarian,"Garrard, Robert D.",15,000460
+COWLEY,Winfield Ward 2 Central,United States Senate,,Republican,"Moran, Jerry",150,000460
+COWLEY,Winfield Ward 2 East,United States Senate,,write - in,"Smith, DJ",0,000470
+COWLEY,Winfield Ward 2 East,United States Senate,,Democratic,"Wiesner, Patrick",97,000470
+COWLEY,Winfield Ward 2 East,United States Senate,,Libertarian,"Garrard, Robert D.",19,000470
+COWLEY,Winfield Ward 2 East,United States Senate,,Republican,"Moran, Jerry",171,000470
+COWLEY,Winfield Ward 2 South,United States Senate,,write - in,"Smith, DJ",0,000480
+COWLEY,Winfield Ward 2 South,United States Senate,,Democratic,"Wiesner, Patrick",103,000480
+COWLEY,Winfield Ward 2 South,United States Senate,,Libertarian,"Garrard, Robert D.",25,000480
+COWLEY,Winfield Ward 2 South,United States Senate,,Republican,"Moran, Jerry",266,000480
+COWLEY,Winfield Ward 2 West,United States Senate,,write - in,"Smith, DJ",0,000490
+COWLEY,Winfield Ward 2 West,United States Senate,,Democratic,"Wiesner, Patrick",78,000490
+COWLEY,Winfield Ward 2 West,United States Senate,,Libertarian,"Garrard, Robert D.",14,000490
+COWLEY,Winfield Ward 2 West,United States Senate,,Republican,"Moran, Jerry",134,000490
+COWLEY,Winfield Ward 3,United States Senate,,write - in,"Smith, DJ",0,000500
+COWLEY,Winfield Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",107,000500
+COWLEY,Winfield Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",22,000500
+COWLEY,Winfield Ward 3,United States Senate,,Republican,"Moran, Jerry",211,000500
+COWLEY,Winfield Ward 3 South,United States Senate,,write - in,"Smith, DJ",0,00051A
+COWLEY,Winfield Ward 3 South,United States Senate,,Democratic,"Wiesner, Patrick",21,00051A
+COWLEY,Winfield Ward 3 South,United States Senate,,Libertarian,"Garrard, Robert D.",0,00051A
+COWLEY,Winfield Ward 3 South,United States Senate,,Republican,"Moran, Jerry",96,00051A
+COWLEY,Winfield Ward 8,United States Senate,,write - in,"Smith, DJ",0,00051B
+COWLEY,Winfield Ward 8,United States Senate,,Democratic,"Wiesner, Patrick",7,00051B
+COWLEY,Winfield Ward 8,United States Senate,,Libertarian,"Garrard, Robert D.",2,00051B
+COWLEY,Winfield Ward 8,United States Senate,,Republican,"Moran, Jerry",26,00051B
+COWLEY,Winfield Ward 4,United States Senate,,write - in,"Smith, DJ",0,000520
+COWLEY,Winfield Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",32,000520
+COWLEY,Winfield Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",8,000520
+COWLEY,Winfield Ward 4,United States Senate,,Republican,"Moran, Jerry",72,000520
+COWLEY,Winfield Ward 5 East,United States Senate,,write - in,"Smith, DJ",0,00053A
+COWLEY,Winfield Ward 5 East,United States Senate,,Democratic,"Wiesner, Patrick",202,00053A
+COWLEY,Winfield Ward 5 East,United States Senate,,Libertarian,"Garrard, Robert D.",29,00053A
+COWLEY,Winfield Ward 5 East,United States Senate,,Republican,"Moran, Jerry",300,00053A
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,write - in,"Smith, DJ",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,Democratic,"Wiesner, Patrick",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,Libertarian,"Garrard, Robert D.",0,00053B
+COWLEY,Winfield Ward 5 East Exclave Lake,United States Senate,,Republican,"Moran, Jerry",0,00053B
+COWLEY,Winfield Ward 5 West,United States Senate,,write - in,"Smith, DJ",0,000540
+COWLEY,Winfield Ward 5 West,United States Senate,,Democratic,"Wiesner, Patrick",85,000540
+COWLEY,Winfield Ward 5 West,United States Senate,,Libertarian,"Garrard, Robert D.",11,000540
+COWLEY,Winfield Ward 5 West,United States Senate,,Republican,"Moran, Jerry",114,000540
+COWLEY,Winfield Ward 6,United States Senate,,write - in,"Smith, DJ",0,000550
+COWLEY,Winfield Ward 6,United States Senate,,Democratic,"Wiesner, Patrick",140,000550
+COWLEY,Winfield Ward 6,United States Senate,,Libertarian,"Garrard, Robert D.",26,000550
+COWLEY,Winfield Ward 6,United States Senate,,Republican,"Moran, Jerry",320,000550
+COWLEY,Winfield Ward 6 A,United States Senate,,write - in,"Smith, DJ",0,000560
+COWLEY,Winfield Ward 6 A,United States Senate,,Democratic,"Wiesner, Patrick",59,000560
+COWLEY,Winfield Ward 6 A,United States Senate,,Libertarian,"Garrard, Robert D.",4,000560
+COWLEY,Winfield Ward 6 A,United States Senate,,Republican,"Moran, Jerry",135,000560
+COWLEY,Winfield Ward 7,United States Senate,,write - in,"Smith, DJ",0,000570
+COWLEY,Winfield Ward 7,United States Senate,,Democratic,"Wiesner, Patrick",97,000570
+COWLEY,Winfield Ward 7,United States Senate,,Libertarian,"Garrard, Robert D.",18,000570
+COWLEY,Winfield Ward 7,United States Senate,,Republican,"Moran, Jerry",196,000570
+COWLEY,Bolton,United States Senate,,write - in,"Smith, DJ",0,130010
+COWLEY,Bolton,United States Senate,,Democratic,"Wiesner, Patrick",126,130010
+COWLEY,Bolton,United States Senate,,Libertarian,"Garrard, Robert D.",40,130010
+COWLEY,Bolton,United States Senate,,Republican,"Moran, Jerry",486,130010
+COWLEY,Arkansas City Ward 5,United States Senate,,write - in,"Smith, DJ",0,900010
+COWLEY,Arkansas City Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+COWLEY,Arkansas City Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+COWLEY,Arkansas City Ward 5,United States Senate,,Republican,"Moran, Jerry",0,900010
+COWLEY,West Creswell Enclave A,United States Senate,,write - in,"Smith, DJ",0,900020
+COWLEY,West Creswell Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+COWLEY,West Creswell Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+COWLEY,West Creswell Enclave A,United States Senate,,Republican,"Moran, Jerry",0,900020
+COWLEY,West Creswell Enclave B,United States Senate,,write - in,"Smith, DJ",0,900030
+COWLEY,West Creswell Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+COWLEY,West Creswell Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+COWLEY,West Creswell Enclave B,United States Senate,,Republican,"Moran, Jerry",0,900030
+COWLEY,West Creswell Enclave C,United States Senate,,write - in,"Smith, DJ",0,900040
+COWLEY,West Creswell Enclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+COWLEY,West Creswell Enclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+COWLEY,West Creswell Enclave C,United States Senate,,Republican,"Moran, Jerry",0,900040
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+COWLEY,Arkansas City Ward 2 D Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900050
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,write - in,"Smith, DJ",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+COWLEY,Arkansas City Ward 1 D Exclave A,United States Senate,,Republican,"Moran, Jerry",0,900060
+COWLEY,Winfield Ward 9,United States Senate,,write - in,"Smith, DJ",0,900070
+COWLEY,Winfield Ward 9,United States Senate,,Democratic,"Wiesner, Patrick",0,900070
+COWLEY,Winfield Ward 9,United States Senate,,Libertarian,"Garrard, Robert D.",0,900070
+COWLEY,Winfield Ward 9,United States Senate,,Republican,"Moran, Jerry",0,900070

--- a/2016/20161108__ks__general__crawford__precinct.csv
+++ b/2016/20161108__ks__general__crawford__precinct.csv
@@ -1,1107 +1,2196 @@
-county,precinct,office,district,party,candidate,votes
-Crawford,Total,President,,D,Hillary Clinton,5199
-Crawford,Total,President,,LBT,Gary Johnson,672
-Crawford,Total,President,,IND,Jill Stein,314
-Crawford,Total,President,,R,Donald J Trump,8624
-Crawford,01 Arcadia,President,,,Registered Voters,257
-Crawford,01 Arcadia,President,,D,Hillary Clinton,49
-Crawford,01 Arcadia,President,,LBT,Gary Johnson,9
-Crawford,01 Arcadia,President,,IND,Jill Stein,2
-Crawford,01 Arcadia,President,,R,Donald J Trump,86
-Crawford,01 Arcadia,President,,,Write-ins,1
-Crawford,Total,U.S. Senate,,LBT,Robert D. Garrard,780
-Crawford,Total,U.S. Senate,,R,Jerry Moran,8957
-Crawford,Total,U.S. Senate,,D,Patrick Wiesner,5065
-Crawford,Total,U.S. Senate,,,Write-ins,21
-Crawford,Total,U.S. House,2,LBT,James Bales,770
-Crawford,Total,U.S. House,2,R,Lynn Jenkins,9532
-Crawford,Total,U.S. House,2,D,Britani Potter,4582
-Crawford,Total,U.S. House,2,,Write-ins,30
-Crawford,Total,State Senate,13,R,Jake LaTurner,7309
-Crawford,Total,State Senate,13,D,Lynn Grant,7642
-Crawford,Total,State Senate,13,,Write-ins,25
-Crawford,Total,State House,2,D,Adam J Lusker Sr.,5540
-Crawford,Total,State House,2,,Write-ins,138
-Crawford,01 Arcadia,U.S. Senate,,LBT,Robert D. Garrard,9
-Crawford,01 Arcadia,U.S. Senate,,R,Jerry Moran,74
-Crawford,01 Arcadia,U.S. Senate,,D,Patrick Wiesner,56
-Crawford,01 Arcadia,U.S. Senate,,,Write-ins,0
-Crawford,01 Arcadia,U.S. House,2,LBT,James Bales,13
-Crawford,01 Arcadia,U.S. House,2,R,Lynn Jenkins,75
-Crawford,01 Arcadia,U.S. House,2,D,Britani Potter,53
-Crawford,01 Arcadia,U.S. House,2,,Write-ins,0
-Crawford,01 Arcadia,State Senate,13,R,Jake LaTurner,75
-Crawford,01 Arcadia,State Senate,13,D,Lynn Grant,67
-Crawford,01 Arcadia,State Senate,13,,Write-ins,0
-Crawford,01 Arcadia,State House,2,D,Adam J Lusker Sr.,118
-Crawford,01 Arcadia,State House,2,,Write-ins,8
-Crawford,02 Baker,President,,,Registered Voters,730
-Crawford,02 Baker,President,,D,Hillary Clinton,149
-Crawford,02 Baker,President,,LBT,Gary Johnson,18
-Crawford,02 Baker,President,,IND,Jill Stein,13
-Crawford,02 Baker,President,,R,Donald J Trump,333
-Crawford,02 Baker,President,,,Write-ins,12
-Crawford,02 Baker,U.S. Senate,,LBT,Robert D. Garrard,24
-Crawford,02 Baker,U.S. Senate,,R,Jerry Moran,343
-Crawford,02 Baker,U.S. Senate,,D,Patrick Wiesner,144
-Crawford,02 Baker,U.S. Senate,,,Write-ins,1
-Crawford,02 Baker,U.S. House,2,LBT,James Bales,25
-Crawford,02 Baker,U.S. House,2,R,Lynn Jenkins,366
-Crawford,02 Baker,U.S. House,2,D,Britani Potter,118
-Crawford,02 Baker,U.S. House,2,,Write-ins,0
-Crawford,02 Baker,State Senate,13,R,Jake LaTurner,296
-Crawford,02 Baker,State Senate,13,D,Lynn Grant,218
-Crawford,02 Baker,State Senate,13,,Write-ins,2
-Crawford,Total,State House,3,D,Monica Murnan,4351
-Crawford,Total,State House,3,R,Charles Smith,3939
-Crawford,Total,State House,3,,Write-ins,7
-Crawford,02 Baker,State House,3,D,Monica Murnan,228
-Crawford,02 Baker,State House,3,R,Charles Smith,292
-Crawford,02 Baker,State House,3,,Write-ins,0
-Crawford,03 Beulah,President,,,Registered Voters,197
-Crawford,03 Beulah,President,,D,Hillary Clinton,35
-Crawford,03 Beulah,President,,LBT,Gary Johnson,11
-Crawford,03 Beulah,President,,IND,Jill Stein,2
-Crawford,03 Beulah,President,,R,Donald J Trump,89
-Crawford,03 Beulah,President,,,Write-ins,1
-Crawford,03 Beulah,U.S. Senate,,LBT,Robert D. Garrard,6
-Crawford,03 Beulah,U.S. Senate,,R,Jerry Moran,94
-Crawford,03 Beulah,U.S. Senate,,D,Patrick Wiesner,34
-Crawford,03 Beulah,U.S. Senate,,,Write-ins,0
-Crawford,03 Beulah,U.S. House,2,LBT,James Bales,6
-Crawford,03 Beulah,U.S. House,2,R,Lynn Jenkins,105
-Crawford,03 Beulah,U.S. House,2,D,Britani Potter,24
-Crawford,03 Beulah,U.S. House,2,,Write-ins,0
-Crawford,03 Beulah,State Senate,13,R,Jake LaTurner,74
-Crawford,03 Beulah,State Senate,13,D,Lynn Grant,63
-Crawford,03 Beulah,State Senate,13,,Write-ins,0
-Crawford,03 Beulah,State House,2,D,Adam J Lusker Sr.,109
-Crawford,03 Beulah,State House,2,,Write-ins,4
-Crawford,04 Brazilton,President,,,Registered Voters,47
-Crawford,04 Brazilton,President,,D,Hillary Clinton,7
-Crawford,04 Brazilton,President,,LBT,Gary Johnson,0
-Crawford,04 Brazilton,President,,IND,Jill Stein,0
-Crawford,04 Brazilton,President,,R,Donald J Trump,29
-Crawford,04 Brazilton,President,,,Write-ins,0
-Crawford,04 Brazilton,U.S. Senate,,LBT,Robert D. Garrard,1
-Crawford,04 Brazilton,U.S. Senate,,R,Jerry Moran,24
-Crawford,04 Brazilton,U.S. Senate,,D,Patrick Wiesner,11
-Crawford,04 Brazilton,U.S. Senate,,,Write-ins,0
-Crawford,04 Brazilton,U.S. House,2,LBT,James Bales,0
-Crawford,04 Brazilton,U.S. House,2,R,Lynn Jenkins,26
-Crawford,04 Brazilton,U.S. House,2,D,Britani Potter,9
-Crawford,04 Brazilton,U.S. House,2,,Write-ins,0
-Crawford,04 Brazilton,State Senate,13,R,Jake LaTurner,22
-Crawford,04 Brazilton,State Senate,13,D,Lynn Grant,14
-Crawford,04 Brazilton,State Senate,13,,Write-ins,0
-Crawford,04 Brazilton,State House,2,D,Adam J Lusker Sr.,26
-Crawford,04 Brazilton,State House,2,,Write-ins,0
-Crawford,05 Capaldo,President,,,Registered Voters,367
-Crawford,05 Capaldo,President,,D,Hillary Clinton,68
-Crawford,05 Capaldo,President,,LBT,Gary Johnson,8
-Crawford,05 Capaldo,President,,IND,Jill Stein,6
-Crawford,05 Capaldo,President,,R,Donald J Trump,154
-Crawford,05 Capaldo,President,,,Write-ins,5
-Crawford,05 Capaldo,U.S. Senate,,LBT,Robert D. Garrard,9
-Crawford,05 Capaldo,U.S. Senate,,R,Jerry Moran,147
-Crawford,05 Capaldo,U.S. Senate,,D,Patrick Wiesner,77
-Crawford,05 Capaldo,U.S. Senate,,,Write-ins,1
-Crawford,05 Capaldo,U.S. House,2,LBT,James Bales,12
-Crawford,05 Capaldo,U.S. House,2,R,Lynn Jenkins,162
-Crawford,05 Capaldo,U.S. House,2,D,Britani Potter,64
-Crawford,05 Capaldo,U.S. House,2,,Write-ins,0
-Crawford,05 Capaldo,State Senate,13,R,Jake LaTurner,118
-Crawford,05 Capaldo,State Senate,13,D,Lynn Grant,124
-Crawford,05 Capaldo,State Senate,13,,Write-ins,0
-Crawford,05 Capaldo,State House,2,D,Adam J Lusker Sr.,203
-Crawford,05 Capaldo,State House,2,,Write-ins,5
-Crawford,06 Cherokee,President,,,Registered Voters,384
-Crawford,06 Cherokee,President,,D,Hillary Clinton,65
-Crawford,06 Cherokee,President,,LBT,Gary Johnson,13
-Crawford,06 Cherokee,President,,IND,Jill Stein,7
-Crawford,06 Cherokee,President,,R,Donald J Trump,147
-Crawford,06 Cherokee,President,,,Write-ins,1
-Crawford,06 Cherokee,U.S. Senate,,LBT,Robert D. Garrard,27
-Crawford,06 Cherokee,U.S. Senate,,R,Jerry Moran,131
-Crawford,06 Cherokee,U.S. Senate,,D,Patrick Wiesner,69
-Crawford,06 Cherokee,U.S. Senate,,,Write-ins,0
-Crawford,06 Cherokee,U.S. House,2,LBT,James Bales,26
-Crawford,06 Cherokee,U.S. House,2,R,Lynn Jenkins,144
-Crawford,06 Cherokee,U.S. House,2,D,Britani Potter,57
-Crawford,06 Cherokee,U.S. House,2,,Write-ins,0
-Crawford,06 Cherokee,State Senate,13,R,Jake LaTurner,118
-Crawford,06 Cherokee,State Senate,13,D,Lynn Grant,111
-Crawford,06 Cherokee,State Senate,13,,Write-ins,1
-Crawford,06 Cherokee,State House,2,D,Adam J Lusker Sr.,163
-Crawford,06 Cherokee,State House,2,,Write-ins,5
-Crawford,07 Cherokee-Sheridan,President,,,Registered Voters,222
-Crawford,07 Cherokee-Sheridan,President,,D,Hillary Clinton,22
-Crawford,07 Cherokee-Sheridan,President,,LBT,Gary Johnson,6
-Crawford,07 Cherokee-Sheridan,President,,IND,Jill Stein,4
-Crawford,07 Cherokee-Sheridan,President,,R,Donald J Trump,112
-Crawford,07 Cherokee-Sheridan,President,,,Write-ins,0
-Crawford,07 Cherokee-Sheridan,U.S. Senate,,LBT,Robert D. Garrard,9
-Crawford,07 Cherokee-Sheridan,U.S. Senate,,R,Jerry Moran,102
-Crawford,07 Cherokee-Sheridan,U.S. Senate,,D,Patrick Wiesner,32
-Crawford,07 Cherokee-Sheridan,U.S. Senate,,,Write-ins,0
-Crawford,07 Cherokee-Sheridan,U.S. House,2,LBT,James Bales,7
-Crawford,07 Cherokee-Sheridan,U.S. House,2,R,Lynn Jenkins,104
-Crawford,07 Cherokee-Sheridan,U.S. House,2,D,Britani Potter,32
-Crawford,07 Cherokee-Sheridan,U.S. House,2,,Write-ins,1
-Crawford,07 Cherokee-Sheridan,State Senate,13,R,Jake LaTurner,77
-Crawford,07 Cherokee-Sheridan,State Senate,13,D,Lynn Grant,67
-Crawford,07 Cherokee-Sheridan,State Senate,13,,Write-ins,0
-Crawford,07 Cherokee-Sheridan,State House,2,D,Adam J Lusker Sr.,103
-Crawford,07 Cherokee-Sheridan,State House,2,,Write-ins,2
-Crawford,08 Chicopee,President,,,Registered Voters,387
-Crawford,08 Chicopee,President,,D,Hillary Clinton,84
-Crawford,08 Chicopee,President,,LBT,Gary Johnson,16
-Crawford,08 Chicopee,President,,IND,Jill Stein,3
-Crawford,08 Chicopee,President,,R,Donald J Trump,182
-Crawford,08 Chicopee,President,,,Write-ins,4
-Crawford,08 Chicopee,U.S. Senate,,LBT,Robert D. Garrard,9
-Crawford,08 Chicopee,U.S. Senate,,R,Jerry Moran,199
-Crawford,08 Chicopee,U.S. Senate,,D,Patrick Wiesner,77
-Crawford,08 Chicopee,U.S. Senate,,,Write-ins,0
-Crawford,08 Chicopee,U.S. House,2,LBT,James Bales,11
-Crawford,08 Chicopee,U.S. House,2,R,Lynn Jenkins,200
-Crawford,08 Chicopee,U.S. House,2,D,Britani Potter,75
-Crawford,08 Chicopee,U.S. House,2,,Write-ins,0
-Crawford,08 Chicopee,State Senate,13,R,Jake LaTurner,153
-Crawford,08 Chicopee,State Senate,13,D,Lynn Grant,134
-Crawford,08 Chicopee,State Senate,13,,Write-ins,0
-Crawford,08 Chicopee,State House,3,D,Monica Murnan,124
-Crawford,08 Chicopee,State House,3,R,Charles Smith,165
-Crawford,08 Chicopee,State House,3,,Write-ins,0
-Crawford,09 Crawford,President,,,Registered Voters,307
-Crawford,09 Crawford,President,,D,Hillary Clinton,37
-Crawford,09 Crawford,President,,LBT,Gary Johnson,11
-Crawford,09 Crawford,President,,IND,Jill Stein,4
-Crawford,09 Crawford,President,,R,Donald J Trump,154
-Crawford,09 Crawford,President,,,Write-ins,4
-Crawford,09 Crawford,U.S. Senate,,LBT,Robert D. Garrard,5
-Crawford,09 Crawford,U.S. Senate,,R,Jerry Moran,177
-Crawford,09 Crawford,U.S. Senate,,D,Patrick Wiesner,24
-Crawford,09 Crawford,U.S. Senate,,,Write-ins,2
-Crawford,09 Crawford,U.S. House,2,LBT,James Bales,8
-Crawford,09 Crawford,U.S. House,2,R,Lynn Jenkins,175
-Crawford,09 Crawford,U.S. House,2,D,Britani Potter,25
-Crawford,09 Crawford,U.S. House,2,,Write-ins,2
-Crawford,09 Crawford,State Senate,13,R,Jake LaTurner,147
-Crawford,09 Crawford,State Senate,13,D,Lynn Grant,62
-Crawford,09 Crawford,State Senate,13,,Write-ins,2
-Crawford,09 Crawford,State House,2,D,Adam J Lusker Sr.,151
-Crawford,09 Crawford,State House,2,,Write-ins,4
-Crawford,10 Crowe,President,,,Registered Voters,181
-Crawford,10 Crowe,President,,D,Hillary Clinton,38
-Crawford,10 Crowe,President,,LBT,Gary Johnson,5
-Crawford,10 Crowe,President,,IND,Jill Stein,1
-Crawford,10 Crowe,President,,R,Donald J Trump,61
-Crawford,10 Crowe,President,,,Write-ins,1
-Crawford,10 Crowe,U.S. Senate,,LBT,Robert D. Garrard,6
-Crawford,10 Crowe,U.S. Senate,,R,Jerry Moran,60
-Crawford,10 Crowe,U.S. Senate,,D,Patrick Wiesner,41
-Crawford,10 Crowe,U.S. Senate,,,Write-ins,0
-Crawford,10 Crowe,U.S. House,2,LBT,James Bales,8
-Crawford,10 Crowe,U.S. House,2,R,Lynn Jenkins,59
-Crawford,10 Crowe,U.S. House,2,D,Britani Potter,36
-Crawford,10 Crowe,U.S. House,2,,Write-ins,0
-Crawford,10 Crowe,State Senate,13,R,Jake LaTurner,46
-Crawford,10 Crowe,State Senate,13,D,Lynn Grant,59
-Crawford,10 Crowe,State Senate,13,,Write-ins,0
-Crawford,10 Crowe,State House,2,D,Adam J Lusker Sr.,87
-Crawford,10 Crowe,State House,2,,Write-ins,2
-Crawford,11 Franklin,President,,,Registered Voters,346
-Crawford,11 Franklin,President,,D,Hillary Clinton,76
-Crawford,11 Franklin,President,,LBT,Gary Johnson,5
-Crawford,11 Franklin,President,,IND,Jill Stein,4
-Crawford,11 Franklin,President,,R,Donald J Trump,143
-Crawford,11 Franklin,President,,,Write-ins,2
-Crawford,11 Franklin,U.S. Senate,,LBT,Robert D. Garrard,9
-Crawford,11 Franklin,U.S. Senate,,R,Jerry Moran,135
-Crawford,11 Franklin,U.S. Senate,,D,Patrick Wiesner,84
-Crawford,11 Franklin,U.S. Senate,,,Write-ins,1
-Crawford,11 Franklin,U.S. House,2,LBT,James Bales,8
-Crawford,11 Franklin,U.S. House,2,R,Lynn Jenkins,150
-Crawford,11 Franklin,U.S. House,2,D,Britani Potter,71
-Crawford,11 Franklin,U.S. House,2,,Write-ins,0
-Crawford,11 Franklin,State Senate,13,R,Jake LaTurner,114
-Crawford,11 Franklin,State Senate,13,D,Lynn Grant,115
-Crawford,11 Franklin,State Senate,13,,Write-ins,2
-Crawford,11 Franklin,State House,2,D,Adam J Lusker Sr.,189
-Crawford,11 Franklin,State House,2,,Write-ins,13
-Crawford,12 Frontenac W1,President,,,Registered Voters,722
-Crawford,12 Frontenac W1,President,,D,Hillary Clinton,189
-Crawford,12 Frontenac W1,President,,LBT,Gary Johnson,18
-Crawford,12 Frontenac W1,President,,IND,Jill Stein,7
-Crawford,12 Frontenac W1,President,,R,Donald J Trump,208
-Crawford,12 Frontenac W1,President,,,Write-ins,6
-Crawford,12 Frontenac W1,U.S. Senate,,LBT,Robert D. Garrard,17
-Crawford,12 Frontenac W1,U.S. Senate,,R,Jerry Moran,203
-Crawford,12 Frontenac W1,U.S. Senate,,D,Patrick Wiesner,198
-Crawford,12 Frontenac W1,U.S. Senate,,,Write-ins,3
-Crawford,12 Frontenac W1,U.S. House,2,LBT,James Bales,22
-Crawford,12 Frontenac W1,U.S. House,2,R,Lynn Jenkins,235
-Crawford,12 Frontenac W1,U.S. House,2,D,Britani Potter,165
-Crawford,12 Frontenac W1,U.S. House,2,,Write-ins,3
-Crawford,12 Frontenac W1,State Senate,13,R,Jake LaTurner,147
-Crawford,12 Frontenac W1,State Senate,13,D,Lynn Grant,280
-Crawford,12 Frontenac W1,State Senate,13,,Write-ins,2
-Crawford,12 Frontenac W1,State House,2,D,Adam J Lusker Sr.,396
-Crawford,12 Frontenac W1,State House,2,,Write-ins,5
-Crawford,13 Frontenac W2,President,,,Registered Voters,958
-Crawford,13 Frontenac W2,President,,D,Hillary Clinton,306
-Crawford,13 Frontenac W2,President,,LBT,Gary Johnson,21
-Crawford,13 Frontenac W2,President,,IND,Jill Stein,5
-Crawford,13 Frontenac W2,President,,R,Donald J Trump,312
-Crawford,13 Frontenac W2,President,,,Write-ins,9
-Crawford,13 Frontenac W2,U.S. Senate,,LBT,Robert D. Garrard,26
-Crawford,13 Frontenac W2,U.S. Senate,,R,Jerry Moran,326
-Crawford,13 Frontenac W2,U.S. Senate,,D,Patrick Wiesner,284
-Crawford,13 Frontenac W2,U.S. Senate,,,Write-ins,2
-Crawford,13 Frontenac W2,U.S. House,2,LBT,James Bales,27
-Crawford,13 Frontenac W2,U.S. House,2,R,Lynn Jenkins,358
-Crawford,13 Frontenac W2,U.S. House,2,D,Britani Potter,261
-Crawford,13 Frontenac W2,U.S. House,2,,Write-ins,2
-Crawford,13 Frontenac W2,State Senate,13,R,Jake LaTurner,216
-Crawford,13 Frontenac W2,State Senate,13,D,Lynn Grant,434
-Crawford,13 Frontenac W2,State Senate,13,,Write-ins,1
-Crawford,13 Frontenac W2,State House,2,D,Adam J Lusker Sr.,595
-Crawford,13 Frontenac W2,State House,2,,Write-ins,9
-Crawford,14 Frontenac W3,President,,,Registered Voters,389
-Crawford,14 Frontenac W3,President,,D,Hillary Clinton,81
-Crawford,14 Frontenac W3,President,,LBT,Gary Johnson,9
-Crawford,14 Frontenac W3,President,,IND,Jill Stein,4
-Crawford,14 Frontenac W3,President,,R,Donald J Trump,152
-Crawford,14 Frontenac W3,President,,,Write-ins,5
-Crawford,14 Frontenac W3,U.S. Senate,,LBT,Robert D. Garrard,9
-Crawford,14 Frontenac W3,U.S. Senate,,R,Jerry Moran,138
-Crawford,14 Frontenac W3,U.S. Senate,,D,Patrick Wiesner,98
-Crawford,14 Frontenac W3,U.S. Senate,,,Write-ins,0
-Crawford,14 Frontenac W3,U.S. House,2,LBT,James Bales,10
-Crawford,14 Frontenac W3,U.S. House,2,R,Lynn Jenkins,149
-Crawford,14 Frontenac W3,U.S. House,2,D,Britani Potter,89
-Crawford,14 Frontenac W3,U.S. House,2,,Write-ins,0
-Crawford,14 Frontenac W3,State Senate,13,R,Jake LaTurner,98
-Crawford,14 Frontenac W3,State Senate,13,D,Lynn Grant,153
-Crawford,14 Frontenac W3,State Senate,13,,Write-ins,0
-Crawford,14 Frontenac W3,State House,2,D,Adam J Lusker Sr.,227
-Crawford,14 Frontenac W3,State House,2,,Write-ins,7
-Crawford,15 Frontenac W4,President,,,Registered Voters,322
-Crawford,15 Frontenac W4,President,,D,Hillary Clinton,87
-Crawford,15 Frontenac W4,President,,LBT,Gary Johnson,16
-Crawford,15 Frontenac W4,President,,IND,Jill Stein,5
-Crawford,15 Frontenac W4,President,,R,Donald J Trump,98
-Crawford,15 Frontenac W4,President,,,Write-ins,4
-Crawford,15 Frontenac W4,U.S. Senate,,LBT,Robert D. Garrard,13
-Crawford,15 Frontenac W4,U.S. Senate,,R,Jerry Moran,99
-Crawford,15 Frontenac W4,U.S. Senate,,D,Patrick Wiesner,93
-Crawford,15 Frontenac W4,U.S. Senate,,,Write-ins,0
-Crawford,15 Frontenac W4,U.S. House,2,LBT,James Bales,12
-Crawford,15 Frontenac W4,U.S. House,2,R,Lynn Jenkins,104
-Crawford,15 Frontenac W4,U.S. House,2,D,Britani Potter,90
-Crawford,15 Frontenac W4,U.S. House,2,,Write-ins,0
-Crawford,15 Frontenac W4,State Senate,13,R,Jake LaTurner,63
-Crawford,15 Frontenac W4,State Senate,13,D,Lynn Grant,144
-Crawford,15 Frontenac W4,State Senate,13,,Write-ins,0
-Crawford,15 Frontenac W4,State House,2,D,Adam J Lusker Sr.,190
-Crawford,15 Frontenac W4,State House,2,,Write-ins,2
-Crawford,16 Girard W1,President,,,Registered Voters,215
-Crawford,16 Girard W1,President,,D,Hillary Clinton,27
-Crawford,16 Girard W1,President,,LBT,Gary Johnson,3
-Crawford,16 Girard W1,President,,IND,Jill Stein,2
-Crawford,16 Girard W1,President,,R,Donald J Trump,74
-Crawford,16 Girard W1,President,,,Write-ins,4
-Crawford,16 Girard W1,U.S. Senate,,LBT,Robert D. Garrard,3
-Crawford,16 Girard W1,U.S. Senate,,R,Jerry Moran,70
-Crawford,16 Girard W1,U.S. Senate,,D,Patrick Wiesner,31
-Crawford,16 Girard W1,U.S. Senate,,,Write-ins,0
-Crawford,16 Girard W1,U.S. House,2,LBT,James Bales,7
-Crawford,16 Girard W1,U.S. House,2,R,Lynn Jenkins,77
-Crawford,16 Girard W1,U.S. House,2,D,Britani Potter,21
-Crawford,16 Girard W1,U.S. House,2,,Write-ins,0
-Crawford,16 Girard W1,State Senate,13,R,Jake LaTurner,60
-Crawford,16 Girard W1,State Senate,13,D,Lynn Grant,47
-Crawford,16 Girard W1,State Senate,13,,Write-ins,0
-Crawford,16 Girard W1,State House,2,D,Adam J Lusker Sr.,82
-Crawford,16 Girard W1,State House,2,,Write-ins,2
-Crawford,17 Girard W2,President,,,Registered Voters,572
-Crawford,17 Girard W2,President,,D,Hillary Clinton,102
-Crawford,17 Girard W2,President,,LBT,Gary Johnson,12
-Crawford,17 Girard W2,President,,IND,Jill Stein,6
-Crawford,17 Girard W2,President,,R,Donald J Trump,217
-Crawford,17 Girard W2,President,,,Write-ins,6
-Crawford,17 Girard W2,U.S. Senate,,LBT,Robert D. Garrard,18
-Crawford,17 Girard W2,U.S. Senate,,R,Jerry Moran,245
-Crawford,17 Girard W2,U.S. Senate,,D,Patrick Wiesner,80
-Crawford,17 Girard W2,U.S. Senate,,,Write-ins,0
-Crawford,17 Girard W2,U.S. House,2,LBT,James Bales,16
-Crawford,17 Girard W2,U.S. House,2,R,Lynn Jenkins,235
-Crawford,17 Girard W2,U.S. House,2,D,Britani Potter,88
-Crawford,17 Girard W2,U.S. House,2,,Write-ins,1
-Crawford,17 Girard W2,State Senate,13,R,Jake LaTurner,165
-Crawford,17 Girard W2,State Senate,13,D,Lynn Grant,182
-Crawford,17 Girard W2,State Senate,13,,Write-ins,0
-Crawford,17 Girard W2,State House,2,D,Adam J Lusker Sr.,269
-Crawford,17 Girard W2,State House,2,,Write-ins,4
-Crawford,18 Girard W3,President,,,Registered Voters,412
-Crawford,18 Girard W3,President,,D,Hillary Clinton,71
-Crawford,18 Girard W3,President,,LBT,Gary Johnson,10
-Crawford,18 Girard W3,President,,IND,Jill Stein,3
-Crawford,18 Girard W3,President,,R,Donald J Trump,136
-Crawford,18 Girard W3,President,,,Write-ins,8
-Crawford,18 Girard W3,U.S. Senate,,LBT,Robert D. Garrard,13
-Crawford,18 Girard W3,U.S. Senate,,R,Jerry Moran,133
-Crawford,18 Girard W3,U.S. Senate,,D,Patrick Wiesner,78
-Crawford,18 Girard W3,U.S. Senate,,,Write-ins,0
-Crawford,18 Girard W3,U.S. House,2,LBT,James Bales,16
-Crawford,18 Girard W3,U.S. House,2,R,Lynn Jenkins,145
-Crawford,18 Girard W3,U.S. House,2,D,Britani Potter,66
-Crawford,18 Girard W3,U.S. House,2,,Write-ins,0
-Crawford,18 Girard W3,State Senate,13,R,Jake LaTurner,96
-Crawford,18 Girard W3,State Senate,13,D,Lynn Grant,131
-Crawford,18 Girard W3,State Senate,13,,Write-ins,0
-Crawford,18 Girard W3,State House,2,D,Adam J Lusker Sr.,200
-Crawford,18 Girard W3,State House,2,,Write-ins,3
-Crawford,19 Girard W4,President,,,Registered Voters,548
-Crawford,19 Girard W4,President,,D,Hillary Clinton,81
-Crawford,19 Girard W4,President,,LBT,Gary Johnson,13
-Crawford,19 Girard W4,President,,IND,Jill Stein,13
-Crawford,19 Girard W4,President,,R,Donald J Trump,204
-Crawford,19 Girard W4,President,,,Write-ins,5
-Crawford,19 Girard W4,U.S. Senate,,LBT,Robert D. Garrard,14
-Crawford,19 Girard W4,U.S. Senate,,R,Jerry Moran,203
-Crawford,19 Girard W4,U.S. Senate,,D,Patrick Wiesner,90
-Crawford,19 Girard W4,U.S. Senate,,,Write-ins,0
-Crawford,19 Girard W4,U.S. House,2,LBT,James Bales,15
-Crawford,19 Girard W4,U.S. House,2,R,Lynn Jenkins,220
-Crawford,19 Girard W4,U.S. House,2,D,Britani Potter,79
-Crawford,19 Girard W4,U.S. House,2,,Write-ins,1
-Crawford,19 Girard W4,State Senate,13,R,Jake LaTurner,161
-Crawford,19 Girard W4,State Senate,13,D,Lynn Grant,156
-Crawford,19 Girard W4,State Senate,13,,Write-ins,0
-Crawford,19 Girard W4,State House,2,D,Adam J Lusker Sr.,267
-Crawford,19 Girard W4,State House,2,,Write-ins,5
-Crawford,20 Grant,President,,,Registered Voters,183
-Crawford,20 Grant,President,,D,Hillary Clinton,34
-Crawford,20 Grant,President,,LBT,Gary Johnson,4
-Crawford,20 Grant,President,,IND,Jill Stein,6
-Crawford,20 Grant,President,,R,Donald J Trump,86
-Crawford,20 Grant,President,,,Write-ins,1
-Crawford,20 Grant,U.S. Senate,,LBT,Robert D. Garrard,4
-Crawford,20 Grant,U.S. Senate,,R,Jerry Moran,97
-Crawford,20 Grant,U.S. Senate,,D,Patrick Wiesner,28
-Crawford,20 Grant,U.S. Senate,,,Write-ins,1
-Crawford,20 Grant,U.S. House,2,LBT,James Bales,7
-Crawford,20 Grant,U.S. House,2,R,Lynn Jenkins,99
-Crawford,20 Grant,U.S. House,2,D,Britani Potter,25
-Crawford,20 Grant,U.S. House,2,,Write-ins,0
-Crawford,20 Grant,State Senate,13,R,Jake LaTurner,73
-Crawford,20 Grant,State Senate,13,D,Lynn Grant,58
-Crawford,20 Grant,State Senate,13,,Write-ins,0
-Crawford,20 Grant,State House,2,D,Adam J Lusker Sr.,102
-Crawford,20 Grant,State House,2,,Write-ins,0
-Crawford,21 Hepler,President,,,Registered Voters,77
-Crawford,21 Hepler,President,,D,Hillary Clinton,5
-Crawford,21 Hepler,President,,LBT,Gary Johnson,2
-Crawford,21 Hepler,President,,IND,Jill Stein,0
-Crawford,21 Hepler,President,,R,Donald J Trump,28
-Crawford,21 Hepler,President,,,Write-ins,0
-Crawford,21 Hepler,U.S. Senate,,LBT,Robert D. Garrard,2
-Crawford,21 Hepler,U.S. Senate,,R,Jerry Moran,31
-Crawford,21 Hepler,U.S. Senate,,D,Patrick Wiesner,3
-Crawford,21 Hepler,U.S. Senate,,,Write-ins,0
-Crawford,21 Hepler,U.S. House,2,LBT,James Bales,2
-Crawford,21 Hepler,U.S. House,2,R,Lynn Jenkins,29
-Crawford,21 Hepler,U.S. House,2,D,Britani Potter,6
-Crawford,21 Hepler,U.S. House,2,,Write-ins,0
-Crawford,21 Hepler,State Senate,13,R,Jake LaTurner,16
-Crawford,21 Hepler,State Senate,13,D,Lynn Grant,20
-Crawford,21 Hepler,State Senate,13,,Write-ins,0
-Crawford,21 Hepler,State House,2,D,Adam J Lusker Sr.,25
-Crawford,21 Hepler,State House,2,,Write-ins,0
-Crawford,22 Lincoln,President,,,Registered Voters,252
-Crawford,22 Lincoln,President,,D,Hillary Clinton,48
-Crawford,22 Lincoln,President,,LBT,Gary Johnson,6
-Crawford,22 Lincoln,President,,IND,Jill Stein,3
-Crawford,22 Lincoln,President,,R,Donald J Trump,108
-Crawford,22 Lincoln,President,,,Write-ins,1
-Crawford,22 Lincoln,U.S. Senate,,LBT,Robert D. Garrard,10
-Crawford,22 Lincoln,U.S. Senate,,R,Jerry Moran,107
-Crawford,22 Lincoln,U.S. Senate,,D,Patrick Wiesner,45
-Crawford,22 Lincoln,U.S. Senate,,,Write-ins,0
-Crawford,22 Lincoln,U.S. House,2,LBT,James Bales,7
-Crawford,22 Lincoln,U.S. House,2,R,Lynn Jenkins,122
-Crawford,22 Lincoln,U.S. House,2,D,Britani Potter,37
-Crawford,22 Lincoln,U.S. House,2,,Write-ins,0
-Crawford,22 Lincoln,State Senate,13,R,Jake LaTurner,98
-Crawford,22 Lincoln,State Senate,13,D,Lynn Grant,63
-Crawford,22 Lincoln,State Senate,13,,Write-ins,0
-Crawford,22 Lincoln,State House,2,D,Adam J Lusker Sr.,135
-Crawford,22 Lincoln,State House,2,,Write-ins,4
-Crawford,23 Lincoln-Arcadia,President,,,Registered Voters,107
-Crawford,23 Lincoln-Arcadia,President,,D,Hillary Clinton,9
-Crawford,23 Lincoln-Arcadia,President,,LBT,Gary Johnson,5
-Crawford,23 Lincoln-Arcadia,President,,IND,Jill Stein,0
-Crawford,23 Lincoln-Arcadia,President,,R,Donald J Trump,46
-Crawford,23 Lincoln-Arcadia,President,,,Write-ins,2
-Crawford,23 Lincoln-Arcadia,U.S. Senate,,LBT,Robert D. Garrard,1
-Crawford,23 Lincoln-Arcadia,U.S. Senate,,R,Jerry Moran,46
-Crawford,23 Lincoln-Arcadia,U.S. Senate,,D,Patrick Wiesner,14
-Crawford,23 Lincoln-Arcadia,U.S. Senate,,,Write-ins,0
-Crawford,23 Lincoln-Arcadia,U.S. House,2,LBT,James Bales,5
-Crawford,23 Lincoln-Arcadia,U.S. House,2,R,Lynn Jenkins,45
-Crawford,23 Lincoln-Arcadia,U.S. House,2,D,Britani Potter,9
-Crawford,23 Lincoln-Arcadia,U.S. House,2,,Write-ins,0
-Crawford,23 Lincoln-Arcadia,State Senate,13,R,Jake LaTurner,45
-Crawford,23 Lincoln-Arcadia,State Senate,13,D,Lynn Grant,17
-Crawford,23 Lincoln-Arcadia,State Senate,13,,Write-ins,0
-Crawford,23 Lincoln-Arcadia,State House,2,D,Adam J Lusker Sr.,45
-Crawford,23 Lincoln-Arcadia,State House,2,,Write-ins,2
-Crawford,24 Lone Star,President,,,Registered Voters,876
-Crawford,24 Lone Star,President,,D,Hillary Clinton,195
-Crawford,24 Lone Star,President,,LBT,Gary Johnson,16
-Crawford,24 Lone Star,President,,IND,Jill Stein,15
-Crawford,24 Lone Star,President,,R,Donald J Trump,352
-Crawford,24 Lone Star,President,,,Write-ins,11
-Crawford,24 Lone Star,U.S. Senate,,LBT,Robert D. Garrard,30
-Crawford,24 Lone Star,U.S. Senate,,R,Jerry Moran,376
-Crawford,24 Lone Star,U.S. Senate,,D,Patrick Wiesner,174
-Crawford,24 Lone Star,U.S. Senate,,,Write-ins,1
-Crawford,24 Lone Star,U.S. House,2,LBT,James Bales,29
-Crawford,24 Lone Star,U.S. House,2,R,Lynn Jenkins,382
-Crawford,24 Lone Star,U.S. House,2,D,Britani Potter,175
-Crawford,24 Lone Star,U.S. House,2,,Write-ins,1
-Crawford,24 Lone Star,State Senate,13,R,Jake LaTurner,297
-Crawford,24 Lone Star,State Senate,13,D,Lynn Grant,288
-Crawford,24 Lone Star,State Senate,13,,Write-ins,1
-Crawford,24 Lone Star,State House,3,D,Monica Murnan,288
-Crawford,24 Lone Star,State House,3,R,Charles Smith,304
-Crawford,24 Lone Star,State House,3,,Write-ins,0
-Crawford,25 McCune,President,,,Registered Voters,272
-Crawford,25 McCune,President,,D,Hillary Clinton,31
-Crawford,25 McCune,President,,LBT,Gary Johnson,17
-Crawford,25 McCune,President,,IND,Jill Stein,4
-Crawford,25 McCune,President,,R,Donald J Trump,116
-Crawford,25 McCune,President,,,Write-ins,2
-Crawford,25 McCune,U.S. Senate,,LBT,Robert D. Garrard,18
-Crawford,25 McCune,U.S. Senate,,R,Jerry Moran,107
-Crawford,25 McCune,U.S. Senate,,D,Patrick Wiesner,40
-Crawford,25 McCune,U.S. Senate,,,Write-ins,0
-Crawford,25 McCune,U.S. House,2,LBT,James Bales,17
-Crawford,25 McCune,U.S. House,2,R,Lynn Jenkins,114
-Crawford,25 McCune,U.S. House,2,D,Britani Potter,35
-Crawford,25 McCune,U.S. House,2,,Write-ins,1
-Crawford,25 McCune,State Senate,13,R,Jake LaTurner,103
-Crawford,25 McCune,State Senate,13,D,Lynn Grant,62
-Crawford,25 McCune,State Senate,13,,Write-ins,0
-Crawford,25 McCune,State House,2,D,Adam J Lusker Sr.,130
-Crawford,25 McCune,State House,2,,Write-ins,7
-Crawford,26 Mulberry W1,President,,,Registered Voters,157
-Crawford,26 Mulberry W1,President,,D,Hillary Clinton,26
-Crawford,26 Mulberry W1,President,,LBT,Gary Johnson,8
-Crawford,26 Mulberry W1,President,,IND,Jill Stein,3
-Crawford,26 Mulberry W1,President,,R,Donald J Trump,35
-Crawford,26 Mulberry W1,President,,,Write-ins,1
-Crawford,26 Mulberry W1,U.S. Senate,,LBT,Robert D. Garrard,8
-Crawford,26 Mulberry W1,U.S. Senate,,R,Jerry Moran,35
-Crawford,26 Mulberry W1,U.S. Senate,,D,Patrick Wiesner,30
-Crawford,26 Mulberry W1,U.S. Senate,,,Write-ins,0
-Crawford,26 Mulberry W1,U.S. House,2,LBT,James Bales,7
-Crawford,26 Mulberry W1,U.S. House,2,R,Lynn Jenkins,47
-Crawford,26 Mulberry W1,U.S. House,2,D,Britani Potter,21
-Crawford,26 Mulberry W1,U.S. House,2,,Write-ins,0
-Crawford,26 Mulberry W1,State Senate,13,R,Jake LaTurner,25
-Crawford,26 Mulberry W1,State Senate,13,D,Lynn Grant,50
-Crawford,26 Mulberry W1,State Senate,13,,Write-ins,0
-Crawford,26 Mulberry W1,State House,2,D,Adam J Lusker Sr.,66
-Crawford,26 Mulberry W1,State House,2,,Write-ins,4
-Crawford,27 Mulberry W2,President,,,Registered Voters,183
-Crawford,27 Mulberry W2,President,,D,Hillary Clinton,25
-Crawford,27 Mulberry W2,President,,LBT,Gary Johnson,3
-Crawford,27 Mulberry W2,President,,IND,Jill Stein,4
-Crawford,27 Mulberry W2,President,,R,Donald J Trump,49
-Crawford,27 Mulberry W2,President,,,Write-ins,3
-Crawford,27 Mulberry W2,U.S. Senate,,LBT,Robert D. Garrard,6
-Crawford,27 Mulberry W2,U.S. Senate,,R,Jerry Moran,44
-Crawford,27 Mulberry W2,U.S. Senate,,D,Patrick Wiesner,31
-Crawford,27 Mulberry W2,U.S. Senate,,,Write-ins,1
-Crawford,27 Mulberry W2,U.S. House,2,LBT,James Bales,8
-Crawford,27 Mulberry W2,U.S. House,2,R,Lynn Jenkins,46
-Crawford,27 Mulberry W2,U.S. House,2,D,Britani Potter,30
-Crawford,27 Mulberry W2,U.S. House,2,,Write-ins,0
-Crawford,27 Mulberry W2,State Senate,13,R,Jake LaTurner,42
-Crawford,27 Mulberry W2,State Senate,13,D,Lynn Grant,41
-Crawford,27 Mulberry W2,State Senate,13,,Write-ins,0
-Crawford,27 Mulberry W2,State House,2,D,Adam J Lusker Sr.,66
-Crawford,27 Mulberry W2,State House,2,,Write-ins,2
-Crawford,28 North Arma,President,,,Registered Voters,614
-Crawford,28 North Arma,President,,D,Hillary Clinton,117
-Crawford,28 North Arma,President,,LBT,Gary Johnson,16
-Crawford,28 North Arma,President,,IND,Jill Stein,5
-Crawford,28 North Arma,President,,R,Donald J Trump,206
-Crawford,28 North Arma,President,,,Write-ins,1
-Crawford,28 North Arma,U.S. Senate,,LBT,Robert D. Garrard,20
-Crawford,28 North Arma,U.S. Senate,,R,Jerry Moran,209
-Crawford,28 North Arma,U.S. Senate,,D,Patrick Wiesner,102
-Crawford,28 North Arma,U.S. Senate,,,Write-ins,0
-Crawford,28 North Arma,U.S. House,2,LBT,James Bales,16
-Crawford,28 North Arma,U.S. House,2,R,Lynn Jenkins,236
-Crawford,28 North Arma,U.S. House,2,D,Britani Potter,92
-Crawford,28 North Arma,U.S. House,2,,Write-ins,1
-Crawford,28 North Arma,State Senate,13,R,Jake LaTurner,174
-Crawford,28 North Arma,State Senate,13,D,Lynn Grant,175
-Crawford,28 North Arma,State Senate,13,,Write-ins,0
-Crawford,28 North Arma,State House,2,D,Adam J Lusker Sr.,283
-Crawford,28 North Arma,State House,2,,Write-ins,9
-Crawford,29 Opolis,President,,,Registered Voters,263
-Crawford,29 Opolis,President,,D,Hillary Clinton,63
-Crawford,29 Opolis,President,,LBT,Gary Johnson,5
-Crawford,29 Opolis,President,,IND,Jill Stein,2
-Crawford,29 Opolis,President,,R,Donald J Trump,107
-Crawford,29 Opolis,President,,,Write-ins,3
-Crawford,29 Opolis,U.S. Senate,,LBT,Robert D. Garrard,11
-Crawford,29 Opolis,U.S. Senate,,R,Jerry Moran,118
-Crawford,29 Opolis,U.S. Senate,,D,Patrick Wiesner,50
-Crawford,29 Opolis,U.S. Senate,,,Write-ins,0
-Crawford,29 Opolis,U.S. House,2,LBT,James Bales,9
-Crawford,29 Opolis,U.S. House,2,R,Lynn Jenkins,118
-Crawford,29 Opolis,U.S. House,2,D,Britani Potter,52
-Crawford,29 Opolis,U.S. House,2,,Write-ins,0
-Crawford,29 Opolis,State Senate,13,R,Jake LaTurner,98
-Crawford,29 Opolis,State Senate,13,D,Lynn Grant,82
-Crawford,29 Opolis,State Senate,13,,Write-ins,0
-Crawford,29 Opolis,State House,3,D,Monica Murnan,87
-Crawford,29 Opolis,State House,3,R,Charles Smith,92
-Crawford,29 Opolis,State House,3,,Write-ins,0
-Crawford,30 Osage-McCune,President,,,Registered Voters,261
-Crawford,30 Osage-McCune,President,,D,Hillary Clinton,28
-Crawford,30 Osage-McCune,President,,LBT,Gary Johnson,9
-Crawford,30 Osage-McCune,President,,IND,Jill Stein,0
-Crawford,30 Osage-McCune,President,,R,Donald J Trump,163
-Crawford,30 Osage-McCune,President,,,Write-ins,5
-Crawford,30 Osage-McCune,U.S. Senate,,LBT,Robert D. Garrard,12
-Crawford,30 Osage-McCune,U.S. Senate,,R,Jerry Moran,163
-Crawford,30 Osage-McCune,U.S. Senate,,D,Patrick Wiesner,31
-Crawford,30 Osage-McCune,U.S. Senate,,,Write-ins,0
-Crawford,30 Osage-McCune,U.S. House,2,LBT,James Bales,5
-Crawford,30 Osage-McCune,U.S. House,2,R,Lynn Jenkins,172
-Crawford,30 Osage-McCune,U.S. House,2,D,Britani Potter,28
-Crawford,30 Osage-McCune,U.S. House,2,,Write-ins,0
-Crawford,30 Osage-McCune,State Senate,13,R,Jake LaTurner,138
-Crawford,30 Osage-McCune,State Senate,13,D,Lynn Grant,68
-Crawford,30 Osage-McCune,State Senate,13,,Write-ins,0
-Crawford,30 Osage-McCune,State House,2,D,Adam J Lusker Sr.,142
-Crawford,30 Osage-McCune,State House,2,,Write-ins,0
-Crawford,31 Parkview,President,,,Registered Voters,368
-Crawford,31 Parkview,President,,D,Hillary Clinton,84
-Crawford,31 Parkview,President,,LBT,Gary Johnson,3
-Crawford,31 Parkview,President,,IND,Jill Stein,5
-Crawford,31 Parkview,President,,R,Donald J Trump,147
-Crawford,31 Parkview,President,,,Write-ins,1
-Crawford,31 Parkview,U.S. Senate,,LBT,Robert D. Garrard,11
-Crawford,31 Parkview,U.S. Senate,,R,Jerry Moran,136
-Crawford,31 Parkview,U.S. Senate,,D,Patrick Wiesner,91
-Crawford,31 Parkview,U.S. Senate,,,Write-ins,0
-Crawford,31 Parkview,U.S. House,2,LBT,James Bales,7
-Crawford,31 Parkview,U.S. House,2,R,Lynn Jenkins,150
-Crawford,31 Parkview,U.S. House,2,D,Britani Potter,84
-Crawford,31 Parkview,U.S. House,2,,Write-ins,0
-Crawford,31 Parkview,State Senate,13,R,Jake LaTurner,108
-Crawford,31 Parkview,State Senate,13,D,Lynn Grant,134
-Crawford,31 Parkview,State Senate,13,,Write-ins,1
-Crawford,31 Parkview,State House,2,D,Adam J Lusker Sr.,204
-Crawford,31 Parkview,State House,2,,Write-ins,11
-Crawford,32 Pittsburg W1P1,President,,,Registered Voters,677
-Crawford,32 Pittsburg W1P1,President,,D,Hillary Clinton,121
-Crawford,32 Pittsburg W1P1,President,,LBT,Gary Johnson,24
-Crawford,32 Pittsburg W1P1,President,,IND,Jill Stein,3
-Crawford,32 Pittsburg W1P1,President,,R,Donald J Trump,175
-Crawford,32 Pittsburg W1P1,President,,,Write-ins,9
-Crawford,32 Pittsburg W1P1,U.S. Senate,,LBT,Robert D. Garrard,26
-Crawford,32 Pittsburg W1P1,U.S. Senate,,R,Jerry Moran,186
-Crawford,32 Pittsburg W1P1,U.S. Senate,,D,Patrick Wiesner,118
-Crawford,32 Pittsburg W1P1,U.S. Senate,,,Write-ins,0
-Crawford,32 Pittsburg W1P1,U.S. House,2,LBT,James Bales,23
-Crawford,32 Pittsburg W1P1,U.S. House,2,R,Lynn Jenkins,193
-Crawford,32 Pittsburg W1P1,U.S. House,2,D,Britani Potter,108
-Crawford,32 Pittsburg W1P1,U.S. House,2,,Write-ins,1
-Crawford,32 Pittsburg W1P1,State Senate,13,R,Jake LaTurner,183
-Crawford,32 Pittsburg W1P1,State Senate,13,D,Lynn Grant,148
-Crawford,32 Pittsburg W1P1,State Senate,13,,Write-ins,0
-Crawford,32 Pittsburg W1P1,State House,3,D,Monica Murnan,162
-Crawford,32 Pittsburg W1P1,State House,3,R,Charles Smith,170
-Crawford,32 Pittsburg W1P1,State House,3,,Write-ins,0
-Crawford,33 Pittsburg W1P2,President,,,Registered Voters,1068
-Crawford,33 Pittsburg W1P2,President,,D,Hillary Clinton,216
-Crawford,33 Pittsburg W1P2,President,,LBT,Gary Johnson,29
-Crawford,33 Pittsburg W1P2,President,,IND,Jill Stein,7
-Crawford,33 Pittsburg W1P2,President,,R,Donald J Trump,285
-Crawford,33 Pittsburg W1P2,President,,,Write-ins,11
-Crawford,33 Pittsburg W1P2,U.S. Senate,,LBT,Robert D. Garrard,26
-Crawford,33 Pittsburg W1P2,U.S. Senate,,R,Jerry Moran,318
-Crawford,33 Pittsburg W1P2,U.S. Senate,,D,Patrick Wiesner,196
-Crawford,33 Pittsburg W1P2,U.S. Senate,,,Write-ins,2
-Crawford,33 Pittsburg W1P2,U.S. House,2,LBT,James Bales,24
-Crawford,33 Pittsburg W1P2,U.S. House,2,R,Lynn Jenkins,332
-Crawford,33 Pittsburg W1P2,U.S. House,2,D,Britani Potter,185
-Crawford,33 Pittsburg W1P2,U.S. House,2,,Write-ins,2
-Crawford,33 Pittsburg W1P2,State Senate,13,R,Jake LaTurner,265
-Crawford,33 Pittsburg W1P2,State Senate,13,D,Lynn Grant,274
-Crawford,33 Pittsburg W1P2,State Senate,13,,Write-ins,2
-Crawford,33 Pittsburg W1P2,State House,3,D,Monica Murnan,279
-Crawford,33 Pittsburg W1P2,State House,3,R,Charles Smith,262
-Crawford,33 Pittsburg W1P2,State House,3,,Write-ins,2
-Crawford,34 Pittsburg W1P3,President,,,Registered Voters,1939
-Crawford,34 Pittsburg W1P3,President,,D,Hillary Clinton,526
-Crawford,34 Pittsburg W1P3,President,,LBT,Gary Johnson,54
-Crawford,34 Pittsburg W1P3,President,,IND,Jill Stein,28
-Crawford,34 Pittsburg W1P3,President,,R,Donald J Trump,601
-Crawford,34 Pittsburg W1P3,President,,,Write-ins,26
-Crawford,34 Pittsburg W1P3,U.S. Senate,,LBT,Robert D. Garrard,50
-Crawford,34 Pittsburg W1P3,U.S. Senate,,R,Jerry Moran,709
-Crawford,34 Pittsburg W1P3,U.S. Senate,,D,Patrick Wiesner,460
-Crawford,34 Pittsburg W1P3,U.S. Senate,,,Write-ins,1
-Crawford,34 Pittsburg W1P3,U.S. House,2,LBT,James Bales,48
-Crawford,34 Pittsburg W1P3,U.S. House,2,R,Lynn Jenkins,743
-Crawford,34 Pittsburg W1P3,U.S. House,2,D,Britani Potter,422
-Crawford,34 Pittsburg W1P3,U.S. House,2,,Write-ins,3
-Crawford,34 Pittsburg W1P3,State Senate,13,R,Jake LaTurner,607
-Crawford,34 Pittsburg W1P3,State Senate,13,D,Lynn Grant,601
-Crawford,34 Pittsburg W1P3,State Senate,13,,Write-ins,4
-Crawford,34 Pittsburg W1P3,State House,3,D,Monica Murnan,641
-Crawford,34 Pittsburg W1P3,State House,3,R,Charles Smith,574
-Crawford,34 Pittsburg W1P3,State House,3,,Write-ins,1
-Crawford,35 Pittsburg W2P1,President,,,Registered Voters,466
-Crawford,35 Pittsburg W2P1,President,,D,Hillary Clinton,81
-Crawford,35 Pittsburg W2P1,President,,LBT,Gary Johnson,13
-Crawford,35 Pittsburg W2P1,President,,IND,Jill Stein,7
-Crawford,35 Pittsburg W2P1,President,,R,Donald J Trump,126
-Crawford,35 Pittsburg W2P1,President,,,Write-ins,5
-Crawford,35 Pittsburg W2P1,U.S. Senate,,LBT,Robert D. Garrard,15
-Crawford,35 Pittsburg W2P1,U.S. Senate,,R,Jerry Moran,113
-Crawford,35 Pittsburg W2P1,U.S. Senate,,D,Patrick Wiesner,98
-Crawford,35 Pittsburg W2P1,U.S. Senate,,,Write-ins,1
-Crawford,35 Pittsburg W2P1,U.S. House,2,LBT,James Bales,13
-Crawford,35 Pittsburg W2P1,U.S. House,2,R,Lynn Jenkins,139
-Crawford,35 Pittsburg W2P1,U.S. House,2,D,Britani Potter,79
-Crawford,35 Pittsburg W2P1,U.S. House,2,,Write-ins,0
-Crawford,35 Pittsburg W2P1,State Senate,13,R,Jake LaTurner,109
-Crawford,35 Pittsburg W2P1,State Senate,13,D,Lynn Grant,119
-Crawford,35 Pittsburg W2P1,State Senate,13,,Write-ins,2
-Crawford,35 Pittsburg W2P1,State House,3,D,Monica Murnan,142
-Crawford,35 Pittsburg W2P1,State House,3,R,Charles Smith,85
-Crawford,35 Pittsburg W2P1,State House,3,,Write-ins,0
-Crawford,36 Pittsburg W2P2,President,,,Registered Voters,503
-Crawford,36 Pittsburg W2P2,President,,D,Hillary Clinton,128
-Crawford,36 Pittsburg W2P2,President,,LBT,Gary Johnson,5
-Crawford,36 Pittsburg W2P2,President,,IND,Jill Stein,7
-Crawford,36 Pittsburg W2P2,President,,R,Donald J Trump,150
-Crawford,36 Pittsburg W2P2,President,,,Write-ins,9
-Crawford,36 Pittsburg W2P2,U.S. Senate,,LBT,Robert D. Garrard,10
-Crawford,36 Pittsburg W2P2,U.S. Senate,,R,Jerry Moran,158
-Crawford,36 Pittsburg W2P2,U.S. Senate,,D,Patrick Wiesner,124
-Crawford,36 Pittsburg W2P2,U.S. Senate,,,Write-ins,1
-Crawford,36 Pittsburg W2P2,U.S. House,2,LBT,James Bales,14
-Crawford,36 Pittsburg W2P2,U.S. House,2,R,Lynn Jenkins,169
-Crawford,36 Pittsburg W2P2,U.S. House,2,D,Britani Potter,109
-Crawford,36 Pittsburg W2P2,U.S. House,2,,Write-ins,1
-Crawford,36 Pittsburg W2P2,State Senate,13,R,Jake LaTurner,147
-Crawford,36 Pittsburg W2P2,State Senate,13,D,Lynn Grant,147
-Crawford,36 Pittsburg W2P2,State Senate,13,,Write-ins,0
-Crawford,36 Pittsburg W2P2,State House,3,D,Monica Murnan,157
-Crawford,36 Pittsburg W2P2,State House,3,R,Charles Smith,138
-Crawford,36 Pittsburg W2P2,State House,3,,Write-ins,0
-Crawford,37 Pittsburg W2P3,President,,,Registered Voters,626
-Crawford,37 Pittsburg W2P3,President,,D,Hillary Clinton,169
-Crawford,37 Pittsburg W2P3,President,,LBT,Gary Johnson,13
-Crawford,37 Pittsburg W2P3,President,,IND,Jill Stein,9
-Crawford,37 Pittsburg W2P3,President,,R,Donald J Trump,164
-Crawford,37 Pittsburg W2P3,President,,,Write-ins,3
-Crawford,37 Pittsburg W2P3,U.S. Senate,,LBT,Robert D. Garrard,19
-Crawford,37 Pittsburg W2P3,U.S. Senate,,R,Jerry Moran,180
-Crawford,37 Pittsburg W2P3,U.S. Senate,,D,Patrick Wiesner,151
-Crawford,37 Pittsburg W2P3,U.S. Senate,,,Write-ins,0
-Crawford,37 Pittsburg W2P3,U.S. House,2,LBT,James Bales,16
-Crawford,37 Pittsburg W2P3,U.S. House,2,R,Lynn Jenkins,195
-Crawford,37 Pittsburg W2P3,U.S. House,2,D,Britani Potter,141
-Crawford,37 Pittsburg W2P3,U.S. House,2,,Write-ins,1
-Crawford,37 Pittsburg W2P3,State Senate,13,R,Jake LaTurner,148
-Crawford,37 Pittsburg W2P3,State Senate,13,D,Lynn Grant,206
-Crawford,37 Pittsburg W2P3,State Senate,13,,Write-ins,1
-Crawford,37 Pittsburg W2P3,State House,3,D,Monica Murnan,215
-Crawford,37 Pittsburg W2P3,State House,3,R,Charles Smith,140
-Crawford,37 Pittsburg W2P3,State House,3,,Write-ins,1
-Crawford,38 Pittsburg W2P4,President,,,Registered Voters,447
-Crawford,38 Pittsburg W2P4,President,,D,Hillary Clinton,128
-Crawford,38 Pittsburg W2P4,President,,LBT,Gary Johnson,25
-Crawford,38 Pittsburg W2P4,President,,IND,Jill Stein,10
-Crawford,38 Pittsburg W2P4,President,,R,Donald J Trump,148
-Crawford,38 Pittsburg W2P4,President,,,Write-ins,9
-Crawford,38 Pittsburg W2P4,U.S. Senate,,LBT,Robert D. Garrard,15
-Crawford,38 Pittsburg W2P4,U.S. Senate,,R,Jerry Moran,183
-Crawford,38 Pittsburg W2P4,U.S. Senate,,D,Patrick Wiesner,122
-Crawford,38 Pittsburg W2P4,U.S. Senate,,,Write-ins,0
-Crawford,38 Pittsburg W2P4,U.S. House,2,LBT,James Bales,10
-Crawford,38 Pittsburg W2P4,U.S. House,2,R,Lynn Jenkins,195
-Crawford,38 Pittsburg W2P4,U.S. House,2,D,Britani Potter,113
-Crawford,38 Pittsburg W2P4,U.S. House,2,,Write-ins,0
-Crawford,38 Pittsburg W2P4,State Senate,13,R,Jake LaTurner,163
-Crawford,38 Pittsburg W2P4,State Senate,13,D,Lynn Grant,158
-Crawford,38 Pittsburg W2P4,State Senate,13,,Write-ins,0
-Crawford,38 Pittsburg W2P4,State House,3,D,Monica Murnan,163
-Crawford,38 Pittsburg W2P4,State House,3,R,Charles Smith,157
-Crawford,38 Pittsburg W2P4,State House,3,,Write-ins,0
-Crawford,39 Pittsburg W2P5,President,,,Registered Voters,832
-Crawford,39 Pittsburg W2P5,President,,D,Hillary Clinton,186
-Crawford,39 Pittsburg W2P5,President,,LBT,Gary Johnson,29
-Crawford,39 Pittsburg W2P5,President,,IND,Jill Stein,3
-Crawford,39 Pittsburg W2P5,President,,R,Donald J Trump,220
-Crawford,39 Pittsburg W2P5,President,,,Write-ins,17
-Crawford,39 Pittsburg W2P5,U.S. Senate,,LBT,Robert D. Garrard,23
-Crawford,39 Pittsburg W2P5,U.S. Senate,,R,Jerry Moran,264
-Crawford,39 Pittsburg W2P5,U.S. Senate,,D,Patrick Wiesner,158
-Crawford,39 Pittsburg W2P5,U.S. Senate,,,Write-ins,0
-Crawford,39 Pittsburg W2P5,U.S. House,2,LBT,James Bales,25
-Crawford,39 Pittsburg W2P5,U.S. House,2,R,Lynn Jenkins,271
-Crawford,39 Pittsburg W2P5,U.S. House,2,D,Britani Potter,151
-Crawford,39 Pittsburg W2P5,U.S. House,2,,Write-ins,1
-Crawford,39 Pittsburg W2P5,State Senate,13,R,Jake LaTurner,214
-Crawford,39 Pittsburg W2P5,State Senate,13,D,Lynn Grant,237
-Crawford,39 Pittsburg W2P5,State Senate,13,,Write-ins,0
-Crawford,39 Pittsburg W2P5,State House,3,D,Monica Murnan,257
-Crawford,39 Pittsburg W2P5,State House,3,R,Charles Smith,193
-Crawford,39 Pittsburg W2P5,State House,3,,Write-ins,1
-Crawford,40 Pittsburg W3P1,President,,,Registered Voters,649
-Crawford,40 Pittsburg W3P1,President,,D,Hillary Clinton,123
-Crawford,40 Pittsburg W3P1,President,,LBT,Gary Johnson,19
-Crawford,40 Pittsburg W3P1,President,,IND,Jill Stein,6
-Crawford,40 Pittsburg W3P1,President,,R,Donald J Trump,149
-Crawford,40 Pittsburg W3P1,President,,,Write-ins,4
-Crawford,40 Pittsburg W3P1,U.S. Senate,,LBT,Robert D. Garrard,15
-Crawford,40 Pittsburg W3P1,U.S. Senate,,R,Jerry Moran,156
-Crawford,40 Pittsburg W3P1,U.S. Senate,,D,Patrick Wiesner,129
-Crawford,40 Pittsburg W3P1,U.S. Senate,,,Write-ins,0
-Crawford,40 Pittsburg W3P1,U.S. House,2,LBT,James Bales,25
-Crawford,40 Pittsburg W3P1,U.S. House,2,R,Lynn Jenkins,162
-Crawford,40 Pittsburg W3P1,U.S. House,2,D,Britani Potter,113
-Crawford,40 Pittsburg W3P1,U.S. House,2,,Write-ins,0
-Crawford,40 Pittsburg W3P1,State Senate,13,R,Jake LaTurner,147
-Crawford,40 Pittsburg W3P1,State Senate,13,D,Lynn Grant,151
-Crawford,40 Pittsburg W3P1,State Senate,13,,Write-ins,0
-Crawford,40 Pittsburg W3P1,State House,3,D,Monica Murnan,162
-Crawford,40 Pittsburg W3P1,State House,3,R,Charles Smith,137
-Crawford,40 Pittsburg W3P1,State House,3,,Write-ins,0
-Crawford,41 Pittsburg W3P2,President,,,Registered Voters,738
-Crawford,41 Pittsburg W3P2,President,,D,Hillary Clinton,136
-Crawford,41 Pittsburg W3P2,President,,LBT,Gary Johnson,21
-Crawford,41 Pittsburg W3P2,President,,IND,Jill Stein,7
-Crawford,41 Pittsburg W3P2,President,,R,Donald J Trump,217
-Crawford,41 Pittsburg W3P2,President,,,Write-ins,10
-Crawford,41 Pittsburg W3P2,U.S. Senate,,LBT,Robert D. Garrard,24
-Crawford,41 Pittsburg W3P2,U.S. Senate,,R,Jerry Moran,204
-Crawford,41 Pittsburg W3P2,U.S. Senate,,D,Patrick Wiesner,154
-Crawford,41 Pittsburg W3P2,U.S. Senate,,,Write-ins,0
-Crawford,41 Pittsburg W3P2,U.S. House,2,LBT,James Bales,22
-Crawford,41 Pittsburg W3P2,U.S. House,2,R,Lynn Jenkins,227
-Crawford,41 Pittsburg W3P2,U.S. House,2,D,Britani Potter,133
-Crawford,41 Pittsburg W3P2,U.S. House,2,,Write-ins,1
-Crawford,41 Pittsburg W3P2,State Senate,13,R,Jake LaTurner,188
-Crawford,41 Pittsburg W3P2,State Senate,13,D,Lynn Grant,200
-Crawford,41 Pittsburg W3P2,State Senate,13,,Write-ins,1
-Crawford,41 Pittsburg W3P2,State House,3,D,Monica Murnan,199
-Crawford,41 Pittsburg W3P2,State House,3,R,Charles Smith,189
-Crawford,41 Pittsburg W3P2,State House,3,,Write-ins,1
-Crawford,42 Pittsburg W4P1,President,,,Registered Voters,298
-Crawford,42 Pittsburg W4P1,President,,D,Hillary Clinton,56
-Crawford,42 Pittsburg W4P1,President,,LBT,Gary Johnson,3
-Crawford,42 Pittsburg W4P1,President,,IND,Jill Stein,4
-Crawford,42 Pittsburg W4P1,President,,R,Donald J Trump,52
-Crawford,42 Pittsburg W4P1,President,,,Write-ins,5
-Crawford,42 Pittsburg W4P1,U.S. Senate,,LBT,Robert D. Garrard,7
-Crawford,42 Pittsburg W4P1,U.S. Senate,,R,Jerry Moran,52
-Crawford,42 Pittsburg W4P1,U.S. Senate,,D,Patrick Wiesner,59
-Crawford,42 Pittsburg W4P1,U.S. Senate,,,Write-ins,0
-Crawford,42 Pittsburg W4P1,U.S. House,2,LBT,James Bales,4
-Crawford,42 Pittsburg W4P1,U.S. House,2,R,Lynn Jenkins,54
-Crawford,42 Pittsburg W4P1,U.S. House,2,D,Britani Potter,60
-Crawford,42 Pittsburg W4P1,U.S. House,2,,Write-ins,0
-Crawford,42 Pittsburg W4P1,State Senate,13,R,Jake LaTurner,44
-Crawford,42 Pittsburg W4P1,State Senate,13,D,Lynn Grant,71
-Crawford,42 Pittsburg W4P1,State Senate,13,,Write-ins,0
-Crawford,42 Pittsburg W4P1,State House,3,D,Monica Murnan,72
-Crawford,42 Pittsburg W4P1,State House,3,R,Charles Smith,45
-Crawford,42 Pittsburg W4P1,State House,3,,Write-ins,0
-Crawford,43 Pittsburg W4P2,President,,,Registered Voters,587
-Crawford,43 Pittsburg W4P2,President,,D,Hillary Clinton,118
-Crawford,43 Pittsburg W4P2,President,,LBT,Gary Johnson,15
-Crawford,43 Pittsburg W4P2,President,,IND,Jill Stein,12
-Crawford,43 Pittsburg W4P2,President,,R,Donald J Trump,109
-Crawford,43 Pittsburg W4P2,President,,,Write-ins,6
-Crawford,43 Pittsburg W4P2,U.S. Senate,,LBT,Robert D. Garrard,19
-Crawford,43 Pittsburg W4P2,U.S. Senate,,R,Jerry Moran,119
-Crawford,43 Pittsburg W4P2,U.S. Senate,,D,Patrick Wiesner,117
-Crawford,43 Pittsburg W4P2,U.S. Senate,,,Write-ins,0
-Crawford,43 Pittsburg W4P2,U.S. House,2,LBT,James Bales,14
-Crawford,43 Pittsburg W4P2,U.S. House,2,R,Lynn Jenkins,142
-Crawford,43 Pittsburg W4P2,U.S. House,2,D,Britani Potter,100
-Crawford,43 Pittsburg W4P2,U.S. House,2,,Write-ins,0
-Crawford,43 Pittsburg W4P2,State Senate,13,R,Jake LaTurner,98
-Crawford,43 Pittsburg W4P2,State Senate,13,D,Lynn Grant,158
-Crawford,43 Pittsburg W4P2,State Senate,13,,Write-ins,1
-Crawford,43 Pittsburg W4P2,State House,3,D,Monica Murnan,162
-Crawford,43 Pittsburg W4P2,State House,3,R,Charles Smith,95
-Crawford,43 Pittsburg W4P2,State House,3,,Write-ins,0
-Crawford,44 Pittsburg W4P3,President,,,Registered Voters,851
-Crawford,44 Pittsburg W4P3,President,,D,Hillary Clinton,165
-Crawford,44 Pittsburg W4P3,President,,LBT,Gary Johnson,19
-Crawford,44 Pittsburg W4P3,President,,IND,Jill Stein,24
-Crawford,44 Pittsburg W4P3,President,,R,Donald J Trump,266
-Crawford,44 Pittsburg W4P3,President,,,Write-ins,10
-Crawford,44 Pittsburg W4P3,U.S. Senate,,LBT,Robert D. Garrard,49
-Crawford,44 Pittsburg W4P3,U.S. Senate,,R,Jerry Moran,259
-Crawford,44 Pittsburg W4P3,U.S. Senate,,D,Patrick Wiesner,167
-Crawford,44 Pittsburg W4P3,U.S. Senate,,,Write-ins,1
-Crawford,44 Pittsburg W4P3,U.S. House,2,LBT,James Bales,45
-Crawford,44 Pittsburg W4P3,U.S. House,2,R,Lynn Jenkins,275
-Crawford,44 Pittsburg W4P3,U.S. House,2,D,Britani Potter,161
-Crawford,44 Pittsburg W4P3,U.S. House,2,,Write-ins,0
-Crawford,44 Pittsburg W4P3,State Senate,13,R,Jake LaTurner,227
-Crawford,44 Pittsburg W4P3,State Senate,13,D,Lynn Grant,255
-Crawford,44 Pittsburg W4P3,State Senate,13,,Write-ins,0
-Crawford,44 Pittsburg W4P3,State House,3,D,Monica Murnan,268
-Crawford,44 Pittsburg W4P3,State House,3,R,Charles Smith,212
-Crawford,44 Pittsburg W4P3,State House,3,,Write-ins,0
-Crawford,45 Pittsburg W4P4,President,,,Registered Voters,553
-Crawford,45 Pittsburg W4P4,President,,D,Hillary Clinton,99
-Crawford,45 Pittsburg W4P4,President,,LBT,Gary Johnson,8
-Crawford,45 Pittsburg W4P4,President,,IND,Jill Stein,10
-Crawford,45 Pittsburg W4P4,President,,R,Donald J Trump,140
-Crawford,45 Pittsburg W4P4,President,,,Write-ins,4
-Crawford,45 Pittsburg W4P4,U.S. Senate,,LBT,Robert D. Garrard,20
-Crawford,45 Pittsburg W4P4,U.S. Senate,,R,Jerry Moran,141
-Crawford,45 Pittsburg W4P4,U.S. Senate,,D,Patrick Wiesner,100
-Crawford,45 Pittsburg W4P4,U.S. Senate,,,Write-ins,1
-Crawford,45 Pittsburg W4P4,U.S. House,2,LBT,James Bales,22
-Crawford,45 Pittsburg W4P4,U.S. House,2,R,Lynn Jenkins,149
-Crawford,45 Pittsburg W4P4,U.S. House,2,D,Britani Potter,90
-Crawford,45 Pittsburg W4P4,U.S. House,2,,Write-ins,3
-Crawford,45 Pittsburg W4P4,State Senate,13,R,Jake LaTurner,120
-Crawford,45 Pittsburg W4P4,State Senate,13,D,Lynn Grant,145
-Crawford,45 Pittsburg W4P4,State Senate,13,,Write-ins,0
-Crawford,45 Pittsburg W4P4,State House,3,D,Monica Murnan,153
-Crawford,45 Pittsburg W4P4,State House,3,R,Charles Smith,112
-Crawford,45 Pittsburg W4P4,State House,3,,Write-ins,0
-Crawford,46 Pittsburg W4P5,President,,,Registered Voters,1026
-Crawford,46 Pittsburg W4P5,President,,D,Hillary Clinton,241
-Crawford,46 Pittsburg W4P5,President,,LBT,Gary Johnson,42
-Crawford,46 Pittsburg W4P5,President,,IND,Jill Stein,16
-Crawford,46 Pittsburg W4P5,President,,R,Donald J Trump,363
-Crawford,46 Pittsburg W4P5,President,,,Write-ins,13
-Crawford,46 Pittsburg W4P5,U.S. Senate,,LBT,Robert D. Garrard,35
-Crawford,46 Pittsburg W4P5,U.S. Senate,,R,Jerry Moran,414
-Crawford,46 Pittsburg W4P5,U.S. Senate,,D,Patrick Wiesner,207
-Crawford,46 Pittsburg W4P5,U.S. Senate,,,Write-ins,1
-Crawford,46 Pittsburg W4P5,U.S. House,2,LBT,James Bales,30
-Crawford,46 Pittsburg W4P5,U.S. House,2,R,Lynn Jenkins,452
-Crawford,46 Pittsburg W4P5,U.S. House,2,D,Britani Potter,185
-Crawford,46 Pittsburg W4P5,U.S. House,2,,Write-ins,0
-Crawford,46 Pittsburg W4P5,State Senate,13,R,Jake LaTurner,331
-Crawford,46 Pittsburg W4P5,State Senate,13,D,Lynn Grant,337
-Crawford,46 Pittsburg W4P5,State Senate,13,,Write-ins,1
-Crawford,46 Pittsburg W4P5,State House,3,D,Monica Murnan,363
-Crawford,46 Pittsburg W4P5,State House,3,R,Charles Smith,308
-Crawford,46 Pittsburg W4P5,State House,3,,Write-ins,1
-Crawford,47 Pittsburg W4P6,President,,,Registered Voters,160
-Crawford,47 Pittsburg W4P6,President,,D,Hillary Clinton,31
-Crawford,47 Pittsburg W4P6,President,,LBT,Gary Johnson,3
-Crawford,47 Pittsburg W4P6,President,,IND,Jill Stein,1
-Crawford,47 Pittsburg W4P6,President,,R,Donald J Trump,86
-Crawford,47 Pittsburg W4P6,President,,,Write-ins,0
-Crawford,47 Pittsburg W4P6,U.S. Senate,,LBT,Robert D. Garrard,3
-Crawford,47 Pittsburg W4P6,U.S. Senate,,R,Jerry Moran,90
-Crawford,47 Pittsburg W4P6,U.S. Senate,,D,Patrick Wiesner,30
-Crawford,47 Pittsburg W4P6,U.S. Senate,,,Write-ins,0
-Crawford,47 Pittsburg W4P6,U.S. House,2,LBT,James Bales,4
-Crawford,47 Pittsburg W4P6,U.S. House,2,R,Lynn Jenkins,90
-Crawford,47 Pittsburg W4P6,U.S. House,2,D,Britani Potter,29
-Crawford,47 Pittsburg W4P6,U.S. House,2,,Write-ins,0
-Crawford,47 Pittsburg W4P6,State Senate,13,R,Jake LaTurner,82
-Crawford,47 Pittsburg W4P6,State Senate,13,D,Lynn Grant,41
-Crawford,47 Pittsburg W4P6,State Senate,13,,Write-ins,0
-Crawford,47 Pittsburg W4P6,State House,3,D,Monica Murnan,46
-Crawford,47 Pittsburg W4P6,State House,3,R,Charles Smith,76
-Crawford,47 Pittsburg W4P6,State House,3,,Write-ins,0
-Crawford,48 Raymond,President,,,Registered Voters,488
-Crawford,48 Raymond,President,,D,Hillary Clinton,87
-Crawford,48 Raymond,President,,LBT,Gary Johnson,8
-Crawford,48 Raymond,President,,IND,Jill Stein,3
-Crawford,48 Raymond,President,,R,Donald J Trump,248
-Crawford,48 Raymond,President,,,Write-ins,3
-Crawford,48 Raymond,U.S. Senate,,LBT,Robert D. Garrard,5
-Crawford,48 Raymond,U.S. Senate,,R,Jerry Moran,270
-Crawford,48 Raymond,U.S. Senate,,D,Patrick Wiesner,72
-Crawford,48 Raymond,U.S. Senate,,,Write-ins,0
-Crawford,48 Raymond,U.S. House,2,LBT,James Bales,8
-Crawford,48 Raymond,U.S. House,2,R,Lynn Jenkins,265
-Crawford,48 Raymond,U.S. House,2,D,Britani Potter,72
-Crawford,48 Raymond,U.S. House,2,,Write-ins,1
-Crawford,48 Raymond,State Senate,13,R,Jake LaTurner,182
-Crawford,48 Raymond,State Senate,13,D,Lynn Grant,165
-Crawford,48 Raymond,State Senate,13,,Write-ins,0
-Crawford,48 Raymond,State House,2,D,Adam J Lusker Sr.,277
-Crawford,48 Raymond,State House,2,,Write-ins,6
-Crawford,49 Sheridan,President,,,Registered Voters,98
-Crawford,49 Sheridan,President,,D,Hillary Clinton,14
-Crawford,49 Sheridan,President,,LBT,Gary Johnson,1
-Crawford,49 Sheridan,President,,IND,Jill Stein,2
-Crawford,49 Sheridan,President,,R,Donald J Trump,58
-Crawford,49 Sheridan,President,,,Write-ins,2
-Crawford,49 Sheridan,U.S. Senate,,LBT,Robert D. Garrard,3
-Crawford,49 Sheridan,U.S. Senate,,R,Jerry Moran,53
-Crawford,49 Sheridan,U.S. Senate,,D,Patrick Wiesner,17
-Crawford,49 Sheridan,U.S. Senate,,,Write-ins,0
-Crawford,49 Sheridan,U.S. House,2,LBT,James Bales,7
-Crawford,49 Sheridan,U.S. House,2,R,Lynn Jenkins,53
-Crawford,49 Sheridan,U.S. House,2,D,Britani Potter,13
-Crawford,49 Sheridan,U.S. House,2,,Write-ins,0
-Crawford,49 Sheridan,State Senate,13,R,Jake LaTurner,43
-Crawford,49 Sheridan,State Senate,13,D,Lynn Grant,32
-Crawford,49 Sheridan,State Senate,13,,Write-ins,0
-Crawford,49 Sheridan,State House,3,D,Monica Murnan,27
-Crawford,49 Sheridan,State House,3,R,Charles Smith,49
-Crawford,49 Sheridan,State House,3,,Write-ins,0
-Crawford,50 Sheridan-Cherokee City,President,,,Registered Voters,78
-Crawford,50 Sheridan-Cherokee City,President,,D,Hillary Clinton,21
-Crawford,50 Sheridan-Cherokee City,President,,LBT,Gary Johnson,1
-Crawford,50 Sheridan-Cherokee City,President,,IND,Jill Stein,1
-Crawford,50 Sheridan-Cherokee City,President,,R,Donald J Trump,28
-Crawford,50 Sheridan-Cherokee City,President,,,Write-ins,0
-Crawford,50 Sheridan-Cherokee City,U.S. Senate,,LBT,Robert D. Garrard,2
-Crawford,50 Sheridan-Cherokee City,U.S. Senate,,R,Jerry Moran,27
-Crawford,50 Sheridan-Cherokee City,U.S. Senate,,D,Patrick Wiesner,22
-Crawford,50 Sheridan-Cherokee City,U.S. Senate,,,Write-ins,0
-Crawford,50 Sheridan-Cherokee City,U.S. House,2,LBT,James Bales,1
-Crawford,50 Sheridan-Cherokee City,U.S. House,2,R,Lynn Jenkins,32
-Crawford,50 Sheridan-Cherokee City,U.S. House,2,D,Britani Potter,18
-Crawford,50 Sheridan-Cherokee City,U.S. House,2,,Write-ins,0
-Crawford,50 Sheridan-Cherokee City,State Senate,13,R,Jake LaTurner,21
-Crawford,50 Sheridan-Cherokee City,State Senate,13,D,Lynn Grant,30
-Crawford,50 Sheridan-Cherokee City,State Senate,13,,Write-ins,0
-Crawford,50 Sheridan-Cherokee City,State House,2,D,Adam J Lusker Sr.,45
-Crawford,50 Sheridan-Cherokee City,State House,2,,Write-ins,0
-Crawford,51 Sherman,President,,,Registered Voters,403
-Crawford,51 Sherman,President,,D,Hillary Clinton,71
-Crawford,51 Sherman,President,,LBT,Gary Johnson,13
-Crawford,51 Sherman,President,,IND,Jill Stein,3
-Crawford,51 Sherman,President,,R,Donald J Trump,198
-Crawford,51 Sherman,President,,,Write-ins,3
-Crawford,51 Sherman,U.S. Senate,,LBT,Robert D. Garrard,14
-Crawford,51 Sherman,U.S. Senate,,R,Jerry Moran,201
-Crawford,51 Sherman,U.S. Senate,,D,Patrick Wiesner,69
-Crawford,51 Sherman,U.S. Senate,,,Write-ins,0
-Crawford,51 Sherman,U.S. House,2,LBT,James Bales,14
-Crawford,51 Sherman,U.S. House,2,R,Lynn Jenkins,208
-Crawford,51 Sherman,U.S. House,2,D,Britani Potter,62
-Crawford,51 Sherman,U.S. House,2,,Write-ins,2
-Crawford,51 Sherman,State Senate,13,R,Jake LaTurner,141
-Crawford,51 Sherman,State Senate,13,D,Lynn Grant,139
-Crawford,51 Sherman,State Senate,13,,Write-ins,1
-Crawford,51 Sherman,State House,2,D,Adam J Lusker Sr.,229
-Crawford,51 Sherman,State House,2,,Write-ins,6
-Crawford,52 Smelter,President,,,Registered Voters,403
-Crawford,52 Smelter,President,,D,Hillary Clinton,82
-Crawford,52 Smelter,President,,LBT,Gary Johnson,11
-Crawford,52 Smelter,President,,IND,Jill Stein,5
-Crawford,52 Smelter,President,,R,Donald J Trump,200
-Crawford,52 Smelter,President,,,Write-ins,2
-Crawford,52 Smelter,U.S. Senate,,LBT,Robert D. Garrard,10
-Crawford,52 Smelter,U.S. Senate,,R,Jerry Moran,198
-Crawford,52 Smelter,U.S. Senate,,D,Patrick Wiesner,90
-Crawford,52 Smelter,U.S. Senate,,,Write-ins,0
-Crawford,52 Smelter,U.S. House,2,LBT,James Bales,11
-Crawford,52 Smelter,U.S. House,2,R,Lynn Jenkins,205
-Crawford,52 Smelter,U.S. House,2,D,Britani Potter,80
-Crawford,52 Smelter,U.S. House,2,,Write-ins,0
-Crawford,52 Smelter,State Senate,13,R,Jake LaTurner,164
-Crawford,52 Smelter,State Senate,13,D,Lynn Grant,136
-Crawford,52 Smelter,State Senate,13,,Write-ins,0
-Crawford,52 Smelter,State House,3,D,Monica Murnan,156
-Crawford,52 Smelter,State House,3,R,Charles Smith,144
-Crawford,52 Smelter,State House,3,,Write-ins,0
-Crawford,53 South Arma,President,,,Registered Voters,639
-Crawford,53 South Arma,President,,D,Hillary Clinton,145
-Crawford,53 South Arma,President,,LBT,Gary Johnson,14
-Crawford,53 South Arma,President,,IND,Jill Stein,4
-Crawford,53 South Arma,President,,R,Donald J Trump,224
-Crawford,53 South Arma,President,,,Write-ins,5
-Crawford,53 South Arma,U.S. Senate,,LBT,Robert D. Garrard,24
-Crawford,53 South Arma,U.S. Senate,,R,Jerry Moran,216
-Crawford,53 South Arma,U.S. Senate,,D,Patrick Wiesner,142
-Crawford,53 South Arma,U.S. Senate,,,Write-ins,0
-Crawford,53 South Arma,U.S. House,2,LBT,James Bales,16
-Crawford,53 South Arma,U.S. House,2,R,Lynn Jenkins,255
-Crawford,53 South Arma,U.S. House,2,D,Britani Potter,119
-Crawford,53 South Arma,U.S. House,2,,Write-ins,1
-Crawford,53 South Arma,State Senate,13,R,Jake LaTurner,168
-Crawford,53 South Arma,State Senate,13,D,Lynn Grant,224
-Crawford,53 South Arma,State Senate,13,,Write-ins,0
-Crawford,53 South Arma,State House,2,D,Adam J Lusker Sr.,331
-Crawford,53 South Arma,State House,2,,Write-ins,4
-Crawford,54 Walnut,President,,,Registered Voters,112
-Crawford,54 Walnut,President,,D,Hillary Clinton,8
-Crawford,54 Walnut,President,,LBT,Gary Johnson,2
-Crawford,54 Walnut,President,,IND,Jill Stein,3
-Crawford,54 Walnut,President,,R,Donald J Trump,36
-Crawford,54 Walnut,President,,,Write-ins,0
-Crawford,54 Walnut,U.S. Senate,,LBT,Robert D. Garrard,2
-Crawford,54 Walnut,U.S. Senate,,R,Jerry Moran,33
-Crawford,54 Walnut,U.S. Senate,,D,Patrick Wiesner,12
-Crawford,54 Walnut,U.S. Senate,,,Write-ins,0
-Crawford,54 Walnut,U.S. House,2,LBT,James Bales,4
-Crawford,54 Walnut,U.S. House,2,R,Lynn Jenkins,39
-Crawford,54 Walnut,U.S. House,2,D,Britani Potter,6
-Crawford,54 Walnut,U.S. House,2,,Write-ins,0
-Crawford,54 Walnut,State Senate,13,R,Jake LaTurner,25
-Crawford,54 Walnut,State Senate,13,D,Lynn Grant,23
-Crawford,54 Walnut,State Senate,13,,Write-ins,0
-Crawford,54 Walnut,State House,2,D,Adam J Lusker Sr.,34
-Crawford,54 Walnut,State House,2,,Write-ins,2
-Crawford,55 Walnut twp,President,,,Registered Voters,34
-Crawford,55 Walnut twp,President,,D,Hillary Clinton,1
-Crawford,55 Walnut twp,President,,LBT,Gary Johnson,1
-Crawford,55 Walnut twp,President,,IND,Jill Stein,1
-Crawford,55 Walnut twp,President,,R,Donald J Trump,19
-Crawford,55 Walnut twp,President,,,Write-ins,0
-Crawford,55 Walnut twp,U.S. Senate,,LBT,Robert D. Garrard,3
-Crawford,55 Walnut twp,U.S. Senate,,R,Jerry Moran,14
-Crawford,55 Walnut twp,U.S. Senate,,D,Patrick Wiesner,5
-Crawford,55 Walnut twp,U.S. Senate,,,Write-ins,0
-Crawford,55 Walnut twp,U.S. House,2,LBT,James Bales,0
-Crawford,55 Walnut twp,U.S. House,2,R,Lynn Jenkins,14
-Crawford,55 Walnut twp,U.S. House,2,D,Britani Potter,8
-Crawford,55 Walnut twp,U.S. House,2,,Write-ins,0
-Crawford,55 Walnut twp,State Senate,13,R,Jake LaTurner,9
-Crawford,55 Walnut twp,State Senate,13,D,Lynn Grant,14
-Crawford,55 Walnut twp,State Senate,13,,Write-ins,0
-Crawford,55 Walnut twp,State House,2,D,Adam J Lusker Sr.,21
-Crawford,55 Walnut twp,State House,2,,Write-ins,0
-Crawford,56 Walnut-Hepler,President,,,Registered Voters,50
-Crawford,56 Walnut-Hepler,President,,D,Hillary Clinton,7
-Crawford,56 Walnut-Hepler,President,,LBT,Gary Johnson,1
-Crawford,56 Walnut-Hepler,President,,IND,Jill Stein,0
-Crawford,56 Walnut-Hepler,President,,R,Donald J Trump,28
-Crawford,56 Walnut-Hepler,President,,,Write-ins,0
-Crawford,56 Walnut-Hepler,U.S. Senate,,LBT,Robert D. Garrard,1
-Crawford,56 Walnut-Hepler,U.S. Senate,,R,Jerry Moran,27
-Crawford,56 Walnut-Hepler,U.S. Senate,,D,Patrick Wiesner,6
-Crawford,56 Walnut-Hepler,U.S. Senate,,,Write-ins,0
-Crawford,56 Walnut-Hepler,U.S. House,2,LBT,James Bales,2
-Crawford,56 Walnut-Hepler,U.S. House,2,R,Lynn Jenkins,24
-Crawford,56 Walnut-Hepler,U.S. House,2,D,Britani Potter,8
-Crawford,56 Walnut-Hepler,U.S. House,2,,Write-ins,0
-Crawford,56 Walnut-Hepler,State Senate,13,R,Jake LaTurner,20
-Crawford,56 Walnut-Hepler,State Senate,13,D,Lynn Grant,12
-Crawford,56 Walnut-Hepler,State Senate,13,,Write-ins,0
-Crawford,56 Walnut-Hepler,State House,2,D,Adam J Lusker Sr.,30
-Crawford,56 Walnut-Hepler,State House,2,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+CRAWFORD,Lincoln - Arcadia,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",45,000A41
+CRAWFORD,Osage - McCune,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",142,000A51
+CRAWFORD,Cherokee - Sheridan,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",103,000A62
+CRAWFORD,Walnut - Helper,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",30,000A82
+CRAWFORD,Walnut Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",21,000A83
+CRAWFORD,Arcadia,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",118,000010
+CRAWFORD,Baker,Kansas House of Representatives,3,Democratic,"Murnan, Monica",228,000020
+CRAWFORD,Baker,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",292,000020
+CRAWFORD,Beulah,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",109,000030
+CRAWFORD,Sheridan - Cherokee City,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",45,000033
+CRAWFORD,Brazilton,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",26,000040
+CRAWFORD,Capaldo,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",203,000050
+CRAWFORD,Cherokee,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",163,000060
+CRAWFORD,Chicopee,Kansas House of Representatives,3,Democratic,"Murnan, Monica",124,000070
+CRAWFORD,Chicopee,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",165,000070
+CRAWFORD,Crawford,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",151,000080
+CRAWFORD,Crowe,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",87,000090
+CRAWFORD,Frontenac Ward 1,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",396,000110
+CRAWFORD,Frontenac Ward 2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",595,00012A
+CRAWFORD,Frontenac Ward 3,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",227,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,00013B
+CRAWFORD,Frontenac Ward 4,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",190,00014A
+CRAWFORD,Girard Ward 1,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",82,000150
+CRAWFORD,Girard Ward 2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",269,00016A
+CRAWFORD,Girard Ward 3,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",200,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,00017B
+CRAWFORD,Girard Ward 4,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",267,000180
+CRAWFORD,Grant,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",102,000190
+CRAWFORD,Hepler,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",25,000200
+CRAWFORD,Lincoln,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",135,000210
+CRAWFORD,Lone Star,Kansas House of Representatives,3,Democratic,"Murnan, Monica",288,00022A
+CRAWFORD,Lone Star,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",304,00022A
+CRAWFORD,McCune,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",130,000230
+CRAWFORD,Mulberry Ward 1,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",66,000240
+CRAWFORD,Mulberry Ward 2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",66,000250
+CRAWFORD,North Arma,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",283,000260
+CRAWFORD,Opolis,Kansas House of Representatives,3,Democratic,"Murnan, Monica",87,000270
+CRAWFORD,Opolis,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",92,000270
+CRAWFORD,Parkview,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",204,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas House of Representatives,3,Democratic,"Murnan, Monica",162,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",170,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas House of Representatives,3,Democratic,"Murnan, Monica",279,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",262,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas House of Representatives,3,Democratic,"Murnan, Monica",641,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",574,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas House of Representatives,3,Democratic,"Murnan, Monica",142,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",85,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas House of Representatives,3,Democratic,"Murnan, Monica",157,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",138,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas House of Representatives,3,Democratic,"Murnan, Monica",215,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",140,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas House of Representatives,3,Democratic,"Murnan, Monica",163,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",157,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas House of Representatives,3,Democratic,"Murnan, Monica",257,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",193,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas House of Representatives,3,Democratic,"Murnan, Monica",162,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",137,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas House of Representatives,3,Democratic,"Murnan, Monica",199,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",189,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas House of Representatives,3,Democratic,"Murnan, Monica",72,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",45,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas House of Representatives,3,Democratic,"Murnan, Monica",162,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",95,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas House of Representatives,3,Democratic,"Murnan, Monica",268,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",212,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas House of Representatives,3,Democratic,"Murnan, Monica",153,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",112,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas House of Representatives,3,Democratic,"Murnan, Monica",363,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",308,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas House of Representatives,3,Democratic,"Murnan, Monica",46,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",76,00044A
+CRAWFORD,Raymond,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",277,000450
+CRAWFORD,Sheridan,Kansas House of Representatives,3,Democratic,"Murnan, Monica",27,000460
+CRAWFORD,Sheridan,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",49,000460
+CRAWFORD,Sherman,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",229,000470
+CRAWFORD,Smelter,Kansas House of Representatives,3,Democratic,"Murnan, Monica",156,000480
+CRAWFORD,Smelter,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",144,000480
+CRAWFORD,South Arma,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",331,000490
+CRAWFORD,Walnut,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",34,000500
+CRAWFORD,Franklin,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",189,700100
+CRAWFORD,Baker Enclave,Kansas House of Representatives,3,Democratic,"Murnan, Monica",0,900010
+CRAWFORD,Baker Enclave,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",0,900010
+CRAWFORD,Parkview Enclave,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Kansas House of Representatives,3,Democratic,"Murnan, Monica",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Kansas House of Representatives,3,Democratic,"Murnan, Monica",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Kansas House of Representatives,3,Republican,"Smith, Charles (Chuck)",0,900040
+CRAWFORD,Lincoln - Arcadia,Kansas Senate,13,Democratic,"Grant, Lynn D.",17,000A41
+CRAWFORD,Lincoln - Arcadia,Kansas Senate,13,Republican,"LaTurner, Jake",45,000A41
+CRAWFORD,Osage - McCune,Kansas Senate,13,Democratic,"Grant, Lynn D.",68,000A51
+CRAWFORD,Osage - McCune,Kansas Senate,13,Republican,"LaTurner, Jake",138,000A51
+CRAWFORD,Cherokee - Sheridan,Kansas Senate,13,Democratic,"Grant, Lynn D.",67,000A62
+CRAWFORD,Cherokee - Sheridan,Kansas Senate,13,Republican,"LaTurner, Jake",77,000A62
+CRAWFORD,Walnut - Helper,Kansas Senate,13,Democratic,"Grant, Lynn D.",12,000A82
+CRAWFORD,Walnut - Helper,Kansas Senate,13,Republican,"LaTurner, Jake",20,000A82
+CRAWFORD,Walnut Township,Kansas Senate,13,Democratic,"Grant, Lynn D.",14,000A83
+CRAWFORD,Walnut Township,Kansas Senate,13,Republican,"LaTurner, Jake",9,000A83
+CRAWFORD,Arcadia,Kansas Senate,13,Democratic,"Grant, Lynn D.",67,000010
+CRAWFORD,Arcadia,Kansas Senate,13,Republican,"LaTurner, Jake",75,000010
+CRAWFORD,Baker,Kansas Senate,13,Democratic,"Grant, Lynn D.",218,000020
+CRAWFORD,Baker,Kansas Senate,13,Republican,"LaTurner, Jake",296,000020
+CRAWFORD,Beulah,Kansas Senate,13,Democratic,"Grant, Lynn D.",63,000030
+CRAWFORD,Beulah,Kansas Senate,13,Republican,"LaTurner, Jake",74,000030
+CRAWFORD,Sheridan - Cherokee City,Kansas Senate,13,Democratic,"Grant, Lynn D.",30,000033
+CRAWFORD,Sheridan - Cherokee City,Kansas Senate,13,Republican,"LaTurner, Jake",21,000033
+CRAWFORD,Brazilton,Kansas Senate,13,Democratic,"Grant, Lynn D.",14,000040
+CRAWFORD,Brazilton,Kansas Senate,13,Republican,"LaTurner, Jake",22,000040
+CRAWFORD,Capaldo,Kansas Senate,13,Democratic,"Grant, Lynn D.",124,000050
+CRAWFORD,Capaldo,Kansas Senate,13,Republican,"LaTurner, Jake",118,000050
+CRAWFORD,Cherokee,Kansas Senate,13,Democratic,"Grant, Lynn D.",111,000060
+CRAWFORD,Cherokee,Kansas Senate,13,Republican,"LaTurner, Jake",118,000060
+CRAWFORD,Chicopee,Kansas Senate,13,Democratic,"Grant, Lynn D.",134,000070
+CRAWFORD,Chicopee,Kansas Senate,13,Republican,"LaTurner, Jake",153,000070
+CRAWFORD,Crawford,Kansas Senate,13,Democratic,"Grant, Lynn D.",62,000080
+CRAWFORD,Crawford,Kansas Senate,13,Republican,"LaTurner, Jake",147,000080
+CRAWFORD,Crowe,Kansas Senate,13,Democratic,"Grant, Lynn D.",59,000090
+CRAWFORD,Crowe,Kansas Senate,13,Republican,"LaTurner, Jake",46,000090
+CRAWFORD,Frontenac Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",280,000110
+CRAWFORD,Frontenac Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",147,000110
+CRAWFORD,Frontenac Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",434,00012A
+CRAWFORD,Frontenac Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",216,00012A
+CRAWFORD,Frontenac Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",153,00013A
+CRAWFORD,Frontenac Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",98,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,Kansas Senate,13,Republican,"LaTurner, Jake",0,00013B
+CRAWFORD,Frontenac Ward 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",144,00014A
+CRAWFORD,Frontenac Ward 4,Kansas Senate,13,Republican,"LaTurner, Jake",63,00014A
+CRAWFORD,Girard Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",47,000150
+CRAWFORD,Girard Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",60,000150
+CRAWFORD,Girard Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",182,00016A
+CRAWFORD,Girard Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",165,00016A
+CRAWFORD,Girard Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",131,00017A
+CRAWFORD,Girard Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",96,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,Kansas Senate,13,Republican,"LaTurner, Jake",0,00017B
+CRAWFORD,Girard Ward 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",156,000180
+CRAWFORD,Girard Ward 4,Kansas Senate,13,Republican,"LaTurner, Jake",161,000180
+CRAWFORD,Grant,Kansas Senate,13,Democratic,"Grant, Lynn D.",58,000190
+CRAWFORD,Grant,Kansas Senate,13,Republican,"LaTurner, Jake",73,000190
+CRAWFORD,Hepler,Kansas Senate,13,Democratic,"Grant, Lynn D.",20,000200
+CRAWFORD,Hepler,Kansas Senate,13,Republican,"LaTurner, Jake",16,000200
+CRAWFORD,Lincoln,Kansas Senate,13,Democratic,"Grant, Lynn D.",63,000210
+CRAWFORD,Lincoln,Kansas Senate,13,Republican,"LaTurner, Jake",98,000210
+CRAWFORD,Lone Star,Kansas Senate,13,Democratic,"Grant, Lynn D.",288,00022A
+CRAWFORD,Lone Star,Kansas Senate,13,Republican,"LaTurner, Jake",297,00022A
+CRAWFORD,McCune,Kansas Senate,13,Democratic,"Grant, Lynn D.",62,000230
+CRAWFORD,McCune,Kansas Senate,13,Republican,"LaTurner, Jake",103,000230
+CRAWFORD,Mulberry Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",50,000240
+CRAWFORD,Mulberry Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",25,000240
+CRAWFORD,Mulberry Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",41,000250
+CRAWFORD,Mulberry Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",42,000250
+CRAWFORD,North Arma,Kansas Senate,13,Democratic,"Grant, Lynn D.",175,000260
+CRAWFORD,North Arma,Kansas Senate,13,Republican,"LaTurner, Jake",174,000260
+CRAWFORD,Opolis,Kansas Senate,13,Democratic,"Grant, Lynn D.",82,000270
+CRAWFORD,Opolis,Kansas Senate,13,Republican,"LaTurner, Jake",98,000270
+CRAWFORD,Parkview,Kansas Senate,13,Democratic,"Grant, Lynn D.",134,000280
+CRAWFORD,Parkview,Kansas Senate,13,Republican,"LaTurner, Jake",108,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",148,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jake",183,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",274,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jake",265,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",601,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,Kansas Senate,13,Republican,"LaTurner, Jake",607,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",119,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jake",109,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",147,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jake",147,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",206,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,Kansas Senate,13,Republican,"LaTurner, Jake",148,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",158,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,Kansas Senate,13,Republican,"LaTurner, Jake",163,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas Senate,13,Democratic,"Grant, Lynn D.",237,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,Kansas Senate,13,Republican,"LaTurner, Jake",214,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",151,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jake",147,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",200,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jake",188,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",71,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,Kansas Senate,13,Republican,"LaTurner, Jake",44,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",158,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,Kansas Senate,13,Republican,"LaTurner, Jake",98,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",255,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,Kansas Senate,13,Republican,"LaTurner, Jake",227,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas Senate,13,Democratic,"Grant, Lynn D.",145,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,Kansas Senate,13,Republican,"LaTurner, Jake",120,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas Senate,13,Democratic,"Grant, Lynn D.",337,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,Kansas Senate,13,Republican,"LaTurner, Jake",331,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas Senate,13,Democratic,"Grant, Lynn D.",41,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,Kansas Senate,13,Republican,"LaTurner, Jake",82,00044A
+CRAWFORD,Raymond,Kansas Senate,13,Democratic,"Grant, Lynn D.",165,000450
+CRAWFORD,Raymond,Kansas Senate,13,Republican,"LaTurner, Jake",182,000450
+CRAWFORD,Sheridan,Kansas Senate,13,Democratic,"Grant, Lynn D.",32,000460
+CRAWFORD,Sheridan,Kansas Senate,13,Republican,"LaTurner, Jake",43,000460
+CRAWFORD,Sherman,Kansas Senate,13,Democratic,"Grant, Lynn D.",139,000470
+CRAWFORD,Sherman,Kansas Senate,13,Republican,"LaTurner, Jake",141,000470
+CRAWFORD,Smelter,Kansas Senate,13,Democratic,"Grant, Lynn D.",136,000480
+CRAWFORD,Smelter,Kansas Senate,13,Republican,"LaTurner, Jake",164,000480
+CRAWFORD,South Arma,Kansas Senate,13,Democratic,"Grant, Lynn D.",224,000490
+CRAWFORD,South Arma,Kansas Senate,13,Republican,"LaTurner, Jake",168,000490
+CRAWFORD,Walnut,Kansas Senate,13,Democratic,"Grant, Lynn D.",23,000500
+CRAWFORD,Walnut,Kansas Senate,13,Republican,"LaTurner, Jake",25,000500
+CRAWFORD,Franklin,Kansas Senate,13,Democratic,"Grant, Lynn D.",115,700100
+CRAWFORD,Franklin,Kansas Senate,13,Republican,"LaTurner, Jake",114,700100
+CRAWFORD,Baker Enclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900010
+CRAWFORD,Baker Enclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,900010
+CRAWFORD,Parkview Enclave,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900020
+CRAWFORD,Parkview Enclave,Kansas Senate,13,Republican,"LaTurner, Jake",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,Kansas Senate,13,Republican,"LaTurner, Jake",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,Kansas Senate,13,Republican,"LaTurner, Jake",0,900040
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,independent,"Stein, Jill",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Basiago, Andrew D.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Castle, Darrell L",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Giordani, Rocky",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Hedges, James A",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Hoefling, Tom",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Kahn, Lynn",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"La Riva, Gloria",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Levinson, Michael S.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Maturen, Michael A",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"McMullin, Evan",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Moorehead, Monica G.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Perry, Darryl",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Schriner, Joe C",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Smith, Mike",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Sood, Ajay",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Sterling, Shawna",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Valdivia, Anthony J",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Libertarian,"Johnson, Gary",5,000A41
+CRAWFORD,Lincoln - Arcadia,President / Vice President,,Republican,"Trump, Donald J.",46,000A41
+CRAWFORD,Osage - McCune,President / Vice President,,independent,"Stein, Jill",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Basiago, Andrew D.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Castle, Darrell L",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Giordani, Rocky",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Hedges, James A",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Hoefling, Tom",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Kahn, Lynn",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"La Riva, Gloria",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Levinson, Michael S.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Maturen, Michael A",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"McMullin, Evan",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Moorehead, Monica G.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Perry, Darryl",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Schriner, Joe C",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Smith, Mike",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Sood, Ajay",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Sterling, Shawna",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Valdivia, Anthony J",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Libertarian,"Johnson, Gary",9,000A51
+CRAWFORD,Osage - McCune,President / Vice President,,Republican,"Trump, Donald J.",163,000A51
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,independent,"Stein, Jill",4,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Basiago, Andrew D.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Castle, Darrell L",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Giordani, Rocky",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Hedges, James A",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Hoefling, Tom",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Kahn, Lynn",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"La Riva, Gloria",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Levinson, Michael S.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Maturen, Michael A",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"McMullin, Evan",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Moorehead, Monica G.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Perry, Darryl",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Schriner, Joe C",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Smith, Mike",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Sood, Ajay",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Sterling, Shawna",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Valdivia, Anthony J",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Libertarian,"Johnson, Gary",6,000A62
+CRAWFORD,Cherokee - Sheridan,President / Vice President,,Republican,"Trump, Donald J.",112,000A62
+CRAWFORD,Walnut - Helper,President / Vice President,,independent,"Stein, Jill",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Basiago, Andrew D.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Castle, Darrell L",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Giordani, Rocky",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Hedges, James A",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Hoefling, Tom",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Kahn, Lynn",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"La Riva, Gloria",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Levinson, Michael S.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Maturen, Michael A",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"McMullin, Evan",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Moorehead, Monica G.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Perry, Darryl",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Schriner, Joe C",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Smith, Mike",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Sood, Ajay",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Sterling, Shawna",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Valdivia, Anthony J",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Libertarian,"Johnson, Gary",1,000A82
+CRAWFORD,Walnut - Helper,President / Vice President,,Republican,"Trump, Donald J.",28,000A82
+CRAWFORD,Walnut Township,President / Vice President,,independent,"Stein, Jill",1,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000A83
+CRAWFORD,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",19,000A83
+CRAWFORD,Arcadia,President / Vice President,,independent,"Stein, Jill",2,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Hedges, James A",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"McMullin, Evan",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Perry, Darryl",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Smith, Mike",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Sood, Ajay",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+CRAWFORD,Arcadia,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+CRAWFORD,Arcadia,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000010
+CRAWFORD,Arcadia,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+CRAWFORD,Arcadia,President / Vice President,,Republican,"Trump, Donald J.",86,000010
+CRAWFORD,Baker,President / Vice President,,independent,"Stein, Jill",13,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Castle, Darrell L",3,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Hedges, James A",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"McMullin, Evan",1,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Perry, Darryl",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Smith, Mike",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Sood, Ajay",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+CRAWFORD,Baker,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+CRAWFORD,Baker,President / Vice President,,Democratic,"Clinton, Hillary Rodham",149,000020
+CRAWFORD,Baker,President / Vice President,,Libertarian,"Johnson, Gary",18,000020
+CRAWFORD,Baker,President / Vice President,,Republican,"Trump, Donald J.",333,000020
+CRAWFORD,Beulah,President / Vice President,,independent,"Stein, Jill",2,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Hedges, James A",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"McMullin, Evan",1,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Perry, Darryl",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Smith, Mike",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Sood, Ajay",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+CRAWFORD,Beulah,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+CRAWFORD,Beulah,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000030
+CRAWFORD,Beulah,President / Vice President,,Libertarian,"Johnson, Gary",11,000030
+CRAWFORD,Beulah,President / Vice President,,Republican,"Trump, Donald J.",89,000030
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,independent,"Stein, Jill",1,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Castle, Darrell L",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Giordani, Rocky",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Hedges, James A",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Hoefling, Tom",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Kahn, Lynn",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"La Riva, Gloria",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Levinson, Michael S.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Maturen, Michael A",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"McMullin, Evan",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Perry, Darryl",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Schriner, Joe C",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Smith, Mike",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Sood, Ajay",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Sterling, Shawna",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Libertarian,"Johnson, Gary",1,000033
+CRAWFORD,Sheridan - Cherokee City,President / Vice President,,Republican,"Trump, Donald J.",28,000033
+CRAWFORD,Brazilton,President / Vice President,,independent,"Stein, Jill",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Hedges, James A",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"McMullin, Evan",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Perry, Darryl",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Smith, Mike",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Sood, Ajay",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+CRAWFORD,Brazilton,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+CRAWFORD,Brazilton,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000040
+CRAWFORD,Brazilton,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+CRAWFORD,Brazilton,President / Vice President,,Republican,"Trump, Donald J.",29,000040
+CRAWFORD,Capaldo,President / Vice President,,independent,"Stein, Jill",6,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Hedges, James A",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"McMullin, Evan",1,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Perry, Darryl",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Smith, Mike",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Sood, Ajay",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+CRAWFORD,Capaldo,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+CRAWFORD,Capaldo,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,000050
+CRAWFORD,Capaldo,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+CRAWFORD,Capaldo,President / Vice President,,Republican,"Trump, Donald J.",154,000050
+CRAWFORD,Cherokee,President / Vice President,,independent,"Stein, Jill",7,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Hedges, James A",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"McMullin, Evan",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Perry, Darryl",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Smith, Mike",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Sood, Ajay",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+CRAWFORD,Cherokee,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+CRAWFORD,Cherokee,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000060
+CRAWFORD,Cherokee,President / Vice President,,Libertarian,"Johnson, Gary",13,000060
+CRAWFORD,Cherokee,President / Vice President,,Republican,"Trump, Donald J.",147,000060
+CRAWFORD,Chicopee,President / Vice President,,independent,"Stein, Jill",3,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Hedges, James A",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"McMullin, Evan",1,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Perry, Darryl",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Smith, Mike",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Sood, Ajay",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+CRAWFORD,Chicopee,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+CRAWFORD,Chicopee,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,000070
+CRAWFORD,Chicopee,President / Vice President,,Libertarian,"Johnson, Gary",16,000070
+CRAWFORD,Chicopee,President / Vice President,,Republican,"Trump, Donald J.",182,000070
+CRAWFORD,Crawford,President / Vice President,,independent,"Stein, Jill",4,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Hedges, James A",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"McMullin, Evan",2,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Perry, Darryl",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Smith, Mike",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Sood, Ajay",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+CRAWFORD,Crawford,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+CRAWFORD,Crawford,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000080
+CRAWFORD,Crawford,President / Vice President,,Libertarian,"Johnson, Gary",11,000080
+CRAWFORD,Crawford,President / Vice President,,Republican,"Trump, Donald J.",154,000080
+CRAWFORD,Crowe,President / Vice President,,independent,"Stein, Jill",1,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Hedges, James A",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"McMullin, Evan",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Perry, Darryl",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Smith, Mike",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Sood, Ajay",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+CRAWFORD,Crowe,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+CRAWFORD,Crowe,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000090
+CRAWFORD,Crowe,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+CRAWFORD,Crowe,President / Vice President,,Republican,"Trump, Donald J.",61,000090
+CRAWFORD,Frontenac Ward 1,President / Vice President,,independent,"Stein, Jill",7,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",189,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",18,000110
+CRAWFORD,Frontenac Ward 1,President / Vice President,,Republican,"Trump, Donald J.",208,000110
+CRAWFORD,Frontenac Ward 2,President / Vice President,,independent,"Stein, Jill",5,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",306,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",21,00012A
+CRAWFORD,Frontenac Ward 2,President / Vice President,,Republican,"Trump, Donald J.",312,00012A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,independent,"Stein, Jill",4,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,00013A
+CRAWFORD,Frontenac Ward 3,President / Vice President,,Republican,"Trump, Donald J.",152,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,independent,"Stein, Jill",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Castle, Darrell L",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Giordani, Rocky",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Hedges, James A",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Kahn, Lynn",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"La Riva, Gloria",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Levinson, Michael S.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Maturen, Michael A",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"McMullin, Evan",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Perry, Darryl",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Schriner, Joe C",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Smith, Mike",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Sood, Ajay",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Sterling, Shawna",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,President / Vice President,,Republican,"Trump, Donald J.",0,00013B
+CRAWFORD,Frontenac Ward 4,President / Vice President,,independent,"Stein, Jill",5,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",87,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",16,00014A
+CRAWFORD,Frontenac Ward 4,President / Vice President,,Republican,"Trump, Donald J.",98,00014A
+CRAWFORD,Girard Ward 1,President / Vice President,,independent,"Stein, Jill",2,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Castle, Darrell L",4,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000150
+CRAWFORD,Girard Ward 1,President / Vice President,,Republican,"Trump, Donald J.",74,000150
+CRAWFORD,Girard Ward 2,President / Vice President,,independent,"Stein, Jill",6,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",102,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",12,00016A
+CRAWFORD,Girard Ward 2,President / Vice President,,Republican,"Trump, Donald J.",217,00016A
+CRAWFORD,Girard Ward 3,President / Vice President,,independent,"Stein, Jill",3,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Castle, Darrell L",2,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"McMullin, Evan",2,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,00017A
+CRAWFORD,Girard Ward 3,President / Vice President,,Republican,"Trump, Donald J.",136,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,independent,"Stein, Jill",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Castle, Darrell L",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Giordani, Rocky",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Hedges, James A",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Kahn, Lynn",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"La Riva, Gloria",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Levinson, Michael S.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Maturen, Michael A",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"McMullin, Evan",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Perry, Darryl",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Schriner, Joe C",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Smith, Mike",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Sood, Ajay",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Sterling, Shawna",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,President / Vice President,,Republican,"Trump, Donald J.",0,00017B
+CRAWFORD,Girard Ward 4,President / Vice President,,independent,"Stein, Jill",13,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",13,000180
+CRAWFORD,Girard Ward 4,President / Vice President,,Republican,"Trump, Donald J.",204,000180
+CRAWFORD,Grant,President / Vice President,,independent,"Stein, Jill",6,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Hedges, James A",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"McMullin, Evan",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Perry, Darryl",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Smith, Mike",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Sood, Ajay",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+CRAWFORD,Grant,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+CRAWFORD,Grant,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000190
+CRAWFORD,Grant,President / Vice President,,Libertarian,"Johnson, Gary",4,000190
+CRAWFORD,Grant,President / Vice President,,Republican,"Trump, Donald J.",86,000190
+CRAWFORD,Hepler,President / Vice President,,independent,"Stein, Jill",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Hedges, James A",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"McMullin, Evan",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Perry, Darryl",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Smith, Mike",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Sood, Ajay",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+CRAWFORD,Hepler,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+CRAWFORD,Hepler,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000200
+CRAWFORD,Hepler,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+CRAWFORD,Hepler,President / Vice President,,Republican,"Trump, Donald J.",28,000200
+CRAWFORD,Lincoln,President / Vice President,,independent,"Stein, Jill",3,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Hedges, James A",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"McMullin, Evan",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Perry, Darryl",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Smith, Mike",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Sood, Ajay",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+CRAWFORD,Lincoln,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+CRAWFORD,Lincoln,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,000210
+CRAWFORD,Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",6,000210
+CRAWFORD,Lincoln,President / Vice President,,Republican,"Trump, Donald J.",108,000210
+CRAWFORD,Lone Star,President / Vice President,,independent,"Stein, Jill",15,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Castle, Darrell L",1,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Giordani, Rocky",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Hedges, James A",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Kahn, Lynn",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"La Riva, Gloria",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Levinson, Michael S.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Maturen, Michael A",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"McMullin, Evan",3,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Perry, Darryl",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Schriner, Joe C",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Smith, Mike",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Sood, Ajay",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Sterling, Shawna",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022A
+CRAWFORD,Lone Star,President / Vice President,,Democratic,"Clinton, Hillary Rodham",195,00022A
+CRAWFORD,Lone Star,President / Vice President,,Libertarian,"Johnson, Gary",16,00022A
+CRAWFORD,Lone Star,President / Vice President,,Republican,"Trump, Donald J.",352,00022A
+CRAWFORD,McCune,President / Vice President,,independent,"Stein, Jill",4,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Hedges, James A",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"McMullin, Evan",1,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Perry, Darryl",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Smith, Mike",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Sood, Ajay",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+CRAWFORD,McCune,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+CRAWFORD,McCune,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000230
+CRAWFORD,McCune,President / Vice President,,Libertarian,"Johnson, Gary",17,000230
+CRAWFORD,McCune,President / Vice President,,Republican,"Trump, Donald J.",116,000230
+CRAWFORD,Mulberry Ward 1,President / Vice President,,independent,"Stein, Jill",3,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000240
+CRAWFORD,Mulberry Ward 1,President / Vice President,,Republican,"Trump, Donald J.",35,000240
+CRAWFORD,Mulberry Ward 2,President / Vice President,,independent,"Stein, Jill",4,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000250
+CRAWFORD,Mulberry Ward 2,President / Vice President,,Republican,"Trump, Donald J.",49,000250
+CRAWFORD,North Arma,President / Vice President,,independent,"Stein, Jill",5,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Hedges, James A",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"McMullin, Evan",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Perry, Darryl",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Smith, Mike",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Sood, Ajay",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+CRAWFORD,North Arma,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+CRAWFORD,North Arma,President / Vice President,,Democratic,"Clinton, Hillary Rodham",117,000260
+CRAWFORD,North Arma,President / Vice President,,Libertarian,"Johnson, Gary",16,000260
+CRAWFORD,North Arma,President / Vice President,,Republican,"Trump, Donald J.",206,000260
+CRAWFORD,Opolis,President / Vice President,,independent,"Stein, Jill",2,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Hedges, James A",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"McMullin, Evan",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Perry, Darryl",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Smith, Mike",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Sood, Ajay",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+CRAWFORD,Opolis,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+CRAWFORD,Opolis,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000270
+CRAWFORD,Opolis,President / Vice President,,Libertarian,"Johnson, Gary",5,000270
+CRAWFORD,Opolis,President / Vice President,,Republican,"Trump, Donald J.",107,000270
+CRAWFORD,Parkview,President / Vice President,,independent,"Stein, Jill",5,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Hedges, James A",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"McMullin, Evan",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Perry, Darryl",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Smith, Mike",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Sood, Ajay",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+CRAWFORD,Parkview,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+CRAWFORD,Parkview,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,000280
+CRAWFORD,Parkview,President / Vice President,,Libertarian,"Johnson, Gary",3,000280
+CRAWFORD,Parkview,President / Vice President,,Republican,"Trump, Donald J.",147,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",3,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",121,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",24,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",175,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",7,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",216,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",29,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",285,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,independent,"Stein, Jill",28,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",1,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",9,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",526,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",54,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",601,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",7,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",126,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",7,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",3,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",4,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",128,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",150,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",9,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",1,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",169,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",13,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",164,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,independent,"Stein, Jill",10,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",2,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",2,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",128,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",25,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",148,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,independent,"Stein, Jill",3,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",3,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",5,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",186,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",29,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",220,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",6,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",3,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",5,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",19,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",149,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",7,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",136,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",21,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",217,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",4,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",52,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",12,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",118,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",109,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",24,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",1,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",165,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",19,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",266,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,independent,"Stein, Jill",10,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",1,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",99,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",8,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",140,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,independent,"Stein, Jill",16,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",5,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",241,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",42,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",363,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,independent,"Stein, Jill",1,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Castle, Darrell L",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Giordani, Rocky",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Hedges, James A",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Kahn, Lynn",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"La Riva, Gloria",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Levinson, Michael S.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Maturen, Michael A",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"McMullin, Evan",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Perry, Darryl",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Schriner, Joe C",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Smith, Mike",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Sood, Ajay",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Sterling, Shawna",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",3,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,President / Vice President,,Republican,"Trump, Donald J.",86,00044A
+CRAWFORD,Raymond,President / Vice President,,independent,"Stein, Jill",3,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Castle, Darrell L",1,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Hedges, James A",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"McMullin, Evan",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Perry, Darryl",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Smith, Mike",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Sood, Ajay",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+CRAWFORD,Raymond,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+CRAWFORD,Raymond,President / Vice President,,Democratic,"Clinton, Hillary Rodham",87,000450
+CRAWFORD,Raymond,President / Vice President,,Libertarian,"Johnson, Gary",8,000450
+CRAWFORD,Raymond,President / Vice President,,Republican,"Trump, Donald J.",248,000450
+CRAWFORD,Sheridan,President / Vice President,,independent,"Stein, Jill",2,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Basiago, Andrew D.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Castle, Darrell L",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Giordani, Rocky",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Hedges, James A",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Kahn, Lynn",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"La Riva, Gloria",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Levinson, Michael S.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Maturen, Michael A",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"McMullin, Evan",2,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Moorehead, Monica G.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Perry, Darryl",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Schriner, Joe C",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Smith, Mike",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Sood, Ajay",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Sterling, Shawna",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Valdivia, Anthony J",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000460
+CRAWFORD,Sheridan,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000460
+CRAWFORD,Sheridan,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000460
+CRAWFORD,Sheridan,President / Vice President,,Libertarian,"Johnson, Gary",1,000460
+CRAWFORD,Sheridan,President / Vice President,,Republican,"Trump, Donald J.",58,000460
+CRAWFORD,Sherman,President / Vice President,,independent,"Stein, Jill",3,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Basiago, Andrew D.",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Castle, Darrell L",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Giordani, Rocky",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Hedges, James A",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Kahn, Lynn",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"La Riva, Gloria",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Levinson, Michael S.",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Maturen, Michael A",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"McMullin, Evan",2,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Moorehead, Monica G.",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Perry, Darryl",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Schriner, Joe C",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Smith, Mike",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Sood, Ajay",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Sterling, Shawna",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Valdivia, Anthony J",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000470
+CRAWFORD,Sherman,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000470
+CRAWFORD,Sherman,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000470
+CRAWFORD,Sherman,President / Vice President,,Libertarian,"Johnson, Gary",13,000470
+CRAWFORD,Sherman,President / Vice President,,Republican,"Trump, Donald J.",198,000470
+CRAWFORD,Smelter,President / Vice President,,independent,"Stein, Jill",5,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Basiago, Andrew D.",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Castle, Darrell L",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Giordani, Rocky",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Hedges, James A",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Kahn, Lynn",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"La Riva, Gloria",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Levinson, Michael S.",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Maturen, Michael A",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"McMullin, Evan",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Moorehead, Monica G.",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Perry, Darryl",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Schriner, Joe C",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Smith, Mike",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Sood, Ajay",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Sterling, Shawna",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Valdivia, Anthony J",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000480
+CRAWFORD,Smelter,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000480
+CRAWFORD,Smelter,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,000480
+CRAWFORD,Smelter,President / Vice President,,Libertarian,"Johnson, Gary",11,000480
+CRAWFORD,Smelter,President / Vice President,,Republican,"Trump, Donald J.",200,000480
+CRAWFORD,South Arma,President / Vice President,,independent,"Stein, Jill",4,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Basiago, Andrew D.",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Castle, Darrell L",1,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Giordani, Rocky",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Hedges, James A",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Kahn, Lynn",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"La Riva, Gloria",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Levinson, Michael S.",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Maturen, Michael A",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"McMullin, Evan",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Moorehead, Monica G.",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Perry, Darryl",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Schriner, Joe C",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Smith, Mike",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Sood, Ajay",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Sterling, Shawna",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Valdivia, Anthony J",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000490
+CRAWFORD,South Arma,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000490
+CRAWFORD,South Arma,President / Vice President,,Democratic,"Clinton, Hillary Rodham",145,000490
+CRAWFORD,South Arma,President / Vice President,,Libertarian,"Johnson, Gary",14,000490
+CRAWFORD,South Arma,President / Vice President,,Republican,"Trump, Donald J.",224,000490
+CRAWFORD,Walnut,President / Vice President,,independent,"Stein, Jill",3,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Basiago, Andrew D.",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Castle, Darrell L",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Giordani, Rocky",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Hedges, James A",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Kahn, Lynn",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"La Riva, Gloria",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Levinson, Michael S.",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Maturen, Michael A",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"McMullin, Evan",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Moorehead, Monica G.",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Perry, Darryl",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Schriner, Joe C",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Smith, Mike",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Sood, Ajay",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Sterling, Shawna",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Valdivia, Anthony J",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000500
+CRAWFORD,Walnut,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000500
+CRAWFORD,Walnut,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000500
+CRAWFORD,Walnut,President / Vice President,,Libertarian,"Johnson, Gary",2,000500
+CRAWFORD,Walnut,President / Vice President,,Republican,"Trump, Donald J.",36,000500
+CRAWFORD,Franklin,President / Vice President,,independent,"Stein, Jill",4,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Basiago, Andrew D.",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Castle, Darrell L",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Giordani, Rocky",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Hedges, James A",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Hoefling, Tom",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Kahn, Lynn",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"La Riva, Gloria",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Levinson, Michael S.",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Maturen, Michael A",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"McMullin, Evan",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Moorehead, Monica G.",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Perry, Darryl",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Schoenke, Marshall R.",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Schriner, Joe C",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Smith, Mike",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Sood, Ajay",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Sterling, Shawna",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Valdivia, Anthony J",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,700100
+CRAWFORD,Franklin,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,700100
+CRAWFORD,Franklin,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,700100
+CRAWFORD,Franklin,President / Vice President,,Libertarian,"Johnson, Gary",5,700100
+CRAWFORD,Franklin,President / Vice President,,Republican,"Trump, Donald J.",143,700100
+CRAWFORD,Baker Enclave,President / Vice President,,independent,"Stein, Jill",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+CRAWFORD,Baker Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+CRAWFORD,Parkview Enclave,President / Vice President,,independent,"Stein, Jill",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Hedges, James A",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Smith, Mike",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+CRAWFORD,Parkview Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,independent,"Stein, Jill",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,independent,"Stein, Jill",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Democratic,"Potter, Britani",9,000A41
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000A41
+CRAWFORD,Lincoln - Arcadia,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000A41
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Democratic,"Potter, Britani",28,000A51
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000A51
+CRAWFORD,Osage - McCune,United States House of Representatives,2,Republican,"Jenkins, Lynn",172,000A51
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Democratic,"Potter, Britani",32,000A62
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000A62
+CRAWFORD,Cherokee - Sheridan,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,000A62
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Democratic,"Potter, Britani",8,000A82
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000A82
+CRAWFORD,Walnut - Helper,United States House of Representatives,2,Republican,"Jenkins, Lynn",24,000A82
+CRAWFORD,Walnut Township,United States House of Representatives,2,Democratic,"Potter, Britani",8,000A83
+CRAWFORD,Walnut Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000A83
+CRAWFORD,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",14,000A83
+CRAWFORD,Arcadia,United States House of Representatives,2,Democratic,"Potter, Britani",53,000010
+CRAWFORD,Arcadia,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000010
+CRAWFORD,Arcadia,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,000010
+CRAWFORD,Baker,United States House of Representatives,2,Democratic,"Potter, Britani",118,000020
+CRAWFORD,Baker,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000020
+CRAWFORD,Baker,United States House of Representatives,2,Republican,"Jenkins, Lynn",366,000020
+CRAWFORD,Beulah,United States House of Representatives,2,Democratic,"Potter, Britani",24,000030
+CRAWFORD,Beulah,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000030
+CRAWFORD,Beulah,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,000030
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Democratic,"Potter, Britani",18,000033
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000033
+CRAWFORD,Sheridan - Cherokee City,United States House of Representatives,2,Republican,"Jenkins, Lynn",32,000033
+CRAWFORD,Brazilton,United States House of Representatives,2,Democratic,"Potter, Britani",9,000040
+CRAWFORD,Brazilton,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000040
+CRAWFORD,Brazilton,United States House of Representatives,2,Republican,"Jenkins, Lynn",26,000040
+CRAWFORD,Capaldo,United States House of Representatives,2,Democratic,"Potter, Britani",64,000050
+CRAWFORD,Capaldo,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000050
+CRAWFORD,Capaldo,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,000050
+CRAWFORD,Cherokee,United States House of Representatives,2,Democratic,"Potter, Britani",57,000060
+CRAWFORD,Cherokee,United States House of Representatives,2,Libertarian,"Bales, James Houston",26,000060
+CRAWFORD,Cherokee,United States House of Representatives,2,Republican,"Jenkins, Lynn",144,000060
+CRAWFORD,Chicopee,United States House of Representatives,2,Democratic,"Potter, Britani",75,000070
+CRAWFORD,Chicopee,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000070
+CRAWFORD,Chicopee,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,000070
+CRAWFORD,Crawford,United States House of Representatives,2,Democratic,"Potter, Britani",25,000080
+CRAWFORD,Crawford,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000080
+CRAWFORD,Crawford,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000080
+CRAWFORD,Crowe,United States House of Representatives,2,Democratic,"Potter, Britani",36,000090
+CRAWFORD,Crowe,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000090
+CRAWFORD,Crowe,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000090
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",165,000110
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000110
+CRAWFORD,Frontenac Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",235,000110
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",261,00012A
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",27,00012A
+CRAWFORD,Frontenac Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",358,00012A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",89,00013A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,00013A
+CRAWFORD,Frontenac Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States House of Representatives,2,Democratic,"Potter, Britani",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",90,00014A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,00014A
+CRAWFORD,Frontenac Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,00014A
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",21,000150
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000150
+CRAWFORD,Girard Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000150
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",88,00016A
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,00016A
+CRAWFORD,Girard Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",235,00016A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",66,00017A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,00017A
+CRAWFORD,Girard Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States House of Representatives,2,Democratic,"Potter, Britani",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00017B
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",79,000180
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000180
+CRAWFORD,Girard Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",220,000180
+CRAWFORD,Grant,United States House of Representatives,2,Democratic,"Potter, Britani",25,000190
+CRAWFORD,Grant,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000190
+CRAWFORD,Grant,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000190
+CRAWFORD,Hepler,United States House of Representatives,2,Democratic,"Potter, Britani",6,000200
+CRAWFORD,Hepler,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000200
+CRAWFORD,Hepler,United States House of Representatives,2,Republican,"Jenkins, Lynn",29,000200
+CRAWFORD,Lincoln,United States House of Representatives,2,Democratic,"Potter, Britani",37,000210
+CRAWFORD,Lincoln,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000210
+CRAWFORD,Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,000210
+CRAWFORD,Lone Star,United States House of Representatives,2,Democratic,"Potter, Britani",175,00022A
+CRAWFORD,Lone Star,United States House of Representatives,2,Libertarian,"Bales, James Houston",29,00022A
+CRAWFORD,Lone Star,United States House of Representatives,2,Republican,"Jenkins, Lynn",382,00022A
+CRAWFORD,McCune,United States House of Representatives,2,Democratic,"Potter, Britani",35,000230
+CRAWFORD,McCune,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000230
+CRAWFORD,McCune,United States House of Representatives,2,Republican,"Jenkins, Lynn",114,000230
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",21,000240
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000240
+CRAWFORD,Mulberry Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,000240
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",30,000250
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000250
+CRAWFORD,Mulberry Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,000250
+CRAWFORD,North Arma,United States House of Representatives,2,Democratic,"Potter, Britani",92,000260
+CRAWFORD,North Arma,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000260
+CRAWFORD,North Arma,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,000260
+CRAWFORD,Opolis,United States House of Representatives,2,Democratic,"Potter, Britani",52,000270
+CRAWFORD,Opolis,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000270
+CRAWFORD,Opolis,United States House of Representatives,2,Republican,"Jenkins, Lynn",118,000270
+CRAWFORD,Parkview,United States House of Representatives,2,Democratic,"Potter, Britani",84,000280
+CRAWFORD,Parkview,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000280
+CRAWFORD,Parkview,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",108,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",185,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",332,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",422,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",48,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",743,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",79,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",109,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",169,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",141,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",113,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Democratic,"Potter, Britani",151,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",271,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",113,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",133,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",60,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",100,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",161,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",45,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",275,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",90,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",149,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Democratic,"Potter, Britani",185,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",30,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",452,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Democratic,"Potter, Britani",29,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,00044A
+CRAWFORD,Raymond,United States House of Representatives,2,Democratic,"Potter, Britani",72,000450
+CRAWFORD,Raymond,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000450
+CRAWFORD,Raymond,United States House of Representatives,2,Republican,"Jenkins, Lynn",265,000450
+CRAWFORD,Sheridan,United States House of Representatives,2,Democratic,"Potter, Britani",13,000460
+CRAWFORD,Sheridan,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000460
+CRAWFORD,Sheridan,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000460
+CRAWFORD,Sherman,United States House of Representatives,2,Democratic,"Potter, Britani",62,000470
+CRAWFORD,Sherman,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000470
+CRAWFORD,Sherman,United States House of Representatives,2,Republican,"Jenkins, Lynn",208,000470
+CRAWFORD,Smelter,United States House of Representatives,2,Democratic,"Potter, Britani",80,000480
+CRAWFORD,Smelter,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000480
+CRAWFORD,Smelter,United States House of Representatives,2,Republican,"Jenkins, Lynn",205,000480
+CRAWFORD,South Arma,United States House of Representatives,2,Democratic,"Potter, Britani",119,000490
+CRAWFORD,South Arma,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000490
+CRAWFORD,South Arma,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,000490
+CRAWFORD,Walnut,United States House of Representatives,2,Democratic,"Potter, Britani",6,000500
+CRAWFORD,Walnut,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000500
+CRAWFORD,Walnut,United States House of Representatives,2,Republican,"Jenkins, Lynn",39,000500
+CRAWFORD,Franklin,United States House of Representatives,2,Democratic,"Potter, Britani",71,700100
+CRAWFORD,Franklin,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,700100
+CRAWFORD,Franklin,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,700100
+CRAWFORD,Baker Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+CRAWFORD,Baker Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+CRAWFORD,Baker Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+CRAWFORD,Parkview Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+CRAWFORD,Parkview Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+CRAWFORD,Parkview Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+CRAWFORD,Lincoln - Arcadia,United States Senate,,write - in,"Smith, DJ",0,000A41
+CRAWFORD,Lincoln - Arcadia,United States Senate,,Democratic,"Wiesner, Patrick",14,000A41
+CRAWFORD,Lincoln - Arcadia,United States Senate,,Libertarian,"Garrard, Robert D.",1,000A41
+CRAWFORD,Lincoln - Arcadia,United States Senate,,Republican,"Moran, Jerry",46,000A41
+CRAWFORD,Osage - McCune,United States Senate,,write - in,"Smith, DJ",0,000A51
+CRAWFORD,Osage - McCune,United States Senate,,Democratic,"Wiesner, Patrick",31,000A51
+CRAWFORD,Osage - McCune,United States Senate,,Libertarian,"Garrard, Robert D.",12,000A51
+CRAWFORD,Osage - McCune,United States Senate,,Republican,"Moran, Jerry",163,000A51
+CRAWFORD,Cherokee - Sheridan,United States Senate,,write - in,"Smith, DJ",0,000A62
+CRAWFORD,Cherokee - Sheridan,United States Senate,,Democratic,"Wiesner, Patrick",32,000A62
+CRAWFORD,Cherokee - Sheridan,United States Senate,,Libertarian,"Garrard, Robert D.",9,000A62
+CRAWFORD,Cherokee - Sheridan,United States Senate,,Republican,"Moran, Jerry",102,000A62
+CRAWFORD,Walnut - Helper,United States Senate,,write - in,"Smith, DJ",0,000A82
+CRAWFORD,Walnut - Helper,United States Senate,,Democratic,"Wiesner, Patrick",6,000A82
+CRAWFORD,Walnut - Helper,United States Senate,,Libertarian,"Garrard, Robert D.",1,000A82
+CRAWFORD,Walnut - Helper,United States Senate,,Republican,"Moran, Jerry",27,000A82
+CRAWFORD,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000A83
+CRAWFORD,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000A83
+CRAWFORD,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000A83
+CRAWFORD,Walnut Township,United States Senate,,Republican,"Moran, Jerry",14,000A83
+CRAWFORD,Arcadia,United States Senate,,write - in,"Smith, DJ",0,000010
+CRAWFORD,Arcadia,United States Senate,,Democratic,"Wiesner, Patrick",56,000010
+CRAWFORD,Arcadia,United States Senate,,Libertarian,"Garrard, Robert D.",9,000010
+CRAWFORD,Arcadia,United States Senate,,Republican,"Moran, Jerry",74,000010
+CRAWFORD,Baker,United States Senate,,write - in,"Smith, DJ",0,000020
+CRAWFORD,Baker,United States Senate,,Democratic,"Wiesner, Patrick",144,000020
+CRAWFORD,Baker,United States Senate,,Libertarian,"Garrard, Robert D.",24,000020
+CRAWFORD,Baker,United States Senate,,Republican,"Moran, Jerry",343,000020
+CRAWFORD,Beulah,United States Senate,,write - in,"Smith, DJ",0,000030
+CRAWFORD,Beulah,United States Senate,,Democratic,"Wiesner, Patrick",34,000030
+CRAWFORD,Beulah,United States Senate,,Libertarian,"Garrard, Robert D.",6,000030
+CRAWFORD,Beulah,United States Senate,,Republican,"Moran, Jerry",94,000030
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,write - in,"Smith, DJ",0,000033
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,Democratic,"Wiesner, Patrick",22,000033
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,Libertarian,"Garrard, Robert D.",2,000033
+CRAWFORD,Sheridan - Cherokee City,United States Senate,,Republican,"Moran, Jerry",27,000033
+CRAWFORD,Brazilton,United States Senate,,write - in,"Smith, DJ",0,000040
+CRAWFORD,Brazilton,United States Senate,,Democratic,"Wiesner, Patrick",11,000040
+CRAWFORD,Brazilton,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+CRAWFORD,Brazilton,United States Senate,,Republican,"Moran, Jerry",24,000040
+CRAWFORD,Capaldo,United States Senate,,write - in,"Smith, DJ",0,000050
+CRAWFORD,Capaldo,United States Senate,,Democratic,"Wiesner, Patrick",77,000050
+CRAWFORD,Capaldo,United States Senate,,Libertarian,"Garrard, Robert D.",9,000050
+CRAWFORD,Capaldo,United States Senate,,Republican,"Moran, Jerry",147,000050
+CRAWFORD,Cherokee,United States Senate,,write - in,"Smith, DJ",0,000060
+CRAWFORD,Cherokee,United States Senate,,Democratic,"Wiesner, Patrick",69,000060
+CRAWFORD,Cherokee,United States Senate,,Libertarian,"Garrard, Robert D.",27,000060
+CRAWFORD,Cherokee,United States Senate,,Republican,"Moran, Jerry",131,000060
+CRAWFORD,Chicopee,United States Senate,,write - in,"Smith, DJ",0,000070
+CRAWFORD,Chicopee,United States Senate,,Democratic,"Wiesner, Patrick",77,000070
+CRAWFORD,Chicopee,United States Senate,,Libertarian,"Garrard, Robert D.",9,000070
+CRAWFORD,Chicopee,United States Senate,,Republican,"Moran, Jerry",199,000070
+CRAWFORD,Crawford,United States Senate,,write - in,"Smith, DJ",0,000080
+CRAWFORD,Crawford,United States Senate,,Democratic,"Wiesner, Patrick",24,000080
+CRAWFORD,Crawford,United States Senate,,Libertarian,"Garrard, Robert D.",5,000080
+CRAWFORD,Crawford,United States Senate,,Republican,"Moran, Jerry",177,000080
+CRAWFORD,Crowe,United States Senate,,write - in,"Smith, DJ",0,000090
+CRAWFORD,Crowe,United States Senate,,Democratic,"Wiesner, Patrick",41,000090
+CRAWFORD,Crowe,United States Senate,,Libertarian,"Garrard, Robert D.",6,000090
+CRAWFORD,Crowe,United States Senate,,Republican,"Moran, Jerry",60,000090
+CRAWFORD,Frontenac Ward 1,United States Senate,,write - in,"Smith, DJ",0,000110
+CRAWFORD,Frontenac Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",198,000110
+CRAWFORD,Frontenac Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000110
+CRAWFORD,Frontenac Ward 1,United States Senate,,Republican,"Moran, Jerry",203,000110
+CRAWFORD,Frontenac Ward 2,United States Senate,,write - in,"Smith, DJ",0,00012A
+CRAWFORD,Frontenac Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",284,00012A
+CRAWFORD,Frontenac Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",26,00012A
+CRAWFORD,Frontenac Ward 2,United States Senate,,Republican,"Moran, Jerry",326,00012A
+CRAWFORD,Frontenac Ward 3,United States Senate,,write - in,"Smith, DJ",0,00013A
+CRAWFORD,Frontenac Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",98,00013A
+CRAWFORD,Frontenac Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",9,00013A
+CRAWFORD,Frontenac Ward 3,United States Senate,,Republican,"Moran, Jerry",138,00013A
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,write - in,"Smith, DJ",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,Democratic,"Wiesner, Patrick",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,Libertarian,"Garrard, Robert D.",0,00013B
+CRAWFORD,Frontenac Ward 3 Industrial Park,United States Senate,,Republican,"Moran, Jerry",0,00013B
+CRAWFORD,Frontenac Ward 4,United States Senate,,write - in,"Smith, DJ",0,00014A
+CRAWFORD,Frontenac Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",93,00014A
+CRAWFORD,Frontenac Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",13,00014A
+CRAWFORD,Frontenac Ward 4,United States Senate,,Republican,"Moran, Jerry",99,00014A
+CRAWFORD,Girard Ward 1,United States Senate,,write - in,"Smith, DJ",0,000150
+CRAWFORD,Girard Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",31,000150
+CRAWFORD,Girard Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",3,000150
+CRAWFORD,Girard Ward 1,United States Senate,,Republican,"Moran, Jerry",70,000150
+CRAWFORD,Girard Ward 2,United States Senate,,write - in,"Smith, DJ",0,00016A
+CRAWFORD,Girard Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",80,00016A
+CRAWFORD,Girard Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,00016A
+CRAWFORD,Girard Ward 2,United States Senate,,Republican,"Moran, Jerry",245,00016A
+CRAWFORD,Girard Ward 3,United States Senate,,write - in,"Smith, DJ",0,00017A
+CRAWFORD,Girard Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",78,00017A
+CRAWFORD,Girard Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",13,00017A
+CRAWFORD,Girard Ward 3,United States Senate,,Republican,"Moran, Jerry",133,00017A
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,write - in,"Smith, DJ",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,Democratic,"Wiesner, Patrick",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017B
+CRAWFORD,Girard Ward 3 Exclave Golf Course,United States Senate,,Republican,"Moran, Jerry",0,00017B
+CRAWFORD,Girard Ward 4,United States Senate,,write - in,"Smith, DJ",0,000180
+CRAWFORD,Girard Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",90,000180
+CRAWFORD,Girard Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",14,000180
+CRAWFORD,Girard Ward 4,United States Senate,,Republican,"Moran, Jerry",203,000180
+CRAWFORD,Grant,United States Senate,,write - in,"Smith, DJ",0,000190
+CRAWFORD,Grant,United States Senate,,Democratic,"Wiesner, Patrick",28,000190
+CRAWFORD,Grant,United States Senate,,Libertarian,"Garrard, Robert D.",4,000190
+CRAWFORD,Grant,United States Senate,,Republican,"Moran, Jerry",97,000190
+CRAWFORD,Hepler,United States Senate,,write - in,"Smith, DJ",0,000200
+CRAWFORD,Hepler,United States Senate,,Democratic,"Wiesner, Patrick",3,000200
+CRAWFORD,Hepler,United States Senate,,Libertarian,"Garrard, Robert D.",2,000200
+CRAWFORD,Hepler,United States Senate,,Republican,"Moran, Jerry",31,000200
+CRAWFORD,Lincoln,United States Senate,,write - in,"Smith, DJ",0,000210
+CRAWFORD,Lincoln,United States Senate,,Democratic,"Wiesner, Patrick",45,000210
+CRAWFORD,Lincoln,United States Senate,,Libertarian,"Garrard, Robert D.",10,000210
+CRAWFORD,Lincoln,United States Senate,,Republican,"Moran, Jerry",107,000210
+CRAWFORD,Lone Star,United States Senate,,write - in,"Smith, DJ",0,00022A
+CRAWFORD,Lone Star,United States Senate,,Democratic,"Wiesner, Patrick",174,00022A
+CRAWFORD,Lone Star,United States Senate,,Libertarian,"Garrard, Robert D.",30,00022A
+CRAWFORD,Lone Star,United States Senate,,Republican,"Moran, Jerry",376,00022A
+CRAWFORD,McCune,United States Senate,,write - in,"Smith, DJ",0,000230
+CRAWFORD,McCune,United States Senate,,Democratic,"Wiesner, Patrick",40,000230
+CRAWFORD,McCune,United States Senate,,Libertarian,"Garrard, Robert D.",18,000230
+CRAWFORD,McCune,United States Senate,,Republican,"Moran, Jerry",107,000230
+CRAWFORD,Mulberry Ward 1,United States Senate,,write - in,"Smith, DJ",0,000240
+CRAWFORD,Mulberry Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",30,000240
+CRAWFORD,Mulberry Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",8,000240
+CRAWFORD,Mulberry Ward 1,United States Senate,,Republican,"Moran, Jerry",35,000240
+CRAWFORD,Mulberry Ward 2,United States Senate,,write - in,"Smith, DJ",0,000250
+CRAWFORD,Mulberry Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",31,000250
+CRAWFORD,Mulberry Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",6,000250
+CRAWFORD,Mulberry Ward 2,United States Senate,,Republican,"Moran, Jerry",44,000250
+CRAWFORD,North Arma,United States Senate,,write - in,"Smith, DJ",0,000260
+CRAWFORD,North Arma,United States Senate,,Democratic,"Wiesner, Patrick",102,000260
+CRAWFORD,North Arma,United States Senate,,Libertarian,"Garrard, Robert D.",20,000260
+CRAWFORD,North Arma,United States Senate,,Republican,"Moran, Jerry",209,000260
+CRAWFORD,Opolis,United States Senate,,write - in,"Smith, DJ",0,000270
+CRAWFORD,Opolis,United States Senate,,Democratic,"Wiesner, Patrick",50,000270
+CRAWFORD,Opolis,United States Senate,,Libertarian,"Garrard, Robert D.",11,000270
+CRAWFORD,Opolis,United States Senate,,Republican,"Moran, Jerry",118,000270
+CRAWFORD,Parkview,United States Senate,,write - in,"Smith, DJ",0,000280
+CRAWFORD,Parkview,United States Senate,,Democratic,"Wiesner, Patrick",91,000280
+CRAWFORD,Parkview,United States Senate,,Libertarian,"Garrard, Robert D.",11,000280
+CRAWFORD,Parkview,United States Senate,,Republican,"Moran, Jerry",136,000280
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",118,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",26,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",186,000290
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",196,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",26,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",318,000300
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",460,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",50,000310
+CRAWFORD,Pittsburg Ward 1 Precinct 3,United States Senate,,Republican,"Moran, Jerry",709,000310
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",98,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",15,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",113,000320
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",124,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",10,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",158,000330
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",151,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",19,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",180,000340
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",122,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",15,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 4,United States Senate,,Republican,"Moran, Jerry",183,000350
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",158,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",23,000360
+CRAWFORD,Pittsburg Ward 2 Precinct 5,United States Senate,,Republican,"Moran, Jerry",264,000360
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",129,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",15,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",156,000370
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",154,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",24,00038A
+CRAWFORD,Pittsburg Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",204,00038A
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",59,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",7,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",52,000390
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",117,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",119,000400
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",167,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",49,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",259,000410
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",100,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",20,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 4,United States Senate,,Republican,"Moran, Jerry",141,00042A
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",207,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",35,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 5,United States Senate,,Republican,"Moran, Jerry",414,000430
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,write - in,"Smith, DJ",0,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,Democratic,"Wiesner, Patrick",30,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,Libertarian,"Garrard, Robert D.",3,00044A
+CRAWFORD,Pittsburg Ward 4 Precinct 6,United States Senate,,Republican,"Moran, Jerry",90,00044A
+CRAWFORD,Raymond,United States Senate,,write - in,"Smith, DJ",0,000450
+CRAWFORD,Raymond,United States Senate,,Democratic,"Wiesner, Patrick",72,000450
+CRAWFORD,Raymond,United States Senate,,Libertarian,"Garrard, Robert D.",5,000450
+CRAWFORD,Raymond,United States Senate,,Republican,"Moran, Jerry",270,000450
+CRAWFORD,Sheridan,United States Senate,,write - in,"Smith, DJ",0,000460
+CRAWFORD,Sheridan,United States Senate,,Democratic,"Wiesner, Patrick",17,000460
+CRAWFORD,Sheridan,United States Senate,,Libertarian,"Garrard, Robert D.",3,000460
+CRAWFORD,Sheridan,United States Senate,,Republican,"Moran, Jerry",53,000460
+CRAWFORD,Sherman,United States Senate,,write - in,"Smith, DJ",0,000470
+CRAWFORD,Sherman,United States Senate,,Democratic,"Wiesner, Patrick",69,000470
+CRAWFORD,Sherman,United States Senate,,Libertarian,"Garrard, Robert D.",14,000470
+CRAWFORD,Sherman,United States Senate,,Republican,"Moran, Jerry",201,000470
+CRAWFORD,Smelter,United States Senate,,write - in,"Smith, DJ",0,000480
+CRAWFORD,Smelter,United States Senate,,Democratic,"Wiesner, Patrick",90,000480
+CRAWFORD,Smelter,United States Senate,,Libertarian,"Garrard, Robert D.",10,000480
+CRAWFORD,Smelter,United States Senate,,Republican,"Moran, Jerry",198,000480
+CRAWFORD,South Arma,United States Senate,,write - in,"Smith, DJ",0,000490
+CRAWFORD,South Arma,United States Senate,,Democratic,"Wiesner, Patrick",142,000490
+CRAWFORD,South Arma,United States Senate,,Libertarian,"Garrard, Robert D.",24,000490
+CRAWFORD,South Arma,United States Senate,,Republican,"Moran, Jerry",216,000490
+CRAWFORD,Walnut,United States Senate,,write - in,"Smith, DJ",0,000500
+CRAWFORD,Walnut,United States Senate,,Democratic,"Wiesner, Patrick",12,000500
+CRAWFORD,Walnut,United States Senate,,Libertarian,"Garrard, Robert D.",2,000500
+CRAWFORD,Walnut,United States Senate,,Republican,"Moran, Jerry",33,000500
+CRAWFORD,Franklin,United States Senate,,write - in,"Smith, DJ",0,700100
+CRAWFORD,Franklin,United States Senate,,Democratic,"Wiesner, Patrick",84,700100
+CRAWFORD,Franklin,United States Senate,,Libertarian,"Garrard, Robert D.",9,700100
+CRAWFORD,Franklin,United States Senate,,Republican,"Moran, Jerry",135,700100
+CRAWFORD,Baker Enclave,United States Senate,,write - in,"Smith, DJ",0,900010
+CRAWFORD,Baker Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+CRAWFORD,Baker Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+CRAWFORD,Baker Enclave,United States Senate,,Republican,"Moran, Jerry",0,900010
+CRAWFORD,Parkview Enclave,United States Senate,,write - in,"Smith, DJ",0,900020
+CRAWFORD,Parkview Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+CRAWFORD,Parkview Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+CRAWFORD,Parkview Enclave,United States Senate,,Republican,"Moran, Jerry",0,900020
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,write - in,"Smith, DJ",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,900030
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,write - in,"Smith, DJ",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+CRAWFORD,Pittsburg Ward 2 Precinct 5 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,900040

--- a/2016/20161108__ks__general__decatur__precinct.csv
+++ b/2016/20161108__ks__general__decatur__precinct.csv
@@ -1,462 +1,1037 @@
-county,precinct,office,district,party,candidate,votes
-Decatur,Custer,President,,DEM,Hillary Clinton,0
-Decatur,Lyon,President,,DEM,Hillary Clinton,3
-Decatur,Dresden Twp/DC,President,,DEM,Hillary Clinton,2
-Decatur,Allison,President,,DEM,Hillary Clinton,1
-Decatur,Pleasant Valley/CC,President,,DEM,Hillary Clinton,4
-Decatur,Jennings Twp/JC,President,,DEM,Hillary Clinton,18
-Decatur,Garfield,President,,DEM,Hillary Clinton,1
-Decatur,Grant,President,,DEM,Hillary Clinton,0
-Decatur,Lincoln/NC,President,,DEM,Hillary Clinton,5
-Decatur,Beaver,President,,DEM,Hillary Clinton,1
-Decatur,Finley,President,,DEM,Hillary Clinton,1
-Decatur,Harlan,President,,DEM,Hillary Clinton,0
-Decatur,Liberty,President,,DEM,Hillary Clinton,1
-Decatur,Logan,President,,DEM,Hillary Clinton,0
-Decatur,Olive,President,,DEM,Hillary Clinton,5
-Decatur,Roosevelt,President,,DEM,Hillary Clinton,1
-Decatur,Sherman,President,,DEM,Hillary Clinton,0
-Decatur,Altory,President,,DEM,Hillary Clinton,0
-Decatur,Bassettville,President,,DEM,Hillary Clinton,0
-Decatur,Center,President,,DEM,Hillary Clinton,0
-Decatur,Cook,President,,DEM,Hillary Clinton,0
-Decatur,Oberlin,President,,DEM,Hillary Clinton,4
-Decatur,Prairie Dog,President,,DEM,Hillary Clinton,0
-Decatur,Sappa,President,,DEM,Hillary Clinton,0
-Decatur,Summit,President,,DEM,Hillary Clinton,3
-Decatur,Oberlin City 1,President,,DEM,Hillary Clinton,39
-Decatur,Oberlin City 2,President,,DEM,Hillary Clinton,29
-Decatur,Advance,President,,DEM,Hillary Clinton,60
-Decatur,Custer,President,,LIB,Gary Johnson,0
-Decatur,Lyon,President,,LIB,Gary Johnson,0
-Decatur,Dresden Twp/DC,President,,LIB,Gary Johnson,2
-Decatur,Allison,President,,LIB,Gary Johnson,0
-Decatur,Pleasant Valley/CC,President,,LIB,Gary Johnson,1
-Decatur,Jennings Twp/JC,President,,LIB,Gary Johnson,0
-Decatur,Garfield,President,,LIB,Gary Johnson,1
-Decatur,Grant,President,,LIB,Gary Johnson,0
-Decatur,Lincoln/NC,President,,LIB,Gary Johnson,6
-Decatur,Beaver,President,,LIB,Gary Johnson,0
-Decatur,Finley,President,,LIB,Gary Johnson,0
-Decatur,Harlan,President,,LIB,Gary Johnson,0
-Decatur,Liberty,President,,LIB,Gary Johnson,0
-Decatur,Logan,President,,LIB,Gary Johnson,0
-Decatur,Olive,President,,LIB,Gary Johnson,0
-Decatur,Roosevelt,President,,LIB,Gary Johnson,0
-Decatur,Sherman,President,,LIB,Gary Johnson,1
-Decatur,Altory,President,,LIB,Gary Johnson,2
-Decatur,Bassettville,President,,LIB,Gary Johnson,0
-Decatur,Center,President,,LIB,Gary Johnson,0
-Decatur,Cook,President,,LIB,Gary Johnson,0
-Decatur,Oberlin,President,,LIB,Gary Johnson,0
-Decatur,Prairie Dog,President,,LIB,Gary Johnson,0
-Decatur,Sappa,President,,LIB,Gary Johnson,0
-Decatur,Summit,President,,LIB,Gary Johnson,0
-Decatur,Oberlin City 1,President,,LIB,Gary Johnson,9
-Decatur,Oberlin City 2,President,,LIB,Gary Johnson,11
-Decatur,Advance,President,,LIB,Gary Johnson,9
-Decatur,Custer,President,,IND,Jill Stein,0
-Decatur,Lyon,President,,IND,Jill Stein,0
-Decatur,Dresden Twp/DC,President,,IND,Jill Stein,1
-Decatur,Allison,President,,IND,Jill Stein,2
-Decatur,Pleasant Valley/CC,President,,IND,Jill Stein,0
-Decatur,Jennings Twp/JC,President,,IND,Jill Stein,2
-Decatur,Garfield,President,,IND,Jill Stein,0
-Decatur,Grant,President,,IND,Jill Stein,0
-Decatur,Lincoln/NC,President,,IND,Jill Stein,0
-Decatur,Beaver,President,,IND,Jill Stein,0
-Decatur,Finley,President,,IND,Jill Stein,0
-Decatur,Harlan,President,,IND,Jill Stein,0
-Decatur,Liberty,President,,IND,Jill Stein,0
-Decatur,Logan,President,,IND,Jill Stein,0
-Decatur,Olive,President,,IND,Jill Stein,0
-Decatur,Roosevelt,President,,IND,Jill Stein,0
-Decatur,Sherman,President,,IND,Jill Stein,0
-Decatur,Altory,President,,IND,Jill Stein,0
-Decatur,Bassettville,President,,IND,Jill Stein,0
-Decatur,Center,President,,IND,Jill Stein,0
-Decatur,Cook,President,,IND,Jill Stein,0
-Decatur,Oberlin,President,,IND,Jill Stein,1
-Decatur,Prairie Dog,President,,IND,Jill Stein,0
-Decatur,Sappa,President,,IND,Jill Stein,0
-Decatur,Summit,President,,IND,Jill Stein,0
-Decatur,Oberlin City 1,President,,IND,Jill Stein,5
-Decatur,Oberlin City 2,President,,IND,Jill Stein,1
-Decatur,Advance,President,,IND,Jill Stein,8
-Decatur,Custer,President,,REP,Donald J Trump,15
-Decatur,Lyon,President,,REP,Donald J Trump,4
-Decatur,Dresden Twp/DC,President,,REP,Donald J Trump,34
-Decatur,Allison,President,,REP,Donald J Trump,12
-Decatur,Pleasant Valley/CC,President,,REP,Donald J Trump,10
-Decatur,Jennings Twp/JC,President,,REP,Donald J Trump,43
-Decatur,Garfield,President,,REP,Donald J Trump,15
-Decatur,Grant,President,,REP,Donald J Trump,7
-Decatur,Lincoln/NC,President,,REP,Donald J Trump,57
-Decatur,Beaver,President,,REP,Donald J Trump,21
-Decatur,Finley,President,,REP,Donald J Trump,14
-Decatur,Harlan,President,,REP,Donald J Trump,11
-Decatur,Liberty,President,,REP,Donald J Trump,22
-Decatur,Logan,President,,REP,Donald J Trump,13
-Decatur,Olive,President,,REP,Donald J Trump,19
-Decatur,Roosevelt,President,,REP,Donald J Trump,6
-Decatur,Sherman,President,,REP,Donald J Trump,10
-Decatur,Altory,President,,REP,Donald J Trump,7
-Decatur,Bassettville,President,,REP,Donald J Trump,12
-Decatur,Center,President,,REP,Donald J Trump,29
-Decatur,Cook,President,,REP,Donald J Trump,10
-Decatur,Oberlin,President,,REP,Donald J Trump,38
-Decatur,Prairie Dog,President,,REP,Donald J Trump,18
-Decatur,Sappa,President,,REP,Donald J Trump,15
-Decatur,Summit,President,,REP,Donald J Trump,9
-Decatur,Oberlin City 1,President,,REP,Donald J Trump,240
-Decatur,Oberlin City 2,President,,REP,Donald J Trump,277
-Decatur,Advance,President,,REP,Donald J Trump,242
-Decatur,Advance,President,,,Bernie Sanders write in ,1
-Decatur,Oberlin City 1,President,,,Ken Boone write in ,1
-Decatur,Dresden Twp/DC,President,,,Castle/Bradley write in ,1
-Decatur,Pleasant Valley/CC,President,,,Mccain write in,1
-Decatur,Jennings Twp/JC,President,,,Paul Ryan write in,2
-Decatur,Jennings Twp/JC,President,,,Evan McMulen/Nathan write in,1
-Decatur,Custer,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Lyon,U.S. Senate,,LIB,Robert D Garrard,2
-Decatur,Dresden Twp/DC,U.S. Senate,,LIB,Robert D Garrard,2
-Decatur,Allison,U.S. Senate,,LIB,Robert D Garrard,2
-Decatur,Pleasant Valley/CC,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Jennings Twp/JC,U.S. Senate,,LIB,Robert D Garrard,3
-Decatur,Garfield,U.S. Senate,,LIB,Robert D Garrard,1
-Decatur,Grant,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Lincoln/NC,U.S. Senate,,LIB,Robert D Garrard,8
-Decatur,Beaver,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Finley,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Harlan,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Liberty,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Logan,U.S. Senate,,LIB,Robert D Garrard,1
-Decatur,Olive,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Roosevelt,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Sherman,U.S. Senate,,LIB,Robert D Garrard,1
-Decatur,Altory,U.S. Senate,,LIB,Robert D Garrard,1
-Decatur,Bassettville,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Center,U.S. Senate,,LIB,Robert D Garrard,3
-Decatur,Cook,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Oberlin,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Prairie Dog,U.S. Senate,,LIB,Robert D Garrard,1
-Decatur,Sappa,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Summit,U.S. Senate,,LIB,Robert D Garrard,0
-Decatur,Oberlin City 1,U.S. Senate,,LIB,Robert D Garrard,6
-Decatur,Oberlin City 2,U.S. Senate,,LIB,Robert D Garrard,7
-Decatur,Advance,U.S. Senate,,LIB,Robert D Garrard,16
-Decatur,Custer,U.S. Senate,,REP,Jerry Moran,15
-Decatur,Lyon,U.S. Senate,,REP,Jerry Moran,5
-Decatur,Dresden Twp/DC,U.S. Senate,,REP,Jerry Moran,33
-Decatur,Allison,U.S. Senate,,REP,Jerry Moran,10
-Decatur,Pleasant Valley/CC,U.S. Senate,,REP,Jerry Moran,15
-Decatur,Jennings Twp/JC,U.S. Senate,,REP,Jerry Moran,46
-Decatur,Garfield,U.S. Senate,,REP,Jerry Moran,16
-Decatur,Grant,U.S. Senate,,REP,Jerry Moran,6
-Decatur,Lincoln/NC,U.S. Senate,,REP,Jerry Moran,53
-Decatur,Beaver,U.S. Senate,,REP,Jerry Moran,20
-Decatur,Finley,U.S. Senate,,REP,Jerry Moran,15
-Decatur,Harlan,U.S. Senate,,REP,Jerry Moran,9
-Decatur,Liberty,U.S. Senate,,REP,Jerry Moran,21
-Decatur,Logan,U.S. Senate,,REP,Jerry Moran,12
-Decatur,Olive,U.S. Senate,,REP,Jerry Moran,22
-Decatur,Roosevelt,U.S. Senate,,REP,Jerry Moran,7
-Decatur,Sherman,U.S. Senate,,REP,Jerry Moran,10
-Decatur,Altory,U.S. Senate,,REP,Jerry Moran,8
-Decatur,Bassettville,U.S. Senate,,REP,Jerry Moran,11
-Decatur,Center,U.S. Senate,,REP,Jerry Moran,24
-Decatur,Cook,U.S. Senate,,REP,Jerry Moran,10
-Decatur,Oberlin,U.S. Senate,,REP,Jerry Moran,40
-Decatur,Prairie Dog,U.S. Senate,,REP,Jerry Moran,16
-Decatur,Sappa,U.S. Senate,,REP,Jerry Moran,14
-Decatur,Summit,U.S. Senate,,REP,Jerry Moran,11
-Decatur,Oberlin City 1,U.S. Senate,,REP,Jerry Moran,250
-Decatur,Oberlin City 2,U.S. Senate,,REP,Jerry Moran,284
-Decatur,Advance,U.S. Senate,,REP,Jerry Moran,254
-Decatur,Custer,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Lyon,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Dresden Twp/DC,U.S. Senate,,DEM,Patrick Wiesner,4
-Decatur,Allison,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Pleasant Valley/CC,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Jennings Twp/JC,U.S. Senate,,DEM,Patrick Wiesner,14
-Decatur,Garfield,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Grant,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Lincoln/NC,U.S. Senate,,DEM,Patrick Wiesner,3
-Decatur,Beaver,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Finley,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Harlan,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Liberty,U.S. Senate,,DEM,Patrick Wiesner,2
-Decatur,Logan,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Olive,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Roosevelt,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Sherman,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Altory,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Bassettville,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Center,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Cook,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Oberlin,U.S. Senate,,DEM,Patrick Wiesner,3
-Decatur,Prairie Dog,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Sappa,U.S. Senate,,DEM,Patrick Wiesner,0
-Decatur,Summit,U.S. Senate,,DEM,Patrick Wiesner,1
-Decatur,Oberlin City 1,U.S. Senate,,DEM,Patrick Wiesner,23
-Decatur,Oberlin City 2,U.S. Senate,,DEM,Patrick Wiesner,22
-Decatur,Advance,U.S. Senate,,DEM,Patrick Wiesner,47
-Decatur,Liberty,U.S. Senate,,,Capt Jack Sparrow write in,1
-Decatur,Custer,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Lyon,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Dresden Twp/DC,U.S. House,1,LIB,Kerry Burt,3
-Decatur,Allison,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Pleasant Valley/CC,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Jennings Twp/JC,U.S. House,1,LIB,Kerry Burt,4
-Decatur,Garfield,U.S. House,1,LIB,Kerry Burt,1
-Decatur,Grant,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Lincoln/NC,U.S. House,1,LIB,Kerry Burt,5
-Decatur,Beaver,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Finley,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Harlan,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Liberty,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Logan,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Olive,U.S. House,1,LIB,Kerry Burt,4
-Decatur,Roosevelt,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Sherman,U.S. House,1,LIB,Kerry Burt,1
-Decatur,Altory,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Bassettville,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Center,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Cook,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Oberlin,U.S. House,1,LIB,Kerry Burt,1
-Decatur,Prairie Dog,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Sappa,U.S. House,1,LIB,Kerry Burt,1
-Decatur,Summit,U.S. House,1,LIB,Kerry Burt,0
-Decatur,Oberlin City 1,U.S. House,1,LIB,Kerry Burt,11
-Decatur,Oberlin City 2,U.S. House,1,LIB,Kerry Burt,9
-Decatur,Advance,U.S. House,1,LIB,Kerry Burt,16
-Decatur,Custer,U.S. House,1,IND,Alan LaPolice,2
-Decatur,Lyon,U.S. House,1,IND,Alan LaPolice,3
-Decatur,Dresden Twp/DC,U.S. House,1,IND,Alan LaPolice,9
-Decatur,Allison,U.S. House,1,IND,Alan LaPolice,3
-Decatur,Pleasant Valley/CC,U.S. House,1,IND,Alan LaPolice,6
-Decatur,Jennings Twp/JC,U.S. House,1,IND,Alan LaPolice,21
-Decatur,Garfield,U.S. House,1,IND,Alan LaPolice,2
-Decatur,Grant,U.S. House,1,IND,Alan LaPolice,0
-Decatur,Lincoln/NC,U.S. House,1,IND,Alan LaPolice,16
-Decatur,Beaver,U.S. House,1,IND,Alan LaPolice,1
-Decatur,Finley,U.S. House,1,IND,Alan LaPolice,1
-Decatur,Harlan,U.S. House,1,IND,Alan LaPolice,1
-Decatur,Liberty,U.S. House,1,IND,Alan LaPolice,2
-Decatur,Logan,U.S. House,1,IND,Alan LaPolice,2
-Decatur,Olive,U.S. House,1,IND,Alan LaPolice,3
-Decatur,Roosevelt,U.S. House,1,IND,Alan LaPolice,0
-Decatur,Sherman,U.S. House,1,IND,Alan LaPolice,2
-Decatur,Altory,U.S. House,1,IND,Alan LaPolice,1
-Decatur,Bassettville,U.S. House,1,IND,Alan LaPolice,1
-Decatur,Center,U.S. House,1,IND,Alan LaPolice,3
-Decatur,Cook,U.S. House,1,IND,Alan LaPolice,0
-Decatur,Oberlin,U.S. House,1,IND,Alan LaPolice,9
-Decatur,Prairie Dog,U.S. House,1,IND,Alan LaPolice,1
-Decatur,Sappa,U.S. House,1,IND,Alan LaPolice,3
-Decatur,Summit,U.S. House,1,IND,Alan LaPolice,0
-Decatur,Oberlin City 1,U.S. House,1,IND,Alan LaPolice,47
-Decatur,Oberlin City 2,U.S. House,1,IND,Alan LaPolice,48
-Decatur,Advance,U.S. House,1,IND,Alan LaPolice,68
-Decatur,Custer,U.S. House,1,REP,Roger Marshall,13
-Decatur,Lyon,U.S. House,1,REP,Roger Marshall,4
-Decatur,Dresden Twp/DC,U.S. House,1,REP,Roger Marshall,26
-Decatur,Allison,U.S. House,1,REP,Roger Marshall,11
-Decatur,Pleasant Valley/CC,U.S. House,1,REP,Roger Marshall,10
-Decatur,Jennings Twp/JC,U.S. House,1,REP,Roger Marshall,35
-Decatur,Garfield,U.S. House,1,REP,Roger Marshall,14
-Decatur,Grant,U.S. House,1,REP,Roger Marshall,6
-Decatur,Lincoln/NC,U.S. House,1,REP,Roger Marshall,43
-Decatur,Beaver,U.S. House,1,REP,Roger Marshall,20
-Decatur,Finley,U.S. House,1,REP,Roger Marshall,14
-Decatur,Harlan,U.S. House,1,REP,Roger Marshall,9
-Decatur,Liberty,U.S. House,1,REP,Roger Marshall,20
-Decatur,Logan,U.S. House,1,REP,Roger Marshall,9
-Decatur,Olive,U.S. House,1,REP,Roger Marshall,15
-Decatur,Roosevelt,U.S. House,1,REP,Roger Marshall,6
-Decatur,Sherman,U.S. House,1,REP,Roger Marshall,8
-Decatur,Altory,U.S. House,1,REP,Roger Marshall,8
-Decatur,Bassettville,U.S. House,1,REP,Roger Marshall,11
-Decatur,Center,U.S. House,1,REP,Roger Marshall,24
-Decatur,Cook,U.S. House,1,REP,Roger Marshall,10
-Decatur,Oberlin,U.S. House,1,REP,Roger Marshall,31
-Decatur,Prairie Dog,U.S. House,1,REP,Roger Marshall,16
-Decatur,Sappa,U.S. House,1,REP,Roger Marshall,11
-Decatur,Summit,U.S. House,1,REP,Roger Marshall,12
-Decatur,Oberlin City 1,U.S. House,1,REP,Roger Marshall,225
-Decatur,Oberlin City 2,U.S. House,1,REP,Roger Marshall,250
-Decatur,Advance,U.S. House,1,REP,Roger Marshall,223
-Decatur,Advance,U.S. House,1,,Tim Huelskamp write in,2
-Decatur,Custer,State Senate,40,REP,"Richard ""Rick"" Billinger",14
-Decatur,Lyon,State Senate,40,REP,"Richard ""Rick"" Billinger",3
-Decatur,Dresden Twp/DC,State Senate,40,REP,"Richard ""Rick"" Billinger",34
-Decatur,Allison,State Senate,40,REP,"Richard ""Rick"" Billinger",9
-Decatur,Pleasant Valley/CC,State Senate,40,REP,"Richard ""Rick"" Billinger",14
-Decatur,Jennings Twp/JC,State Senate,40,REP,"Richard ""Rick"" Billinger",46
-Decatur,Garfield,State Senate,40,REP,"Richard ""Rick"" Billinger",12
-Decatur,Grant,State Senate,40,REP,"Richard ""Rick"" Billinger",5
-Decatur,Lincoln/NC,State Senate,40,REP,"Richard ""Rick"" Billinger",52
-Decatur,Beaver,State Senate,40,REP,"Richard ""Rick"" Billinger",20
-Decatur,Finley,State Senate,40,REP,"Richard ""Rick"" Billinger",14
-Decatur,Harlan,State Senate,40,REP,"Richard ""Rick"" Billinger",10
-Decatur,Liberty,State Senate,40,REP,"Richard ""Rick"" Billinger",21
-Decatur,Logan,State Senate,40,REP,"Richard ""Rick"" Billinger",12
-Decatur,Olive,State Senate,40,REP,"Richard ""Rick"" Billinger",19
-Decatur,Roosevelt,State Senate,40,REP,"Richard ""Rick"" Billinger",5
-Decatur,Sherman,State Senate,40,REP,"Richard ""Rick"" Billinger",11
-Decatur,Altory,State Senate,40,REP,"Richard ""Rick"" Billinger",8
-Decatur,Bassettville,State Senate,40,REP,"Richard ""Rick"" Billinger",11
-Decatur,Center,State Senate,40,REP,"Richard ""Rick"" Billinger",26
-Decatur,Cook,State Senate,40,REP,"Richard ""Rick"" Billinger",10
-Decatur,Oberlin,State Senate,40,REP,"Richard ""Rick"" Billinger",35
-Decatur,Prairie Dog,State Senate,40,REP,"Richard ""Rick"" Billinger",17
-Decatur,Sappa,State Senate,40,REP,"Richard ""Rick"" Billinger",15
-Decatur,Summit,State Senate,40,REP,"Richard ""Rick"" Billinger",10
-Decatur,Oberlin City 1,State Senate,40,REP,"Richard ""Rick"" Billinger",237
-Decatur,Oberlin City 2,State Senate,40,REP,"Richard ""Rick"" Billinger",272
-Decatur,Advance,State Senate,40,REP,"Richard ""Rick"" Billinger",246
-Decatur,Custer,State Senate,40,DEM,Alex Herman,1
-Decatur,Lyon,State Senate,40,DEM,Alex Herman,3
-Decatur,Dresden Twp/DC,State Senate,40,DEM,Alex Herman,5
-Decatur,Allison,State Senate,40,DEM,Alex Herman,4
-Decatur,Pleasant Valley/CC,State Senate,40,DEM,Alex Herman,1
-Decatur,Jennings Twp/JC,State Senate,40,DEM,Alex Herman,15
-Decatur,Garfield,State Senate,40,DEM,Alex Herman,5
-Decatur,Grant,State Senate,40,DEM,Alex Herman,0
-Decatur,Lincoln/NC,State Senate,40,DEM,Alex Herman,14
-Decatur,Beaver,State Senate,40,DEM,Alex Herman,1
-Decatur,Finley,State Senate,40,DEM,Alex Herman,1
-Decatur,Harlan,State Senate,40,DEM,Alex Herman,1
-Decatur,Liberty,State Senate,40,DEM,Alex Herman,1
-Decatur,Logan,State Senate,40,DEM,Alex Herman,0
-Decatur,Olive,State Senate,40,DEM,Alex Herman,3
-Decatur,Roosevelt,State Senate,40,DEM,Alex Herman,2
-Decatur,Sherman,State Senate,40,DEM,Alex Herman,0
-Decatur,Altory,State Senate,40,DEM,Alex Herman,0
-Decatur,Bassettville,State Senate,40,DEM,Alex Herman,1
-Decatur,Center,State Senate,40,DEM,Alex Herman,2
-Decatur,Cook,State Senate,40,DEM,Alex Herman,0
-Decatur,Oberlin,State Senate,40,DEM,Alex Herman,6
-Decatur,Prairie Dog,State Senate,40,DEM,Alex Herman,0
-Decatur,Sappa,State Senate,40,DEM,Alex Herman,0
-Decatur,Summit,State Senate,40,DEM,Alex Herman,2
-Decatur,Oberlin City 1,State Senate,40,DEM,Alex Herman,40
-Decatur,Oberlin City 2,State Senate,40,DEM,Alex Herman,39
-Decatur,Advance,State Senate,40,DEM,Alex Herman,64
-Decatur,Custer,State House,120,REP,Adam Smith,14
-Decatur,Lyon,State House,120,REP,Adam Smith,3
-Decatur,Dresden Twp/DC,State House,120,REP,Adam Smith,30
-Decatur,Allison,State House,120,REP,Adam Smith,10
-Decatur,Pleasant Valley/CC,State House,120,REP,Adam Smith,15
-Decatur,Jennings Twp/JC,State House,120,REP,Adam Smith,42
-Decatur,Garfield,State House,120,REP,Adam Smith,11
-Decatur,Grant,State House,120,REP,Adam Smith,4
-Decatur,Lincoln/NC,State House,120,REP,Adam Smith,50
-Decatur,Beaver,State House,120,REP,Adam Smith,20
-Decatur,Finley,State House,120,REP,Adam Smith,15
-Decatur,Harlan,State House,120,REP,Adam Smith,7
-Decatur,Liberty,State House,120,REP,Adam Smith,20
-Decatur,Logan,State House,120,REP,Adam Smith,12
-Decatur,Olive,State House,120,REP,Adam Smith,20
-Decatur,Roosevelt,State House,120,REP,Adam Smith,6
-Decatur,Sherman,State House,120,REP,Adam Smith,10
-Decatur,Altory,State House,120,REP,Adam Smith,8
-Decatur,Bassettville,State House,120,REP,Adam Smith,11
-Decatur,Center,State House,120,REP,Adam Smith,25
-Decatur,Cook,State House,120,REP,Adam Smith,10
-Decatur,Oberlin,State House,120,REP,Adam Smith,37
-Decatur,Prairie Dog,State House,120,REP,Adam Smith,16
-Decatur,Sappa,State House,120,REP,Adam Smith,15
-Decatur,Summit,State House,120,REP,Adam Smith,10
-Decatur,Oberlin City 1,State House,120,REP,Adam Smith,229
-Decatur,Oberlin City 2,State House,120,REP,Adam Smith,252
-Decatur,Advance,State House,120,REP,Adam Smith,228
-Decatur,Custer,State House,120,DEM,Bonita L Peterson,1
-Decatur,Lyon,State House,120,DEM,Bonita L Peterson,2
-Decatur,Dresden Twp/DC,State House,120,DEM,Bonita L Peterson,6
-Decatur,Allison,State House,120,DEM,Bonita L Peterson,3
-Decatur,Pleasant Valley/CC,State House,120,DEM,Bonita L Peterson,1
-Decatur,Jennings Twp/JC,State House,120,DEM,Bonita L Peterson,20
-Decatur,Garfield,State House,120,DEM,Bonita L Peterson,6
-Decatur,Grant,State House,120,DEM,Bonita L Peterson,0
-Decatur,Lincoln/NC,State House,120,DEM,Bonita L Peterson,15
-Decatur,Beaver,State House,120,DEM,Bonita L Peterson,1
-Decatur,Finley,State House,120,DEM,Bonita L Peterson,0
-Decatur,Harlan,State House,120,DEM,Bonita L Peterson,2
-Decatur,Liberty,State House,120,DEM,Bonita L Peterson,4
-Decatur,Logan,State House,120,DEM,Bonita L Peterson,1
-Decatur,Olive,State House,120,DEM,Bonita L Peterson,1
-Decatur,Roosevelt,State House,120,DEM,Bonita L Peterson,1
-Decatur,Sherman,State House,120,DEM,Bonita L Peterson,1
-Decatur,Altory,State House,120,DEM,Bonita L Peterson,0
-Decatur,Bassettville,State House,120,DEM,Bonita L Peterson,1
-Decatur,Center,State House,120,DEM,Bonita L Peterson,4
-Decatur,Cook,State House,120,DEM,Bonita L Peterson,0
-Decatur,Oberlin,State House,120,DEM,Bonita L Peterson,5
-Decatur,Prairie Dog,State House,120,DEM,Bonita L Peterson,1
-Decatur,Sappa,State House,120,DEM,Bonita L Peterson,0
-Decatur,Summit,State House,120,DEM,Bonita L Peterson,2
-Decatur,Oberlin City 1,State House,120,DEM,Bonita L Peterson,48
-Decatur,Oberlin City 2,State House,120,DEM,Bonita L Peterson,56
-Decatur,Advance,State House,120,DEM,Bonita L Peterson,80
-Decatur,Custer,Dist. Court Judge,,REP,Preston A Pratt,8
-Decatur,Lyon,Dist. Court Judge,,REP,Preston A Pratt,5
-Decatur,Dresden Twp/DC,Dist. Court Judge,,REP,Preston A Pratt,32
-Decatur,Allison,Dist. Court Judge,,REP,Preston A Pratt,13
-Decatur,Pleasant Valley/CC,Dist. Court Judge,,REP,Preston A Pratt,14
-Decatur,Jennings Twp/JC,Dist. Court Judge,,REP,Preston A Pratt,57
-Decatur,Garfield,Dist. Court Judge,,REP,Preston A Pratt,17
-Decatur,Grant,Dist. Court Judge,,REP,Preston A Pratt,6
-Decatur,Lincoln/NC,Dist. Court Judge,,REP,Preston A Pratt,59
-Decatur,Beaver,Dist. Court Judge,,REP,Preston A Pratt,20
-Decatur,Finley,Dist. Court Judge,,REP,Preston A Pratt,15
-Decatur,Harlan,Dist. Court Judge,,REP,Preston A Pratt,11
-Decatur,Liberty,Dist. Court Judge,,REP,Preston A Pratt,22
-Decatur,Logan,Dist. Court Judge,,REP,Preston A Pratt,12
-Decatur,Olive,Dist. Court Judge,,REP,Preston A Pratt,22
-Decatur,Roosevelt,Dist. Court Judge,,REP,Preston A Pratt,7
-Decatur,Sherman,Dist. Court Judge,,REP,Preston A Pratt,11
-Decatur,Altory,Dist. Court Judge,,REP,Preston A Pratt,8
-Decatur,Bassettville,Dist. Court Judge,,REP,Preston A Pratt,12
-Decatur,Center,Dist. Court Judge,,REP,Preston A Pratt,24
-Decatur,Cook,Dist. Court Judge,,REP,Preston A Pratt,10
-Decatur,Oberlin,Dist. Court Judge,,REP,Preston A Pratt,37
-Decatur,Prairie Dog,Dist. Court Judge,,REP,Preston A Pratt,15
-Decatur,Sappa,Dist. Court Judge,,REP,Preston A Pratt,15
-Decatur,Summit,Dist. Court Judge,,REP,Preston A Pratt,11
-Decatur,Oberlin City 1,Dist. Court Judge,,REP,Preston A Pratt,259
-Decatur,Oberlin City 2,Dist. Court Judge,,REP,Preston A Pratt,285
-Decatur,Advance,Dist. Court Judge,,REP,Preston A Pratt,284
-Decatur,Altory,Dist. Court Judge,,,Homer Simpson write in,1
-Decatur,Dresden Twp/DC,Dist. Court Judge,,,Steve Hirsch write in,1
-Decatur,Jennings Twp/JC,Dist. Court Judge,,,Daniel Coffman write in,2
-Decatur,Custer,Dist. Mag. Judge,,,Jay E Tate,12
-Decatur,Lyon,Dist. Mag. Judge,,,Jay E Tate,5
-Decatur,Dresden Twp/DC,Dist. Mag. Judge,,,Jay E Tate,33
-Decatur,Allison,Dist. Mag. Judge,,,Jay E Tate,11
-Decatur,Pleasant Valley/CC,Dist. Mag. Judge,,,Jay E Tate,15
-Decatur,Jennings Twp/JC,Dist. Mag. Judge,,,Jay E Tate,56
-Decatur,Garfield,Dist. Mag. Judge,,,Jay E Tate,17
-Decatur,Grant,Dist. Mag. Judge,,,Jay E Tate,5
-Decatur,Lincoln/NC,Dist. Mag. Judge,,,Jay E Tate,59
-Decatur,Beaver,Dist. Mag. Judge,,,Jay E Tate,21
-Decatur,Finley,Dist. Mag. Judge,,,Jay E Tate,15
-Decatur,Harlan,Dist. Mag. Judge,,,Jay E Tate,9
-Decatur,Liberty,Dist. Mag. Judge,,,Jay E Tate,23
-Decatur,Logan,Dist. Mag. Judge,,,Jay E Tate,13
-Decatur,Olive,Dist. Mag. Judge,,,Jay E Tate,22
-Decatur,Roosevelt,Dist. Mag. Judge,,,Jay E Tate,7
-Decatur,Sherman,Dist. Mag. Judge,,,Jay E Tate,11
-Decatur,Altory,Dist. Mag. Judge,,,Jay E Tate,9
-Decatur,Bassettville,Dist. Mag. Judge,,,Jay E Tate,11
-Decatur,Center,Dist. Mag. Judge,,,Jay E Tate,26
-Decatur,Cook,Dist. Mag. Judge,,,Jay E Tate,10
-Decatur,Oberlin,Dist. Mag. Judge,,,Jay E Tate,38
-Decatur,Prairie Dog,Dist. Mag. Judge,,,Jay E Tate,16
-Decatur,Sappa,Dist. Mag. Judge,,,Jay E Tate,15
-Decatur,Summit,Dist. Mag. Judge,,,Jay E Tate,10
-Decatur,Oberlin City 1,Dist. Mag. Judge,,,Jay E Tate,267
-Decatur,Oberlin City 2,Dist. Mag. Judge,,,Jay E Tate,296
-Decatur,Advance,Dist. Mag. Judge,,,Jay E Tate,293
-Decatur,Custer,Dist. Mag. Judge,,,Andy May write in,1
-Decatur,Jennings Twp/JC,Dist. Mag. Judge,,,Daniel Coffman write in,2
+county,precinct,office,district,party,candidate,votes,vtd
+DECATUR,Allison Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",4,000010
+DECATUR,Allison Township,Kansas House of Representatives,120,Republican,"Smith, Adam",11,000010
+DECATUR,Altory Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000020
+DECATUR,Altory Township,Kansas House of Representatives,120,Republican,"Smith, Adam",9,000020
+DECATUR,Bassettville Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000030
+DECATUR,Bassettville Township,Kansas House of Representatives,120,Republican,"Smith, Adam",14,000030
+DECATUR,Beaver Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000040
+DECATUR,Beaver Township,Kansas House of Representatives,120,Republican,"Smith, Adam",25,000040
+DECATUR,Center Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",6,000050
+DECATUR,Center Township,Kansas House of Representatives,120,Republican,"Smith, Adam",28,000050
+DECATUR,Cook Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000060
+DECATUR,Cook Township,Kansas House of Representatives,120,Republican,"Smith, Adam",11,000060
+DECATUR,Custer Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000070
+DECATUR,Custer Township,Kansas House of Representatives,120,Republican,"Smith, Adam",17,000070
+DECATUR,Dresden Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",13,000080
+DECATUR,Dresden Township,Kansas House of Representatives,120,Republican,"Smith, Adam",43,000080
+DECATUR,Finley Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000090
+DECATUR,Finley Township,Kansas House of Representatives,120,Republican,"Smith, Adam",20,000090
+DECATUR,Garfield Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",10,000100
+DECATUR,Garfield Township,Kansas House of Representatives,120,Republican,"Smith, Adam",12,000100
+DECATUR,Grant Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000110
+DECATUR,Grant Township,Kansas House of Representatives,120,Republican,"Smith, Adam",4,000110
+DECATUR,Harlan Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000120
+DECATUR,Harlan Township,Kansas House of Representatives,120,Republican,"Smith, Adam",10,000120
+DECATUR,Jennings Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",21,000130
+DECATUR,Jennings Township,Kansas House of Representatives,120,Republican,"Smith, Adam",47,000130
+DECATUR,Liberty Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",4,000140
+DECATUR,Liberty Township,Kansas House of Representatives,120,Republican,"Smith, Adam",28,000140
+DECATUR,Lincoln Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",20,000150
+DECATUR,Lincoln Township,Kansas House of Representatives,120,Republican,"Smith, Adam",63,000150
+DECATUR,Logan Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000160
+DECATUR,Logan Township,Kansas House of Representatives,120,Republican,"Smith, Adam",17,000160
+DECATUR,Lyon Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000170
+DECATUR,Lyon Township,Kansas House of Representatives,120,Republican,"Smith, Adam",3,000170
+DECATUR,Oberlin City Precinct 1,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",70,000180
+DECATUR,Oberlin City Precinct 1,Kansas House of Representatives,120,Republican,"Smith, Adam",298,000180
+DECATUR,Oberlin City Precinct 2,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",84,00019A
+DECATUR,Oberlin City Precinct 2,Kansas House of Representatives,120,Republican,"Smith, Adam",314,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas House of Representatives,120,Republican,"Smith, Adam",0,00019B
+DECATUR,Oberlin Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",9,000200
+DECATUR,Oberlin Township,Kansas House of Representatives,120,Republican,"Smith, Adam",43,000200
+DECATUR,Olive Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000210
+DECATUR,Olive Township,Kansas House of Representatives,120,Republican,"Smith, Adam",27,000210
+DECATUR,Pleasant Valley Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000220
+DECATUR,Pleasant Valley Township,Kansas House of Representatives,120,Republican,"Smith, Adam",18,000220
+DECATUR,Prairie Dog Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000230
+DECATUR,Prairie Dog Township,Kansas House of Representatives,120,Republican,"Smith, Adam",17,000230
+DECATUR,Roosevelt Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000240
+DECATUR,Roosevelt Township,Kansas House of Representatives,120,Republican,"Smith, Adam",7,000240
+DECATUR,Sappa Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000250
+DECATUR,Sappa Township,Kansas House of Representatives,120,Republican,"Smith, Adam",22,000250
+DECATUR,Sherman Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000260
+DECATUR,Sherman Township,Kansas House of Representatives,120,Republican,"Smith, Adam",10,000260
+DECATUR,Summit Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000270
+DECATUR,Summit Township,Kansas House of Representatives,120,Republican,"Smith, Adam",12,000270
+DECATUR,Allison Township,Kansas Senate,40,Democratic,"Herman, Alex",5,000010
+DECATUR,Allison Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",10,000010
+DECATUR,Altory Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000020
+DECATUR,Altory Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",8,000020
+DECATUR,Bassettville Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000030
+DECATUR,Bassettville Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",14,000030
+DECATUR,Beaver Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000040
+DECATUR,Beaver Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",25,000040
+DECATUR,Center Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000050
+DECATUR,Center Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",30,000050
+DECATUR,Cook Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000060
+DECATUR,Cook Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",11,000060
+DECATUR,Custer Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000070
+DECATUR,Custer Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",18,000070
+DECATUR,Dresden Township,Kansas Senate,40,Democratic,"Herman, Alex",11,000080
+DECATUR,Dresden Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",48,000080
+DECATUR,Finley Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000090
+DECATUR,Finley Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",19,000090
+DECATUR,Garfield Township,Kansas Senate,40,Democratic,"Herman, Alex",9,000100
+DECATUR,Garfield Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",13,000100
+DECATUR,Grant Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000110
+DECATUR,Grant Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",5,000110
+DECATUR,Harlan Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000120
+DECATUR,Harlan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",13,000120
+DECATUR,Jennings Township,Kansas Senate,40,Democratic,"Herman, Alex",16,000130
+DECATUR,Jennings Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",51,000130
+DECATUR,Liberty Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000140
+DECATUR,Liberty Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",28,000140
+DECATUR,Lincoln Township,Kansas Senate,40,Democratic,"Herman, Alex",15,000150
+DECATUR,Lincoln Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",69,000150
+DECATUR,Logan Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000160
+DECATUR,Logan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",17,000160
+DECATUR,Lyon Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000170
+DECATUR,Lyon Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",3,000170
+DECATUR,Oberlin City Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",60,000180
+DECATUR,Oberlin City Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",309,000180
+DECATUR,Oberlin City Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",59,00019A
+DECATUR,Oberlin City Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",343,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas Senate,40,Democratic,"Herman, Alex",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,00019B
+DECATUR,Oberlin Township,Kansas Senate,40,Democratic,"Herman, Alex",10,000200
+DECATUR,Oberlin Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",41,000200
+DECATUR,Olive Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000210
+DECATUR,Olive Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",27,000210
+DECATUR,Pleasant Valley Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000220
+DECATUR,Pleasant Valley Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",17,000220
+DECATUR,Prairie Dog Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000230
+DECATUR,Prairie Dog Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",19,000230
+DECATUR,Roosevelt Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000240
+DECATUR,Roosevelt Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",6,000240
+DECATUR,Sappa Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000250
+DECATUR,Sappa Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",21,000250
+DECATUR,Sherman Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000260
+DECATUR,Sherman Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",11,000260
+DECATUR,Summit Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000270
+DECATUR,Summit Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",12,000270
+DECATUR,Allison Township,President / Vice President,,independent,"Stein, Jill",3,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+DECATUR,Allison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+DECATUR,Allison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000010
+DECATUR,Allison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+DECATUR,Allison Township,President / Vice President,,Republican,"Trump, Donald J.",13,000010
+DECATUR,Altory Township,President / Vice President,,independent,"Stein, Jill",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+DECATUR,Altory Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+DECATUR,Altory Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+DECATUR,Altory Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+DECATUR,Altory Township,President / Vice President,,Republican,"Trump, Donald J.",8,000020
+DECATUR,Bassettville Township,President / Vice President,,independent,"Stein, Jill",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+DECATUR,Bassettville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+DECATUR,Bassettville Township,President / Vice President,,Republican,"Trump, Donald J.",14,000030
+DECATUR,Beaver Township,President / Vice President,,independent,"Stein, Jill",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+DECATUR,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+DECATUR,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000040
+DECATUR,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+DECATUR,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",27,000040
+DECATUR,Center Township,President / Vice President,,independent,"Stein, Jill",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+DECATUR,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+DECATUR,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000050
+DECATUR,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+DECATUR,Center Township,President / Vice President,,Republican,"Trump, Donald J.",33,000050
+DECATUR,Cook Township,President / Vice President,,independent,"Stein, Jill",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+DECATUR,Cook Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+DECATUR,Cook Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000060
+DECATUR,Cook Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+DECATUR,Cook Township,President / Vice President,,Republican,"Trump, Donald J.",12,000060
+DECATUR,Custer Township,President / Vice President,,independent,"Stein, Jill",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+DECATUR,Custer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+DECATUR,Custer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000070
+DECATUR,Custer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+DECATUR,Custer Township,President / Vice President,,Republican,"Trump, Donald J.",19,000070
+DECATUR,Dresden Township,President / Vice President,,independent,"Stein, Jill",1,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Castle, Darrell L",1,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+DECATUR,Dresden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+DECATUR,Dresden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000080
+DECATUR,Dresden Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+DECATUR,Dresden Township,President / Vice President,,Republican,"Trump, Donald J.",51,000080
+DECATUR,Finley Township,President / Vice President,,independent,"Stein, Jill",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+DECATUR,Finley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+DECATUR,Finley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000090
+DECATUR,Finley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+DECATUR,Finley Township,President / Vice President,,Republican,"Trump, Donald J.",19,000090
+DECATUR,Garfield Township,President / Vice President,,independent,"Stein, Jill",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+DECATUR,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+DECATUR,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000100
+DECATUR,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+DECATUR,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",16,000100
+DECATUR,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+DECATUR,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+DECATUR,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000110
+DECATUR,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+DECATUR,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",7,000110
+DECATUR,Harlan Township,President / Vice President,,independent,"Stein, Jill",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+DECATUR,Harlan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+DECATUR,Harlan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+DECATUR,Harlan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+DECATUR,Harlan Township,President / Vice President,,Republican,"Trump, Donald J.",14,000120
+DECATUR,Jennings Township,President / Vice President,,independent,"Stein, Jill",2,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"McMullin, Evan",1,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+DECATUR,Jennings Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+DECATUR,Jennings Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000130
+DECATUR,Jennings Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+DECATUR,Jennings Township,President / Vice President,,Republican,"Trump, Donald J.",47,000130
+DECATUR,Liberty Township,President / Vice President,,independent,"Stein, Jill",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+DECATUR,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+DECATUR,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000140
+DECATUR,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+DECATUR,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",30,000140
+DECATUR,Lincoln Township,President / Vice President,,independent,"Stein, Jill",1,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+DECATUR,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+DECATUR,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000150
+DECATUR,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000150
+DECATUR,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",70,000150
+DECATUR,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+DECATUR,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+DECATUR,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000160
+DECATUR,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+DECATUR,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",18,000160
+DECATUR,Lyon Township,President / Vice President,,independent,"Stein, Jill",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+DECATUR,Lyon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+DECATUR,Lyon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000170
+DECATUR,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+DECATUR,Lyon Township,President / Vice President,,Republican,"Trump, Donald J.",4,000170
+DECATUR,Oberlin City Precinct 1,President / Vice President,,independent,"Stein, Jill",8,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000180
+DECATUR,Oberlin City Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",312,000180
+DECATUR,Oberlin City Precinct 2,President / Vice President,,independent,"Stein, Jill",1,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,00019A
+DECATUR,Oberlin City Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",344,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00019B
+DECATUR,Oberlin Township,President / Vice President,,independent,"Stein, Jill",3,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+DECATUR,Oberlin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+DECATUR,Oberlin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000200
+DECATUR,Oberlin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+DECATUR,Oberlin Township,President / Vice President,,Republican,"Trump, Donald J.",44,000200
+DECATUR,Olive Township,President / Vice President,,independent,"Stein, Jill",1,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+DECATUR,Olive Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+DECATUR,Olive Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000210
+DECATUR,Olive Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+DECATUR,Olive Township,President / Vice President,,Republican,"Trump, Donald J.",25,000210
+DECATUR,Pleasant Valley Township,President / Vice President,,independent,"Stein, Jill",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+DECATUR,Pleasant Valley Township,President / Vice President,,Republican,"Trump, Donald J.",14,000220
+DECATUR,Prairie Dog Township,President / Vice President,,independent,"Stein, Jill",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+DECATUR,Prairie Dog Township,President / Vice President,,Republican,"Trump, Donald J.",20,000230
+DECATUR,Roosevelt Township,President / Vice President,,independent,"Stein, Jill",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000240
+DECATUR,Roosevelt Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+DECATUR,Roosevelt Township,President / Vice President,,Republican,"Trump, Donald J.",7,000240
+DECATUR,Sappa Township,President / Vice President,,independent,"Stein, Jill",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+DECATUR,Sappa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+DECATUR,Sappa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000250
+DECATUR,Sappa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+DECATUR,Sappa Township,President / Vice President,,Republican,"Trump, Donald J.",22,000250
+DECATUR,Sherman Township,President / Vice President,,independent,"Stein, Jill",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+DECATUR,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+DECATUR,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000260
+DECATUR,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+DECATUR,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",10,000260
+DECATUR,Summit Township,President / Vice President,,independent,"Stein, Jill",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+DECATUR,Summit Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+DECATUR,Summit Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000270
+DECATUR,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000270
+DECATUR,Summit Township,President / Vice President,,Republican,"Trump, Donald J.",10,000270
+DECATUR,Allison Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000010
+DECATUR,Allison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+DECATUR,Allison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+DECATUR,Allison Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000010
+DECATUR,Altory Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000020
+DECATUR,Altory Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+DECATUR,Altory Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+DECATUR,Altory Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000020
+DECATUR,Bassettville Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000030
+DECATUR,Bassettville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+DECATUR,Bassettville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+DECATUR,Bassettville Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000030
+DECATUR,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000040
+DECATUR,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+DECATUR,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+DECATUR,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000040
+DECATUR,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000050
+DECATUR,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+DECATUR,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+DECATUR,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000050
+DECATUR,Cook Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000060
+DECATUR,Cook Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+DECATUR,Cook Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+DECATUR,Cook Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000060
+DECATUR,Custer Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000070
+DECATUR,Custer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+DECATUR,Custer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000070
+DECATUR,Custer Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000070
+DECATUR,Dresden Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000080
+DECATUR,Dresden Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+DECATUR,Dresden Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000080
+DECATUR,Dresden Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000080
+DECATUR,Finley Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000090
+DECATUR,Finley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+DECATUR,Finley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+DECATUR,Finley Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000090
+DECATUR,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000100
+DECATUR,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+DECATUR,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+DECATUR,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000100
+DECATUR,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000110
+DECATUR,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+DECATUR,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+DECATUR,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",6,000110
+DECATUR,Harlan Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000120
+DECATUR,Harlan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+DECATUR,Harlan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+DECATUR,Harlan Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000120
+DECATUR,Jennings Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000130
+DECATUR,Jennings Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+DECATUR,Jennings Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000130
+DECATUR,Jennings Township,United States House of Representatives,1,Republican,"Marshall, Roger",38,000130
+DECATUR,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000140
+DECATUR,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+DECATUR,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+DECATUR,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000140
+DECATUR,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000150
+DECATUR,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+DECATUR,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000150
+DECATUR,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000150
+DECATUR,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000160
+DECATUR,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+DECATUR,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000160
+DECATUR,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000160
+DECATUR,Lyon Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000170
+DECATUR,Lyon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+DECATUR,Lyon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+DECATUR,Lyon Township,United States House of Representatives,1,Republican,"Marshall, Roger",4,000170
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",65,000180
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000180
+DECATUR,Oberlin City Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",292,000180
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",70,00019A
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00019A
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,00019A
+DECATUR,Oberlin City Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",313,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00019B
+DECATUR,Oberlin Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000200
+DECATUR,Oberlin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+DECATUR,Oberlin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000200
+DECATUR,Oberlin Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000200
+DECATUR,Olive Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000210
+DECATUR,Olive Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+DECATUR,Olive Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000210
+DECATUR,Olive Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000210
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000220
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+DECATUR,Pleasant Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000220
+DECATUR,Prairie Dog Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000230
+DECATUR,Prairie Dog Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+DECATUR,Prairie Dog Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000230
+DECATUR,Prairie Dog Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000230
+DECATUR,Roosevelt Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000240
+DECATUR,Roosevelt Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+DECATUR,Roosevelt Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000240
+DECATUR,Roosevelt Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000240
+DECATUR,Sappa Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000250
+DECATUR,Sappa Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+DECATUR,Sappa Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000250
+DECATUR,Sappa Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000250
+DECATUR,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000260
+DECATUR,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+DECATUR,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000260
+DECATUR,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000260
+DECATUR,Summit Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000270
+DECATUR,Summit Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+DECATUR,Summit Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000270
+DECATUR,Summit Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000270
+DECATUR,Allison Township,United States Senate,,write - in,"Smith, DJ",0,000010
+DECATUR,Allison Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+DECATUR,Allison Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+DECATUR,Allison Township,United States Senate,,Republican,"Moran, Jerry",11,000010
+DECATUR,Altory Township,United States Senate,,write - in,"Smith, DJ",0,000020
+DECATUR,Altory Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+DECATUR,Altory Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+DECATUR,Altory Township,United States Senate,,Republican,"Moran, Jerry",9,000020
+DECATUR,Bassettville Township,United States Senate,,write - in,"Smith, DJ",0,000030
+DECATUR,Bassettville Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000030
+DECATUR,Bassettville Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+DECATUR,Bassettville Township,United States Senate,,Republican,"Moran, Jerry",15,000030
+DECATUR,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000040
+DECATUR,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+DECATUR,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+DECATUR,Beaver Township,United States Senate,,Republican,"Moran, Jerry",26,000040
+DECATUR,Center Township,United States Senate,,write - in,"Smith, DJ",0,000050
+DECATUR,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000050
+DECATUR,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000050
+DECATUR,Center Township,United States Senate,,Republican,"Moran, Jerry",28,000050
+DECATUR,Cook Township,United States Senate,,write - in,"Smith, DJ",0,000060
+DECATUR,Cook Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+DECATUR,Cook Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+DECATUR,Cook Township,United States Senate,,Republican,"Moran, Jerry",12,000060
+DECATUR,Custer Township,United States Senate,,write - in,"Smith, DJ",0,000070
+DECATUR,Custer Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000070
+DECATUR,Custer Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+DECATUR,Custer Township,United States Senate,,Republican,"Moran, Jerry",19,000070
+DECATUR,Dresden Township,United States Senate,,write - in,"Smith, DJ",0,000080
+DECATUR,Dresden Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000080
+DECATUR,Dresden Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+DECATUR,Dresden Township,United States Senate,,Republican,"Moran, Jerry",47,000080
+DECATUR,Finley Township,United States Senate,,write - in,"Smith, DJ",0,000090
+DECATUR,Finley Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000090
+DECATUR,Finley Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000090
+DECATUR,Finley Township,United States Senate,,Republican,"Moran, Jerry",20,000090
+DECATUR,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000100
+DECATUR,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000100
+DECATUR,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+DECATUR,Garfield Township,United States Senate,,Republican,"Moran, Jerry",18,000100
+DECATUR,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000110
+DECATUR,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000110
+DECATUR,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+DECATUR,Grant Township,United States Senate,,Republican,"Moran, Jerry",6,000110
+DECATUR,Harlan Township,United States Senate,,write - in,"Smith, DJ",0,000120
+DECATUR,Harlan Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000120
+DECATUR,Harlan Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+DECATUR,Harlan Township,United States Senate,,Republican,"Moran, Jerry",12,000120
+DECATUR,Jennings Township,United States Senate,,write - in,"Smith, DJ",0,000130
+DECATUR,Jennings Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000130
+DECATUR,Jennings Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+DECATUR,Jennings Township,United States Senate,,Republican,"Moran, Jerry",50,000130
+DECATUR,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000140
+DECATUR,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000140
+DECATUR,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000140
+DECATUR,Liberty Township,United States Senate,,Republican,"Moran, Jerry",29,000140
+DECATUR,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000150
+DECATUR,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000150
+DECATUR,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000150
+DECATUR,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",66,000150
+DECATUR,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000160
+DECATUR,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000160
+DECATUR,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+DECATUR,Logan Township,United States Senate,,Republican,"Moran, Jerry",17,000160
+DECATUR,Lyon Township,United States Senate,,write - in,"Smith, DJ",0,000170
+DECATUR,Lyon Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000170
+DECATUR,Lyon Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000170
+DECATUR,Lyon Township,United States Senate,,Republican,"Moran, Jerry",5,000170
+DECATUR,Oberlin City Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000180
+DECATUR,Oberlin City Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",34,000180
+DECATUR,Oberlin City Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",12,000180
+DECATUR,Oberlin City Precinct 1,United States Senate,,Republican,"Moran, Jerry",328,000180
+DECATUR,Oberlin City Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00019A
+DECATUR,Oberlin City Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",37,00019A
+DECATUR,Oberlin City Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,00019A
+DECATUR,Oberlin City Precinct 2,United States Senate,,Republican,"Moran, Jerry",357,00019A
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00019B
+DECATUR,Oberlin City Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00019B
+DECATUR,Oberlin Township,United States Senate,,write - in,"Smith, DJ",0,000200
+DECATUR,Oberlin Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000200
+DECATUR,Oberlin Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000200
+DECATUR,Oberlin Township,United States Senate,,Republican,"Moran, Jerry",46,000200
+DECATUR,Olive Township,United States Senate,,write - in,"Smith, DJ",0,000210
+DECATUR,Olive Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000210
+DECATUR,Olive Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000210
+DECATUR,Olive Township,United States Senate,,Republican,"Moran, Jerry",29,000210
+DECATUR,Pleasant Valley Township,United States Senate,,write - in,"Smith, DJ",0,000220
+DECATUR,Pleasant Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000220
+DECATUR,Pleasant Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000220
+DECATUR,Pleasant Valley Township,United States Senate,,Republican,"Moran, Jerry",18,000220
+DECATUR,Prairie Dog Township,United States Senate,,write - in,"Smith, DJ",0,000230
+DECATUR,Prairie Dog Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000230
+DECATUR,Prairie Dog Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000230
+DECATUR,Prairie Dog Township,United States Senate,,Republican,"Moran, Jerry",18,000230
+DECATUR,Roosevelt Township,United States Senate,,write - in,"Smith, DJ",0,000240
+DECATUR,Roosevelt Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000240
+DECATUR,Roosevelt Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000240
+DECATUR,Roosevelt Township,United States Senate,,Republican,"Moran, Jerry",8,000240
+DECATUR,Sappa Township,United States Senate,,write - in,"Smith, DJ",0,000250
+DECATUR,Sappa Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000250
+DECATUR,Sappa Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000250
+DECATUR,Sappa Township,United States Senate,,Republican,"Moran, Jerry",21,000250
+DECATUR,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000260
+DECATUR,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000260
+DECATUR,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000260
+DECATUR,Sherman Township,United States Senate,,Republican,"Moran, Jerry",10,000260
+DECATUR,Summit Township,United States Senate,,write - in,"Smith, DJ",0,000270
+DECATUR,Summit Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000270
+DECATUR,Summit Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000270
+DECATUR,Summit Township,United States Senate,,Republican,"Moran, Jerry",12,000270

--- a/2016/20161108__ks__general__dickinson__precinct.csv
+++ b/2016/20161108__ks__general__dickinson__precinct.csv
@@ -1,519 +1,1407 @@
-county,precinct,office,district,party,candidate,votes
-Dickinson,AB W1,President,,REP,Trump/Pence,255
-Dickinson,AB W1,President,,DEM,Clinton/Kaine,94
-Dickinson,AB W1,President,,LBT,Johnson/Weld,25
-Dickinson,AB W1,President,,IND,Stein/Baraka,9
-Dickinson,AB W1,President,,,McMullin/Johnson,1
-Dickinson,AB W1,President,,,Castle/Bradley,2
-Dickinson,AB W1,President,,,Maturen/Munoz,1
-Dickinson,AB W1,President,,,Basiago/Kinnison,0
-Dickinson,AB W1,U.S. Senate,,REP,Jerry Moran,247
-Dickinson,AB W1,U.S. Senate,,DEM,Patrick Wiesner,93
-Dickinson,AB W1,U.S. Senate,,LBT,Robert Garrard,40
-Dickinson,AB W1,U.S. House,1,REP,Roger Marshall,205
-Dickinson,AB W1,U.S. House,1,IND,Alan LaPolice,119
-Dickinson,AB W1,U.S. House,1,LBT,Kerry Burt,47
-Dickinson,AB W1,U.S. House,1,,Tim Huelskamp,1
-Dickinson,AB W1,State Senate,24,REP,Randall Hardy,244
-Dickinson,AB W1,State Senate,24,DEM,Donald Merriam,119
-Dickinson,AB W1,State House,70,REP,John Barker,213
-Dickinson,AB W1,State House,70,DEM,Jo Schwartz,165
-Dickinson,AB W2,President,,REP,Trump/Pence,470
-Dickinson,AB W2,President,,DEM,Clinton/Kaine,154
-Dickinson,AB W2,President,,LBT,Johnson/Weld,44
-Dickinson,AB W2,President,,IND,Stein/Baraka,18
-Dickinson,AB W2,President,,,McMullin/Johnson,3
-Dickinson,AB W2,President,,,Castle/Bradley,1
-Dickinson,AB W2,President,,,Maturen/Munoz,0
-Dickinson,AB W2,President,,,Basiago/Kinnison,0
-Dickinson,AB W2,U.S. Senate,,REP,Jerry Moran,506
-Dickinson,AB W2,U.S. Senate,,DEM,Patrick Wiesner,119
-Dickinson,AB W2,U.S. Senate,,LBT,Robert Garrard,57
-Dickinson,AB W2,U.S. House,1,REP,Roger Marshall,417
-Dickinson,AB W2,U.S. House,1,IND,Alan LaPolice,202
-Dickinson,AB W2,U.S. House,1,LBT,Kerry Burt,55
-Dickinson,AB W2,State Senate,24,REP,Randall Hardy,493
-Dickinson,AB W2,State Senate,24,DEM,Donald Merriam,172
-Dickinson,AB W2,State House,70,REP,John Barker,406
-Dickinson,AB W2,State House,70,DEM,Jo Schwartz,282
-Dickinson,AB W3,President,,REP,Trump/Pence,251
-Dickinson,AB W3,President,,DEM,Clinton/Kaine,79
-Dickinson,AB W3,President,,LBT,Johnson/Weld,17
-Dickinson,AB W3,President,,IND,Stein/Baraka,10
-Dickinson,AB W3,President,,,McMullin/Johnson,0
-Dickinson,AB W3,President,,,Castle/Bradley,0
-Dickinson,AB W3,President,,,Maturen/Munoz,0
-Dickinson,AB W3,President,,,Basiago/Kinnison,0
-Dickinson,AB W3,U.S. Senate,,REP,Jerry Moran,274
-Dickinson,AB W3,U.S. Senate,,DEM,Patrick Wiesner,59
-Dickinson,AB W3,U.S. Senate,,LBT,Robert Garrard,25
-Dickinson,AB W3,U.S. House,1,REP,Roger Marshall,208
-Dickinson,AB W3,U.S. House,1,IND,Alan LaPolice,127
-Dickinson,AB W3,U.S. House,1,LBT,Kerry Burt,20
-Dickinson,AB W3,State Senate,24,REP,Randall Hardy,262
-Dickinson,AB W3,State Senate,24,DEM,Donald Merriam,87
-Dickinson,AB W3,State House,70,REP,John Barker,217
-Dickinson,AB W3,State House,70,DEM,Jo Schwartz,141
-Dickinson,AB W4-1,President,,REP,Trump/Pence,362
-Dickinson,AB W4-1,President,,DEM,Clinton/Kaine,155
-Dickinson,AB W4-1,President,,LBT,Johnson/Weld,40
-Dickinson,AB W4-1,President,,IND,Stein/Baraka,10
-Dickinson,AB W4-1,President,,,McMullin/Johnson,0
-Dickinson,AB W4-1,President,,,Castle/Bradley,0
-Dickinson,AB W4-1,President,,,Maturen/Munoz,0
-Dickinson,AB W4-1,President,,,Basiago/Kinnison,0
-Dickinson,AB W4-1,U.S. Senate,,REP,Jerry Moran,395
-Dickinson,AB W4-1,U.S. Senate,,DEM,Patrick Wiesner,135
-Dickinson,AB W4-1,U.S. Senate,,LBT,Robert Garrard,33
-Dickinson,AB W4-1,U.S. House,1,REP,Roger Marshall,315
-Dickinson,AB W4-1,U.S. House,1,IND,Alan LaPolice,196
-Dickinson,AB W4-1,U.S. House,1,LBT,Kerry Burt,41
-Dickinson,AB W4-1,State Senate,24,REP,Randall Hardy,368
-Dickinson,AB W4-1,State Senate,24,DEM,Donald Merriam,178
-Dickinson,AB W4-1,State House,70,REP,John Barker,306
-Dickinson,AB W4-1,State House,70,DEM,Jo Schwartz,263
-Dickinson,AB W4-2,President,,REP,Trump/Pence,490
-Dickinson,AB W4-2,President,,DEM,Clinton/Kaine,155
-Dickinson,AB W4-2,President,,LBT,Johnson/Weld,39
-Dickinson,AB W4-2,President,,IND,Stein/Baraka,13
-Dickinson,AB W4-2,President,,,McMullin/Johnson,0
-Dickinson,AB W4-2,President,,,Castle/Bradley,0
-Dickinson,AB W4-2,President,,,Maturen/Munoz,0
-Dickinson,AB W4-2,President,,,Basiago/Kinnison,0
-Dickinson,AB W4-2,U.S. Senate,,REP,Jerry Moran,546
-Dickinson,AB W4-2,U.S. Senate,,DEM,Patrick Wiesner,113
-Dickinson,AB W4-2,U.S. Senate,,LBT,Robert Garrard,42
-Dickinson,AB W4-2,U.S. House,1,REP,Roger Marshall,434
-Dickinson,AB W4-2,U.S. House,1,IND,Alan LaPolice,202
-Dickinson,AB W4-2,U.S. House,1,LBT,Kerry Burt,43
-Dickinson,AB W4-2,State Senate,24,REP,Randall Hardy,507
-Dickinson,AB W4-2,State Senate,24,DEM,Donald Merriam,166
-Dickinson,AB W4-2,State House,70,REP,John Barker,438
-Dickinson,AB W4-2,State House,70,DEM,Jo Schwartz,252
-Dickinson,Banner,President,,REP,Trump/Pence,41
-Dickinson,Banner,President,,DEM,Clinton/Kaine,6
-Dickinson,Banner,President,,LBT,Johnson/Weld,4
-Dickinson,Banner,President,,IND,Stein/Baraka,3
-Dickinson,Banner,U.S. Senate,,REP,Jerry Moran,46
-Dickinson,Banner,U.S. Senate,,DEM,Patrick Wiesner,5
-Dickinson,Banner,U.S. Senate,,LBT,Robert Garrard,3
-Dickinson,Banner,U.S. House,1,REP,Roger Marshall,29
-Dickinson,Banner,U.S. House,1,IND,Alan LaPolice,22
-Dickinson,Banner,U.S. House,1,LBT,Kerry Burt,2
-Dickinson,Banner,State Senate,35,REP,Richard Wilborn,43
-Dickinson,Banner,State Senate,35,DEM,Levi Morris,11
-Dickinson,Banner,State House,70,REP,John Barker,39
-Dickinson,Banner,State House,70,DEM,Jo Schwartz,12
-Dickinson,Buckeye,President,,REP,Trump/Pence,176
-Dickinson,Buckeye,President,,DEM,Clinton/Kaine,31
-Dickinson,Buckeye,President,,LBT,Johnson/Weld,11
-Dickinson,Buckeye,President,,IND,Stein/Baraka,7
-Dickinson,Buckeye,President,,,McMullin/Johnson,1
-Dickinson,Buckeye,U.S. Senate,,REP,Jerry Moran,193
-Dickinson,Buckeye,U.S. Senate,,DEM,Patrick Wiesner,24
-Dickinson,Buckeye,U.S. Senate,,LBT,Robert Garrard,12
-Dickinson,Buckeye,U.S. House,1,REP,Roger Marshall,152
-Dickinson,Buckeye,U.S. House,1,IND,Alan LaPolice,61
-Dickinson,Buckeye,U.S. House,1,LBT,Kerry Burt,12
-Dickinson,Buckeye,U.S. House,1,,Tim Huelskamp,1
-Dickinson,Buckeye,State Senate,24,REP,Randall Hardy,186
-Dickinson,Buckeye,State Senate,24,DEM,Donald Merriam,38
-Dickinson,Buckeye,State House,70,REP,John Barker,155
-Dickinson,Buckeye,State House,70,DEM,Jo Schwartz,64
-Dickinson,Center,President,,REP,Trump/Pence,350
-Dickinson,Center,President,,DEM,Clinton/Kaine,69
-Dickinson,Center,President,,LBT,Johnson/Weld,15
-Dickinson,Center,President,,IND,Stein/Baraka,11
-Dickinson,Center,President,,,McMullin/Johnson,3
-Dickinson,Center,President,,,Castle/Bradley,1
-Dickinson,Center,U.S. Senate,,REP,Jerry Moran,370
-Dickinson,Center,U.S. Senate,,DEM,Patrick Wiesner,52
-Dickinson,Center,U.S. Senate,,LBT,Robert Garrard,24
-Dickinson,Center,U.S. House,1,REP,Roger Marshall,289
-Dickinson,Center,U.S. House,1,IND,Alan LaPolice,109
-Dickinson,Center,U.S. House,1,LBT,Kerry Burt,38
-Dickinson,Center,State Senate,24,REP,Randall Hardy,352
-Dickinson,Center,State Senate,24,DEM,Donald Merriam,79
-Dickinson,Center,State House,70,REP,John Barker,333
-Dickinson,Center,State House,70,DEM,Jo Schwartz,109
-Dickinson,Cheever,President,,REP,Trump/Pence,57
-Dickinson,Cheever,President,,DEM,Clinton/Kaine,9
-Dickinson,Cheever,President,,LBT,Johnson/Weld,2
-Dickinson,Cheever,President,,IND,Stein/Baraka,1
-Dickinson,Cheever,U.S. Senate,,REP,Jerry Moran,58
-Dickinson,Cheever,U.S. Senate,,DEM,Patrick Wiesner,5
-Dickinson,Cheever,U.S. Senate,,LBT,Robert Garrard,4
-Dickinson,Cheever,U.S. House,1,REP,Roger Marshall,47
-Dickinson,Cheever,U.S. House,1,IND,Alan LaPolice,15
-Dickinson,Cheever,U.S. House,1,LBT,Kerry Burt,4
-Dickinson,Cheever,U.S. House,1,,Tim Huelskamp,2
-Dickinson,Cheever,State Senate,24,REP,Randall Hardy,51
-Dickinson,Cheever,State Senate,24,DEM,Donald Merriam,13
-Dickinson,Cheever,State House,70,REP,John Barker,53
-Dickinson,Cheever,State House,70,DEM,Jo Schwartz,15
-Dickinson,Flora,President,,REP,Trump/Pence,69
-Dickinson,Flora,President,,DEM,Clinton/Kaine,18
-Dickinson,Flora,President,,LBT,Johnson/Weld,1
-Dickinson,Flora,President,,IND,Stein/Baraka,3
-Dickinson,Flora,U.S. Senate,,REP,Jerry Moran,64
-Dickinson,Flora,U.S. Senate,,DEM,Patrick Wiesner,17
-Dickinson,Flora,U.S. Senate,,LBT,Robert Garrard,9
-Dickinson,Flora,U.S. House,1,REP,Roger Marshall,54
-Dickinson,Flora,U.S. House,1,IND,Alan LaPolice,30
-Dickinson,Flora,U.S. House,1,LBT,Kerry Burt,4
-Dickinson,Flora,U.S. House,1,,Tim Huelskamp,4
-Dickinson,Flora,State Senate,24,REP,Randall Hardy,59
-Dickinson,Flora,State Senate,24,DEM,Donald Merriam,25
-Dickinson,Flora,State House,70,REP,John Barker,64
-Dickinson,Flora,State House,70,DEM,Jo Schwartz,27
-Dickinson,Frag Hill,President,,REP,Trump/Pence,114
-Dickinson,Frag Hill,President,,DEM,Clinton/Kaine,12
-Dickinson,Frag Hill,President,,LBT,Johnson/Weld,8
-Dickinson,Frag Hill,President,,IND,Stein/Baraka,1
-Dickinson,Frag Hill,U.S. Senate,,REP,Jerry Moran,115
-Dickinson,Frag Hill,U.S. Senate,,DEM,Patrick Wiesner,13
-Dickinson,Frag Hill,U.S. Senate,,LBT,Robert Garrard,6
-Dickinson,Frag Hill,U.S. House,1,REP,Roger Marshall,95
-Dickinson,Frag Hill,U.S. House,1,IND,Alan LaPolice,23
-Dickinson,Frag Hill,U.S. House,1,LBT,Kerry Burt,15
-Dickinson,Frag Hill,U.S. House,1,,Tim Huelskamp,1
-Dickinson,Frag Hill,State Senate,24,REP,Randall Hardy,113
-Dickinson,Frag Hill,State Senate,24,DEM,Donald Merriam,17
-Dickinson,Frag Hill,State House,70,REP,John Barker,104
-Dickinson,Frag Hill,State House,70,DEM,Jo Schwartz,28
-Dickinson,Garfield,President,,REP,Trump/Pence,79
-Dickinson,Garfield,President,,DEM,Clinton/Kaine,21
-Dickinson,Garfield,President,,LBT,Johnson/Weld,4
-Dickinson,Garfield,President,,IND,Stein/Baraka,0
-Dickinson,Garfield,U.S. Senate,,REP,Jerry Moran,88
-Dickinson,Garfield,U.S. Senate,,DEM,Patrick Wiesner,12
-Dickinson,Garfield,U.S. Senate,,LBT,Robert Garrard,4
-Dickinson,Garfield,U.S. House,1,REP,Roger Marshall,61
-Dickinson,Garfield,U.S. House,1,IND,Alan LaPolice,39
-Dickinson,Garfield,U.S. House,1,LBT,Kerry Burt,3
-Dickinson,Garfield,State Senate,35,REP,Richard Wilborn,84
-Dickinson,Garfield,State Senate,35,DEM,Levi Morris,16
-Dickinson,Garfield,State House,70,REP,John Barker,72
-Dickinson,Garfield,State House,70,DEM,Jo Schwartz,29
-Dickinson,Grant,President,,REP,Trump/Pence,410
-Dickinson,Grant,President,,DEM,Clinton/Kaine,67
-Dickinson,Grant,President,,LBT,Johnson/Weld,17
-Dickinson,Grant,President,,IND,Stein/Baraka,6
-Dickinson,Grant,President,,,McMullin/Johnson,5
-Dickinson,Grant,President,,,Basiago/Kinnison,1
-Dickinson,Grant,U.S. Senate,,REP,Jerry Moran,418
-Dickinson,Grant,U.S. Senate,,DEM,Patrick Wiesner,56
-Dickinson,Grant,U.S. Senate,,LBT,Robert Garrard,26
-Dickinson,Grant,U.S. House,1,REP,Roger Marshall,338
-Dickinson,Grant,U.S. House,1,IND,Alan LaPolice,132
-Dickinson,Grant,U.S. House,1,LBT,Kerry Burt,25
-Dickinson,Grant,State Senate,24,REP,Randall Hardy,411
-Dickinson,Grant,State Senate,24,DEM,Donald Merriam,93
-Dickinson,Grant,State House,70,REP,John Barker,367
-Dickinson,Grant,State House,70,DEM,Jo Schwartz,138
-Dickinson,Hayes,President,,REP,Trump/Pence,121
-Dickinson,Hayes,President,,DEM,Clinton/Kaine,8
-Dickinson,Hayes,President,,LBT,Johnson/Weld,3
-Dickinson,Hayes,President,,IND,Stein/Baraka,2
-Dickinson,Hayes,U.S. Senate,,REP,Jerry Moran,122
-Dickinson,Hayes,U.S. Senate,,DEM,Patrick Wiesner,5
-Dickinson,Hayes,U.S. Senate,,LBT,Robert Garrard,7
-Dickinson,Hayes,U.S. House,1,REP,Roger Marshall,86
-Dickinson,Hayes,U.S. House,1,IND,Alan LaPolice,36
-Dickinson,Hayes,U.S. House,1,LBT,Kerry Burt,5
-Dickinson,Hayes,U.S. House,1,,Tim Huelskamp,2
-Dickinson,Hayes,State Senate,24,REP,Randall Hardy,114
-Dickinson,Hayes,State Senate,24,DEM,Donald Merriam,13
-Dickinson,Hayes,State House,70,REP,John Barker,103
-Dickinson,Hayes,State House,70,DEM,Jo Schwartz,24
-Dickinson,HE W1,President,,REP,Trump/Pence,198
-Dickinson,HE W1,President,,DEM,Clinton/Kaine,97
-Dickinson,HE W1,President,,LBT,Johnson/Weld,13
-Dickinson,HE W1,President,,IND,Stein/Baraka,7
-Dickinson,HE W1,U.S. Senate,,REP,Jerry Moran,212
-Dickinson,HE W1,U.S. Senate,,DEM,Patrick Wiesner,81
-Dickinson,HE W1,U.S. Senate,,LBT,Robert Garrard,21
-Dickinson,HE W1,U.S. House,1,REP,Roger Marshall,194
-Dickinson,HE W1,U.S. House,1,IND,Alan LaPolice,91
-Dickinson,HE W1,U.S. House,1,LBT,Kerry Burt,25
-Dickinson,HE W1,U.S. House,1,,Tim Huelskamp,1
-Dickinson,HE W1,State Senate,35,REP,Richard Wilborn,184
-Dickinson,HE W1,State Senate,35,DEM,Levi Morris,125
-Dickinson,HE W1,State House,68,REP,Dave Baker,194
-Dickinson,HE W1,State House,68,DEM,Laura Blevins,114
-Dickinson,HE W2,President,,REP,Trump/Pence,195
-Dickinson,HE W2,President,,DEM,Clinton/Kaine,88
-Dickinson,HE W2,President,,LBT,Johnson/Weld,18
-Dickinson,HE W2,President,,IND,Stein/Baraka,9
-Dickinson,HE W2,U.S. Senate,,REP,Jerry Moran,206
-Dickinson,HE W2,U.S. Senate,,DEM,Patrick Wiesner,80
-Dickinson,HE W2,U.S. Senate,,LBT,Robert Garrard,26
-Dickinson,HE W2,U.S. House,1,REP,Roger Marshall,181
-Dickinson,HE W2,U.S. House,1,IND,Alan LaPolice,100
-Dickinson,HE W2,U.S. House,1,LBT,Kerry Burt,27
-Dickinson,HE W2,State Senate,35,REP,Richard Wilborn,176
-Dickinson,HE W2,State Senate,35,DEM,Levi Morris,128
-Dickinson,HE W2,State House,68,REP,Dave Baker,190
-Dickinson,HE W2,State House,68,DEM,Laura Blevins,113
-Dickinson,HE W4,President,,REP,Trump/Pence,130
-Dickinson,HE W4,President,,DEM,Clinton/Kaine,38
-Dickinson,HE W4,President,,LBT,Johnson/Weld,14
-Dickinson,HE W4,President,,IND,Stein/Baraka,8
-Dickinson,HE W4,U.S. Senate,,REP,Jerry Moran,131
-Dickinson,HE W4,U.S. Senate,,DEM,Patrick Wiesner,37
-Dickinson,HE W4,U.S. Senate,,LBT,Robert Garrard,19
-Dickinson,HE W4,U.S. House,1,REP,Roger Marshall,108
-Dickinson,HE W4,U.S. House,1,IND,Alan LaPolice,53
-Dickinson,HE W4,U.S. House,1,LBT,Kerry Burt,23
-Dickinson,HE W4,State Senate,35,REP,Richard Wilborn,125
-Dickinson,HE W4,State Senate,35,DEM,Levi Morris,56
-Dickinson,HE W4,State House,68,REP,Dave Baker,120
-Dickinson,HE W4,State House,68,DEM,Laura Blevins,61
-Dickinson,Holland,President,,REP,Trump/Pence,56
-Dickinson,Holland,President,,DEM,Clinton/Kaine,3
-Dickinson,Holland,President,,LBT,Johnson/Weld,1
-Dickinson,Holland,President,,IND,Stein/Baraka,1
-Dickinson,Holland,U.S. Senate,,REP,Jerry Moran,54
-Dickinson,Holland,U.S. Senate,,DEM,Patrick Wiesner,4
-Dickinson,Holland,U.S. Senate,,LBT,Robert Garrard,4
-Dickinson,Holland,U.S. House,1,REP,Roger Marshall,41
-Dickinson,Holland,U.S. House,1,IND,Alan LaPolice,22
-Dickinson,Holland,U.S. House,1,LBT,Kerry Burt,1
-Dickinson,Holland,State Senate,35,REP,Richard Wilborn,56
-Dickinson,Holland,State Senate,35,DEM,Levi Morris,4
-Dickinson,Holland,State House,70,REP,John Barker,47
-Dickinson,Holland,State House,70,DEM,Jo Schwartz,16
-Dickinson,Hope twp,President,,REP,Trump/Pence,153
-Dickinson,Hope twp,President,,DEM,Clinton/Kaine,43
-Dickinson,Hope twp,President,,LBT,Johnson/Weld,5
-Dickinson,Hope twp,President,,IND,Stein/Baraka,0
-Dickinson,Hope twp,U.S. Senate,,REP,Jerry Moran,158
-Dickinson,Hope twp,U.S. Senate,,DEM,Patrick Wiesner,34
-Dickinson,Hope twp,U.S. Senate,,LBT,Robert Garrard,10
-Dickinson,Hope twp,U.S. House,1,REP,Roger Marshall,127
-Dickinson,Hope twp,U.S. House,1,IND,Alan LaPolice,56
-Dickinson,Hope twp,U.S. House,1,LBT,Kerry Burt,16
-Dickinson,Hope twp,U.S. House,1,,Tim Huelskamp,1
-Dickinson,Hope twp,State Senate,35,REP,Richard Wilborn,127
-Dickinson,Hope twp,State Senate,35,DEM,Levi Morris,68
-Dickinson,Hope twp,State House,70,REP,John Barker,122
-Dickinson,Hope twp,State House,70,DEM,Jo Schwartz,78
-Dickinson,Jefferson,President,,REP,Trump/Pence,106
-Dickinson,Jefferson,President,,DEM,Clinton/Kaine,9
-Dickinson,Jefferson,President,,LBT,Johnson/Weld,2
-Dickinson,Jefferson,President,,IND,Stein/Baraka,3
-Dickinson,Jefferson,President,,,McMullin/Johnson,1
-Dickinson,Jefferson,U.S. Senate,,REP,Jerry Moran,101
-Dickinson,Jefferson,U.S. Senate,,DEM,Patrick Wiesner,11
-Dickinson,Jefferson,U.S. Senate,,LBT,Robert Garrard,7
-Dickinson,Jefferson,U.S. House,1,REP,Roger Marshall,79
-Dickinson,Jefferson,U.S. House,1,IND,Alan LaPolice,35
-Dickinson,Jefferson,U.S. House,1,LBT,Kerry Burt,5
-Dickinson,Jefferson,State Senate,35,REP,Richard Wilborn,102
-Dickinson,Jefferson,State Senate,35,DEM,Levi Morris,16
-Dickinson,Jefferson,State House,70,REP,John Barker,94
-Dickinson,Jefferson,State House,70,DEM,Jo Schwartz,26
-Dickinson,Liberty,President,,REP,Trump/Pence,116
-Dickinson,Liberty,President,,DEM,Clinton/Kaine,32
-Dickinson,Liberty,President,,LBT,Johnson/Weld,2
-Dickinson,Liberty,President,,IND,Stein/Baraka,6
-Dickinson,Liberty,President,,,Castle/Bradley,1
-Dickinson,Liberty,U.S. Senate,,REP,Jerry Moran,116
-Dickinson,Liberty,U.S. Senate,,DEM,Patrick Wiesner,26
-Dickinson,Liberty,U.S. Senate,,LBT,Robert Garrard,14
-Dickinson,Liberty,U.S. House,1,REP,Roger Marshall,106
-Dickinson,Liberty,U.S. House,1,IND,Alan LaPolice,41
-Dickinson,Liberty,U.S. House,1,LBT,Kerry Burt,10
-Dickinson,Liberty,State Senate,35,REP,Richard Wilborn,108
-Dickinson,Liberty,State Senate,35,DEM,Levi Morris,45
-Dickinson,Liberty,State House,70,REP,John Barker,101
-Dickinson,Liberty,State House,70,DEM,Jo Schwartz,52
-Dickinson,Lincoln,President,,REP,Trump/Pence,494
-Dickinson,Lincoln,President,,DEM,Clinton/Kaine,121
-Dickinson,Lincoln,President,,LBT,Johnson/Weld,18
-Dickinson,Lincoln,President,,IND,Stein/Baraka,8
-Dickinson,Lincoln,President,,,McMullin/Johnson,3
-Dickinson,Lincoln,President,,,Castle/Bradley,4
-Dickinson,Lincoln,U.S. Senate,,REP,Jerry Moran,512
-Dickinson,Lincoln,U.S. Senate,,DEM,Patrick Wiesner,82
-Dickinson,Lincoln,U.S. Senate,,LBT,Robert Garrard,46
-Dickinson,Lincoln,U.S. House,1,REP,Roger Marshall,404
-Dickinson,Lincoln,U.S. House,1,IND,Alan LaPolice,197
-Dickinson,Lincoln,U.S. House,1,LBT,Kerry Burt,33
-Dickinson,Lincoln,U.S. House,1,,Tim Huelskamp,2
-Dickinson,Lincoln,State Senate,24,REP,Randall Hardy,463
-Dickinson,Lincoln,State Senate,24,DEM,Donald Merriam,163
-Dickinson,Lincoln,State House,70,REP,John Barker,448
-Dickinson,Lincoln,State House,70,DEM,Jo Schwartz,189
-Dickinson,Logan,President,,REP,Trump/Pence,62
-Dickinson,Logan,President,,DEM,Clinton/Kaine,23
-Dickinson,Logan,President,,LBT,Johnson/Weld,5
-Dickinson,Logan,President,,IND,Stein/Baraka,1
-Dickinson,Logan,U.S. Senate,,REP,Jerry Moran,72
-Dickinson,Logan,U.S. Senate,,DEM,Patrick Wiesner,8
-Dickinson,Logan,U.S. Senate,,LBT,Robert Garrard,7
-Dickinson,Logan,U.S. House,1,REP,Roger Marshall,58
-Dickinson,Logan,U.S. House,1,IND,Alan LaPolice,24
-Dickinson,Logan,U.S. House,1,LBT,Kerry Burt,3
-Dickinson,Logan,State Senate,35,REP,Richard Wilborn,64
-Dickinson,Logan,State Senate,35,DEM,Levi Morris,22
-Dickinson,Logan,State House,70,REP,John Barker,53
-Dickinson,Logan,State House,70,DEM,Jo Schwartz,36
-Dickinson,Lyon 68,President,,REP,Trump/Pence,25
-Dickinson,Lyon 68,President,,DEM,Clinton/Kaine,7
-Dickinson,Lyon 68,President,,LBT,Johnson/Weld,0
-Dickinson,Lyon 68,President,,IND,Stein/Baraka,2
-Dickinson,Lyon 68,U.S. Senate,,REP,Jerry Moran,27
-Dickinson,Lyon 68,U.S. Senate,,DEM,Patrick Wiesner,5
-Dickinson,Lyon 68,U.S. Senate,,LBT,Robert Garrard,1
-Dickinson,Lyon 68,U.S. House,1,REP,Roger Marshall,25
-Dickinson,Lyon 68,U.S. House,1,IND,Alan LaPolice,7
-Dickinson,Lyon 68,U.S. House,1,LBT,Kerry Burt,2
-Dickinson,Lyon 68,State Senate,35,REP,Richard Wilborn,21
-Dickinson,Lyon 68,State Senate,35,DEM,Levi Morris,13
-Dickinson,Lyon 68,State House,68,REP,Dave Baker,26
-Dickinson,Lyon 68,State House,68,DEM,Laura Blevins,8
-Dickinson,Lyon 68A,President,,REP,Trump/Pence,2
-Dickinson,Lyon 68A,President,,DEM,Clinton/Kaine,1
-Dickinson,Lyon 68A,President,,LBT,Johnson/Weld,0
-Dickinson,Lyon 68A,President,,IND,Stein/Baraka,0
-Dickinson,Lyon 68A,U.S. Senate,,REP,Jerry Moran,2
-Dickinson,Lyon 68A,U.S. Senate,,DEM,Patrick Wiesner,1
-Dickinson,Lyon 68A,U.S. Senate,,LBT,Robert Garrard,0
-Dickinson,Lyon 68A,U.S. House,1,REP,Roger Marshall,2
-Dickinson,Lyon 68A,U.S. House,1,IND,Alan LaPolice,1
-Dickinson,Lyon 68A,U.S. House,1,LBT,Kerry Burt,0
-Dickinson,Lyon 68A,State Senate,35,REP,Richard Wilborn,2
-Dickinson,Lyon 68A,State Senate,35,DEM,Levi Morris,1
-Dickinson,Lyon 68A,State House,68,REP,Dave Baker,2
-Dickinson,Lyon 68A,State House,68,DEM,Laura Blevins,1
-Dickinson,Lyon 70,President,,REP,Trump/Pence,60
-Dickinson,Lyon 70,President,,DEM,Clinton/Kaine,16
-Dickinson,Lyon 70,President,,LBT,Johnson/Weld,1
-Dickinson,Lyon 70,President,,IND,Stein/Baraka,3
-Dickinson,Lyon 70,U.S. Senate,,REP,Jerry Moran,66
-Dickinson,Lyon 70,U.S. Senate,,DEM,Patrick Wiesner,11
-Dickinson,Lyon 70,U.S. Senate,,LBT,Robert Garrard,5
-Dickinson,Lyon 70,U.S. House,1,REP,Roger Marshall,56
-Dickinson,Lyon 70,U.S. House,1,IND,Alan LaPolice,18
-Dickinson,Lyon 70,U.S. House,1,LBT,Kerry Burt,7
-Dickinson,Lyon 70,State Senate,35,REP,Richard Wilborn,62
-Dickinson,Lyon 70,State Senate,35,DEM,Levi Morris,19
-Dickinson,Lyon 70,State House,70,REP,John Barker,52
-Dickinson,Lyon 70,State House,70,DEM,Jo Schwartz,27
-Dickinson,Newbern,President,,REP,Trump/Pence,174
-Dickinson,Newbern,President,,DEM,Clinton/Kaine,32
-Dickinson,Newbern,President,,LBT,Johnson/Weld,6
-Dickinson,Newbern,President,,IND,Stein/Baraka,3
-Dickinson,Newbern,President,,,McMullin/Johnson,1
-Dickinson,Newbern,U.S. Senate,,REP,Jerry Moran,170
-Dickinson,Newbern,U.S. Senate,,DEM,Patrick Wiesner,30
-Dickinson,Newbern,U.S. Senate,,LBT,Robert Garrard,15
-Dickinson,Newbern,U.S. House,1,REP,Roger Marshall,136
-Dickinson,Newbern,U.S. House,1,IND,Alan LaPolice,67
-Dickinson,Newbern,U.S. House,1,LBT,Kerry Burt,13
-Dickinson,Newbern,State Senate,35,REP,Richard Wilborn,166
-Dickinson,Newbern,State Senate,35,DEM,Levi Morris,43
-Dickinson,Newbern,State House,70,REP,John Barker,143
-Dickinson,Newbern,State House,70,DEM,Jo Schwartz,73
-Dickinson,Noble,President,,REP,Trump/Pence,544
-Dickinson,Noble,President,,DEM,Clinton/Kaine,146
-Dickinson,Noble,President,,LBT,Johnson/Weld,43
-Dickinson,Noble,President,,IND,Stein/Baraka,17
-Dickinson,Noble,President,,,McMullin/Johnson,3
-Dickinson,Noble,U.S. Senate,,REP,Jerry Moran,615
-Dickinson,Noble,U.S. Senate,,DEM,Patrick Wiesner,98
-Dickinson,Noble,U.S. Senate,,LBT,Robert Garrard,46
-Dickinson,Noble,U.S. House,1,REP,Roger Marshall,519
-Dickinson,Noble,U.S. House,1,IND,Alan LaPolice,178
-Dickinson,Noble,U.S. House,1,LBT,Kerry Burt,49
-Dickinson,Noble,State Senate,24,REP,Randall Hardy,545
-Dickinson,Noble,State Senate,24,DEM,Donald Merriam,184
-Dickinson,Noble,State House,70,REP,John Barker,495
-Dickinson,Noble,State House,70,DEM,Jo Schwartz,253
-Dickinson,Ridge,President,,REP,Trump/Pence,60
-Dickinson,Ridge,President,,DEM,Clinton/Kaine,8
-Dickinson,Ridge,President,,LBT,Johnson/Weld,4
-Dickinson,Ridge,President,,IND,Stein/Baraka,1
-Dickinson,Ridge,U.S. Senate,,REP,Jerry Moran,65
-Dickinson,Ridge,U.S. Senate,,DEM,Patrick Wiesner,5
-Dickinson,Ridge,U.S. Senate,,LBT,Robert Garrard,2
-Dickinson,Ridge,U.S. House,1,REP,Roger Marshall,50
-Dickinson,Ridge,U.S. House,1,IND,Alan LaPolice,19
-Dickinson,Ridge,U.S. House,1,LBT,Kerry Burt,3
-Dickinson,Ridge,State Senate,35,REP,Richard Wilborn,56
-Dickinson,Ridge,State Senate,35,DEM,Levi Morris,13
-Dickinson,Ridge,State House,70,REP,John Barker,47
-Dickinson,Ridge,State House,70,DEM,Jo Schwartz,22
-Dickinson,Rinehart,President,,REP,Trump/Pence,108
-Dickinson,Rinehart,President,,DEM,Clinton/Kaine,19
-Dickinson,Rinehart,President,,LBT,Johnson/Weld,2
-Dickinson,Rinehart,President,,IND,Stein/Baraka,0
-Dickinson,Rinehart,U.S. Senate,,REP,Jerry Moran,111
-Dickinson,Rinehart,U.S. Senate,,DEM,Patrick Wiesner,11
-Dickinson,Rinehart,U.S. Senate,,LBT,Robert Garrard,4
-Dickinson,Rinehart,U.S. House,1,REP,Roger Marshall,96
-Dickinson,Rinehart,U.S. House,1,IND,Alan LaPolice,30
-Dickinson,Rinehart,U.S. House,1,LBT,Kerry Burt,1
-Dickinson,Rinehart,State Senate,24,REP,Randall Hardy,109
-Dickinson,Rinehart,State Senate,24,DEM,Donald Merriam,17
-Dickinson,Rinehart,State House,70,REP,John Barker,103
-Dickinson,Rinehart,State House,70,DEM,Jo Schwartz,25
-Dickinson,Sherman,President,,REP,Trump/Pence,60
-Dickinson,Sherman,President,,DEM,Clinton/Kaine,14
-Dickinson,Sherman,President,,LBT,Johnson/Weld,0
-Dickinson,Sherman,President,,IND,Stein/Baraka,1
-Dickinson,Sherman,President,,,Castle/Bradley,2
-Dickinson,Sherman,U.S. Senate,,REP,Jerry Moran,60
-Dickinson,Sherman,U.S. Senate,,DEM,Patrick Wiesner,13
-Dickinson,Sherman,U.S. Senate,,LBT,Robert Garrard,3
-Dickinson,Sherman,U.S. House,1,REP,Roger Marshall,46
-Dickinson,Sherman,U.S. House,1,IND,Alan LaPolice,20
-Dickinson,Sherman,U.S. House,1,LBT,Kerry Burt,8
-Dickinson,Sherman,U.S. House,1,,Tim Huelskamp,2
-Dickinson,Sherman,State Senate,24,REP,Randall Hardy,59
-Dickinson,Sherman,State Senate,24,DEM,Donald Merriam,16
-Dickinson,Sherman,State House,70,REP,John Barker,56
-Dickinson,Sherman,State House,70,DEM,Jo Schwartz,21
-Dickinson,Union,President,,REP,Trump/Pence,59
-Dickinson,Union,President,,DEM,Clinton/Kaine,14
-Dickinson,Union,President,,LBT,Johnson/Weld,1
-Dickinson,Union,President,,IND,Stein/Baraka,2
-Dickinson,Union,U.S. Senate,,REP,Jerry Moran,65
-Dickinson,Union,U.S. Senate,,DEM,Patrick Wiesner,10
-Dickinson,Union,U.S. Senate,,LBT,Robert Garrard,2
-Dickinson,Union,U.S. House,1,REP,Roger Marshall,52
-Dickinson,Union,U.S. House,1,IND,Alan LaPolice,17
-Dickinson,Union,U.S. House,1,LBT,Kerry Burt,7
-Dickinson,Union,State Senate,35,REP,Richard Wilborn,54
-Dickinson,Union,State Senate,35,DEM,Levi Morris,21
-Dickinson,Union,State House,70,REP,John Barker,54
-Dickinson,Union,State House,70,DEM,Jo Schwartz,22
-Dickinson,Wheatland,President,,REP,Trump/Pence,68
-Dickinson,Wheatland,President,,DEM,Clinton/Kaine,4
-Dickinson,Wheatland,President,,LBT,Johnson/Weld,1
-Dickinson,Wheatland,President,,IND,Stein/Baraka,2
-Dickinson,Wheatland,U.S. Senate,,REP,Jerry Moran,71
-Dickinson,Wheatland,U.S. Senate,,DEM,Patrick Wiesner,2
-Dickinson,Wheatland,U.S. Senate,,LBT,Robert Garrard,1
-Dickinson,Wheatland,U.S. House,1,REP,Roger Marshall,53
-Dickinson,Wheatland,U.S. House,1,IND,Alan LaPolice,19
-Dickinson,Wheatland,U.S. House,1,LBT,Kerry Burt,2
-Dickinson,Wheatland,State Senate,35,REP,Richard Wilborn,68
-Dickinson,Wheatland,State Senate,35,DEM,Levi Morris,7
-Dickinson,Wheatland,State House,70,REP,John Barker,64
-Dickinson,Wheatland,State House,70,DEM,Jo Schwartz,11
-Dickinson,Willowdale,President,,REP,Trump/Pence,114
-Dickinson,Willowdale,President,,DEM,Clinton/Kaine,16
-Dickinson,Willowdale,President,,LBT,Johnson/Weld,3
-Dickinson,Willowdale,President,,IND,Stein/Baraka,1
-Dickinson,Willowdale,U.S. Senate,,REP,Jerry Moran,112
-Dickinson,Willowdale,U.S. Senate,,DEM,Patrick Wiesner,16
-Dickinson,Willowdale,U.S. Senate,,LBT,Robert Garrard,7
-Dickinson,Willowdale,U.S. House,1,REP,Roger Marshall,88
-Dickinson,Willowdale,U.S. House,1,IND,Alan LaPolice,37
-Dickinson,Willowdale,U.S. House,1,LBT,Kerry Burt,8
-Dickinson,Willowdale,State Senate,24,REP,Randall Hardy,114
-Dickinson,Willowdale,State Senate,24,DEM,Donald Merriam,15
-Dickinson,Willowdale,State House,70,REP,John Barker,99
-Dickinson,Willowdale,State House,70,DEM,Jo Schwartz,37
+county,precinct,office,district,party,candidate,votes,vtd
+DICKINSON,Abilene Ward 1,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",165,000010
+DICKINSON,Abilene Ward 1,Kansas House of Representatives,70,Republican,"Barker, John E.",213,000010
+DICKINSON,Abilene Ward 2,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",282,00002A
+DICKINSON,Abilene Ward 2,Kansas House of Representatives,70,Republican,"Barker, John E.",406,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Kansas House of Representatives,70,Republican,"Barker, John E.",0,00002B
+DICKINSON,Abilene Ward 3,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",141,000030
+DICKINSON,Abilene Ward 3,Kansas House of Representatives,70,Republican,"Barker, John E.",217,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",263,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas House of Representatives,70,Republican,"Barker, John E.",306,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",262,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas House of Representatives,70,Republican,"Barker, John E.",438,000050
+DICKINSON,Banner Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",12,000060
+DICKINSON,Banner Township,Kansas House of Representatives,70,Republican,"Barker, John E.",39,000060
+DICKINSON,Buckeye Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",64,000070
+DICKINSON,Buckeye Township,Kansas House of Representatives,70,Republican,"Barker, John E.",155,000070
+DICKINSON,Center Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",109,000080
+DICKINSON,Center Township,Kansas House of Representatives,70,Republican,"Barker, John E.",333,000080
+DICKINSON,Cheever Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",15,000090
+DICKINSON,Cheever Township,Kansas House of Representatives,70,Republican,"Barker, John E.",53,000090
+DICKINSON,Flora Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",27,000100
+DICKINSON,Flora Township,Kansas House of Representatives,70,Republican,"Barker, John E.",64,000100
+DICKINSON,Fragrant Hill Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",28,000110
+DICKINSON,Fragrant Hill Township,Kansas House of Representatives,70,Republican,"Barker, John E.",104,000110
+DICKINSON,Garfield Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",29,000120
+DICKINSON,Garfield Township,Kansas House of Representatives,70,Republican,"Barker, John E.",72,000120
+DICKINSON,Grant Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",138,000130
+DICKINSON,Grant Township,Kansas House of Representatives,70,Republican,"Barker, John E.",367,000130
+DICKINSON,Hayes Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",24,000140
+DICKINSON,Hayes Township,Kansas House of Representatives,70,Republican,"Barker, John E.",103,000140
+DICKINSON,Herington Ward 1,Kansas House of Representatives,68,Democratic,"Blevins, Laura",114,000150
+DICKINSON,Herington Ward 1,Kansas House of Representatives,68,Republican,"Baker, Dave",194,000150
+DICKINSON,Herington Ward 2,Kansas House of Representatives,68,Democratic,"Blevins, Laura",113,000160
+DICKINSON,Herington Ward 2,Kansas House of Representatives,68,Republican,"Baker, Dave",190,000160
+DICKINSON,Herington Ward 4,Kansas House of Representatives,68,Democratic,"Blevins, Laura",61,000170
+DICKINSON,Herington Ward 4,Kansas House of Representatives,68,Republican,"Baker, Dave",120,000170
+DICKINSON,Holland Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",16,000180
+DICKINSON,Holland Township,Kansas House of Representatives,70,Republican,"Barker, John E.",47,000180
+DICKINSON,Hope Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",78,000190
+DICKINSON,Hope Township,Kansas House of Representatives,70,Republican,"Barker, John E.",122,000190
+DICKINSON,Jefferson Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",26,000200
+DICKINSON,Jefferson Township,Kansas House of Representatives,70,Republican,"Barker, John E.",94,000200
+DICKINSON,Liberty Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",52,000210
+DICKINSON,Liberty Township,Kansas House of Representatives,70,Republican,"Barker, John E.",101,000210
+DICKINSON,Lincoln Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",189,000220
+DICKINSON,Lincoln Township,Kansas House of Representatives,70,Republican,"Barker, John E.",448,000220
+DICKINSON,Logan Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",36,000230
+DICKINSON,Logan Township,Kansas House of Representatives,70,Republican,"Barker, John E.",53,000230
+DICKINSON,Newbern Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",73,000250
+DICKINSON,Newbern Township,Kansas House of Representatives,70,Republican,"Barker, John E.",143,000250
+DICKINSON,Noble Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",253,000260
+DICKINSON,Noble Township,Kansas House of Representatives,70,Republican,"Barker, John E.",495,000260
+DICKINSON,Ridge Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",22,000270
+DICKINSON,Ridge Township,Kansas House of Representatives,70,Republican,"Barker, John E.",47,000270
+DICKINSON,Rinehart Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",25,000280
+DICKINSON,Rinehart Township,Kansas House of Representatives,70,Republican,"Barker, John E.",103,000280
+DICKINSON,Sherman Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",21,000290
+DICKINSON,Sherman Township,Kansas House of Representatives,70,Republican,"Barker, John E.",56,000290
+DICKINSON,Union Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",22,000300
+DICKINSON,Union Township,Kansas House of Representatives,70,Republican,"Barker, John E.",54,000300
+DICKINSON,Wheatland Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",11,000310
+DICKINSON,Wheatland Township,Kansas House of Representatives,70,Republican,"Barker, John E.",64,000310
+DICKINSON,Willowdale Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",37,000320
+DICKINSON,Willowdale Township,Kansas House of Representatives,70,Republican,"Barker, John E.",99,000320
+DICKINSON,Lyon Township H68 A,Kansas House of Representatives,68,Democratic,"Blevins, Laura",1,12002A
+DICKINSON,Lyon Township H68 A,Kansas House of Representatives,68,Republican,"Baker, Dave",2,12002A
+DICKINSON,Lyon Township H68,Kansas House of Representatives,68,Democratic,"Blevins, Laura",8,120020
+DICKINSON,Lyon Township H68,Kansas House of Representatives,68,Republican,"Baker, Dave",26,120020
+DICKINSON,Lyon Township H70,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",27,120030
+DICKINSON,Lyon Township H70,Kansas House of Representatives,70,Republican,"Barker, John E.",52,120030
+DICKINSON,Abilene Ward 1 Exclave A,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Kansas House of Representatives,70,Republican,"Barker, John E.",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Kansas House of Representatives,70,Republican,"Barker, John E.",0,900020
+DICKINSON,Grant Township Enclave,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",0,900030
+DICKINSON,Grant Township Enclave,Kansas House of Representatives,70,Republican,"Barker, John E.",0,900030
+DICKINSON,Abilene Ward 1,Kansas Senate,24,Democratic,"Merriman, Donald R.",119,000010
+DICKINSON,Abilene Ward 1,Kansas Senate,24,Republican,"Hardy, Randall R.",244,000010
+DICKINSON,Abilene Ward 2,Kansas Senate,24,Democratic,"Merriman, Donald R.",172,00002A
+DICKINSON,Abilene Ward 2,Kansas Senate,24,Republican,"Hardy, Randall R.",493,00002A
+DICKINSON,Abilene Ward 2 Exclave A,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,Kansas Senate,24,Republican,"Hardy, Randall R.",0,00002B
+DICKINSON,Abilene Ward 3,Kansas Senate,24,Democratic,"Merriman, Donald R.",87,000030
+DICKINSON,Abilene Ward 3,Kansas Senate,24,Republican,"Hardy, Randall R.",262,000030
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas Senate,24,Democratic,"Merriman, Donald R.",178,000040
+DICKINSON,Abilene Ward 4 Precinct 1,Kansas Senate,24,Republican,"Hardy, Randall R.",368,000040
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas Senate,24,Democratic,"Merriman, Donald R.",166,000050
+DICKINSON,Abilene Ward 4 Precinct 2,Kansas Senate,24,Republican,"Hardy, Randall R.",507,000050
+DICKINSON,Banner Township,Kansas Senate,35,Democratic,"Morris, Levi",11,000060
+DICKINSON,Banner Township,Kansas Senate,35,Republican,"Wilborn, Richard",43,000060
+DICKINSON,Buckeye Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",38,000070
+DICKINSON,Buckeye Township,Kansas Senate,24,Republican,"Hardy, Randall R.",186,000070
+DICKINSON,Center Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",79,000080
+DICKINSON,Center Township,Kansas Senate,24,Republican,"Hardy, Randall R.",352,000080
+DICKINSON,Cheever Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",13,000090
+DICKINSON,Cheever Township,Kansas Senate,24,Republican,"Hardy, Randall R.",51,000090
+DICKINSON,Flora Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",25,000100
+DICKINSON,Flora Township,Kansas Senate,24,Republican,"Hardy, Randall R.",59,000100
+DICKINSON,Fragrant Hill Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",17,000110
+DICKINSON,Fragrant Hill Township,Kansas Senate,24,Republican,"Hardy, Randall R.",113,000110
+DICKINSON,Garfield Township,Kansas Senate,35,Democratic,"Morris, Levi",16,000120
+DICKINSON,Garfield Township,Kansas Senate,35,Republican,"Wilborn, Richard",84,000120
+DICKINSON,Grant Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",93,000130
+DICKINSON,Grant Township,Kansas Senate,24,Republican,"Hardy, Randall R.",411,000130
+DICKINSON,Hayes Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",13,000140
+DICKINSON,Hayes Township,Kansas Senate,24,Republican,"Hardy, Randall R.",114,000140
+DICKINSON,Herington Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",125,000150
+DICKINSON,Herington Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",184,000150
+DICKINSON,Herington Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",128,000160
+DICKINSON,Herington Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",176,000160
+DICKINSON,Herington Ward 4,Kansas Senate,35,Democratic,"Morris, Levi",56,000170
+DICKINSON,Herington Ward 4,Kansas Senate,35,Republican,"Wilborn, Richard",125,000170
+DICKINSON,Holland Township,Kansas Senate,35,Democratic,"Morris, Levi",4,000180
+DICKINSON,Holland Township,Kansas Senate,35,Republican,"Wilborn, Richard",56,000180
+DICKINSON,Hope Township,Kansas Senate,35,Democratic,"Morris, Levi",68,000190
+DICKINSON,Hope Township,Kansas Senate,35,Republican,"Wilborn, Richard",127,000190
+DICKINSON,Jefferson Township,Kansas Senate,35,Democratic,"Morris, Levi",16,000200
+DICKINSON,Jefferson Township,Kansas Senate,35,Republican,"Wilborn, Richard",102,000200
+DICKINSON,Liberty Township,Kansas Senate,35,Democratic,"Morris, Levi",45,000210
+DICKINSON,Liberty Township,Kansas Senate,35,Republican,"Wilborn, Richard",108,000210
+DICKINSON,Lincoln Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",163,000220
+DICKINSON,Lincoln Township,Kansas Senate,24,Republican,"Hardy, Randall R.",463,000220
+DICKINSON,Logan Township,Kansas Senate,35,Democratic,"Morris, Levi",22,000230
+DICKINSON,Logan Township,Kansas Senate,35,Republican,"Wilborn, Richard",64,000230
+DICKINSON,Newbern Township,Kansas Senate,35,Democratic,"Morris, Levi",43,000250
+DICKINSON,Newbern Township,Kansas Senate,35,Republican,"Wilborn, Richard",166,000250
+DICKINSON,Noble Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",184,000260
+DICKINSON,Noble Township,Kansas Senate,24,Republican,"Hardy, Randall R.",545,000260
+DICKINSON,Ridge Township,Kansas Senate,35,Democratic,"Morris, Levi",13,000270
+DICKINSON,Ridge Township,Kansas Senate,35,Republican,"Wilborn, Richard",56,000270
+DICKINSON,Rinehart Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",17,000280
+DICKINSON,Rinehart Township,Kansas Senate,24,Republican,"Hardy, Randall R.",109,000280
+DICKINSON,Sherman Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",16,000290
+DICKINSON,Sherman Township,Kansas Senate,24,Republican,"Hardy, Randall R.",59,000290
+DICKINSON,Union Township,Kansas Senate,35,Democratic,"Morris, Levi",21,000300
+DICKINSON,Union Township,Kansas Senate,35,Republican,"Wilborn, Richard",54,000300
+DICKINSON,Wheatland Township,Kansas Senate,35,Democratic,"Morris, Levi",7,000310
+DICKINSON,Wheatland Township,Kansas Senate,35,Republican,"Wilborn, Richard",68,000310
+DICKINSON,Willowdale Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",15,000320
+DICKINSON,Willowdale Township,Kansas Senate,24,Republican,"Hardy, Randall R.",114,000320
+DICKINSON,Lyon Township H68 A,Kansas Senate,35,Democratic,"Morris, Levi",1,12002A
+DICKINSON,Lyon Township H68 A,Kansas Senate,35,Republican,"Wilborn, Richard",2,12002A
+DICKINSON,Lyon Township H68,Kansas Senate,35,Democratic,"Morris, Levi",13,120020
+DICKINSON,Lyon Township H68,Kansas Senate,35,Republican,"Wilborn, Richard",21,120020
+DICKINSON,Lyon Township H70,Kansas Senate,35,Democratic,"Morris, Levi",19,120030
+DICKINSON,Lyon Township H70,Kansas Senate,35,Republican,"Wilborn, Richard",62,120030
+DICKINSON,Abilene Ward 1 Exclave A,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900020
+DICKINSON,Grant Township Enclave,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900030
+DICKINSON,Grant Township Enclave,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900030
+DICKINSON,Abilene Ward 1,President / Vice President,,independent,"Stein, Jill",9,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Castle, Darrell L",2,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Maturen, Michael A",1,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",94,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",25,000010
+DICKINSON,Abilene Ward 1,President / Vice President,,Republican,"Trump, Donald J.",255,000010
+DICKINSON,Abilene Ward 2,President / Vice President,,independent,"Stein, Jill",18,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",154,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",44,00002A
+DICKINSON,Abilene Ward 2,President / Vice President,,Republican,"Trump, Donald J.",470,00002A
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00002B
+DICKINSON,Abilene Ward 3,President / Vice President,,independent,"Stein, Jill",10,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",17,000030
+DICKINSON,Abilene Ward 3,President / Vice President,,Republican,"Trump, Donald J.",251,000030
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",10,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",155,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",40,000040
+DICKINSON,Abilene Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",362,000040
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",13,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",155,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",39,000050
+DICKINSON,Abilene Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",490,000050
+DICKINSON,Banner Township,President / Vice President,,independent,"Stein, Jill",3,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+DICKINSON,Banner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+DICKINSON,Banner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000060
+DICKINSON,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000060
+DICKINSON,Banner Township,President / Vice President,,Republican,"Trump, Donald J.",41,000060
+DICKINSON,Buckeye Township,President / Vice President,,independent,"Stein, Jill",7,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+DICKINSON,Buckeye Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000070
+DICKINSON,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000070
+DICKINSON,Buckeye Township,President / Vice President,,Republican,"Trump, Donald J.",176,000070
+DICKINSON,Center Township,President / Vice President,,independent,"Stein, Jill",11,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Castle, Darrell L",1,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"McMullin, Evan",3,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+DICKINSON,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+DICKINSON,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,000080
+DICKINSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000080
+DICKINSON,Center Township,President / Vice President,,Republican,"Trump, Donald J.",350,000080
+DICKINSON,Cheever Township,President / Vice President,,independent,"Stein, Jill",1,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+DICKINSON,Cheever Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+DICKINSON,Cheever Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000090
+DICKINSON,Cheever Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+DICKINSON,Cheever Township,President / Vice President,,Republican,"Trump, Donald J.",57,000090
+DICKINSON,Flora Township,President / Vice President,,independent,"Stein, Jill",3,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+DICKINSON,Flora Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+DICKINSON,Flora Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000100
+DICKINSON,Flora Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+DICKINSON,Flora Township,President / Vice President,,Republican,"Trump, Donald J.",69,000100
+DICKINSON,Fragrant Hill Township,President / Vice President,,independent,"Stein, Jill",1,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000110
+DICKINSON,Fragrant Hill Township,President / Vice President,,Republican,"Trump, Donald J.",114,000110
+DICKINSON,Garfield Township,President / Vice President,,independent,"Stein, Jill",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+DICKINSON,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+DICKINSON,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000120
+DICKINSON,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000120
+DICKINSON,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",79,000120
+DICKINSON,Grant Township,President / Vice President,,independent,"Stein, Jill",6,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",1,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"McMullin, Evan",5,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+DICKINSON,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+DICKINSON,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000130
+DICKINSON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000130
+DICKINSON,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",410,000130
+DICKINSON,Hayes Township,President / Vice President,,independent,"Stein, Jill",2,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+DICKINSON,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+DICKINSON,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000140
+DICKINSON,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+DICKINSON,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",121,000140
+DICKINSON,Herington Ward 1,President / Vice President,,independent,"Stein, Jill",7,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000150
+DICKINSON,Herington Ward 1,President / Vice President,,Republican,"Trump, Donald J.",198,000150
+DICKINSON,Herington Ward 2,President / Vice President,,independent,"Stein, Jill",9,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",18,000160
+DICKINSON,Herington Ward 2,President / Vice President,,Republican,"Trump, Donald J.",195,000160
+DICKINSON,Herington Ward 4,President / Vice President,,independent,"Stein, Jill",8,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",14,000170
+DICKINSON,Herington Ward 4,President / Vice President,,Republican,"Trump, Donald J.",130,000170
+DICKINSON,Holland Township,President / Vice President,,independent,"Stein, Jill",1,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+DICKINSON,Holland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+DICKINSON,Holland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000180
+DICKINSON,Holland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+DICKINSON,Holland Township,President / Vice President,,Republican,"Trump, Donald J.",56,000180
+DICKINSON,Hope Township,President / Vice President,,independent,"Stein, Jill",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+DICKINSON,Hope Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+DICKINSON,Hope Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000190
+DICKINSON,Hope Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000190
+DICKINSON,Hope Township,President / Vice President,,Republican,"Trump, Donald J.",153,000190
+DICKINSON,Jefferson Township,President / Vice President,,independent,"Stein, Jill",3,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",1,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+DICKINSON,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000200
+DICKINSON,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+DICKINSON,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",106,000200
+DICKINSON,Liberty Township,President / Vice President,,independent,"Stein, Jill",6,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",1,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+DICKINSON,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+DICKINSON,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000210
+DICKINSON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+DICKINSON,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",116,000210
+DICKINSON,Lincoln Township,President / Vice President,,independent,"Stein, Jill",8,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",4,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",3,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+DICKINSON,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",121,000220
+DICKINSON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000220
+DICKINSON,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",494,000220
+DICKINSON,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+DICKINSON,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+DICKINSON,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000230
+DICKINSON,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000230
+DICKINSON,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",62,000230
+DICKINSON,Newbern Township,President / Vice President,,independent,"Stein, Jill",3,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"McMullin, Evan",1,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+DICKINSON,Newbern Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+DICKINSON,Newbern Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000250
+DICKINSON,Newbern Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000250
+DICKINSON,Newbern Township,President / Vice President,,Republican,"Trump, Donald J.",174,000250
+DICKINSON,Noble Township,President / Vice President,,independent,"Stein, Jill",17,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"McMullin, Evan",3,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+DICKINSON,Noble Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+DICKINSON,Noble Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",146,000260
+DICKINSON,Noble Township,President / Vice President,,Libertarian,"Johnson, Gary",43,000260
+DICKINSON,Noble Township,President / Vice President,,Republican,"Trump, Donald J.",544,000260
+DICKINSON,Ridge Township,President / Vice President,,independent,"Stein, Jill",1,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+DICKINSON,Ridge Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+DICKINSON,Ridge Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000270
+DICKINSON,Ridge Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000270
+DICKINSON,Ridge Township,President / Vice President,,Republican,"Trump, Donald J.",60,000270
+DICKINSON,Rinehart Township,President / Vice President,,independent,"Stein, Jill",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+DICKINSON,Rinehart Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000280
+DICKINSON,Rinehart Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000280
+DICKINSON,Rinehart Township,President / Vice President,,Republican,"Trump, Donald J.",108,000280
+DICKINSON,Sherman Township,President / Vice President,,independent,"Stein, Jill",1,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",2,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+DICKINSON,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+DICKINSON,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000290
+DICKINSON,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000290
+DICKINSON,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",60,000290
+DICKINSON,Union Township,President / Vice President,,independent,"Stein, Jill",2,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+DICKINSON,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+DICKINSON,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000300
+DICKINSON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000300
+DICKINSON,Union Township,President / Vice President,,Republican,"Trump, Donald J.",59,000300
+DICKINSON,Wheatland Township,President / Vice President,,independent,"Stein, Jill",2,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"McMullin, Evan",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+DICKINSON,Wheatland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000310
+DICKINSON,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000310
+DICKINSON,Wheatland Township,President / Vice President,,Republican,"Trump, Donald J.",68,000310
+DICKINSON,Willowdale Township,President / Vice President,,independent,"Stein, Jill",1,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"McMullin, Evan",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+DICKINSON,Willowdale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000320
+DICKINSON,Willowdale Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000320
+DICKINSON,Willowdale Township,President / Vice President,,Republican,"Trump, Donald J.",114,000320
+DICKINSON,Lyon Township H68 A,President / Vice President,,independent,"Stein, Jill",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Castle, Darrell L",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Giordani, Rocky",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Hedges, James A",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Hoefling, Tom",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Kahn, Lynn",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"La Riva, Gloria",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Maturen, Michael A",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"McMullin, Evan",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Perry, Darryl",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Schriner, Joe C",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Smith, Mike",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Sood, Ajay",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Sterling, Shawna",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12002A
+DICKINSON,Lyon Township H68 A,President / Vice President,,Republican,"Trump, Donald J.",2,12002A
+DICKINSON,Lyon Township H68,President / Vice President,,independent,"Stein, Jill",2,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Hedges, James A",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"McMullin, Evan",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Perry, Darryl",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Smith, Mike",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Sood, Ajay",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+DICKINSON,Lyon Township H68,President / Vice President,,Republican,"Trump, Donald J.",25,120020
+DICKINSON,Lyon Township H70,President / Vice President,,independent,"Stein, Jill",3,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Hedges, James A",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"McMullin, Evan",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Perry, Darryl",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Smith, Mike",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Sood, Ajay",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Libertarian,"Johnson, Gary",1,120030
+DICKINSON,Lyon Township H70,President / Vice President,,Republican,"Trump, Donald J.",60,120030
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,independent,"Stein, Jill",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+DICKINSON,Grant Township Enclave,President / Vice President,,independent,"Stein, Jill",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+DICKINSON,Grant Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",119,000010
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",47,000010
+DICKINSON,Abilene Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",205,000010
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",202,00002A
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002A
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",55,00002A
+DICKINSON,Abilene Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",417,00002A
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00002B
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",127,000030
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000030
+DICKINSON,Abilene Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",208,000030
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",196,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",41,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",315,000040
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",202,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",43,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",434,000050
+DICKINSON,Banner Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000060
+DICKINSON,Banner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+DICKINSON,Banner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000060
+DICKINSON,Banner Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000060
+DICKINSON,Buckeye Township,United States House of Representatives,1,independent,"LaPolice, Alan",61,000070
+DICKINSON,Buckeye Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000070
+DICKINSON,Buckeye Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000070
+DICKINSON,Buckeye Township,United States House of Representatives,1,Republican,"Marshall, Roger",152,000070
+DICKINSON,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",109,000080
+DICKINSON,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+DICKINSON,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000080
+DICKINSON,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",289,000080
+DICKINSON,Cheever Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000090
+DICKINSON,Cheever Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000090
+DICKINSON,Cheever Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000090
+DICKINSON,Cheever Township,United States House of Representatives,1,Republican,"Marshall, Roger",47,000090
+DICKINSON,Flora Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000100
+DICKINSON,Flora Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000100
+DICKINSON,Flora Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000100
+DICKINSON,Flora Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000100
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000110
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000110
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000110
+DICKINSON,Fragrant Hill Township,United States House of Representatives,1,Republican,"Marshall, Roger",95,000110
+DICKINSON,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",39,000120
+DICKINSON,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+DICKINSON,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000120
+DICKINSON,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",61,000120
+DICKINSON,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",132,000130
+DICKINSON,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+DICKINSON,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000130
+DICKINSON,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",338,000130
+DICKINSON,Hayes Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000140
+DICKINSON,Hayes Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000140
+DICKINSON,Hayes Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000140
+DICKINSON,Hayes Township,United States House of Representatives,1,Republican,"Marshall, Roger",86,000140
+DICKINSON,Herington Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",91,000150
+DICKINSON,Herington Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000150
+DICKINSON,Herington Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000150
+DICKINSON,Herington Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",194,000150
+DICKINSON,Herington Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",100,000160
+DICKINSON,Herington Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+DICKINSON,Herington Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000160
+DICKINSON,Herington Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",181,000160
+DICKINSON,Herington Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",53,000170
+DICKINSON,Herington Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+DICKINSON,Herington Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,000170
+DICKINSON,Herington Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",108,000170
+DICKINSON,Holland Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000180
+DICKINSON,Holland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+DICKINSON,Holland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000180
+DICKINSON,Holland Township,United States House of Representatives,1,Republican,"Marshall, Roger",41,000180
+DICKINSON,Hope Township,United States House of Representatives,1,independent,"LaPolice, Alan",56,000190
+DICKINSON,Hope Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000190
+DICKINSON,Hope Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000190
+DICKINSON,Hope Township,United States House of Representatives,1,Republican,"Marshall, Roger",127,000190
+DICKINSON,Jefferson Township,United States House of Representatives,1,independent,"LaPolice, Alan",35,000200
+DICKINSON,Jefferson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+DICKINSON,Jefferson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000200
+DICKINSON,Jefferson Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000200
+DICKINSON,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",41,000210
+DICKINSON,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+DICKINSON,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000210
+DICKINSON,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",106,000210
+DICKINSON,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",197,000220
+DICKINSON,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000220
+DICKINSON,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,000220
+DICKINSON,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",404,000220
+DICKINSON,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000230
+DICKINSON,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+DICKINSON,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000230
+DICKINSON,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",58,000230
+DICKINSON,Newbern Township,United States House of Representatives,1,independent,"LaPolice, Alan",67,000250
+DICKINSON,Newbern Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+DICKINSON,Newbern Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000250
+DICKINSON,Newbern Township,United States House of Representatives,1,Republican,"Marshall, Roger",136,000250
+DICKINSON,Noble Township,United States House of Representatives,1,independent,"LaPolice, Alan",178,000260
+DICKINSON,Noble Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+DICKINSON,Noble Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,000260
+DICKINSON,Noble Township,United States House of Representatives,1,Republican,"Marshall, Roger",519,000260
+DICKINSON,Ridge Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000270
+DICKINSON,Ridge Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+DICKINSON,Ridge Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000270
+DICKINSON,Ridge Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000270
+DICKINSON,Rinehart Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000280
+DICKINSON,Rinehart Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+DICKINSON,Rinehart Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000280
+DICKINSON,Rinehart Township,United States House of Representatives,1,Republican,"Marshall, Roger",96,000280
+DICKINSON,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000290
+DICKINSON,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000290
+DICKINSON,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000290
+DICKINSON,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",46,000290
+DICKINSON,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",17,000300
+DICKINSON,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000300
+DICKINSON,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000300
+DICKINSON,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",52,000300
+DICKINSON,Wheatland Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000310
+DICKINSON,Wheatland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+DICKINSON,Wheatland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000310
+DICKINSON,Wheatland Township,United States House of Representatives,1,Republican,"Marshall, Roger",53,000310
+DICKINSON,Willowdale Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000320
+DICKINSON,Willowdale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000320
+DICKINSON,Willowdale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000320
+DICKINSON,Willowdale Township,United States House of Representatives,1,Republican,"Marshall, Roger",88,000320
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,independent,"LaPolice, Alan",1,12002A
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,12002A
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,12002A
+DICKINSON,Lyon Township H68 A,United States House of Representatives,1,Republican,"Marshall, Roger",2,12002A
+DICKINSON,Lyon Township H68,United States House of Representatives,1,independent,"LaPolice, Alan",7,120020
+DICKINSON,Lyon Township H68,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+DICKINSON,Lyon Township H68,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120020
+DICKINSON,Lyon Township H68,United States House of Representatives,1,Republican,"Marshall, Roger",25,120020
+DICKINSON,Lyon Township H70,United States House of Representatives,1,independent,"LaPolice, Alan",18,120030
+DICKINSON,Lyon Township H70,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+DICKINSON,Lyon Township H70,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,120030
+DICKINSON,Lyon Township H70,United States House of Representatives,1,Republican,"Marshall, Roger",56,120030
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900030
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900030
+DICKINSON,Grant Township Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900030
+DICKINSON,Abilene Ward 1,United States Senate,,write - in,"Smith, DJ",0,000010
+DICKINSON,Abilene Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",93,000010
+DICKINSON,Abilene Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",40,000010
+DICKINSON,Abilene Ward 1,United States Senate,,Republican,"Moran, Jerry",247,000010
+DICKINSON,Abilene Ward 2,United States Senate,,write - in,"Smith, DJ",0,00002A
+DICKINSON,Abilene Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",119,00002A
+DICKINSON,Abilene Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",57,00002A
+DICKINSON,Abilene Ward 2,United States Senate,,Republican,"Moran, Jerry",506,00002A
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002B
+DICKINSON,Abilene Ward 2 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00002B
+DICKINSON,Abilene Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+DICKINSON,Abilene Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",59,000030
+DICKINSON,Abilene Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",25,000030
+DICKINSON,Abilene Ward 3,United States Senate,,Republican,"Moran, Jerry",274,000030
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",135,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",33,000040
+DICKINSON,Abilene Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",395,000040
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",113,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",42,000050
+DICKINSON,Abilene Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",546,000050
+DICKINSON,Banner Township,United States Senate,,write - in,"Smith, DJ",0,000060
+DICKINSON,Banner Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000060
+DICKINSON,Banner Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000060
+DICKINSON,Banner Township,United States Senate,,Republican,"Moran, Jerry",46,000060
+DICKINSON,Buckeye Township,United States Senate,,write - in,"Smith, DJ",0,000070
+DICKINSON,Buckeye Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000070
+DICKINSON,Buckeye Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000070
+DICKINSON,Buckeye Township,United States Senate,,Republican,"Moran, Jerry",193,000070
+DICKINSON,Center Township,United States Senate,,write - in,"Smith, DJ",0,000080
+DICKINSON,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",52,000080
+DICKINSON,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000080
+DICKINSON,Center Township,United States Senate,,Republican,"Moran, Jerry",370,000080
+DICKINSON,Cheever Township,United States Senate,,write - in,"Smith, DJ",0,000090
+DICKINSON,Cheever Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000090
+DICKINSON,Cheever Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+DICKINSON,Cheever Township,United States Senate,,Republican,"Moran, Jerry",58,000090
+DICKINSON,Flora Township,United States Senate,,write - in,"Smith, DJ",0,000100
+DICKINSON,Flora Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000100
+DICKINSON,Flora Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000100
+DICKINSON,Flora Township,United States Senate,,Republican,"Moran, Jerry",64,000100
+DICKINSON,Fragrant Hill Township,United States Senate,,write - in,"Smith, DJ",0,000110
+DICKINSON,Fragrant Hill Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000110
+DICKINSON,Fragrant Hill Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000110
+DICKINSON,Fragrant Hill Township,United States Senate,,Republican,"Moran, Jerry",115,000110
+DICKINSON,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000120
+DICKINSON,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000120
+DICKINSON,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000120
+DICKINSON,Garfield Township,United States Senate,,Republican,"Moran, Jerry",88,000120
+DICKINSON,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000130
+DICKINSON,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",56,000130
+DICKINSON,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",26,000130
+DICKINSON,Grant Township,United States Senate,,Republican,"Moran, Jerry",418,000130
+DICKINSON,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000140
+DICKINSON,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000140
+DICKINSON,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000140
+DICKINSON,Hayes Township,United States Senate,,Republican,"Moran, Jerry",122,000140
+DICKINSON,Herington Ward 1,United States Senate,,write - in,"Smith, DJ",0,000150
+DICKINSON,Herington Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",81,000150
+DICKINSON,Herington Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",21,000150
+DICKINSON,Herington Ward 1,United States Senate,,Republican,"Moran, Jerry",212,000150
+DICKINSON,Herington Ward 2,United States Senate,,write - in,"Smith, DJ",0,000160
+DICKINSON,Herington Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",80,000160
+DICKINSON,Herington Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",26,000160
+DICKINSON,Herington Ward 2,United States Senate,,Republican,"Moran, Jerry",206,000160
+DICKINSON,Herington Ward 4,United States Senate,,write - in,"Smith, DJ",0,000170
+DICKINSON,Herington Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",37,000170
+DICKINSON,Herington Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",19,000170
+DICKINSON,Herington Ward 4,United States Senate,,Republican,"Moran, Jerry",131,000170
+DICKINSON,Holland Township,United States Senate,,write - in,"Smith, DJ",0,000180
+DICKINSON,Holland Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000180
+DICKINSON,Holland Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000180
+DICKINSON,Holland Township,United States Senate,,Republican,"Moran, Jerry",54,000180
+DICKINSON,Hope Township,United States Senate,,write - in,"Smith, DJ",0,000190
+DICKINSON,Hope Township,United States Senate,,Democratic,"Wiesner, Patrick",34,000190
+DICKINSON,Hope Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000190
+DICKINSON,Hope Township,United States Senate,,Republican,"Moran, Jerry",158,000190
+DICKINSON,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000200
+DICKINSON,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000200
+DICKINSON,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000200
+DICKINSON,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",101,000200
+DICKINSON,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000210
+DICKINSON,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000210
+DICKINSON,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000210
+DICKINSON,Liberty Township,United States Senate,,Republican,"Moran, Jerry",116,000210
+DICKINSON,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000220
+DICKINSON,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",82,000220
+DICKINSON,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",46,000220
+DICKINSON,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",512,000220
+DICKINSON,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000230
+DICKINSON,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000230
+DICKINSON,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000230
+DICKINSON,Logan Township,United States Senate,,Republican,"Moran, Jerry",72,000230
+DICKINSON,Newbern Township,United States Senate,,write - in,"Smith, DJ",0,000250
+DICKINSON,Newbern Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000250
+DICKINSON,Newbern Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000250
+DICKINSON,Newbern Township,United States Senate,,Republican,"Moran, Jerry",170,000250
+DICKINSON,Noble Township,United States Senate,,write - in,"Smith, DJ",0,000260
+DICKINSON,Noble Township,United States Senate,,Democratic,"Wiesner, Patrick",98,000260
+DICKINSON,Noble Township,United States Senate,,Libertarian,"Garrard, Robert D.",46,000260
+DICKINSON,Noble Township,United States Senate,,Republican,"Moran, Jerry",615,000260
+DICKINSON,Ridge Township,United States Senate,,write - in,"Smith, DJ",0,000270
+DICKINSON,Ridge Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000270
+DICKINSON,Ridge Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000270
+DICKINSON,Ridge Township,United States Senate,,Republican,"Moran, Jerry",65,000270
+DICKINSON,Rinehart Township,United States Senate,,write - in,"Smith, DJ",0,000280
+DICKINSON,Rinehart Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000280
+DICKINSON,Rinehart Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000280
+DICKINSON,Rinehart Township,United States Senate,,Republican,"Moran, Jerry",111,000280
+DICKINSON,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000290
+DICKINSON,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000290
+DICKINSON,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000290
+DICKINSON,Sherman Township,United States Senate,,Republican,"Moran, Jerry",60,000290
+DICKINSON,Union Township,United States Senate,,write - in,"Smith, DJ",0,000300
+DICKINSON,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000300
+DICKINSON,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000300
+DICKINSON,Union Township,United States Senate,,Republican,"Moran, Jerry",65,000300
+DICKINSON,Wheatland Township,United States Senate,,write - in,"Smith, DJ",0,000310
+DICKINSON,Wheatland Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000310
+DICKINSON,Wheatland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000310
+DICKINSON,Wheatland Township,United States Senate,,Republican,"Moran, Jerry",71,000310
+DICKINSON,Willowdale Township,United States Senate,,write - in,"Smith, DJ",0,000320
+DICKINSON,Willowdale Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000320
+DICKINSON,Willowdale Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000320
+DICKINSON,Willowdale Township,United States Senate,,Republican,"Moran, Jerry",112,000320
+DICKINSON,Lyon Township H68 A,United States Senate,,write - in,"Smith, DJ",0,12002A
+DICKINSON,Lyon Township H68 A,United States Senate,,Democratic,"Wiesner, Patrick",1,12002A
+DICKINSON,Lyon Township H68 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12002A
+DICKINSON,Lyon Township H68 A,United States Senate,,Republican,"Moran, Jerry",2,12002A
+DICKINSON,Lyon Township H68,United States Senate,,write - in,"Smith, DJ",0,120020
+DICKINSON,Lyon Township H68,United States Senate,,Democratic,"Wiesner, Patrick",5,120020
+DICKINSON,Lyon Township H68,United States Senate,,Libertarian,"Garrard, Robert D.",1,120020
+DICKINSON,Lyon Township H68,United States Senate,,Republican,"Moran, Jerry",27,120020
+DICKINSON,Lyon Township H70,United States Senate,,write - in,"Smith, DJ",0,120030
+DICKINSON,Lyon Township H70,United States Senate,,Democratic,"Wiesner, Patrick",11,120030
+DICKINSON,Lyon Township H70,United States Senate,,Libertarian,"Garrard, Robert D.",5,120030
+DICKINSON,Lyon Township H70,United States Senate,,Republican,"Moran, Jerry",66,120030
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+DICKINSON,Abilene Ward 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,900010
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,write - in,"Smith, DJ",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+DICKINSON,Abilene Ward 2 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,900020
+DICKINSON,Grant Township Enclave,United States Senate,,write - in,"Smith, DJ",0,900030
+DICKINSON,Grant Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+DICKINSON,Grant Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+DICKINSON,Grant Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,900030

--- a/2016/20161108__ks__general__doniphan__precinct.csv
+++ b/2016/20161108__ks__general__doniphan__precinct.csv
@@ -1,129 +1,469 @@
-county,precinct,office,district,party,candidate,votes
-Doniphan,BENDENA,President,,DEM,Hillary Clinton,27
-Doniphan,BLAIR,President,,DEM,Hillary Clinton,12
-Doniphan,BURR OAK,President,,DEM,Hillary Clinton,3
-Doniphan,DENTON,President,,DEM,Hillary Clinton,22
-Doniphan,ELWOOD,President,,DEM,Hillary Clinton,112
-Doniphan,HIGHLAND,President,,DEM,Hillary Clinton,77
-Doniphan,LEONA,President,,DEM,Hillary Clinton,0
-Doniphan,MARION,President,,DEM,Hillary Clinton,12
-Doniphan,SEVERANCE,President,,DEM,Hillary Clinton,9
-Doniphan,TROY,President,,DEM,Hillary Clinton,86
-Doniphan,WATHENA,President,,DEM,Hillary Clinton,89
-Doniphan,WAYNE,President,,DEM,Hillary Clinton,14
-Doniphan,WHITE CLOUD,President,,DEM,Hillary Clinton,12
-Doniphan,ADVANCE,President,,DEM,Hillary Clinton,107
-Doniphan,FEDERAL,President,,DEM,Hillary Clinton,2
-Doniphan,PROVISIONAL,President,,DEM,Hillary Clinton,3
-Doniphan,BENDENA,President,,REP,Donald J. Trump,101
-Doniphan,BLAIR,President,,REP,Donald J. Trump,74
-Doniphan,BURR OAK,President,,REP,Donald J. Trump,67
-Doniphan,DENTON,President,,REP,Donald J. Trump,114
-Doniphan,ELWOOD,President,,REP,Donald J. Trump,226
-Doniphan,HIGHLAND,President,,REP,Donald J. Trump,316
-Doniphan,LEONA,President,,REP,Donald J. Trump,36
-Doniphan,MARION,President,,REP,Donald J. Trump,91
-Doniphan,SEVERANCE,President,,REP,Donald J. Trump,83
-Doniphan,TROY,President,,REP,Donald J. Trump,504
-Doniphan,WATHENA,President,,REP,Donald J. Trump,489
-Doniphan,WAYNE,President,,REP,Donald J. Trump,70
-Doniphan,WHITE CLOUD,President,,REP,Donald J. Trump,72
-Doniphan,ADVANCE,President,,REP,Donald J. Trump,356
-Doniphan,FEDERAL,President,,REP,Donald J. Trump,2
-Doniphan,PROVISIONAL,President,,REP,Donald J. Trump,5
-Doniphan,BENDENA,President,,LBT,Gary Johnson,8
-Doniphan,BLAIR,President,,LBT,Gary Johnson,4
-Doniphan,BURR OAK,President,,LBT,Gary Johnson,0
-Doniphan,DENTON,President,,LBT,Gary Johnson,6
-Doniphan,ELWOOD,President,,LBT,Gary Johnson,20
-Doniphan,HIGHLAND,President,,LBT,Gary Johnson,18
-Doniphan,LEONA,President,,LBT,Gary Johnson,0
-Doniphan,MARION,President,,LBT,Gary Johnson,3
-Doniphan,SEVERANCE,President,,LBT,Gary Johnson,3
-Doniphan,TROY,President,,LBT,Gary Johnson,17
-Doniphan,WATHENA,President,,LBT,Gary Johnson,19
-Doniphan,WAYNE,President,,LBT,Gary Johnson,3
-Doniphan,WHITE CLOUD,President,,LBT,Gary Johnson,5
-Doniphan,ADVANCE,President,,LBT,Gary Johnson,19
-Doniphan,FEDERAL,President,,LBT,Gary Johnson,0
-Doniphan,PROVISIONAL,President,,LBT,Gary Johnson,0
-Doniphan,BENDENA,President,,IND,Jill Stein,5
-Doniphan,BLAIR,President,,IND,Jill Stein,2
-Doniphan,BURR OAK,President,,IND,Jill Stein,1
-Doniphan,DENTON,President,,IND,Jill Stein,3
-Doniphan,ELWOOD,President,,IND,Jill Stein,7
-Doniphan,HIGHLAND,President,,IND,Jill Stein,4
-Doniphan,LEONA,President,,IND,Jill Stein,1
-Doniphan,MARION,President,,IND,Jill Stein,4
-Doniphan,SEVERANCE,President,,IND,Jill Stein,0
-Doniphan,TROY,President,,IND,Jill Stein,10
-Doniphan,WATHENA,President,,IND,Jill Stein,12
-Doniphan,WAYNE,President,,IND,Jill Stein,0
-Doniphan,WHITE CLOUD,President,,IND,Jill Stein,1
-Doniphan,ADVANCE,President,,IND,Jill Stein,6
-Doniphan,FEDERAL,President,,IND,Jill Stein,0
-Doniphan,PROVISIONAL,President,,IND,Jill Stein,0
-Doniphan,BENDENA,President,,,Write-ins,1
-Doniphan,BLAIR,President,,,Write-ins,1
-Doniphan,BURR OAK,President,,,Write-ins,0
-Doniphan,DENTON,President,,,Write-ins,4
-Doniphan,ELWOOD,President,,,Write-ins,2
-Doniphan,HIGHLAND,President,,,Write-ins,2
-Doniphan,LEONA,President,,,Write-ins,2
-Doniphan,MARION,President,,,Write-ins,0
-Doniphan,SEVERANCE,President,,,Write-ins,0
-Doniphan,TROY,President,,,Write-ins,1
-Doniphan,WATHENA,President,,,Write-ins,3
-Doniphan,WAYNE,President,,,Write-ins,0
-Doniphan,WHITE CLOUD,President,,,Write-ins,0
-Doniphan,ADVANCE,President,,,Write-ins,5
-Doniphan,FEDERAL,President,,,Write-ins,0
-Doniphan,PROVISIONAL,President,,,Write-ins,0
-Doniphan,BENDENA,U.S. Senate,,DEM,Patrick Wiesner,18
-Doniphan,BLAIR,U.S. Senate,,DEM,Patrick Wiesner,15
-Doniphan,BURR OAK,U.S. Senate,,DEM,Patrick Wiesner,5
-Doniphan,DENTON,U.S. Senate,,DEM,Patrick Wiesner,19
-Doniphan,ELWOOD,U.S. Senate,,DEM,Patrick Wiesner,123
-Doniphan,HIGHLAND,U.S. Senate,,DEM,Patrick Wiesner,60
-Doniphan,LEONA,U.S. Senate,,DEM,Patrick Wiesner,1
-Doniphan,MARION,U.S. Senate,,DEM,Patrick Wiesner,20
-Doniphan,SEVERANCE,U.S. Senate,,DEM,Patrick Wiesner,16
-Doniphan,TROY,U.S. Senate,,DEM,Patrick Wiesner,99
-Doniphan,WATHENA,U.S. Senate,,DEM,Patrick Wiesner,101
-Doniphan,WAYNE,U.S. Senate,,DEM,Patrick Wiesner,16
-Doniphan,WHITE CLOUD,U.S. Senate,,DEM,Patrick Wiesner,18
-Doniphan,ADVANCE,U.S. Senate,,DEM,Patrick Wiesner,87
-Doniphan,FEDERAL,U.S. Senate,,DEM,Patrick Wiesner,2
-Doniphan,PROVISIONAL,U.S. Senate,,DEM,Patrick Wiesner,2
-Doniphan,BENDENA,U.S. Senate,,REP,Jerry Moran,117
-Doniphan,BLAIR,U.S. Senate,,REP,Jerry Moran,70
-Doniphan,BURR OAK,U.S. Senate,,REP,Jerry Moran,62
-Doniphan,DENTON,U.S. Senate,,REP,Jerry Moran,117
-Doniphan,ELWOOD,U.S. Senate,,REP,Jerry Moran,192
-Doniphan,HIGHLAND,U.S. Senate,,REP,Jerry Moran,326
-Doniphan,LEONA,U.S. Senate,,REP,Jerry Moran,39
-Doniphan,MARION,U.S. Senate,,REP,Jerry Moran,81
-Doniphan,SEVERANCE,U.S. Senate,,REP,Jerry Moran,73
-Doniphan,TROY,U.S. Senate,,REP,Jerry Moran,489
-Doniphan,WATHENA,U.S. Senate,,REP,Jerry Moran,468
-Doniphan,WAYNE,U.S. Senate,,REP,Jerry Moran,66
-Doniphan,WHITE CLOUD,U.S. Senate,,REP,Jerry Moran,64
-Doniphan,ADVANCE,U.S. Senate,,REP,Jerry Moran,367
-Doniphan,FEDERAL,U.S. Senate,,REP,Jerry Moran,2
-Doniphan,PROVISIONAL,U.S. Senate,,REP,Jerry Moran,5
-Doniphan,BENDENA,U.S. Senate,,LBT,Robert Garrard,4
-Doniphan,BLAIR,U.S. Senate,,LBT,Robert Garrard,4
-Doniphan,BURR OAK,U.S. Senate,,LBT,Robert Garrard,3
-Doniphan,DENTON,U.S. Senate,,LBT,Robert Garrard,10
-Doniphan,ELWOOD,U.S. Senate,,LBT,Robert Garrard,35
-Doniphan,HIGHLAND,U.S. Senate,,LBT,Robert Garrard,15
-Doniphan,LEONA,U.S. Senate,,LBT,Robert Garrard,0
-Doniphan,MARION,U.S. Senate,,LBT,Robert Garrard,7
-Doniphan,SEVERANCE,U.S. Senate,,LBT,Robert Garrard,3
-Doniphan,TROY,U.S. Senate,,LBT,Robert Garrard,21
-Doniphan,WATHENA,U.S. Senate,,LBT,Robert Garrard,22
-Doniphan,WAYNE,U.S. Senate,,LBT,Robert Garrard,3
-Doniphan,WHITE CLOUD,U.S. Senate,,LBT,Robert Garrard,7
-Doniphan,ADVANCE,U.S. Senate,,LBT,Robert Garrard,22
-Doniphan,FEDERAL,U.S. Senate,,LBT,Robert Garrard,0
-Doniphan,PROVISIONAL,U.S. Senate,,LBT,Robert Garrard,0
+county,precinct,office,district,party,candidate,votes,vtd
+DONIPHAN,Bendena Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",63,000010
+DONIPHAN,Bendena Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",104,000010
+DONIPHAN,Blair Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",47,000020
+DONIPHAN,Blair Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",58,000020
+DONIPHAN,Burr Oak Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",23,000030
+DONIPHAN,Burr Oak Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",52,000030
+DONIPHAN,Denton Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",55,000040
+DONIPHAN,Denton Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",115,000040
+DONIPHAN,Elwood Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",169,000050
+DONIPHAN,Elwood Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",206,000050
+DONIPHAN,Highland Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",261,000060
+DONIPHAN,Highland Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",215,000060
+DONIPHAN,Leona Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",20,000070
+DONIPHAN,Leona Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",23,000070
+DONIPHAN,Marion Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",38,000080
+DONIPHAN,Marion Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",96,000080
+DONIPHAN,Severance Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",49,000090
+DONIPHAN,Severance Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",69,000090
+DONIPHAN,Troy Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",224,000100
+DONIPHAN,Troy Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",570,000100
+DONIPHAN,Wathena Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",214,000110
+DONIPHAN,Wathena Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",492,000110
+DONIPHAN,Wayne Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",18,000120
+DONIPHAN,Wayne Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",76,000120
+DONIPHAN,White Cloud Township,Kansas House of Representatives,63,Democratic,"Neibling, W. Brett",52,000130
+DONIPHAN,White Cloud Township,Kansas House of Representatives,63,Republican,"Eplee, John R.",41,000130
+DONIPHAN,Bendena Township,Kansas Senate,1,Democratic,"Henry, Jerry",79,000010
+DONIPHAN,Bendena Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",88,000010
+DONIPHAN,Blair Township,Kansas Senate,1,Democratic,"Henry, Jerry",35,000020
+DONIPHAN,Blair Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",70,000020
+DONIPHAN,Burr Oak Township,Kansas Senate,1,Democratic,"Henry, Jerry",24,000030
+DONIPHAN,Burr Oak Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",51,000030
+DONIPHAN,Denton Township,Kansas Senate,1,Democratic,"Henry, Jerry",88,000040
+DONIPHAN,Denton Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",83,000040
+DONIPHAN,Elwood Township,Kansas Senate,1,Democratic,"Henry, Jerry",129,000050
+DONIPHAN,Elwood Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",246,000050
+DONIPHAN,Highland Township,Kansas Senate,1,Democratic,"Henry, Jerry",236,000060
+DONIPHAN,Highland Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",232,000060
+DONIPHAN,Leona Township,Kansas Senate,1,Democratic,"Henry, Jerry",15,000070
+DONIPHAN,Leona Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",28,000070
+DONIPHAN,Marion Township,Kansas Senate,1,Democratic,"Henry, Jerry",34,000080
+DONIPHAN,Marion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",98,000080
+DONIPHAN,Severance Township,Kansas Senate,1,Democratic,"Henry, Jerry",42,000090
+DONIPHAN,Severance Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",75,000090
+DONIPHAN,Troy Township,Kansas Senate,1,Democratic,"Henry, Jerry",265,000100
+DONIPHAN,Troy Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",506,000100
+DONIPHAN,Wathena Township,Kansas Senate,1,Democratic,"Henry, Jerry",211,000110
+DONIPHAN,Wathena Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",484,000110
+DONIPHAN,Wayne Township,Kansas Senate,1,Democratic,"Henry, Jerry",52,000120
+DONIPHAN,Wayne Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",43,000120
+DONIPHAN,White Cloud Township,Kansas Senate,1,Democratic,"Henry, Jerry",36,000130
+DONIPHAN,White Cloud Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",57,000130
+DONIPHAN,Bendena Township,President / Vice President,,independent,"Stein, Jill",7,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Maturen, Michael A",1,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+DONIPHAN,Bendena Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000010
+DONIPHAN,Bendena Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+DONIPHAN,Bendena Township,President / Vice President,,Republican,"Trump, Donald J.",119,000010
+DONIPHAN,Blair Township,President / Vice President,,independent,"Stein, Jill",2,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"McMullin, Evan",1,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+DONIPHAN,Blair Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+DONIPHAN,Blair Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000020
+DONIPHAN,Blair Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+DONIPHAN,Blair Township,President / Vice President,,Republican,"Trump, Donald J.",86,000020
+DONIPHAN,Burr Oak Township,President / Vice President,,independent,"Stein, Jill",1,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+DONIPHAN,Burr Oak Township,President / Vice President,,Republican,"Trump, Donald J.",70,000030
+DONIPHAN,Denton Township,President / Vice President,,independent,"Stein, Jill",3,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+DONIPHAN,Denton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+DONIPHAN,Denton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000040
+DONIPHAN,Denton Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000040
+DONIPHAN,Denton Township,President / Vice President,,Republican,"Trump, Donald J.",132,000040
+DONIPHAN,Elwood Township,President / Vice President,,independent,"Stein, Jill",7,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+DONIPHAN,Elwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",117,000050
+DONIPHAN,Elwood Township,President / Vice President,,Libertarian,"Johnson, Gary",21,000050
+DONIPHAN,Elwood Township,President / Vice President,,Republican,"Trump, Donald J.",244,000050
+DONIPHAN,Highland Township,President / Vice President,,independent,"Stein, Jill",4,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+DONIPHAN,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+DONIPHAN,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,000060
+DONIPHAN,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000060
+DONIPHAN,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",356,000060
+DONIPHAN,Leona Township,President / Vice President,,independent,"Stein, Jill",1,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+DONIPHAN,Leona Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+DONIPHAN,Leona Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000070
+DONIPHAN,Leona Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+DONIPHAN,Leona Township,President / Vice President,,Republican,"Trump, Donald J.",39,000070
+DONIPHAN,Marion Township,President / Vice President,,independent,"Stein, Jill",4,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+DONIPHAN,Marion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+DONIPHAN,Marion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000080
+DONIPHAN,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+DONIPHAN,Marion Township,President / Vice President,,Republican,"Trump, Donald J.",111,000080
+DONIPHAN,Severance Township,President / Vice President,,independent,"Stein, Jill",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+DONIPHAN,Severance Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+DONIPHAN,Severance Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000090
+DONIPHAN,Severance Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+DONIPHAN,Severance Township,President / Vice President,,Republican,"Trump, Donald J.",101,000090
+DONIPHAN,Troy Township,President / Vice President,,independent,"Stein, Jill",13,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+DONIPHAN,Troy Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+DONIPHAN,Troy Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",130,000100
+DONIPHAN,Troy Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000100
+DONIPHAN,Troy Township,President / Vice President,,Republican,"Trump, Donald J.",628,000100
+DONIPHAN,Wathena Township,President / Vice President,,independent,"Stein, Jill",12,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Maturen, Michael A",1,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+DONIPHAN,Wathena Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",113,000110
+DONIPHAN,Wathena Township,President / Vice President,,Libertarian,"Johnson, Gary",25,000110
+DONIPHAN,Wathena Township,President / Vice President,,Republican,"Trump, Donald J.",570,000110
+DONIPHAN,Wayne Township,President / Vice President,,independent,"Stein, Jill",1,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+DONIPHAN,Wayne Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000120
+DONIPHAN,Wayne Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000120
+DONIPHAN,Wayne Township,President / Vice President,,Republican,"Trump, Donald J.",73,000120
+DONIPHAN,White Cloud Township,President / Vice President,,independent,"Stein, Jill",1,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+DONIPHAN,White Cloud Township,President / Vice President,,Republican,"Trump, Donald J.",77,000130
+DONIPHAN,Bendena Township,United States House of Representatives,2,Democratic,"Potter, Britani",18,000010
+DONIPHAN,Bendena Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000010
+DONIPHAN,Bendena Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",138,000010
+DONIPHAN,Blair Township,United States House of Representatives,2,Democratic,"Potter, Britani",10,000020
+DONIPHAN,Blair Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000020
+DONIPHAN,Blair Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,000020
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Democratic,"Potter, Britani",4,000030
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000030
+DONIPHAN,Burr Oak Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000030
+DONIPHAN,Denton Township,United States House of Representatives,2,Democratic,"Potter, Britani",22,000040
+DONIPHAN,Denton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000040
+DONIPHAN,Denton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000040
+DONIPHAN,Elwood Township,United States House of Representatives,2,Democratic,"Potter, Britani",97,000050
+DONIPHAN,Elwood Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",34,000050
+DONIPHAN,Elwood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",248,000050
+DONIPHAN,Highland Township,United States House of Representatives,2,Democratic,"Potter, Britani",84,000060
+DONIPHAN,Highland Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000060
+DONIPHAN,Highland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",365,000060
+DONIPHAN,Leona Township,United States House of Representatives,2,Democratic,"Potter, Britani",0,000070
+DONIPHAN,Leona Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000070
+DONIPHAN,Leona Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000070
+DONIPHAN,Marion Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000080
+DONIPHAN,Marion Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000080
+DONIPHAN,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,000080
+DONIPHAN,Severance Township,United States House of Representatives,2,Democratic,"Potter, Britani",11,000090
+DONIPHAN,Severance Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000090
+DONIPHAN,Severance Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",97,000090
+DONIPHAN,Troy Township,United States House of Representatives,2,Democratic,"Potter, Britani",99,000100
+DONIPHAN,Troy Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",37,000100
+DONIPHAN,Troy Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",640,000100
+DONIPHAN,Wathena Township,United States House of Representatives,2,Democratic,"Potter, Britani",99,000110
+DONIPHAN,Wathena Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",32,000110
+DONIPHAN,Wathena Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",574,000110
+DONIPHAN,Wayne Township,United States House of Representatives,2,Democratic,"Potter, Britani",13,000120
+DONIPHAN,Wayne Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000120
+DONIPHAN,Wayne Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000120
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Democratic,"Potter, Britani",16,000130
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000130
+DONIPHAN,White Cloud Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000130
+DONIPHAN,Bendena Township,United States Senate,,write - in,"Smith, DJ",0,000010
+DONIPHAN,Bendena Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000010
+DONIPHAN,Bendena Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+DONIPHAN,Bendena Township,United States Senate,,Republican,"Moran, Jerry",138,000010
+DONIPHAN,Blair Township,United States Senate,,write - in,"Smith, DJ",0,000020
+DONIPHAN,Blair Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000020
+DONIPHAN,Blair Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+DONIPHAN,Blair Township,United States Senate,,Republican,"Moran, Jerry",82,000020
+DONIPHAN,Burr Oak Township,United States Senate,,write - in,"Smith, DJ",0,000030
+DONIPHAN,Burr Oak Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000030
+DONIPHAN,Burr Oak Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+DONIPHAN,Burr Oak Township,United States Senate,,Republican,"Moran, Jerry",65,000030
+DONIPHAN,Denton Township,United States Senate,,write - in,"Smith, DJ",0,000040
+DONIPHAN,Denton Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000040
+DONIPHAN,Denton Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000040
+DONIPHAN,Denton Township,United States Senate,,Republican,"Moran, Jerry",134,000040
+DONIPHAN,Elwood Township,United States Senate,,write - in,"Smith, DJ",0,000050
+DONIPHAN,Elwood Township,United States Senate,,Democratic,"Wiesner, Patrick",127,000050
+DONIPHAN,Elwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",37,000050
+DONIPHAN,Elwood Township,United States Senate,,Republican,"Moran, Jerry",210,000050
+DONIPHAN,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000060
+DONIPHAN,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",75,000060
+DONIPHAN,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000060
+DONIPHAN,Highland Township,United States Senate,,Republican,"Moran, Jerry",369,000060
+DONIPHAN,Leona Township,United States Senate,,write - in,"Smith, DJ",0,000070
+DONIPHAN,Leona Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000070
+DONIPHAN,Leona Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+DONIPHAN,Leona Township,United States Senate,,Republican,"Moran, Jerry",41,000070
+DONIPHAN,Marion Township,United States Senate,,write - in,"Smith, DJ",0,000080
+DONIPHAN,Marion Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000080
+DONIPHAN,Marion Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+DONIPHAN,Marion Township,United States Senate,,Republican,"Moran, Jerry",101,000080
+DONIPHAN,Severance Township,United States Senate,,write - in,"Smith, DJ",0,000090
+DONIPHAN,Severance Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000090
+DONIPHAN,Severance Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+DONIPHAN,Severance Township,United States Senate,,Republican,"Moran, Jerry",91,000090
+DONIPHAN,Troy Township,United States Senate,,write - in,"Smith, DJ",0,000100
+DONIPHAN,Troy Township,United States Senate,,Democratic,"Wiesner, Patrick",135,000100
+DONIPHAN,Troy Township,United States Senate,,Libertarian,"Garrard, Robert D.",30,000100
+DONIPHAN,Troy Township,United States Senate,,Republican,"Moran, Jerry",612,000100
+DONIPHAN,Wathena Township,United States Senate,,write - in,"Smith, DJ",0,000110
+DONIPHAN,Wathena Township,United States Senate,,Democratic,"Wiesner, Patrick",118,000110
+DONIPHAN,Wathena Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,000110
+DONIPHAN,Wathena Township,United States Senate,,Republican,"Moran, Jerry",554,000110
+DONIPHAN,Wayne Township,United States Senate,,write - in,"Smith, DJ",0,000120
+DONIPHAN,Wayne Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000120
+DONIPHAN,Wayne Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000120
+DONIPHAN,Wayne Township,United States Senate,,Republican,"Moran, Jerry",71,000120
+DONIPHAN,White Cloud Township,United States Senate,,write - in,"Smith, DJ",0,000130
+DONIPHAN,White Cloud Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000130
+DONIPHAN,White Cloud Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000130
+DONIPHAN,White Cloud Township,United States Senate,,Republican,"Moran, Jerry",70,000130

--- a/2016/20161108__ks__general__douglas__precinct.csv
+++ b/2016/20161108__ks__general__douglas__precinct.csv
@@ -1,1372 +1,4358 @@
-county,precinct,office,district,party,candidate,votes
-Douglas,Precinct 01,President,,IND,Jill Stein,34
-Douglas,Precinct 02,President,,IND,Jill Stein,24
-Douglas,Precinct 03,President,,IND,Jill Stein,20
-Douglas,Precinct 04,President,,IND,Jill Stein,27
-Douglas,Precinct 05,President,,IND,Jill Stein,16
-Douglas,Precinct 06,President,,IND,Jill Stein,27
-Douglas,Precinct 07,President,,IND,Jill Stein,26
-Douglas,Precinct 08,President,,IND,Jill Stein,22
-Douglas,Precinct 09,President,,IND,Jill Stein,8
-Douglas,Precinct 10,President,,IND,Jill Stein,6
-Douglas,Precinct 11,President,,IND,Jill Stein,24
-Douglas,Precinct 12,President,,IND,Jill Stein,35
-Douglas,Precinct 13,President,,IND,Jill Stein,13
-Douglas,Precinct 14,President,,IND,Jill Stein,30
-Douglas,Precinct 15,President,,IND,Jill Stein,22
-Douglas,Precinct 16,President,,IND,Jill Stein,16
-Douglas,Precinct 17,President,,IND,Jill Stein,27
-Douglas,Precinct 18,President,,IND,Jill Stein,17
-Douglas,Precinct 19,President,,IND,Jill Stein,16
-Douglas,Precinct 20,President,,IND,Jill Stein,20
-Douglas,Precinct 21,President,,IND,Jill Stein,6
-Douglas,Precinct 22,President,,IND,Jill Stein,21
-Douglas,Precinct 23,President,,IND,Jill Stein,18
-Douglas,Precinct 24,President,,IND,Jill Stein,12
-Douglas,Precinct 25,President,,IND,Jill Stein,14
-Douglas,Precinct 26,President,,IND,Jill Stein,25
-Douglas,Precinct 27,President,,IND,Jill Stein,37
-Douglas,Precinct 28,President,,IND,Jill Stein,10
-Douglas,Precinct 29,President,,IND,Jill Stein,15
-Douglas,Precinct 30 S2,President,,IND,Jill Stein,8
-Douglas,Precinct 30 S3,President,,IND,Jill Stein,12
-Douglas,Precinct 31,President,,IND,Jill Stein,21
-Douglas,Precinct 32,President,,IND,Jill Stein,28
-Douglas,Precinct 33,President,,IND,Jill Stein,37
-Douglas,Precinct 34 S2,President,,IND,Jill Stein,25
-Douglas,Precinct 34 S3,President,,IND,Jill Stein,5
-Douglas,Precinct 35 S2,President,,IND,Jill Stein,39
-Douglas,Precinct 35 S3,President,,IND,Jill Stein,5
-Douglas,Precinct 36 S2,President,,IND,Jill Stein,24
-Douglas,Precinct 37 H10,President,,IND,Jill Stein,41
-Douglas,Precinct 38 H10,President,,IND,Jill Stein,24
-Douglas,Precinct 39,President,,IND,Jill Stein,41
-Douglas,Precinct 40,President,,IND,Jill Stein,37
-Douglas,Precinct 41 S3 H46,President,,IND,Jill Stein,59
-Douglas,Precinct 41 S3 H45,President,,IND,Jill Stein,0
-Douglas,Precinct 41 S2 H46,President,,IND,Jill Stein,1
-Douglas,Precinct 41,President,,IND,Jill Stein,0
-Douglas,Precinct 42 H46,President,,IND,Jill Stein,9
-Douglas,Precinct 42 H45,President,,IND,Jill Stein,3
-Douglas,Precinct 43 CC1,President,,IND,Jill Stein,14
-Douglas,Precinct 43 CC3,President,,IND,Jill Stein,26
-Douglas,Precinct 44 H45,President,,IND,Jill Stein,13
-Douglas,Precinct 44 H44,President,,IND,Jill Stein,10
-Douglas,Precinct 45,President,,IND,Jill Stein,21
-Douglas,Precinct 46 S3,President,,IND,Jill Stein,49
-Douglas,Precinct 47,President,,IND,Jill Stein,11
-Douglas,Precinct 48,President,,IND,Jill Stein,23
-Douglas,Precinct 49,President,,IND,Jill Stein,26
-Douglas,Precinct 50,President,,IND,Jill Stein,26
-Douglas,Precinct 51,President,,IND,Jill Stein,2
-Douglas,Precinct 52,President,,IND,Jill Stein,14
-Douglas,Precinct 53 H10,President,,IND,Jill Stein,10
-Douglas,Precinct 53 H42,President,,IND,Jill Stein,16
-Douglas,Precinct 54,President,,IND,Jill Stein,28
-Douglas,Precinct 55 S3 H45,President,,IND,Jill Stein,5
-Douglas,Precinct 55 S3 H46,President,,IND,Jill Stein,3
-Douglas,Precinct 55 S2 H45,President,,IND,Jill Stein,5
-Douglas,Precinct 56 S19,President,,IND,Jill Stein,14
-Douglas,Precinct 56 S2,President,,IND,Jill Stein,0
-Douglas,Precinct 57 S2,President,,IND,Jill Stein,15
-Douglas,Precinct 57 S19,President,,IND,Jill Stein,3
-Douglas,Precinct 58,President,,IND,Jill Stein,2
-Douglas,Precinct 59 H54,President,,IND,Jill Stein,9
-Douglas,Precinct 59 H45,President,,IND,Jill Stein,10
-Douglas,Precinct 60,President,,IND,Jill Stein,16
-Douglas,Precinct 61,President,,IND,Jill Stein,25
-Douglas,Precinct 62,President,,IND,Jill Stein,23
-Douglas,Precinct 63,President,,IND,Jill Stein,12
-Douglas,Precinct 64 H45,President,,IND,Jill Stein,4
-Douglas,Precinct 64 H46,President,,IND,Jill Stein,0
-Douglas,Precinct 65 H10,President,,IND,Jill Stein,5
-Douglas,Precinct 65 H46,President,,IND,Jill Stein,4
-Douglas,Precinct 66 S19 H45,President,,IND,Jill Stein,4
-Douglas,Precinct 66 S3 H44,President,,IND,Jill Stein,0
-Douglas,Precinct 66 S3 H45,President,,IND,Jill Stein,1
-Douglas,Precinct 66 S19 H10,President,,IND,Jill Stein,2
-Douglas,Precinct 66 S3 H10,President,,IND,Jill Stein,4
-Douglas,Precinct 67 S19 H54,President,,IND,Jill Stein,7
-Douglas,Precinct 67 S19 H45,President,,IND,Jill Stein,9
-Douglas,Precinct 67 S3 H45,President,,IND,Jill Stein,3
-Douglas,Precinct 67 S3 H54,President,,IND,Jill Stein,2
-Douglas,Precinct 70,President,,IND,Jill Stein,0
-Douglas,Precinct 71,President,,IND,Jill Stein,27
-Douglas,Precinct 74,President,,IND,Jill Stein,19
-Douglas,Precinct 76,President,,IND,Jill Stein,0
-Douglas,Precinct 77,President,,IND,Jill Stein,26
-Douglas,Precinct 01,President,,D,Hillary Clinton,420
-Douglas,Precinct 02,President,,D,Hillary Clinton,492
-Douglas,Precinct 03,President,,D,Hillary Clinton,492
-Douglas,Precinct 04,President,,D,Hillary Clinton,397
-Douglas,Precinct 05,President,,D,Hillary Clinton,327
-Douglas,Precinct 06,President,,D,Hillary Clinton,460
-Douglas,Precinct 07,President,,D,Hillary Clinton,233
-Douglas,Precinct 08,President,,D,Hillary Clinton,319
-Douglas,Precinct 09,President,,D,Hillary Clinton,318
-Douglas,Precinct 10,President,,D,Hillary Clinton,184
-Douglas,Precinct 11,President,,D,Hillary Clinton,403
-Douglas,Precinct 12,President,,D,Hillary Clinton,620
-Douglas,Precinct 13,President,,D,Hillary Clinton,570
-Douglas,Precinct 14,President,,D,Hillary Clinton,805
-Douglas,Precinct 15,President,,D,Hillary Clinton,694
-Douglas,Precinct 16,President,,D,Hillary Clinton,506
-Douglas,Precinct 17,President,,D,Hillary Clinton,702
-Douglas,Precinct 18,President,,D,Hillary Clinton,826
-Douglas,Precinct 19,President,,D,Hillary Clinton,612
-Douglas,Precinct 20,President,,D,Hillary Clinton,840
-Douglas,Precinct 21,President,,D,Hillary Clinton,311
-Douglas,Precinct 22,President,,D,Hillary Clinton,464
-Douglas,Precinct 23,President,,D,Hillary Clinton,404
-Douglas,Precinct 24,President,,D,Hillary Clinton,356
-Douglas,Precinct 25,President,,D,Hillary Clinton,329
-Douglas,Precinct 26,President,,D,Hillary Clinton,473
-Douglas,Precinct 27,President,,D,Hillary Clinton,428
-Douglas,Precinct 28,President,,D,Hillary Clinton,280
-Douglas,Precinct 29,President,,D,Hillary Clinton,382
-Douglas,Precinct 30 S2,President,,D,Hillary Clinton,146
-Douglas,Precinct 30 S3,President,,D,Hillary Clinton,255
-Douglas,Precinct 31,President,,D,Hillary Clinton,515
-Douglas,Precinct 32,President,,D,Hillary Clinton,315
-Douglas,Precinct 33,President,,D,Hillary Clinton,545
-Douglas,Precinct 34 S2,President,,D,Hillary Clinton,333
-Douglas,Precinct 34 S3,President,,D,Hillary Clinton,78
-Douglas,Precinct 35 S2,President,,D,Hillary Clinton,473
-Douglas,Precinct 35 S3,President,,D,Hillary Clinton,29
-Douglas,Precinct 36 S2,President,,D,Hillary Clinton,343
-Douglas,Precinct 37 H10,President,,D,Hillary Clinton,487
-Douglas,Precinct 38 H10,President,,D,Hillary Clinton,715
-Douglas,Precinct 39,President,,D,Hillary Clinton,572
-Douglas,Precinct 40,President,,D,Hillary Clinton,521
-Douglas,Precinct 41 S3 H46,President,,D,Hillary Clinton,795
-Douglas,Precinct 41 S3 H45,President,,D,Hillary Clinton,4
-Douglas,Precinct 41 S2 H46,President,,D,Hillary Clinton,9
-Douglas,Precinct 41,President,,D,Hillary Clinton,0
-Douglas,Precinct 42 H46,President,,D,Hillary Clinton,197
-Douglas,Precinct 42 H45,President,,D,Hillary Clinton,212
-Douglas,Precinct 43 CC1,President,,D,Hillary Clinton,296
-Douglas,Precinct 43 CC3,President,,D,Hillary Clinton,516
-Douglas,Precinct 44 H45,President,,D,Hillary Clinton,313
-Douglas,Precinct 44 H44,President,,D,Hillary Clinton,240
-Douglas,Precinct 45,President,,D,Hillary Clinton,668
-Douglas,Precinct 46 S3,President,,D,Hillary Clinton,898
-Douglas,Precinct 47,President,,D,Hillary Clinton,290
-Douglas,Precinct 48,President,,D,Hillary Clinton,699
-Douglas,Precinct 49,President,,D,Hillary Clinton,649
-Douglas,Precinct 50,President,,D,Hillary Clinton,388
-Douglas,Precinct 51,President,,D,Hillary Clinton,179
-Douglas,Precinct 52,President,,D,Hillary Clinton,189
-Douglas,Precinct 53 H10,President,,D,Hillary Clinton,169
-Douglas,Precinct 53 H42,President,,D,Hillary Clinton,196
-Douglas,Precinct 54,President,,D,Hillary Clinton,296
-Douglas,Precinct 55 S3 H45,President,,D,Hillary Clinton,71
-Douglas,Precinct 55 S3 H46,President,,D,Hillary Clinton,29
-Douglas,Precinct 55 S2 H45,President,,D,Hillary Clinton,24
-Douglas,Precinct 56 S19,President,,D,Hillary Clinton,390
-Douglas,Precinct 56 S2,President,,D,Hillary Clinton,31
-Douglas,Precinct 57 S2,President,,D,Hillary Clinton,193
-Douglas,Precinct 57 S19,President,,D,Hillary Clinton,51
-Douglas,Precinct 58,President,,D,Hillary Clinton,95
-Douglas,Precinct 59 H54,President,,D,Hillary Clinton,54
-Douglas,Precinct 59 H45,President,,D,Hillary Clinton,134
-Douglas,Precinct 60,President,,D,Hillary Clinton,334
-Douglas,Precinct 61,President,,D,Hillary Clinton,415
-Douglas,Precinct 62,President,,D,Hillary Clinton,340
-Douglas,Precinct 63,President,,D,Hillary Clinton,289
-Douglas,Precinct 64 H45,President,,D,Hillary Clinton,133
-Douglas,Precinct 64 H46,President,,D,Hillary Clinton,1
-Douglas,Precinct 65 H10,President,,D,Hillary Clinton,182
-Douglas,Precinct 65 H46,President,,D,Hillary Clinton,19
-Douglas,Precinct 66 S19 H45,President,,D,Hillary Clinton,99
-Douglas,Precinct 66 S3 H44,President,,D,Hillary Clinton,0
-Douglas,Precinct 66 S3 H45,President,,D,Hillary Clinton,2
-Douglas,Precinct 66 S19 H10,President,,D,Hillary Clinton,124
-Douglas,Precinct 66 S3 H10,President,,D,Hillary Clinton,83
-Douglas,Precinct 67 S19 H54,President,,D,Hillary Clinton,115
-Douglas,Precinct 67 S19 H45,President,,D,Hillary Clinton,149
-Douglas,Precinct 67 S3 H45,President,,D,Hillary Clinton,50
-Douglas,Precinct 67 S3 H54,President,,D,Hillary Clinton,29
-Douglas,Precinct 70,President,,D,Hillary Clinton,6
-Douglas,Precinct 71,President,,D,Hillary Clinton,646
-Douglas,Precinct 74,President,,D,Hillary Clinton,609
-Douglas,Precinct 76,President,,D,Hillary Clinton,10
-Douglas,Precinct 77,President,,D,Hillary Clinton,311
-Douglas,Precinct 01,President,,R,Donald Trump,58
-Douglas,Precinct 02,President,,R,Donald Trump,55
-Douglas,Precinct 03,President,,R,Donald Trump,61
-Douglas,Precinct 04,President,,R,Donald Trump,94
-Douglas,Precinct 05,President,,R,Donald Trump,160
-Douglas,Precinct 06,President,,R,Donald Trump,206
-Douglas,Precinct 07,President,,R,Donald Trump,26
-Douglas,Precinct 08,President,,R,Donald Trump,52
-Douglas,Precinct 09,President,,R,Donald Trump,32
-Douglas,Precinct 10,President,,R,Donald Trump,33
-Douglas,Precinct 11,President,,R,Donald Trump,113
-Douglas,Precinct 12,President,,R,Donald Trump,209
-Douglas,Precinct 13,President,,R,Donald Trump,158
-Douglas,Precinct 14,President,,R,Donald Trump,353
-Douglas,Precinct 15,President,,R,Donald Trump,144
-Douglas,Precinct 16,President,,R,Donald Trump,165
-Douglas,Precinct 17,President,,R,Donald Trump,306
-Douglas,Precinct 18,President,,R,Donald Trump,332
-Douglas,Precinct 19,President,,R,Donald Trump,303
-Douglas,Precinct 20,President,,R,Donald Trump,322
-Douglas,Precinct 21,President,,R,Donald Trump,74
-Douglas,Precinct 22,President,,R,Donald Trump,193
-Douglas,Precinct 23,President,,R,Donald Trump,103
-Douglas,Precinct 24,President,,R,Donald Trump,134
-Douglas,Precinct 25,President,,R,Donald Trump,49
-Douglas,Precinct 26,President,,R,Donald Trump,78
-Douglas,Precinct 27,President,,R,Donald Trump,87
-Douglas,Precinct 28,President,,R,Donald Trump,60
-Douglas,Precinct 29,President,,R,Donald Trump,94
-Douglas,Precinct 30 S2,President,,R,Donald Trump,41
-Douglas,Precinct 30 S3,President,,R,Donald Trump,56
-Douglas,Precinct 31,President,,R,Donald Trump,181
-Douglas,Precinct 32,President,,R,Donald Trump,110
-Douglas,Precinct 33,President,,R,Donald Trump,79
-Douglas,Precinct 34 S2,President,,R,Donald Trump,58
-Douglas,Precinct 34 S3,President,,R,Donald Trump,2
-Douglas,Precinct 35 S2,President,,R,Donald Trump,100
-Douglas,Precinct 35 S3,President,,R,Donald Trump,17
-Douglas,Precinct 36 S2,President,,R,Donald Trump,124
-Douglas,Precinct 37 H10,President,,R,Donald Trump,218
-Douglas,Precinct 38 H10,President,,R,Donald Trump,292
-Douglas,Precinct 39,President,,R,Donald Trump,48
-Douglas,Precinct 40,President,,R,Donald Trump,37
-Douglas,Precinct 41 S3 H46,President,,R,Donald Trump,232
-Douglas,Precinct 41 S3 H45,President,,R,Donald Trump,0
-Douglas,Precinct 41 S2 H46,President,,R,Donald Trump,3
-Douglas,Precinct 41,President,,R,Donald Trump,0
-Douglas,Precinct 42 H46,President,,R,Donald Trump,54
-Douglas,Precinct 42 H45,President,,R,Donald Trump,99
-Douglas,Precinct 43 CC1,President,,R,Donald Trump,157
-Douglas,Precinct 43 CC3,President,,R,Donald Trump,216
-Douglas,Precinct 44 H45,President,,R,Donald Trump,169
-Douglas,Precinct 44 H44,President,,R,Donald Trump,81
-Douglas,Precinct 45,President,,R,Donald Trump,363
-Douglas,Precinct 46 S3,President,,R,Donald Trump,364
-Douglas,Precinct 47,President,,R,Donald Trump,147
-Douglas,Precinct 48,President,,R,Donald Trump,263
-Douglas,Precinct 49,President,,R,Donald Trump,427
-Douglas,Precinct 50,President,,R,Donald Trump,565
-Douglas,Precinct 51,President,,R,Donald Trump,195
-Douglas,Precinct 52,President,,R,Donald Trump,207
-Douglas,Precinct 53 H10,President,,R,Donald Trump,305
-Douglas,Precinct 53 H42,President,,R,Donald Trump,315
-Douglas,Precinct 54,President,,R,Donald Trump,388
-Douglas,Precinct 55 S3 H45,President,,R,Donald Trump,53
-Douglas,Precinct 55 S3 H46,President,,R,Donald Trump,13
-Douglas,Precinct 55 S2 H45,President,,R,Donald Trump,8
-Douglas,Precinct 56 S19,President,,R,Donald Trump,369
-Douglas,Precinct 56 S2,President,,R,Donald Trump,19
-Douglas,Precinct 57 S2,President,,R,Donald Trump,252
-Douglas,Precinct 57 S19,President,,R,Donald Trump,82
-Douglas,Precinct 58,President,,R,Donald Trump,102
-Douglas,Precinct 59 H54,President,,R,Donald Trump,126
-Douglas,Precinct 59 H45,President,,R,Donald Trump,119
-Douglas,Precinct 60,President,,R,Donald Trump,342
-Douglas,Precinct 61,President,,R,Donald Trump,540
-Douglas,Precinct 62,President,,R,Donald Trump,513
-Douglas,Precinct 63,President,,R,Donald Trump,346
-Douglas,Precinct 64 H45,President,,R,Donald Trump,67
-Douglas,Precinct 64 H46,President,,R,Donald Trump,0
-Douglas,Precinct 65 H10,President,,R,Donald Trump,206
-Douglas,Precinct 65 H46,President,,R,Donald Trump,6
-Douglas,Precinct 66 S19 H45,President,,R,Donald Trump,92
-Douglas,Precinct 66 S3 H44,President,,R,Donald Trump,0
-Douglas,Precinct 66 S3 H45,President,,R,Donald Trump,0
-Douglas,Precinct 66 S19 H10,President,,R,Donald Trump,125
-Douglas,Precinct 66 S3 H10,President,,R,Donald Trump,77
-Douglas,Precinct 67 S19 H54,President,,R,Donald Trump,210
-Douglas,Precinct 67 S19 H45,President,,R,Donald Trump,132
-Douglas,Precinct 67 S3 H45,President,,R,Donald Trump,41
-Douglas,Precinct 67 S3 H54,President,,R,Donald Trump,41
-Douglas,Precinct 70,President,,R,Donald Trump,7
-Douglas,Precinct 71,President,,R,Donald Trump,313
-Douglas,Precinct 74,President,,R,Donald Trump,338
-Douglas,Precinct 76,President,,R,Donald Trump,4
-Douglas,Precinct 77,President,,R,Donald Trump,178
-Douglas,Precinct 01,President,,LBT,Gary Johnson,17
-Douglas,Precinct 02,President,,LBT,Gary Johnson,18
-Douglas,Precinct 03,President,,LBT,Gary Johnson,22
-Douglas,Precinct 04,President,,LBT,Gary Johnson,29
-Douglas,Precinct 05,President,,LBT,Gary Johnson,22
-Douglas,Precinct 06,President,,LBT,Gary Johnson,53
-Douglas,Precinct 07,President,,LBT,Gary Johnson,8
-Douglas,Precinct 08,President,,LBT,Gary Johnson,18
-Douglas,Precinct 09,President,,LBT,Gary Johnson,16
-Douglas,Precinct 10,President,,LBT,Gary Johnson,20
-Douglas,Precinct 11,President,,LBT,Gary Johnson,25
-Douglas,Precinct 12,President,,LBT,Gary Johnson,47
-Douglas,Precinct 13,President,,LBT,Gary Johnson,25
-Douglas,Precinct 14,President,,LBT,Gary Johnson,63
-Douglas,Precinct 15,President,,LBT,Gary Johnson,44
-Douglas,Precinct 16,President,,LBT,Gary Johnson,23
-Douglas,Precinct 17,President,,LBT,Gary Johnson,39
-Douglas,Precinct 18,President,,LBT,Gary Johnson,44
-Douglas,Precinct 19,President,,LBT,Gary Johnson,35
-Douglas,Precinct 20,President,,LBT,Gary Johnson,63
-Douglas,Precinct 21,President,,LBT,Gary Johnson,14
-Douglas,Precinct 22,President,,LBT,Gary Johnson,50
-Douglas,Precinct 23,President,,LBT,Gary Johnson,15
-Douglas,Precinct 24,President,,LBT,Gary Johnson,38
-Douglas,Precinct 25,President,,LBT,Gary Johnson,22
-Douglas,Precinct 26,President,,LBT,Gary Johnson,12
-Douglas,Precinct 27,President,,LBT,Gary Johnson,25
-Douglas,Precinct 28,President,,LBT,Gary Johnson,12
-Douglas,Precinct 29,President,,LBT,Gary Johnson,21
-Douglas,Precinct 30 S2,President,,LBT,Gary Johnson,11
-Douglas,Precinct 30 S3,President,,LBT,Gary Johnson,14
-Douglas,Precinct 31,President,,LBT,Gary Johnson,44
-Douglas,Precinct 32,President,,LBT,Gary Johnson,31
-Douglas,Precinct 33,President,,LBT,Gary Johnson,21
-Douglas,Precinct 34 S2,President,,LBT,Gary Johnson,15
-Douglas,Precinct 34 S3,President,,LBT,Gary Johnson,1
-Douglas,Precinct 35 S2,President,,LBT,Gary Johnson,18
-Douglas,Precinct 35 S3,President,,LBT,Gary Johnson,0
-Douglas,Precinct 36 S2,President,,LBT,Gary Johnson,25
-Douglas,Precinct 37 H10,President,,LBT,Gary Johnson,52
-Douglas,Precinct 38 H10,President,,LBT,Gary Johnson,63
-Douglas,Precinct 39,President,,LBT,Gary Johnson,27
-Douglas,Precinct 40,President,,LBT,Gary Johnson,12
-Douglas,Precinct 41 S3 H46,President,,LBT,Gary Johnson,57
-Douglas,Precinct 41 S3 H45,President,,LBT,Gary Johnson,0
-Douglas,Precinct 41 S2 H46,President,,LBT,Gary Johnson,1
-Douglas,Precinct 41,President,,LBT,Gary Johnson,0
-Douglas,Precinct 42 H46,President,,LBT,Gary Johnson,8
-Douglas,Precinct 42 H45,President,,LBT,Gary Johnson,20
-Douglas,Precinct 43 CC1,President,,LBT,Gary Johnson,19
-Douglas,Precinct 43 CC3,President,,LBT,Gary Johnson,37
-Douglas,Precinct 44 H45,President,,LBT,Gary Johnson,28
-Douglas,Precinct 44 H44,President,,LBT,Gary Johnson,22
-Douglas,Precinct 45,President,,LBT,Gary Johnson,47
-Douglas,Precinct 46 S3,President,,LBT,Gary Johnson,84
-Douglas,Precinct 47,President,,LBT,Gary Johnson,16
-Douglas,Precinct 48,President,,LBT,Gary Johnson,41
-Douglas,Precinct 49,President,,LBT,Gary Johnson,66
-Douglas,Precinct 50,President,,LBT,Gary Johnson,86
-Douglas,Precinct 51,President,,LBT,Gary Johnson,10
-Douglas,Precinct 52,President,,LBT,Gary Johnson,24
-Douglas,Precinct 53 H10,President,,LBT,Gary Johnson,30
-Douglas,Precinct 53 H42,President,,LBT,Gary Johnson,34
-Douglas,Precinct 54,President,,LBT,Gary Johnson,49
-Douglas,Precinct 55 S3 H45,President,,LBT,Gary Johnson,11
-Douglas,Precinct 55 S3 H46,President,,LBT,Gary Johnson,1
-Douglas,Precinct 55 S2 H45,President,,LBT,Gary Johnson,0
-Douglas,Precinct 56 S19,President,,LBT,Gary Johnson,51
-Douglas,Precinct 56 S2,President,,LBT,Gary Johnson,0
-Douglas,Precinct 57 S2,President,,LBT,Gary Johnson,30
-Douglas,Precinct 57 S19,President,,LBT,Gary Johnson,9
-Douglas,Precinct 58,President,,LBT,Gary Johnson,8
-Douglas,Precinct 59 H54,President,,LBT,Gary Johnson,11
-Douglas,Precinct 59 H45,President,,LBT,Gary Johnson,20
-Douglas,Precinct 60,President,,LBT,Gary Johnson,40
-Douglas,Precinct 61,President,,LBT,Gary Johnson,68
-Douglas,Precinct 62,President,,LBT,Gary Johnson,62
-Douglas,Precinct 63,President,,LBT,Gary Johnson,21
-Douglas,Precinct 64 H45,President,,LBT,Gary Johnson,11
-Douglas,Precinct 64 H46,President,,LBT,Gary Johnson,0
-Douglas,Precinct 65 H10,President,,LBT,Gary Johnson,20
-Douglas,Precinct 65 H46,President,,LBT,Gary Johnson,0
-Douglas,Precinct 66 S19 H45,President,,LBT,Gary Johnson,11
-Douglas,Precinct 66 S3 H44,President,,LBT,Gary Johnson,0
-Douglas,Precinct 66 S3 H45,President,,LBT,Gary Johnson,0
-Douglas,Precinct 66 S19 H10,President,,LBT,Gary Johnson,15
-Douglas,Precinct 66 S3 H10,President,,LBT,Gary Johnson,6
-Douglas,Precinct 67 S19 H54,President,,LBT,Gary Johnson,17
-Douglas,Precinct 67 S19 H45,President,,LBT,Gary Johnson,16
-Douglas,Precinct 67 S3 H45,President,,LBT,Gary Johnson,4
-Douglas,Precinct 67 S3 H54,President,,LBT,Gary Johnson,6
-Douglas,Precinct 70,President,,LBT,Gary Johnson,0
-Douglas,Precinct 71,President,,LBT,Gary Johnson,51
-Douglas,Precinct 74,President,,LBT,Gary Johnson,44
-Douglas,Precinct 76,President,,LBT,Gary Johnson,1
-Douglas,Precinct 77,President,,LBT,Gary Johnson,42
-Douglas,Precinct 01,U.S. Senate,,LBT,Robert Garrard,27
-Douglas,Precinct 02,U.S. Senate,,LBT,Robert Garrard,19
-Douglas,Precinct 03,U.S. Senate,,LBT,Robert Garrard,21
-Douglas,Precinct 04,U.S. Senate,,LBT,Robert Garrard,33
-Douglas,Precinct 05,U.S. Senate,,LBT,Robert Garrard,22
-Douglas,Precinct 06,U.S. Senate,,LBT,Robert Garrard,34
-Douglas,Precinct 07,U.S. Senate,,LBT,Robert Garrard,16
-Douglas,Precinct 08,U.S. Senate,,LBT,Robert Garrard,17
-Douglas,Precinct 09,U.S. Senate,,LBT,Robert Garrard,20
-Douglas,Precinct 10,U.S. Senate,,LBT,Robert Garrard,19
-Douglas,Precinct 11,U.S. Senate,,LBT,Robert Garrard,25
-Douglas,Precinct 12,U.S. Senate,,LBT,Robert Garrard,38
-Douglas,Precinct 13,U.S. Senate,,LBT,Robert Garrard,15
-Douglas,Precinct 14,U.S. Senate,,LBT,Robert Garrard,81
-Douglas,Precinct 15,U.S. Senate,,LBT,Robert Garrard,34
-Douglas,Precinct 16,U.S. Senate,,LBT,Robert Garrard,29
-Douglas,Precinct 17,U.S. Senate,,LBT,Robert Garrard,44
-Douglas,Precinct 18,U.S. Senate,,LBT,Robert Garrard,34
-Douglas,Precinct 19,U.S. Senate,,LBT,Robert Garrard,19
-Douglas,Precinct 20,U.S. Senate,,LBT,Robert Garrard,56
-Douglas,Precinct 21,U.S. Senate,,LBT,Robert Garrard,8
-Douglas,Precinct 22,U.S. Senate,,LBT,Robert Garrard,39
-Douglas,Precinct 23,U.S. Senate,,LBT,Robert Garrard,18
-Douglas,Precinct 24,U.S. Senate,,LBT,Robert Garrard,30
-Douglas,Precinct 25,U.S. Senate,,LBT,Robert Garrard,22
-Douglas,Precinct 26,U.S. Senate,,LBT,Robert Garrard,26
-Douglas,Precinct 27,U.S. Senate,,LBT,Robert Garrard,26
-Douglas,Precinct 28,U.S. Senate,,LBT,Robert Garrard,15
-Douglas,Precinct 29,U.S. Senate,,LBT,Robert Garrard,21
-Douglas,Precinct 30 S2,U.S. Senate,,LBT,Robert Garrard,9
-Douglas,Precinct 30 S3,U.S. Senate,,LBT,Robert Garrard,19
-Douglas,Precinct 31,U.S. Senate,,LBT,Robert Garrard,38
-Douglas,Precinct 32,U.S. Senate,,LBT,Robert Garrard,30
-Douglas,Precinct 33,U.S. Senate,,LBT,Robert Garrard,18
-Douglas,Precinct 34 S2,U.S. Senate,,LBT,Robert Garrard,12
-Douglas,Precinct 34 S3,U.S. Senate,,LBT,Robert Garrard,6
-Douglas,Precinct 35 S2,U.S. Senate,,LBT,Robert Garrard,35
-Douglas,Precinct 35 S3,U.S. Senate,,LBT,Robert Garrard,4
-Douglas,Precinct 36 S2,U.S. Senate,,LBT,Robert Garrard,41
-Douglas,Precinct 37 H10,U.S. Senate,,LBT,Robert Garrard,43
-Douglas,Precinct 38 H10,U.S. Senate,,LBT,Robert Garrard,54
-Douglas,Precinct 39,U.S. Senate,,LBT,Robert Garrard,29
-Douglas,Precinct 40,U.S. Senate,,LBT,Robert Garrard,22
-Douglas,Precinct 41 S3 H46,U.S. Senate,,LBT,Robert Garrard,68
-Douglas,Precinct 41 S3 H45,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 41 S2 H46,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 41,U.S. Senate,,LBT,Robert Garrard,0
-Douglas,Precinct 42 H46,U.S. Senate,,LBT,Robert Garrard,15
-Douglas,Precinct 42 H45,U.S. Senate,,LBT,Robert Garrard,15
-Douglas,Precinct 43 CC1,U.S. Senate,,LBT,Robert Garrard,15
-Douglas,Precinct 43 CC3,U.S. Senate,,LBT,Robert Garrard,33
-Douglas,Precinct 44 H45,U.S. Senate,,LBT,Robert Garrard,24
-Douglas,Precinct 44 H44,U.S. Senate,,LBT,Robert Garrard,10
-Douglas,Precinct 45,U.S. Senate,,LBT,Robert Garrard,28
-Douglas,Precinct 46 S3,U.S. Senate,,LBT,Robert Garrard,75
-Douglas,Precinct 47,U.S. Senate,,LBT,Robert Garrard,12
-Douglas,Precinct 48,U.S. Senate,,LBT,Robert Garrard,19
-Douglas,Precinct 49,U.S. Senate,,LBT,Robert Garrard,38
-Douglas,Precinct 50,U.S. Senate,,LBT,Robert Garrard,82
-Douglas,Precinct 51,U.S. Senate,,LBT,Robert Garrard,10
-Douglas,Precinct 52,U.S. Senate,,LBT,Robert Garrard,28
-Douglas,Precinct 53 H10,U.S. Senate,,LBT,Robert Garrard,32
-Douglas,Precinct 53 H42,U.S. Senate,,LBT,Robert Garrard,35
-Douglas,Precinct 54,U.S. Senate,,LBT,Robert Garrard,46
-Douglas,Precinct 55 S3 H45,U.S. Senate,,LBT,Robert Garrard,6
-Douglas,Precinct 55 S3 H46,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 55 S2 H45,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 56 S19,U.S. Senate,,LBT,Robert Garrard,31
-Douglas,Precinct 56 S2,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 57 S2,U.S. Senate,,LBT,Robert Garrard,28
-Douglas,Precinct 57 S19,U.S. Senate,,LBT,Robert Garrard,9
-Douglas,Precinct 58,U.S. Senate,,LBT,Robert Garrard,6
-Douglas,Precinct 59 H54,U.S. Senate,,LBT,Robert Garrard,11
-Douglas,Precinct 59 H45,U.S. Senate,,LBT,Robert Garrard,13
-Douglas,Precinct 60,U.S. Senate,,LBT,Robert Garrard,44
-Douglas,Precinct 61,U.S. Senate,,LBT,Robert Garrard,88
-Douglas,Precinct 62,U.S. Senate,,LBT,Robert Garrard,91
-Douglas,Precinct 63,U.S. Senate,,LBT,Robert Garrard,33
-Douglas,Precinct 64 H45,U.S. Senate,,LBT,Robert Garrard,8
-Douglas,Precinct 64 H46,U.S. Senate,,LBT,Robert Garrard,0
-Douglas,Precinct 65 H10,U.S. Senate,,LBT,Robert Garrard,21
-Douglas,Precinct 65 H46,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 66 S19 H45,U.S. Senate,,LBT,Robert Garrard,6
-Douglas,Precinct 66 S3 H44,U.S. Senate,,LBT,Robert Garrard,0
-Douglas,Precinct 66 S3 H45,U.S. Senate,,LBT,Robert Garrard,0
-Douglas,Precinct 66 S19 H10,U.S. Senate,,LBT,Robert Garrard,8
-Douglas,Precinct 66 S3 H10,U.S. Senate,,LBT,Robert Garrard,6
-Douglas,Precinct 67 S19 H54,U.S. Senate,,LBT,Robert Garrard,23
-Douglas,Precinct 67 S19 H45,U.S. Senate,,LBT,Robert Garrard,15
-Douglas,Precinct 67 S3 H45,U.S. Senate,,LBT,Robert Garrard,5
-Douglas,Precinct 67 S3 H54,U.S. Senate,,LBT,Robert Garrard,6
-Douglas,Precinct 70,U.S. Senate,,LBT,Robert Garrard,0
-Douglas,Precinct 71,U.S. Senate,,LBT,Robert Garrard,29
-Douglas,Precinct 74,U.S. Senate,,LBT,Robert Garrard,31
-Douglas,Precinct 76,U.S. Senate,,LBT,Robert Garrard,1
-Douglas,Precinct 77,U.S. Senate,,LBT,Robert Garrard,52
-Douglas,Precinct 01,U.S. Senate,,R,Jerry Moran,72
-Douglas,Precinct 02,U.S. Senate,,R,Jerry Moran,88
-Douglas,Precinct 03,U.S. Senate,,R,Jerry Moran,90
-Douglas,Precinct 04,U.S. Senate,,R,Jerry Moran,94
-Douglas,Precinct 05,U.S. Senate,,R,Jerry Moran,197
-Douglas,Precinct 06,U.S. Senate,,R,Jerry Moran,266
-Douglas,Precinct 07,U.S. Senate,,R,Jerry Moran,32
-Douglas,Precinct 08,U.S. Senate,,R,Jerry Moran,69
-Douglas,Precinct 09,U.S. Senate,,R,Jerry Moran,50
-Douglas,Precinct 10,U.S. Senate,,R,Jerry Moran,62
-Douglas,Precinct 11,U.S. Senate,,R,Jerry Moran,133
-Douglas,Precinct 12,U.S. Senate,,R,Jerry Moran,242
-Douglas,Precinct 13,U.S. Senate,,R,Jerry Moran,233
-Douglas,Precinct 14,U.S. Senate,,R,Jerry Moran,403
-Douglas,Precinct 15,U.S. Senate,,R,Jerry Moran,186
-Douglas,Precinct 16,U.S. Senate,,R,Jerry Moran,202
-Douglas,Precinct 17,U.S. Senate,,R,Jerry Moran,375
-Douglas,Precinct 18,U.S. Senate,,R,Jerry Moran,462
-Douglas,Precinct 19,U.S. Senate,,R,Jerry Moran,462
-Douglas,Precinct 20,U.S. Senate,,R,Jerry Moran,425
-Douglas,Precinct 21,U.S. Senate,,R,Jerry Moran,122
-Douglas,Precinct 22,U.S. Senate,,R,Jerry Moran,228
-Douglas,Precinct 23,U.S. Senate,,R,Jerry Moran,149
-Douglas,Precinct 24,U.S. Senate,,R,Jerry Moran,212
-Douglas,Precinct 25,U.S. Senate,,R,Jerry Moran,66
-Douglas,Precinct 26,U.S. Senate,,R,Jerry Moran,94
-Douglas,Precinct 27,U.S. Senate,,R,Jerry Moran,126
-Douglas,Precinct 28,U.S. Senate,,R,Jerry Moran,70
-Douglas,Precinct 29,U.S. Senate,,R,Jerry Moran,110
-Douglas,Precinct 30 S2,U.S. Senate,,R,Jerry Moran,45
-Douglas,Precinct 30 S3,U.S. Senate,,R,Jerry Moran,56
-Douglas,Precinct 31,U.S. Senate,,R,Jerry Moran,222
-Douglas,Precinct 32,U.S. Senate,,R,Jerry Moran,123
-Douglas,Precinct 33,U.S. Senate,,R,Jerry Moran,99
-Douglas,Precinct 34 S2,U.S. Senate,,R,Jerry Moran,69
-Douglas,Precinct 34 S3,U.S. Senate,,R,Jerry Moran,4
-Douglas,Precinct 35 S2,U.S. Senate,,R,Jerry Moran,105
-Douglas,Precinct 35 S3,U.S. Senate,,R,Jerry Moran,17
-Douglas,Precinct 36 S2,U.S. Senate,,R,Jerry Moran,129
-Douglas,Precinct 37 H10,U.S. Senate,,R,Jerry Moran,262
-Douglas,Precinct 38 H10,U.S. Senate,,R,Jerry Moran,351
-Douglas,Precinct 39,U.S. Senate,,R,Jerry Moran,60
-Douglas,Precinct 40,U.S. Senate,,R,Jerry Moran,46
-Douglas,Precinct 41 S3 H46,U.S. Senate,,R,Jerry Moran,234
-Douglas,Precinct 41 S3 H45,U.S. Senate,,R,Jerry Moran,0
-Douglas,Precinct 41 S2 H46,U.S. Senate,,R,Jerry Moran,5
-Douglas,Precinct 41,U.S. Senate,,R,Jerry Moran,0
-Douglas,Precinct 42 H46,U.S. Senate,,R,Jerry Moran,59
-Douglas,Precinct 42 H45,U.S. Senate,,R,Jerry Moran,119
-Douglas,Precinct 43 CC1,U.S. Senate,,R,Jerry Moran,198
-Douglas,Precinct 43 CC3,U.S. Senate,,R,Jerry Moran,295
-Douglas,Precinct 44 H45,U.S. Senate,,R,Jerry Moran,193
-Douglas,Precinct 44 H44,U.S. Senate,,R,Jerry Moran,104
-Douglas,Precinct 45,U.S. Senate,,R,Jerry Moran,517
-Douglas,Precinct 46 S3,U.S. Senate,,R,Jerry Moran,435
-Douglas,Precinct 47,U.S. Senate,,R,Jerry Moran,213
-Douglas,Precinct 48,U.S. Senate,,R,Jerry Moran,410
-Douglas,Precinct 49,U.S. Senate,,R,Jerry Moran,576
-Douglas,Precinct 50,U.S. Senate,,R,Jerry Moran,602
-Douglas,Precinct 51,U.S. Senate,,R,Jerry Moran,220
-Douglas,Precinct 52,U.S. Senate,,R,Jerry Moran,206
-Douglas,Precinct 53 H10,U.S. Senate,,R,Jerry Moran,317
-Douglas,Precinct 53 H42,U.S. Senate,,R,Jerry Moran,323
-Douglas,Precinct 54,U.S. Senate,,R,Jerry Moran,403
-Douglas,Precinct 55 S3 H45,U.S. Senate,,R,Jerry Moran,56
-Douglas,Precinct 55 S3 H46,U.S. Senate,,R,Jerry Moran,14
-Douglas,Precinct 55 S2 H45,U.S. Senate,,R,Jerry Moran,11
-Douglas,Precinct 56 S19,U.S. Senate,,R,Jerry Moran,443
-Douglas,Precinct 56 S2,U.S. Senate,,R,Jerry Moran,19
-Douglas,Precinct 57 S2,U.S. Senate,,R,Jerry Moran,255
-Douglas,Precinct 57 S19,U.S. Senate,,R,Jerry Moran,86
-Douglas,Precinct 58,U.S. Senate,,R,Jerry Moran,112
-Douglas,Precinct 59 H54,U.S. Senate,,R,Jerry Moran,137
-Douglas,Precinct 59 H45,U.S. Senate,,R,Jerry Moran,151
-Douglas,Precinct 60,U.S. Senate,,R,Jerry Moran,365
-Douglas,Precinct 61,U.S. Senate,,R,Jerry Moran,571
-Douglas,Precinct 62,U.S. Senate,,R,Jerry Moran,523
-Douglas,Precinct 63,U.S. Senate,,R,Jerry Moran,354
-Douglas,Precinct 64 H45,U.S. Senate,,R,Jerry Moran,85
-Douglas,Precinct 64 H46,U.S. Senate,,R,Jerry Moran,0
-Douglas,Precinct 65 H10,U.S. Senate,,R,Jerry Moran,203
-Douglas,Precinct 65 H46,U.S. Senate,,R,Jerry Moran,6
-Douglas,Precinct 66 S19 H45,U.S. Senate,,R,Jerry Moran,113
-Douglas,Precinct 66 S3 H44,U.S. Senate,,R,Jerry Moran,0
-Douglas,Precinct 66 S3 H45,U.S. Senate,,R,Jerry Moran,0
-Douglas,Precinct 66 S19 H10,U.S. Senate,,R,Jerry Moran,145
-Douglas,Precinct 66 S3 H10,U.S. Senate,,R,Jerry Moran,88
-Douglas,Precinct 67 S19 H54,U.S. Senate,,R,Jerry Moran,218
-Douglas,Precinct 67 S19 H45,U.S. Senate,,R,Jerry Moran,151
-Douglas,Precinct 67 S3 H45,U.S. Senate,,R,Jerry Moran,45
-Douglas,Precinct 67 S3 H54,U.S. Senate,,R,Jerry Moran,46
-Douglas,Precinct 70,U.S. Senate,,R,Jerry Moran,11
-Douglas,Precinct 71,U.S. Senate,,R,Jerry Moran,405
-Douglas,Precinct 74,U.S. Senate,,R,Jerry Moran,449
-Douglas,Precinct 76,U.S. Senate,,R,Jerry Moran,3
-Douglas,Precinct 77,U.S. Senate,,R,Jerry Moran,161
-Douglas,Precinct 01,U.S. Senate,,D,Patrick Wiesner,437
-Douglas,Precinct 02,U.S. Senate,,D,Patrick Wiesner,490
-Douglas,Precinct 03,U.S. Senate,,D,Patrick Wiesner,498
-Douglas,Precinct 04,U.S. Senate,,D,Patrick Wiesner,423
-Douglas,Precinct 05,U.S. Senate,,D,Patrick Wiesner,317
-Douglas,Precinct 06,U.S. Senate,,D,Patrick Wiesner,458
-Douglas,Precinct 07,U.S. Senate,,D,Patrick Wiesner,243
-Douglas,Precinct 08,U.S. Senate,,D,Patrick Wiesner,322
-Douglas,Precinct 09,U.S. Senate,,D,Patrick Wiesner,312
-Douglas,Precinct 10,U.S. Senate,,D,Patrick Wiesner,154
-Douglas,Precinct 11,U.S. Senate,,D,Patrick Wiesner,417
-Douglas,Precinct 12,U.S. Senate,,D,Patrick Wiesner,639
-Douglas,Precinct 13,U.S. Senate,,D,Patrick Wiesner,526
-Douglas,Precinct 14,U.S. Senate,,D,Patrick Wiesner,794
-Douglas,Precinct 15,U.S. Senate,,D,Patrick Wiesner,693
-Douglas,Precinct 16,U.S. Senate,,D,Patrick Wiesner,493
-Douglas,Precinct 17,U.S. Senate,,D,Patrick Wiesner,664
-Douglas,Precinct 18,U.S. Senate,,D,Patrick Wiesner,747
-Douglas,Precinct 19,U.S. Senate,,D,Patrick Wiesner,491
-Douglas,Precinct 20,U.S. Senate,,D,Patrick Wiesner,785
-Douglas,Precinct 21,U.S. Senate,,D,Patrick Wiesner,291
-Douglas,Precinct 22,U.S. Senate,,D,Patrick Wiesner,473
-Douglas,Precinct 23,U.S. Senate,,D,Patrick Wiesner,380
-Douglas,Precinct 24,U.S. Senate,,D,Patrick Wiesner,301
-Douglas,Precinct 25,U.S. Senate,,D,Patrick Wiesner,335
-Douglas,Precinct 26,U.S. Senate,,D,Patrick Wiesner,468
-Douglas,Precinct 27,U.S. Senate,,D,Patrick Wiesner,429
-Douglas,Precinct 28,U.S. Senate,,D,Patrick Wiesner,287
-Douglas,Precinct 29,U.S. Senate,,D,Patrick Wiesner,382
-Douglas,Precinct 30 S2,U.S. Senate,,D,Patrick Wiesner,151
-Douglas,Precinct 30 S3,U.S. Senate,,D,Patrick Wiesner,255
-Douglas,Precinct 31,U.S. Senate,,D,Patrick Wiesner,515
-Douglas,Precinct 32,U.S. Senate,,D,Patrick Wiesner,322
-Douglas,Precinct 33,U.S. Senate,,D,Patrick Wiesner,573
-Douglas,Precinct 34 S2,U.S. Senate,,D,Patrick Wiesner,357
-Douglas,Precinct 34 S3,U.S. Senate,,D,Patrick Wiesner,78
-Douglas,Precinct 35 S2,U.S. Senate,,D,Patrick Wiesner,490
-Douglas,Precinct 35 S3,U.S. Senate,,D,Patrick Wiesner,30
-Douglas,Precinct 36 S2,U.S. Senate,,D,Patrick Wiesner,361
-Douglas,Precinct 37 H10,U.S. Senate,,D,Patrick Wiesner,503
-Douglas,Precinct 38 H10,U.S. Senate,,D,Patrick Wiesner,708
-Douglas,Precinct 39,U.S. Senate,,D,Patrick Wiesner,602
-Douglas,Precinct 40,U.S. Senate,,D,Patrick Wiesner,539
-Douglas,Precinct 41 S3 H46,U.S. Senate,,D,Patrick Wiesner,840
-Douglas,Precinct 41 S3 H45,U.S. Senate,,D,Patrick Wiesner,3
-Douglas,Precinct 41 S2 H46,U.S. Senate,,D,Patrick Wiesner,11
-Douglas,Precinct 41,U.S. Senate,,D,Patrick Wiesner,0
-Douglas,Precinct 42 H46,U.S. Senate,,D,Patrick Wiesner,197
-Douglas,Precinct 42 H45,U.S. Senate,,D,Patrick Wiesner,210
-Douglas,Precinct 43 CC1,U.S. Senate,,D,Patrick Wiesner,287
-Douglas,Precinct 43 CC3,U.S. Senate,,D,Patrick Wiesner,476
-Douglas,Precinct 44 H45,U.S. Senate,,D,Patrick Wiesner,301
-Douglas,Precinct 44 H44,U.S. Senate,,D,Patrick Wiesner,241
-Douglas,Precinct 45,U.S. Senate,,D,Patrick Wiesner,562
-Douglas,Precinct 46 S3,U.S. Senate,,D,Patrick Wiesner,882
-Douglas,Precinct 47,U.S. Senate,,D,Patrick Wiesner,242
-Douglas,Precinct 48,U.S. Senate,,D,Patrick Wiesner,605
-Douglas,Precinct 49,U.S. Senate,,D,Patrick Wiesner,582
-Douglas,Precinct 50,U.S. Senate,,D,Patrick Wiesner,385
-Douglas,Precinct 51,U.S. Senate,,D,Patrick Wiesner,160
-Douglas,Precinct 52,U.S. Senate,,D,Patrick Wiesner,200
-Douglas,Precinct 53 H10,U.S. Senate,,D,Patrick Wiesner,170
-Douglas,Precinct 53 H42,U.S. Senate,,D,Patrick Wiesner,199
-Douglas,Precinct 54,U.S. Senate,,D,Patrick Wiesner,307
-Douglas,Precinct 55 S3 H45,U.S. Senate,,D,Patrick Wiesner,77
-Douglas,Precinct 55 S3 H46,U.S. Senate,,D,Patrick Wiesner,30
-Douglas,Precinct 55 S2 H45,U.S. Senate,,D,Patrick Wiesner,25
-Douglas,Precinct 56 S19,U.S. Senate,,D,Patrick Wiesner,367
-Douglas,Precinct 56 S2,U.S. Senate,,D,Patrick Wiesner,32
-Douglas,Precinct 57 S2,U.S. Senate,,D,Patrick Wiesner,208
-Douglas,Precinct 57 S19,U.S. Senate,,D,Patrick Wiesner,49
-Douglas,Precinct 58,U.S. Senate,,D,Patrick Wiesner,95
-Douglas,Precinct 59 H54,U.S. Senate,,D,Patrick Wiesner,51
-Douglas,Precinct 59 H45,U.S. Senate,,D,Patrick Wiesner,120
-Douglas,Precinct 60,U.S. Senate,,D,Patrick Wiesner,321
-Douglas,Precinct 61,U.S. Senate,,D,Patrick Wiesner,388
-Douglas,Precinct 62,U.S. Senate,,D,Patrick Wiesner,333
-Douglas,Precinct 63,U.S. Senate,,D,Patrick Wiesner,288
-Douglas,Precinct 64 H45,U.S. Senate,,D,Patrick Wiesner,124
-Douglas,Precinct 64 H46,U.S. Senate,,D,Patrick Wiesner,1
-Douglas,Precinct 65 H10,U.S. Senate,,D,Patrick Wiesner,187
-Douglas,Precinct 65 H46,U.S. Senate,,D,Patrick Wiesner,22
-Douglas,Precinct 66 S19 H45,U.S. Senate,,D,Patrick Wiesner,88
-Douglas,Precinct 66 S3 H44,U.S. Senate,,D,Patrick Wiesner,0
-Douglas,Precinct 66 S3 H45,U.S. Senate,,D,Patrick Wiesner,3
-Douglas,Precinct 66 S19 H10,U.S. Senate,,D,Patrick Wiesner,111
-Douglas,Precinct 66 S3 H10,U.S. Senate,,D,Patrick Wiesner,76
-Douglas,Precinct 67 S19 H54,U.S. Senate,,D,Patrick Wiesner,104
-Douglas,Precinct 67 S19 H45,U.S. Senate,,D,Patrick Wiesner,145
-Douglas,Precinct 67 S3 H45,U.S. Senate,,D,Patrick Wiesner,49
-Douglas,Precinct 67 S3 H54,U.S. Senate,,D,Patrick Wiesner,26
-Douglas,Precinct 70,U.S. Senate,,D,Patrick Wiesner,1
-Douglas,Precinct 71,U.S. Senate,,D,Patrick Wiesner,623
-Douglas,Precinct 74,U.S. Senate,,D,Patrick Wiesner,539
-Douglas,Precinct 76,U.S. Senate,,D,Patrick Wiesner,11
-Douglas,Precinct 77,U.S. Senate,,D,Patrick Wiesner,349
-Douglas,Precinct 01,U.S. House,2,LBT,James Bales,84
-Douglas,Precinct 02,U.S. House,2,LBT,James Bales,60
-Douglas,Precinct 03,U.S. House,2,LBT,James Bales,69
-Douglas,Precinct 04,U.S. House,2,LBT,James Bales,103
-Douglas,Precinct 05,U.S. House,2,LBT,James Bales,65
-Douglas,Precinct 06,U.S. House,2,LBT,James Bales,84
-Douglas,Precinct 07,U.S. House,2,LBT,James Bales,43
-Douglas,Precinct 08,U.S. House,2,LBT,James Bales,69
-Douglas,Precinct 09,U.S. House,2,LBT,James Bales,53
-Douglas,Precinct 10,U.S. House,2,LBT,James Bales,42
-Douglas,Precinct 11,U.S. House,2,LBT,James Bales,84
-Douglas,Precinct 12,U.S. House,2,LBT,James Bales,109
-Douglas,Precinct 13,U.S. House,2,LBT,James Bales,56
-Douglas,Precinct 14,U.S. House,2,LBT,James Bales,183
-Douglas,Precinct 15,U.S. House,2,LBT,James Bales,106
-Douglas,Precinct 16,U.S. House,2,LBT,James Bales,98
-Douglas,Precinct 17,U.S. House,2,LBT,James Bales,106
-Douglas,Precinct 18,U.S. House,2,LBT,James Bales,141
-Douglas,Precinct 19,U.S. House,2,LBT,James Bales,46
-Douglas,Precinct 20,U.S. House,2,LBT,James Bales,147
-Douglas,Precinct 21,U.S. House,2,LBT,James Bales,30
-Douglas,Precinct 22,U.S. House,2,LBT,James Bales,106
-Douglas,Precinct 23,U.S. House,2,LBT,James Bales,53
-Douglas,Precinct 24,U.S. House,2,LBT,James Bales,50
-Douglas,Precinct 25,U.S. House,2,LBT,James Bales,58
-Douglas,Precinct 26,U.S. House,2,LBT,James Bales,74
-Douglas,Precinct 27,U.S. House,2,LBT,James Bales,73
-Douglas,Precinct 28,U.S. House,2,LBT,James Bales,36
-Douglas,Precinct 29,U.S. House,2,LBT,James Bales,75
-Douglas,Precinct 30 S2,U.S. House,2,LBT,James Bales,28
-Douglas,Precinct 30 S3,U.S. House,2,LBT,James Bales,46
-Douglas,Precinct 31,U.S. House,2,LBT,James Bales,87
-Douglas,Precinct 32,U.S. House,2,LBT,James Bales,82
-Douglas,Precinct 33,U.S. House,2,LBT,James Bales,69
-Douglas,Precinct 34 S2,U.S. House,2,LBT,James Bales,48
-Douglas,Precinct 34 S3,U.S. House,2,LBT,James Bales,17
-Douglas,Precinct 35 S2,U.S. House,2,LBT,James Bales,98
-Douglas,Precinct 35 S3,U.S. House,2,LBT,James Bales,9
-Douglas,Precinct 36 S2,U.S. House,2,LBT,James Bales,87
-Douglas,Precinct 37 H10,U.S. House,2,LBT,James Bales,122
-Douglas,Precinct 38 H10,U.S. House,2,LBT,James Bales,123
-Douglas,Precinct 39,U.S. House,2,LBT,James Bales,85
-Douglas,Precinct 40,U.S. House,2,LBT,James Bales,85
-Douglas,Precinct 41 S3 H46,U.S. House,2,LBT,James Bales,158
-Douglas,Precinct 41 S3 H45,U.S. House,2,LBT,James Bales,1
-Douglas,Precinct 41 S2 H46,U.S. House,2,LBT,James Bales,2
-Douglas,Precinct 41,U.S. House,2,LBT,James Bales,0
-Douglas,Precinct 42 H46,U.S. House,2,LBT,James Bales,48
-Douglas,Precinct 42 H45,U.S. House,2,LBT,James Bales,34
-Douglas,Precinct 43 CC1,U.S. House,2,LBT,James Bales,49
-Douglas,Precinct 43 CC3,U.S. House,2,LBT,James Bales,94
-Douglas,Precinct 44 H45,U.S. House,2,LBT,James Bales,60
-Douglas,Precinct 44 H44,U.S. House,2,LBT,James Bales,37
-Douglas,Precinct 45,U.S. House,2,LBT,James Bales,89
-Douglas,Precinct 46 S3,U.S. House,2,LBT,James Bales,177
-Douglas,Precinct 47,U.S. House,2,LBT,James Bales,34
-Douglas,Precinct 48,U.S. House,2,LBT,James Bales,78
-Douglas,Precinct 49,U.S. House,2,LBT,James Bales,92
-Douglas,Precinct 50,U.S. House,2,LBT,James Bales,126
-Douglas,Precinct 51,U.S. House,2,LBT,James Bales,28
-Douglas,Precinct 52,U.S. House,2,LBT,James Bales,55
-Douglas,Precinct 53 H10,U.S. House,2,LBT,James Bales,45
-Douglas,Precinct 53 H42,U.S. House,2,LBT,James Bales,62
-Douglas,Precinct 54,U.S. House,2,LBT,James Bales,71
-Douglas,Precinct 55 S3 H45,U.S. House,2,LBT,James Bales,15
-Douglas,Precinct 55 S3 H46,U.S. House,2,LBT,James Bales,8
-Douglas,Precinct 55 S2 H45,U.S. House,2,LBT,James Bales,8
-Douglas,Precinct 56 S19,U.S. House,2,LBT,James Bales,78
-Douglas,Precinct 56 S2,U.S. House,2,LBT,James Bales,4
-Douglas,Precinct 57 S2,U.S. House,2,LBT,James Bales,41
-Douglas,Precinct 57 S19,U.S. House,2,LBT,James Bales,9
-Douglas,Precinct 58,U.S. House,2,LBT,James Bales,14
-Douglas,Precinct 59 H54,U.S. House,2,LBT,James Bales,14
-Douglas,Precinct 59 H45,U.S. House,2,LBT,James Bales,20
-Douglas,Precinct 60,U.S. House,2,LBT,James Bales,60
-Douglas,Precinct 61,U.S. House,2,LBT,James Bales,85
-Douglas,Precinct 62,U.S. House,2,LBT,James Bales,92
-Douglas,Precinct 63,U.S. House,2,LBT,James Bales,49
-Douglas,Precinct 64 H45,U.S. House,2,LBT,James Bales,17
-Douglas,Precinct 64 H46,U.S. House,2,LBT,James Bales,0
-Douglas,Precinct 65 H10,U.S. House,2,LBT,James Bales,40
-Douglas,Precinct 65 H46,U.S. House,2,LBT,James Bales,3
-Douglas,Precinct 66 S19 H45,U.S. House,2,LBT,James Bales,21
-Douglas,Precinct 66 S3 H44,U.S. House,2,LBT,James Bales,0
-Douglas,Precinct 66 S3 H45,U.S. House,2,LBT,James Bales,1
-Douglas,Precinct 66 S19 H10,U.S. House,2,LBT,James Bales,18
-Douglas,Precinct 66 S3 H10,U.S. House,2,LBT,James Bales,12
-Douglas,Precinct 67 S19 H54,U.S. House,2,LBT,James Bales,31
-Douglas,Precinct 67 S19 H45,U.S. House,2,LBT,James Bales,25
-Douglas,Precinct 67 S3 H45,U.S. House,2,LBT,James Bales,8
-Douglas,Precinct 67 S3 H54,U.S. House,2,LBT,James Bales,7
-Douglas,Precinct 70,U.S. House,2,LBT,James Bales,0
-Douglas,Precinct 71,U.S. House,2,LBT,James Bales,98
-Douglas,Precinct 74,U.S. House,2,LBT,James Bales,98
-Douglas,Precinct 76,U.S. House,2,LBT,James Bales,1
-Douglas,Precinct 77,U.S. House,2,LBT,James Bales,104
-Douglas,Precinct 01,U.S. House,2,R,Lynn Jenkins,75
-Douglas,Precinct 02,U.S. House,2,R,Lynn Jenkins,84
-Douglas,Precinct 03,U.S. House,2,R,Lynn Jenkins,88
-Douglas,Precinct 04,U.S. House,2,R,Lynn Jenkins,104
-Douglas,Precinct 05,U.S. House,2,R,Lynn Jenkins,192
-Douglas,Precinct 06,U.S. House,2,R,Lynn Jenkins,293
-Douglas,Precinct 07,U.S. House,2,R,Lynn Jenkins,36
-Douglas,Precinct 08,U.S. House,2,R,Lynn Jenkins,67
-Douglas,Precinct 09,U.S. House,2,R,Lynn Jenkins,54
-Douglas,Precinct 10,U.S. House,2,R,Lynn Jenkins,61
-Douglas,Precinct 11,U.S. House,2,R,Lynn Jenkins,146
-Douglas,Precinct 12,U.S. House,2,R,Lynn Jenkins,258
-Douglas,Precinct 13,U.S. House,2,R,Lynn Jenkins,246
-Douglas,Precinct 14,U.S. House,2,R,Lynn Jenkins,426
-Douglas,Precinct 15,U.S. House,2,R,Lynn Jenkins,201
-Douglas,Precinct 16,U.S. House,2,R,Lynn Jenkins,209
-Douglas,Precinct 17,U.S. House,2,R,Lynn Jenkins,398
-Douglas,Precinct 18,U.S. House,2,R,Lynn Jenkins,495
-Douglas,Precinct 19,U.S. House,2,R,Lynn Jenkins,458
-Douglas,Precinct 20,U.S. House,2,R,Lynn Jenkins,450
-Douglas,Precinct 21,U.S. House,2,R,Lynn Jenkins,124
-Douglas,Precinct 22,U.S. House,2,R,Lynn Jenkins,262
-Douglas,Precinct 23,U.S. House,2,R,Lynn Jenkins,167
-Douglas,Precinct 24,U.S. House,2,R,Lynn Jenkins,218
-Douglas,Precinct 25,U.S. House,2,R,Lynn Jenkins,76
-Douglas,Precinct 26,U.S. House,2,R,Lynn Jenkins,102
-Douglas,Precinct 27,U.S. House,2,R,Lynn Jenkins,131
-Douglas,Precinct 28,U.S. House,2,R,Lynn Jenkins,76
-Douglas,Precinct 29,U.S. House,2,R,Lynn Jenkins,117
-Douglas,Precinct 30 S2,U.S. House,2,R,Lynn Jenkins,47
-Douglas,Precinct 30 S3,U.S. House,2,R,Lynn Jenkins,58
-Douglas,Precinct 31,U.S. House,2,R,Lynn Jenkins,227
-Douglas,Precinct 32,U.S. House,2,R,Lynn Jenkins,130
-Douglas,Precinct 33,U.S. House,2,R,Lynn Jenkins,110
-Douglas,Precinct 34 S2,U.S. House,2,R,Lynn Jenkins,73
-Douglas,Precinct 34 S3,U.S. House,2,R,Lynn Jenkins,4
-Douglas,Precinct 35 S2,U.S. House,2,R,Lynn Jenkins,112
-Douglas,Precinct 35 S3,U.S. House,2,R,Lynn Jenkins,17
-Douglas,Precinct 36 S2,U.S. House,2,R,Lynn Jenkins,155
-Douglas,Precinct 37 H10,U.S. House,2,R,Lynn Jenkins,277
-Douglas,Precinct 38 H10,U.S. House,2,R,Lynn Jenkins,395
-Douglas,Precinct 39,U.S. House,2,R,Lynn Jenkins,66
-Douglas,Precinct 40,U.S. House,2,R,Lynn Jenkins,52
-Douglas,Precinct 41 S3 H46,U.S. House,2,R,Lynn Jenkins,263
-Douglas,Precinct 41 S3 H45,U.S. House,2,R,Lynn Jenkins,0
-Douglas,Precinct 41 S2 H46,U.S. House,2,R,Lynn Jenkins,6
-Douglas,Precinct 41,U.S. House,2,R,Lynn Jenkins,0
-Douglas,Precinct 42 H46,U.S. House,2,R,Lynn Jenkins,64
-Douglas,Precinct 42 H45,U.S. House,2,R,Lynn Jenkins,128
-Douglas,Precinct 43 CC1,U.S. House,2,R,Lynn Jenkins,190
-Douglas,Precinct 43 CC3,U.S. House,2,R,Lynn Jenkins,302
-Douglas,Precinct 44 H45,U.S. House,2,R,Lynn Jenkins,215
-Douglas,Precinct 44 H44,U.S. House,2,R,Lynn Jenkins,108
-Douglas,Precinct 45,U.S. House,2,R,Lynn Jenkins,522
-Douglas,Precinct 46 S3,U.S. House,2,R,Lynn Jenkins,458
-Douglas,Precinct 47,U.S. House,2,R,Lynn Jenkins,213
-Douglas,Precinct 48,U.S. House,2,R,Lynn Jenkins,422
-Douglas,Precinct 49,U.S. House,2,R,Lynn Jenkins,591
-Douglas,Precinct 50,U.S. House,2,R,Lynn Jenkins,616
-Douglas,Precinct 51,U.S. House,2,R,Lynn Jenkins,224
-Douglas,Precinct 52,U.S. House,2,R,Lynn Jenkins,231
-Douglas,Precinct 53 H10,U.S. House,2,R,Lynn Jenkins,337
-Douglas,Precinct 53 H42,U.S. House,2,R,Lynn Jenkins,323
-Douglas,Precinct 54,U.S. House,2,R,Lynn Jenkins,441
-Douglas,Precinct 55 S3 H45,U.S. House,2,R,Lynn Jenkins,68
-Douglas,Precinct 55 S3 H46,U.S. House,2,R,Lynn Jenkins,19
-Douglas,Precinct 55 S2 H45,U.S. House,2,R,Lynn Jenkins,9
-Douglas,Precinct 56 S19,U.S. House,2,R,Lynn Jenkins,437
-Douglas,Precinct 56 S2,U.S. House,2,R,Lynn Jenkins,21
-Douglas,Precinct 57 S2,U.S. House,2,R,Lynn Jenkins,258
-Douglas,Precinct 57 S19,U.S. House,2,R,Lynn Jenkins,98
-Douglas,Precinct 58,U.S. House,2,R,Lynn Jenkins,109
-Douglas,Precinct 59 H54,U.S. House,2,R,Lynn Jenkins,132
-Douglas,Precinct 59 H45,U.S. House,2,R,Lynn Jenkins,155
-Douglas,Precinct 60,U.S. House,2,R,Lynn Jenkins,379
-Douglas,Precinct 61,U.S. House,2,R,Lynn Jenkins,617
-Douglas,Precinct 62,U.S. House,2,R,Lynn Jenkins,562
-Douglas,Precinct 63,U.S. House,2,R,Lynn Jenkins,374
-Douglas,Precinct 64 H45,U.S. House,2,R,Lynn Jenkins,79
-Douglas,Precinct 64 H46,U.S. House,2,R,Lynn Jenkins,0
-Douglas,Precinct 65 H10,U.S. House,2,R,Lynn Jenkins,231
-Douglas,Precinct 65 H46,U.S. House,2,R,Lynn Jenkins,7
-Douglas,Precinct 66 S19 H45,U.S. House,2,R,Lynn Jenkins,119
-Douglas,Precinct 66 S3 H44,U.S. House,2,R,Lynn Jenkins,0
-Douglas,Precinct 66 S3 H45,U.S. House,2,R,Lynn Jenkins,0
-Douglas,Precinct 66 S19 H10,U.S. House,2,R,Lynn Jenkins,162
-Douglas,Precinct 66 S3 H10,U.S. House,2,R,Lynn Jenkins,100
-Douglas,Precinct 67 S19 H54,U.S. House,2,R,Lynn Jenkins,217
-Douglas,Precinct 67 S19 H45,U.S. House,2,R,Lynn Jenkins,156
-Douglas,Precinct 67 S3 H45,U.S. House,2,R,Lynn Jenkins,47
-Douglas,Precinct 67 S3 H54,U.S. House,2,R,Lynn Jenkins,46
-Douglas,Precinct 70,U.S. House,2,R,Lynn Jenkins,10
-Douglas,Precinct 71,U.S. House,2,R,Lynn Jenkins,428
-Douglas,Precinct 74,U.S. House,2,R,Lynn Jenkins,444
-Douglas,Precinct 76,U.S. House,2,R,Lynn Jenkins,4
-Douglas,Precinct 77,U.S. House,2,R,Lynn Jenkins,184
-Douglas,Precinct 01,U.S. House,2,D,Britani Potter,374
-Douglas,Precinct 02,U.S. House,2,D,Britani Potter,451
-Douglas,Precinct 03,U.S. House,2,D,Britani Potter,450
-Douglas,Precinct 04,U.S. House,2,D,Britani Potter,344
-Douglas,Precinct 05,U.S. House,2,D,Britani Potter,277
-Douglas,Precinct 06,U.S. House,2,D,Britani Potter,380
-Douglas,Precinct 07,U.S. House,2,D,Britani Potter,213
-Douglas,Precinct 08,U.S. House,2,D,Britani Potter,271
-Douglas,Precinct 09,U.S. House,2,D,Britani Potter,270
-Douglas,Precinct 10,U.S. House,2,D,Britani Potter,131
-Douglas,Precinct 11,U.S. House,2,D,Britani Potter,342
-Douglas,Precinct 12,U.S. House,2,D,Britani Potter,552
-Douglas,Precinct 13,U.S. House,2,D,Britani Potter,471
-Douglas,Precinct 14,U.S. House,2,D,Britani Potter,662
-Douglas,Precinct 15,U.S. House,2,D,Britani Potter,605
-Douglas,Precinct 16,U.S. House,2,D,Britani Potter,415
-Douglas,Precinct 17,U.S. House,2,D,Britani Potter,578
-Douglas,Precinct 18,U.S. House,2,D,Britani Potter,608
-Douglas,Precinct 19,U.S. House,2,D,Britani Potter,468
-Douglas,Precinct 20,U.S. House,2,D,Britani Potter,662
-Douglas,Precinct 21,U.S. House,2,D,Britani Potter,263
-Douglas,Precinct 22,U.S. House,2,D,Britani Potter,375
-Douglas,Precinct 23,U.S. House,2,D,Britani Potter,326
-Douglas,Precinct 24,U.S. House,2,D,Britani Potter,280
-Douglas,Precinct 25,U.S. House,2,D,Britani Potter,284
-Douglas,Precinct 26,U.S. House,2,D,Britani Potter,415
-Douglas,Precinct 27,U.S. House,2,D,Britani Potter,376
-Douglas,Precinct 28,U.S. House,2,D,Britani Potter,256
-Douglas,Precinct 29,U.S. House,2,D,Britani Potter,317
-Douglas,Precinct 30 S2,U.S. House,2,D,Britani Potter,129
-Douglas,Precinct 30 S3,U.S. House,2,D,Britani Potter,222
-Douglas,Precinct 31,U.S. House,2,D,Britani Potter,457
-Douglas,Precinct 32,U.S. House,2,D,Britani Potter,268
-Douglas,Precinct 33,U.S. House,2,D,Britani Potter,509
-Douglas,Precinct 34 S2,U.S. House,2,D,Britani Potter,314
-Douglas,Precinct 34 S3,U.S. House,2,D,Britani Potter,65
-Douglas,Precinct 35 S2,U.S. House,2,D,Britani Potter,416
-Douglas,Precinct 35 S3,U.S. House,2,D,Britani Potter,23
-Douglas,Precinct 36 S2,U.S. House,2,D,Britani Potter,292
-Douglas,Precinct 37 H10,U.S. House,2,D,Britani Potter,406
-Douglas,Precinct 38 H10,U.S. House,2,D,Britani Potter,590
-Douglas,Precinct 39,U.S. House,2,D,Britani Potter,536
-Douglas,Precinct 40,U.S. House,2,D,Britani Potter,467
-Douglas,Precinct 41 S3 H46,U.S. House,2,D,Britani Potter,719
-Douglas,Precinct 41 S3 H45,U.S. House,2,D,Britani Potter,3
-Douglas,Precinct 41 S2 H46,U.S. House,2,D,Britani Potter,9
-Douglas,Precinct 41,U.S. House,2,D,Britani Potter,0
-Douglas,Precinct 42 H46,U.S. House,2,D,Britani Potter,158
-Douglas,Precinct 42 H45,U.S. House,2,D,Britani Potter,181
-Douglas,Precinct 43 CC1,U.S. House,2,D,Britani Potter,263
-Douglas,Precinct 43 CC3,U.S. House,2,D,Britani Potter,405
-Douglas,Precinct 44 H45,U.S. House,2,D,Britani Potter,250
-Douglas,Precinct 44 H44,U.S. House,2,D,Britani Potter,214
-Douglas,Precinct 45,U.S. House,2,D,Britani Potter,495
-Douglas,Precinct 46 S3,U.S. House,2,D,Britani Potter,748
-Douglas,Precinct 47,U.S. House,2,D,Britani Potter,219
-Douglas,Precinct 48,U.S. House,2,D,Britani Potter,535
-Douglas,Precinct 49,U.S. House,2,D,Britani Potter,518
-Douglas,Precinct 50,U.S. House,2,D,Britani Potter,330
-Douglas,Precinct 51,U.S. House,2,D,Britani Potter,139
-Douglas,Precinct 52,U.S. House,2,D,Britani Potter,152
-Douglas,Precinct 53 H10,U.S. House,2,D,Britani Potter,135
-Douglas,Precinct 53 H42,U.S. House,2,D,Britani Potter,172
-Douglas,Precinct 54,U.S. House,2,D,Britani Potter,244
-Douglas,Precinct 55 S3 H45,U.S. House,2,D,Britani Potter,57
-Douglas,Precinct 55 S3 H46,U.S. House,2,D,Britani Potter,18
-Douglas,Precinct 55 S2 H45,U.S. House,2,D,Britani Potter,21
-Douglas,Precinct 56 S19,U.S. House,2,D,Britani Potter,325
-Douglas,Precinct 56 S2,U.S. House,2,D,Britani Potter,27
-Douglas,Precinct 57 S2,U.S. House,2,D,Britani Potter,197
-Douglas,Precinct 57 S19,U.S. House,2,D,Britani Potter,39
-Douglas,Precinct 58,U.S. House,2,D,Britani Potter,89
-Douglas,Precinct 59 H54,U.S. House,2,D,Britani Potter,54
-Douglas,Precinct 59 H45,U.S. House,2,D,Britani Potter,112
-Douglas,Precinct 60,U.S. House,2,D,Britani Potter,295
-Douglas,Precinct 61,U.S. House,2,D,Britani Potter,347
-Douglas,Precinct 62,U.S. House,2,D,Britani Potter,300
-Douglas,Precinct 63,U.S. House,2,D,Britani Potter,251
-Douglas,Precinct 64 H45,U.S. House,2,D,Britani Potter,120
-Douglas,Precinct 64 H46,U.S. House,2,D,Britani Potter,1
-Douglas,Precinct 65 H10,U.S. House,2,D,Britani Potter,149
-Douglas,Precinct 65 H46,U.S. House,2,D,Britani Potter,19
-Douglas,Precinct 66 S19 H45,U.S. House,2,D,Britani Potter,69
-Douglas,Precinct 66 S3 H44,U.S. House,2,D,Britani Potter,0
-Douglas,Precinct 66 S3 H45,U.S. House,2,D,Britani Potter,2
-Douglas,Precinct 66 S19 H10,U.S. House,2,D,Britani Potter,88
-Douglas,Precinct 66 S3 H10,U.S. House,2,D,Britani Potter,59
-Douglas,Precinct 67 S19 H54,U.S. House,2,D,Britani Potter,103
-Douglas,Precinct 67 S19 H45,U.S. House,2,D,Britani Potter,132
-Douglas,Precinct 67 S3 H45,U.S. House,2,D,Britani Potter,45
-Douglas,Precinct 67 S3 H54,U.S. House,2,D,Britani Potter,24
-Douglas,Precinct 70,U.S. House,2,D,Britani Potter,1
-Douglas,Precinct 71,U.S. House,2,D,Britani Potter,524
-Douglas,Precinct 74,U.S. House,2,D,Britani Potter,469
-Douglas,Precinct 76,U.S. House,2,D,Britani Potter,10
-Douglas,Precinct 77,U.S. House,2,D,Britani Potter,268
-Douglas,Precinct 01,State Senate,2,D,Marcy Francisco,467
-Douglas,Precinct 02,State Senate,2,D,Marcy Francisco,524
-Douglas,Precinct 03,State Senate,2,D,Marcy Francisco,528
-Douglas,Precinct 04,State Senate,2,D,Marcy Francisco,455
-Douglas,Precinct 05,State Senate,2,D,Marcy Francisco,350
-Douglas,Precinct 06,State Senate,2,D,Marcy Francisco,507
-Douglas,Precinct 07,State Senate,2,D,Marcy Francisco,262
-Douglas,Precinct 08,State Senate,2,D,Marcy Francisco,347
-Douglas,Precinct 09,State Senate,2,D,Marcy Francisco,337
-Douglas,Precinct 10,State Senate,2,D,Marcy Francisco,174
-Douglas,Precinct 11,State Senate,2,D,Marcy Francisco,450
-Douglas,Precinct 12,State Senate,2,D,Marcy Francisco,689
-Douglas,Precinct 13,State Senate,2,D,Marcy Francisco,595
-Douglas,Precinct 15,State Senate,2,D,Marcy Francisco,743
-Douglas,Precinct 16,State Senate,2,D,Marcy Francisco,532
-Douglas,Precinct 18,State Senate,2,D,Marcy Francisco,866
-Douglas,Precinct 19,State Senate,2,D,Marcy Francisco,618
-Douglas,Precinct 20,State Senate,2,D,Marcy Francisco,864
-Douglas,Precinct 21,State Senate,2,D,Marcy Francisco,326
-Douglas,Precinct 23,State Senate,2,D,Marcy Francisco,428
-Douglas,Precinct 24,State Senate,2,D,Marcy Francisco,381
-Douglas,Precinct 25,State Senate,2,D,Marcy Francisco,351
-Douglas,Precinct 26,State Senate,2,D,Marcy Francisco,511
-Douglas,Precinct 27,State Senate,2,D,Marcy Francisco,470
-Douglas,Precinct 28,State Senate,2,D,Marcy Francisco,306
-Douglas,Precinct 30 S2,State Senate,2,D,Marcy Francisco,149
-Douglas,Precinct 33,State Senate,2,D,Marcy Francisco,596
-Douglas,Precinct 34 S2,State Senate,2,D,Marcy Francisco,365
-Douglas,Precinct 35 S2,State Senate,2,D,Marcy Francisco,540
-Douglas,Precinct 36 S2,State Senate,2,D,Marcy Francisco,399
-Douglas,Precinct 39,State Senate,2,D,Marcy Francisco,634
-Douglas,Precinct 40,State Senate,2,D,Marcy Francisco,573
-Douglas,Precinct 41 S2 H46,State Senate,2,D,Marcy Francisco,13
-Douglas,Precinct 41,State Senate,2,D,Marcy Francisco,0
-Douglas,Precinct 42 H46,State Senate,2,D,Marcy Francisco,214
-Douglas,Precinct 42 H45,State Senate,2,D,Marcy Francisco,243
-Douglas,Precinct 43 CC1,State Senate,2,D,Marcy Francisco,350
-Douglas,Precinct 43 CC3,State Senate,2,D,Marcy Francisco,555
-Douglas,Precinct 44 H45,State Senate,2,D,Marcy Francisco,343
-Douglas,Precinct 44 H44,State Senate,2,D,Marcy Francisco,256
-Douglas,Precinct 45,State Senate,2,D,Marcy Francisco,690
-Douglas,Precinct 47,State Senate,2,D,Marcy Francisco,305
-Douglas,Precinct 48,State Senate,2,D,Marcy Francisco,726
-Douglas,Precinct 49,State Senate,2,D,Marcy Francisco,707
-Douglas,Precinct 55 S2 H45,State Senate,2,D,Marcy Francisco,25
-Douglas,Precinct 56 S2,State Senate,2,D,Marcy Francisco,37
-Douglas,Precinct 57 S2,State Senate,2,D,Marcy Francisco,235
-Douglas,Precinct 64 H45,State Senate,2,D,Marcy Francisco,155
-Douglas,Precinct 64 H46,State Senate,2,D,Marcy Francisco,1
-Douglas,Precinct 70,State Senate,2,D,Marcy Francisco,4
-Douglas,Precinct 71,State Senate,2,D,Marcy Francisco,693
-Douglas,Precinct 74,State Senate,2,D,Marcy Francisco,647
-Douglas,Precinct 01,State Senate,2,R,Meredith Richey,66
-Douglas,Precinct 02,State Senate,2,R,Meredith Richey,70
-Douglas,Precinct 03,State Senate,2,R,Meredith Richey,75
-Douglas,Precinct 04,State Senate,2,R,Meredith Richey,94
-Douglas,Precinct 05,State Senate,2,R,Meredith Richey,180
-Douglas,Precinct 06,State Senate,2,R,Meredith Richey,250
-Douglas,Precinct 07,State Senate,2,R,Meredith Richey,29
-Douglas,Precinct 08,State Senate,2,R,Meredith Richey,55
-Douglas,Precinct 09,State Senate,2,R,Meredith Richey,40
-Douglas,Precinct 10,State Senate,2,R,Meredith Richey,54
-Douglas,Precinct 11,State Senate,2,R,Meredith Richey,123
-Douglas,Precinct 12,State Senate,2,R,Meredith Richey,225
-Douglas,Precinct 13,State Senate,2,R,Meredith Richey,182
-Douglas,Precinct 15,State Senate,2,R,Meredith Richey,164
-Douglas,Precinct 16,State Senate,2,R,Meredith Richey,184
-Douglas,Precinct 18,State Senate,2,R,Meredith Richey,382
-Douglas,Precinct 19,State Senate,2,R,Meredith Richey,343
-Douglas,Precinct 20,State Senate,2,R,Meredith Richey,396
-Douglas,Precinct 21,State Senate,2,R,Meredith Richey,91
-Douglas,Precinct 23,State Senate,2,R,Meredith Richey,120
-Douglas,Precinct 24,State Senate,2,R,Meredith Richey,163
-Douglas,Precinct 25,State Senate,2,R,Meredith Richey,64
-Douglas,Precinct 26,State Senate,2,R,Meredith Richey,78
-Douglas,Precinct 27,State Senate,2,R,Meredith Richey,104
-Douglas,Precinct 28,State Senate,2,R,Meredith Richey,62
-Douglas,Precinct 30 S2,State Senate,2,R,Meredith Richey,53
-Douglas,Precinct 33,State Senate,2,R,Meredith Richey,93
-Douglas,Precinct 34 S2,State Senate,2,R,Meredith Richey,73
-Douglas,Precinct 35 S2,State Senate,2,R,Meredith Richey,86
-Douglas,Precinct 36 S2,State Senate,2,R,Meredith Richey,129
-Douglas,Precinct 39,State Senate,2,R,Meredith Richey,53
-Douglas,Precinct 40,State Senate,2,R,Meredith Richey,35
-Douglas,Precinct 41 S2 H46,State Senate,2,R,Meredith Richey,4
-Douglas,Precinct 41,State Senate,2,R,Meredith Richey,0
-Douglas,Precinct 42 H46,State Senate,2,R,Meredith Richey,55
-Douglas,Precinct 42 H45,State Senate,2,R,Meredith Richey,96
-Douglas,Precinct 43 CC1,State Senate,2,R,Meredith Richey,149
-Douglas,Precinct 43 CC3,State Senate,2,R,Meredith Richey,247
-Douglas,Precinct 44 H45,State Senate,2,R,Meredith Richey,178
-Douglas,Precinct 44 H44,State Senate,2,R,Meredith Richey,104
-Douglas,Precinct 45,State Senate,2,R,Meredith Richey,410
-Douglas,Precinct 47,State Senate,2,R,Meredith Richey,157
-Douglas,Precinct 48,State Senate,2,R,Meredith Richey,309
-Douglas,Precinct 49,State Senate,2,R,Meredith Richey,493
-Douglas,Precinct 55 S2 H45,State Senate,2,R,Meredith Richey,10
-Douglas,Precinct 56 S2,State Senate,2,R,Meredith Richey,16
-Douglas,Precinct 57 S2,State Senate,2,R,Meredith Richey,260
-Douglas,Precinct 64 H45,State Senate,2,R,Meredith Richey,61
-Douglas,Precinct 64 H46,State Senate,2,R,Meredith Richey,0
-Douglas,Precinct 70,State Senate,2,R,Meredith Richey,7
-Douglas,Precinct 71,State Senate,2,R,Meredith Richey,365
-Douglas,Precinct 74,State Senate,2,R,Meredith Richey,365
-Douglas,Precinct 14,State Senate,3,D,Tom Holland,931
-Douglas,Precinct 17,State Senate,3,D,Tom Holland,765
-Douglas,Precinct 22,State Senate,3,D,Tom Holland,533
-Douglas,Precinct 29,State Senate,3,D,Tom Holland,421
-Douglas,Precinct 30 S3,State Senate,3,D,Tom Holland,271
-Douglas,Precinct 31,State Senate,3,D,Tom Holland,580
-Douglas,Precinct 32,State Senate,3,D,Tom Holland,367
-Douglas,Precinct 34 S3,State Senate,3,D,Tom Holland,83
-Douglas,Precinct 35 S3,State Senate,3,D,Tom Holland,35
-Douglas,Prec 37,State Senate,3,D,Tom Holland,558
-Douglas,Prec 38,State Senate,3,D,Tom Holland,814
-Douglas,Prec 41 S3 H46,State Senate,3,D,Tom Holland,901
-Douglas,Prec 41 S3 H45,State Senate,3,D,Tom Holland,4
-Douglas,Prec 46,State Senate,3,D,Tom Holland,1024
-Douglas,Prec 50,State Senate,3,D,Tom Holland,499
-Douglas,Prec 52,State Senate,3,D,Tom Holland,241
-Douglas,Prec 53 H10,State Senate,3,D,Tom Holland,211
-Douglas,Prec 53 H42,State Senate,3,D,Tom Holland,262
-Douglas,Prec 54,State Senate,3,D,Tom Holland,393
-Douglas,Prec 55 S3 H45,State Senate,3,D,Tom Holland,84
-Douglas,Prec 55 S3 H46,State Senate,3,D,Tom Holland,29
-Douglas,Prec 60,State Senate,3,D,Tom Holland,447
-Douglas,Prec 61,State Senate,3,D,Tom Holland,595
-Douglas,Prec 62,State Senate,3,D,Tom Holland,512
-Douglas,Prec 63,State Senate,3,D,Tom Holland,361
-Douglas,Prec 65 H10,State Senate,3,D,Tom Holland,228
-Douglas,Prec 65 H46,State Senate,3,D,Tom Holland,26
-Douglas,Prec 66 S3 H44,State Senate,3,D,Tom Holland,0
-Douglas,Prec 66 S3 H45,State Senate,3,D,Tom Holland,3
-Douglas,Prec 66 S3 H10,State Senate,3,D,Tom Holland,94
-Douglas,Prec 67 S3 H45,State Senate,3,D,Tom Holland,61
-Douglas,Prec 67 S3 H54,State Senate,3,D,Tom Holland,44
-Douglas,Prec 76,State Senate,3,D,Tom Holland,11
-Douglas,Prec 77,State Senate,3,D,Tom Holland,403
-Douglas,Precinct 14,State Senate,3,R,Echo Van Meteren,333
-Douglas,Precinct 17,State Senate,3,R,Echo Van Meteren,305
-Douglas,Precinct 22,State Senate,3,R,Echo Van Meteren,193
-Douglas,Precinct 29,State Senate,3,R,Echo Van Meteren,94
-Douglas,Precinct 30 S3,State Senate,3,R,Echo Van Meteren,53
-Douglas,Precinct 31,State Senate,3,R,Echo Van Meteren,189
-Douglas,Precinct 32,State Senate,3,R,Echo Van Meteren,102
-Douglas,Precinct 34 S3,State Senate,3,R,Echo Van Meteren,4
-Douglas,Precinct 35 S3,State Senate,3,R,Echo Van Meteren,15
-Douglas,Prec 37,State Senate,3,R,Echo Van Meteren,240
-Douglas,Prec 38,State Senate,3,R,Echo Van Meteren,293
-Douglas,Prec 41 S3 H46,State Senate,3,R,Echo Van Meteren,233
-Douglas,Prec 41 S3 H45,State Senate,3,R,Echo Van Meteren,0
-Douglas,Prec 46,State Senate,3,R,Echo Van Meteren,349
-Douglas,Prec 50,State Senate,3,R,Echo Van Meteren,569
-Douglas,Prec 52,State Senate,3,R,Echo Van Meteren,196
-Douglas,Prec 53 H10,State Senate,3,R,Echo Van Meteren,306
-Douglas,Prec 53 H42,State Senate,3,R,Echo Van Meteren,290
-Douglas,Prec 54,State Senate,3,R,Echo Van Meteren,362
-Douglas,Prec 55 S3 H45,State Senate,3,R,Echo Van Meteren,56
-Douglas,Prec 55 S3 H46,State Senate,3,R,Echo Van Meteren,14
-Douglas,Prec 60,State Senate,3,R,Echo Van Meteren,287
-Douglas,Prec 61,State Senate,3,R,Echo Van Meteren,462
-Douglas,Prec 62,State Senate,3,R,Echo Van Meteren,438
-Douglas,Prec 63,State Senate,3,R,Echo Van Meteren,313
-Douglas,Prec 65 H10,State Senate,3,R,Echo Van Meteren,190
-Douglas,Prec 65 H46,State Senate,3,R,Echo Van Meteren,4
-Douglas,Prec 66 S3 H44,State Senate,3,R,Echo Van Meteren,0
-Douglas,Prec 66 S3 H45,State Senate,3,R,Echo Van Meteren,0
-Douglas,Prec 66 S3 H10,State Senate,3,R,Echo Van Meteren,75
-Douglas,Prec 67 S3 H45,State Senate,3,R,Echo Van Meteren,37
-Douglas,Prec 67 S3 H54,State Senate,3,R,Echo Van Meteren,34
-Douglas,Prec 76,State Senate,3,R,Echo Van Meteren,4
-Douglas,Prec 77,State Senate,3,R,Echo Van Meteren,147
-Douglas,Prec 51,State Senate,19,R,Zach Haney,179
-Douglas,Prec 56 S19,State Senate,19,R,Zach Haney,371
-Douglas,Prec 57 S19,State Senate,19,R,Zach Haney,73
-Douglas,Prec 58,State Senate,19,R,Zach Haney,87
-Douglas,Prec 59 H54,State Senate,19,R,Zach Haney,106
-Douglas,Prec 59 H45,State Senate,19,R,Zach Haney,127
-Douglas,Prec 66 S19 H45,State Senate,19,R,Zach Haney,92
-Douglas,Prec 66 S19 H10,State Senate,19,R,Zach Haney,118
-Douglas,Prec 67 S19 H54,State Senate,19,R,Zach Haney,200
-Douglas,Prec 67 S19 H45,State Senate,19,R,Zach Haney,131
-Douglas,Prec 51,State Senate,19,D,Anthony Hensley,204
-Douglas,Prec 56 S19,State Senate,19,D,Anthony Hensley,453
-Douglas,Prec 57 S19,State Senate,19,D,Anthony Hensley,71
-Douglas,Prec 58,State Senate,19,D,Anthony Hensley,126
-Douglas,Prec 59 H54,State Senate,19,D,Anthony Hensley,94
-Douglas,Prec 59 H45,State Senate,19,D,Anthony Hensley,157
-Douglas,Prec 66 S19 H45,State Senate,19,D,Anthony Hensley,115
-Douglas,Prec 66 S19 H10,State Senate,19,D,Anthony Hensley,133
-Douglas,Prec 67 S19 H54,State Senate,19,D,Anthony Hensley,144
-Douglas,Prec 67 S19 H45,State Senate,19,D,Anthony Hensley,172
-Douglas,Precinct 27,State House,10,D,John Wilson,511
-Douglas,Precinct 28,State House,10,D,John Wilson,335
-Douglas,Precinct 29,State House,10,D,John Wilson,441
-Douglas,Precinct 30 S2,State House,10,D,John Wilson,178
-Douglas,Precinct 30 S3,State House,10,D,John Wilson,302
-Douglas,Prec 37,State House,10,D,John Wilson,669
-Douglas,Prec 38,State House,10,D,John Wilson,938
-Douglas,Prec 53 H42,State House,10,D,John Wilson,356
-Douglas,Prec 60,State House,10,D,John Wilson,560
-Douglas,Prec 61,State House,10,D,John Wilson,785
-Douglas,Prec 62,State House,10,D,John Wilson,691
-Douglas,Prec 63,State House,10,D,John Wilson,507
-Douglas,Prec 65,State House,10,D,John Wilson,328
-Douglas,Prec 66 S19 H10,State House,10,D,John Wilson,186
-Douglas,Prec 66 S3 H10,State House,10,D,John Wilson,128
-Douglas,Precinct 31,State House,10,D,John Wilson,660
-Douglas,Precinct 32,State House,10,D,John Wilson,412
-Douglas,Precinct 34 S2,State House,10,D,John Wilson,394
-Douglas,Precinct 34 S3,State House,10,D,John Wilson,85
-Douglas,Prec 50,State House,42,R,Jim Karleskint,547
-Douglas,Prec 52,State House,42,R,Jim Karleskint,192
-Douglas,Prec 53 H42,State House,42,R,Jim Karleskint,290
-Douglas,Prec 54,State House,42,R,Jim Karleskint,362
-Douglas,Prec 50,State House,42,D,Kara Reed,507
-Douglas,Prec 52,State House,42,D,Kara Reed,233
-Douglas,Prec 53 H42,State House,42,D,Kara Reed,256
-Douglas,Prec 54,State House,42,D,Kara Reed,385
-Douglas,Precinct 5,State House,44,D,Barbara Ballard,370
-Douglas,Prec 44 H44,State House,44,D,Barbara Ballard,267
-Douglas,Prec 47,State House,44,D,Barbara Ballard,327
-Douglas,Prec 48,State House,44,D,Barbara Ballard,764
-Douglas,Precinct 11,State House,44,D,Barbara Ballard,468
-Douglas,Precinct 12,State House,44,D,Barbara Ballard,696
-Douglas,Precinct 14,State House,44,D,Barbara Ballard,923
-Douglas,Precinct 15,State House,44,D,Barbara Ballard,744
-Douglas,Precinct 16,State House,44,D,Barbara Ballard,563
-Douglas,Precinct 17,State House,44,D,Barbara Ballard,775
-Douglas,Precinct 18,State House,44,D,Barbara Ballard,885
-Douglas,Precinct 19,State House,44,D,Barbara Ballard,702
-Douglas,Precinct 22,State House,44,D,Barbara Ballard,522
-Douglas,Precinct 23,State House,44,D,Barbara Ballard,432
-Douglas,Precinct 24,State House,44,D,Barbara Ballard,411
-Douglas,Prec 44 H44,State House,44,R,Michael Lindsay,89
-Douglas,Prec 47,State House,44,R,Michael Lindsay,137
-Douglas,Prec 48,State House,44,R,Michael Lindsay,256
-Douglas,Precinct 5,State House,44,R,Michael Lindsay,158
-Douglas,Precinct 11,State House,44,R,Michael Lindsay,100
-Douglas,Precinct 12,State House,44,R,Michael Lindsay,215
-Douglas,Precinct 14,State House,44,R,Michael Lindsay,334
-Douglas,Precinct 15,State House,44,R,Michael Lindsay,156
-Douglas,Precinct 16,State House,44,R,Michael Lindsay,146
-Douglas,Precinct 17,State House,44,R,Michael Lindsay,295
-Douglas,Precinct 18,State House,44,R,Michael Lindsay,336
-Douglas,Precinct 19,State House,44,R,Michael Lindsay,249
-Douglas,Precinct 22,State House,44,R,Michael Lindsay,201
-Douglas,Precinct 23,State House,44,R,Michael Lindsay,116
-Douglas,Precinct 24,State House,44,R,Michael Lindsay,129
-Douglas,Prec 43 CC1,State House,44,D,Terry Manies,225
-Douglas,Prec 41 S3 H45,State House,45,D,Terry Manies,4
-Douglas,Prec 42 H45,State House,45,D,Terry Manies,164
-Douglas,Prec 43 CC3,State House,45,D,Terry Manies,410
-Douglas,Prec 44 H45,State House,45,D,Terry Manies,270
-Douglas,Prec 06,State House,45,D,Terry Manies,365
-Douglas,Prec 13,State House,45,D,Terry Manies,422
-Douglas,Prec 20,State House,45,D,Terry Manies,612
-Douglas,Prec 45,State House,45,D,Terry Manies,438
-Douglas,Prec 46 S3,State House,45,D,Terry Manies,729
-Douglas,Prec 49,State House,45,D,Terry Manies,438
-Douglas,Prec 51,State House,45,D,Terry Manies,138
-Douglas,Precinct 55 S3 H45,State House,45,D,Terry Manies,59
-Douglas,Precinct 55 S2 H45,State House,45,D,Terry Manies,19
-Douglas,Precinct 56 S19,State House,45,D,Terry Manies,253
-Douglas,Precinct 56 S2,State House,45,D,Terry Manies,26
-Douglas,Precinct 57 S2,State House,45,D,Terry Manies,227
-Douglas,Precinct 57 S19,State House,45,D,Terry Manies,58
-Douglas,Precinct 58,State House,45,D,Terry Manies,111
-Douglas,Precinct 59 H45,State House,45,D,Terry Manies,116
-Douglas,Prec 64 H45,State House,45,D,Terry Manies,106
-Douglas,Prec 66 S19 H45,State House,45,D,Terry Manies,77
-Douglas,Prec 66 S3 H45,State House,45,D,Terry Manies,2
-Douglas,Prec 67 S19 H45,State House,45,D,Terry Manies,113
-Douglas,Prec 67 S3 H45,State House,45,D,Terry Manies,40
-Douglas,Prec 70,State House,45,D,Terry Manies,1
-Douglas,Prec 71,State House,45,D,Terry Manies,511
-Douglas,Prec 74,State House,45,D,Terry Manies,435
-Douglas,Prec 75,State House,45,D,Terry Manies,10
-Douglas,Prec 41 S3 H45,State House,45,R,Tom Sloan,0
-Douglas,Prec 42 H45,State House,45,R,Tom Sloan,171
-Douglas,Prec 64 H45,State House,45,R,Tom Sloan,109
-Douglas,Prec 43 CC3,State House,45,R,Tom Sloan,389
-Douglas,Prec 43 CC1,State House,44,R,Tom Sloan,276
-Douglas,Prec 44 H45,State House,45,R,Tom Sloan,243
-Douglas,Prec 06,State House,45,R,Tom Sloan,384
-Douglas,Prec 13,State House,45,R,Tom Sloan,342
-Douglas,Prec 20,State House,45,R,Tom Sloan,647
-Douglas,Prec 45,State House,45,R,Tom Sloan,660
-Douglas,Prec 46 S3,State House,45,R,Tom Sloan,633
-Douglas,Prec 49,State House,45,R,Tom Sloan,751
-Douglas,Prec 51,State House,45,R,Tom Sloan,248
-Douglas,Precinct 55 S3 H45,State House,45,R,Tom Sloan,80
-Douglas,Precinct 55 S2 H45,State House,45,R,Tom Sloan,19
-Douglas,Precinct 56 S19,State House,45,R,Tom Sloan,576
-Douglas,Precinct 56 S2,State House,45,R,Tom Sloan,26
-Douglas,Precinct 57 S2,State House,45,R,Tom Sloan,267
-Douglas,Precinct 57 S19,State House,45,R,Tom Sloan,88
-Douglas,Precinct 58,State House,45,R,Tom Sloan,101
-Douglas,Precinct 59 H45,State House,45,R,Tom Sloan,167
-Douglas,Prec 66 S19 H45,State House,45,R,Tom Sloan,130
-Douglas,Prec 66 S3 H45,State House,45,R,Tom Sloan,1
-Douglas,Prec 67 S19 H45,State House,45,R,Tom Sloan,195
-Douglas,Prec 67 S3 H45,State House,45,R,Tom Sloan,56
-Douglas,Prec 70,State House,45,R,Tom Sloan,10
-Douglas,Prec 71,State House,45,R,Tom Sloan,529
-Douglas,Prec 74,State House,45,R,Tom Sloan,578
-Douglas,Prec 75,State House,45,R,Tom Sloan,5
-Douglas,Precinct 1,State House,46,D,Dennis Highberger,483
-Douglas,Precinct 2,State House,46,D,Dennis Highberger,541
-Douglas,Precinct 3,State House,46,D,Dennis Highberger,553
-Douglas,Precinct 4,State House,46,D,Dennis Highberger,506
-Douglas,Precinct 7,State House,46,D,Dennis Highberger,273
-Douglas,Precinct 8,State House,46,D,Dennis Highberger,380
-Douglas,Precinct 9,State House,46,D,Dennis Highberger,349
-Douglas,Precinct 10,State House,46,D,Dennis Highberger,209
-Douglas,Prec 21,State House,46,D,Dennis Highberger,370
-Douglas,Prec 25,State House,46,D,Dennis Highberger,370
-Douglas,Prec 26,State House,46,D,Dennis Highberger,539
-Douglas,Prec 33,State House,46,D,Dennis Highberger,628
-Douglas,Prec 35 S2,State House,46,D,Dennis Highberger,574
-Douglas,Prec 35 S3,State House,46,D,Dennis Highberger,42
-Douglas,Prec 36 S2,State House,46,D,Dennis Highberger,453
-Douglas,Prec 39,State House,46,D,Dennis Highberger,653
-Douglas,Prec 40,State House,46,D,Dennis Highberger,580
-Douglas,Prec 41 S3 H46,State House,46,D,Dennis Highberger,1015
-Douglas,Prec 41 S2 H46,State House,46,D,Dennis Highberger,15
-Douglas,Prec 55 S3 H46,State House,46,D,Dennis Highberger,39
-Douglas,Prec 64,State House,46,D,Dennis Highberger,1
-Douglas,Prec 65 H46,State House,46,D,Dennis Highberger,25
-Douglas,Prec 77,State House,46,D,Dennis Highberger,469
-Douglas,Prec 42 H46,State House,46,D,Dennis Highberger,231
-Douglas,Precinct 59 H54,State House,54,R,Ken Corbet,106
-Douglas,Prec 67 S19 H54,State House,54,R,Ken Corbet,205
-Douglas,Prec 67 S3 H54,State House,54,R,Ken Corbet,42
-Douglas,Precinct 59 H54,State House,54,D,Renae Hansen,92
-Douglas,Prec 67 S19 H54,State House,54,D,Renae Hansen,138
-Douglas,Prec 67 S3 H54,State House,54,D,Renae Hansen,33
-Douglas,Adv,President,,write-in,Darrell Castle,1
-Douglas,Prec 01,President,,write-in,Darrell Castle,1
-Douglas,Prec 29,President,,write-in,Darrell Castle,1
-Douglas,Prec 09,President,,write-in,Rocky De La Fuente,1
-Douglas,Prec 29,President,,write-in,Tom Hoefling,1
-Douglas,Prec 18,President,,write-in,Gloria LaRiva,1
-Douglas,Prec 10,President,,write-in,Mike Maturen,1
-Douglas,Prec 31,President,,write-in,Mike Maturen,2
-Douglas,Adv,President,,write-in,Evan McMullin,31
-Douglas,Prec 01,President,,write-in,Evan McMullin,3
-Douglas,Prec 02,President,,write-in,Evan McMullin,2
-Douglas,Prec 04,President,,write-in,Evan McMullin,4
-Douglas,Prec 05,President,,write-in,Evan McMullin,3
-Douglas,Prec 06,President,,write-in,Evan McMullin,6
-Douglas,Prec 09,President,,write-in,Evan McMullin,2
-Douglas,Prec 10,President,,write-in,Evan McMullin,1
-Douglas,Prec 11,President,,write-in,Evan McMullin,7
-Douglas,Prec 13,President,,write-in,Evan McMullin,2
-Douglas,Prec 14,President,,write-in,Evan McMullin,10
-Douglas,Prec 16,President,,write-in,Evan McMullin,4
-Douglas,Prec 17,President,,write-in,Evan McMullin,7
-Douglas,Prec 18,President,,write-in,Evan McMullin,7
-Douglas,Prec 20,President,,write-in,Evan McMullin,9
-Douglas,Prec 21,President,,write-in,Evan McMullin,2
-Douglas,Prec 22,President,,write-in,Evan McMullin,4
-Douglas,Prec 23,President,,write-in,Evan McMullin,3
-Douglas,Prec 24,President,,write-in,Evan McMullin,3
-Douglas,Prec 26,President,,write-in,Evan McMullin,1
-Douglas,Prec 27,President,,write-in,Evan McMullin,1
-Douglas,Prec 31,President,,write-in,Evan McMullin,1
-Douglas,Prec 32,President,,write-in,Evan McMullin,1
-Douglas,Prec 34-2,President,,write-in,Evan McMullin,2
-Douglas,Prec 36,President,,write-in,Gloria LaRiva,1
-Douglas,Prec 38,President,,write-in,Mike Maturen,2
-Douglas,Prec 43-1,President,,write-in,Darrell Castle,1
-Douglas,Prec 45,President,,write-in,Mike Maturen,1
-Douglas,Prec 49,President,,write-in,Darrell Castle,2
-Douglas,Prec 51,President,,write-in,Rocky De La Fuente,1
-Douglas,Prec 52-3,President,,write-in,Darrell Castle,1
-Douglas,Prec 53-4,President,,write-in,Darrell Castle,2
-Douglas,Prec 57-3,President,,write-in,Darrell Castle,1
-Douglas,Prec 52-3,President,,write-in,Mike Maturen,1
-Douglas,Prec 35-1,President,,write-in,Evan McMullin,1
-Douglas,Prec 36,President,,write-in,Evan McMullin,2
-Douglas,Prec 37,President,,write-in,Evan McMullin,6
-Douglas,Prec 38,President,,write-in,Evan McMullin,6
-Douglas,Prec 40,President,,write-in,Evan McMullin,2
-Douglas,Prec 40-1,President,,write-in,Evan McMullin,1
-Douglas,Prec 42-234,President,,write-in,Evan McMullin,4
-Douglas,Prec 43-1,President,,write-in,Evan McMullin,3
-Douglas,Prec 43-23,President,,write-in,Evan McMullin,4
-Douglas,Prec 44-1,President,,write-in,Evan McMullin,2
-Douglas,Prec 44-2,President,,write-in,Evan McMullin,2
-Douglas,Prec 45,President,,write-in,Evan McMullin,4
-Douglas,Prec 46,President,,write-in,Evan McMullin,3
-Douglas,Prec 47,President,,write-in,Evan McMullin,3
-Douglas,Prec 48,President,,write-in,Evan McMullin,7
-Douglas,Prec 49,President,,write-in,Evan McMullin,10
-Douglas,Prec 50-2,President,,write-in,Evan McMullin,4
-Douglas,Prec 52-3,President,,write-in,Evan McMullin,2
-Douglas,Prec 53-123,President,,write-in,Evan McMullin,3
-Douglas,Prec 53-4,President,,write-in,Evan McMullin,1
-Douglas,Prec 54,President,,write-in,Evan McMullin,2
-Douglas,Prec 56-1235,President,,write-in,Evan McMullin,14
-Douglas,Prec 58,President,,write-in,Darrell Castle,1
-Douglas,Prec 62,President,,write-in,Mike Maturen,1
-Douglas,Prec 60,President,,write-in,Evan McMullin,2
-Douglas,Prec 61,President,,write-in,Evan McMullin,2
-Douglas,Prec 62,President,,write-in,Evan McMullin,3
-Douglas,Prec 63,President,,write-in,Evan McMullin,4
-Douglas,Prec 67-12,President,,write-in,Evan McMullin,4
-Douglas,Prec 67-78,President,,write-in,Evan McMullin,3
-Douglas,Prec 71,President,,write-in,Evan McMullin,5
-Douglas,Prec 74,President,,write-in,Evan McMullin,5
+county,precinct,office,district,party,candidate,votes,vtd
+DOUGLAS,Big Springs Township,Kansas House of Representatives,45,Democratic,"Manies, Terry",111,000010
+DOUGLAS,Big Springs Township,Kansas House of Representatives,45,Republican,"Sloan, Tom",101,000010
+DOUGLAS,Central Eudora,Kansas House of Representatives,42,Democratic,"Reed, Kara",385,000020
+DOUGLAS,Central Eudora,Kansas House of Representatives,42,Republican,"Karleskint, Jim",362,000020
+DOUGLAS,Clinton Township,Kansas House of Representatives,45,Democratic,"Manies, Terry",138,000030
+DOUGLAS,Clinton Township,Kansas House of Representatives,45,Republican,"Sloan, Tom",248,000030
+DOUGLAS,Lawrence Precinct 01,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",483,00007A
+DOUGLAS,Lawrence Precinct 02,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",541,000080
+DOUGLAS,Lawrence Precinct 03,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",553,000090
+DOUGLAS,Lawrence Precinct 04,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",506,00010A
+DOUGLAS,Lawrence Precinct 05,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",370,000110
+DOUGLAS,Lawrence Precinct 05,Kansas House of Representatives,44,Republican,"Lindsey, Michael",158,000110
+DOUGLAS,Lawrence Precinct 06,Kansas House of Representatives,45,Democratic,"Manies, Terry",365,00012A
+DOUGLAS,Lawrence Precinct 06,Kansas House of Representatives,45,Republican,"Sloan, Tom",384,00012A
+DOUGLAS,Lawrence Precinct 07,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",273,000130
+DOUGLAS,Lawrence Precinct 08,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",380,000140
+DOUGLAS,Lawrence Precinct 09,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",349,000150
+DOUGLAS,Lawrence Precinct 10,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",209,000160
+DOUGLAS,Lawrence Precinct 11,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",468,000170
+DOUGLAS,Lawrence Precinct 11,Kansas House of Representatives,44,Republican,"Lindsey, Michael",100,000170
+DOUGLAS,Lawrence Precinct 12,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",696,000180
+DOUGLAS,Lawrence Precinct 12,Kansas House of Representatives,44,Republican,"Lindsey, Michael",215,000180
+DOUGLAS,Lawrence Precinct 13,Kansas House of Representatives,45,Democratic,"Manies, Terry",422,000190
+DOUGLAS,Lawrence Precinct 13,Kansas House of Representatives,45,Republican,"Sloan, Tom",342,000190
+DOUGLAS,Lawrence Precinct 14,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",923,000200
+DOUGLAS,Lawrence Precinct 14,Kansas House of Representatives,44,Republican,"Lindsey, Michael",334,000200
+DOUGLAS,Lawrence Precinct 15,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",744,000210
+DOUGLAS,Lawrence Precinct 15,Kansas House of Representatives,44,Republican,"Lindsey, Michael",156,000210
+DOUGLAS,Lawrence Precinct 16,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",563,000220
+DOUGLAS,Lawrence Precinct 16,Kansas House of Representatives,44,Republican,"Lindsey, Michael",146,000220
+DOUGLAS,Lawrence Precinct 17,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",775,000230
+DOUGLAS,Lawrence Precinct 17,Kansas House of Representatives,44,Republican,"Lindsey, Michael",295,000230
+DOUGLAS,Lawrence Precinct 18,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",885,000240
+DOUGLAS,Lawrence Precinct 18,Kansas House of Representatives,44,Republican,"Lindsey, Michael",336,000240
+DOUGLAS,Lawrence Precinct 19,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",702,000250
+DOUGLAS,Lawrence Precinct 19,Kansas House of Representatives,44,Republican,"Lindsey, Michael",249,000250
+DOUGLAS,Lawrence Precinct 20,Kansas House of Representatives,45,Democratic,"Manies, Terry",612,000260
+DOUGLAS,Lawrence Precinct 20,Kansas House of Representatives,45,Republican,"Sloan, Tom",647,000260
+DOUGLAS,Lawrence Precinct 21,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",370,000270
+DOUGLAS,Lawrence Precinct 22,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",522,000280
+DOUGLAS,Lawrence Precinct 22,Kansas House of Representatives,44,Republican,"Lindsey, Michael",201,000280
+DOUGLAS,Lawrence Precinct 23,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",432,000290
+DOUGLAS,Lawrence Precinct 23,Kansas House of Representatives,44,Republican,"Lindsey, Michael",116,000290
+DOUGLAS,Lawrence Precinct 24,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",411,000300
+DOUGLAS,Lawrence Precinct 24,Kansas House of Representatives,44,Republican,"Lindsey, Michael",129,000300
+DOUGLAS,Lawrence Precinct 25,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",370,000310
+DOUGLAS,Lawrence Precinct 26,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",539,000320
+DOUGLAS,Lawrence Precinct 27,Kansas House of Representatives,10,Democratic,"Wilson, John",511,000330
+DOUGLAS,Lawrence Precinct 28,Kansas House of Representatives,10,Democratic,"Wilson, John",335,000340
+DOUGLAS,Lawrence Precinct 29,Kansas House of Representatives,10,Democratic,"Wilson, John",441,000350
+DOUGLAS,Lawrence Precinct 31,Kansas House of Representatives,10,Democratic,"Wilson, John",660,000370
+DOUGLAS,Lawrence Precinct 32,Kansas House of Representatives,10,Democratic,"Wilson, John",412,000380
+DOUGLAS,Lawrence Precinct 33,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",628,000400
+DOUGLAS,Lawrence Precinct 38,Kansas House of Representatives,10,Democratic,"Wilson, John",938,000450
+DOUGLAS,Lawrence Precinct 39,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",653,000460
+DOUGLAS,Lawrence Precinct 40,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",580,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas House of Representatives,45,Democratic,"Manies, Terry",225,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas House of Representatives,45,Republican,"Sloan, Tom",276,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas House of Representatives,45,Democratic,"Manies, Terry",410,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas House of Representatives,45,Republican,"Sloan, Tom",389,00050C
+DOUGLAS,Lawrence Precinct 45,Kansas House of Representatives,45,Democratic,"Manies, Terry",438,00052A
+DOUGLAS,Lawrence Precinct 45,Kansas House of Representatives,45,Republican,"Sloan, Tom",660,00052A
+DOUGLAS,Lawrence Precinct 49,Kansas House of Representatives,45,Democratic,"Manies, Terry",438,000560
+DOUGLAS,Lawrence Precinct 49,Kansas House of Representatives,45,Republican,"Sloan, Tom",751,000560
+DOUGLAS,North Eudora Precinct 52,Kansas House of Representatives,42,Democratic,"Reed, Kara",233,000600
+DOUGLAS,North Eudora Precinct 52,Kansas House of Representatives,42,Republican,"Karleskint, Jim",192,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas House of Representatives,10,Democratic,"Wilson, John",785,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas House of Representatives,10,Democratic,"Wilson, John",560,000630
+DOUGLAS,South Baldwin Precinct 62,Kansas House of Representatives,10,Democratic,"Wilson, John",691,000640
+DOUGLAS,Vinland Precinct 63,Kansas House of Representatives,10,Democratic,"Wilson, John",507,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas House of Representatives,44,Republican,"Lindsey, Michael",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,120030
+DOUGLAS,Grant Township S2 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",19,120040
+DOUGLAS,Grant Township S2 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",19,120040
+DOUGLAS,Grant Township S3 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",59,120050
+DOUGLAS,Grant Township S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",80,120050
+DOUGLAS,Grant Township S3 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",39,120060
+DOUGLAS,Kawaka Township S19,Kansas House of Representatives,45,Democratic,"Manies, Terry",253,120070
+DOUGLAS,Kawaka Township S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",576,120070
+DOUGLAS,Kawaka Township S2,Kansas House of Representatives,45,Democratic,"Manies, Terry",26,120080
+DOUGLAS,Kawaka Township S2,Kansas House of Representatives,45,Republican,"Sloan, Tom",26,120080
+DOUGLAS,Lawrence Precinct 30 S2,Kansas House of Representatives,10,Democratic,"Wilson, John",178,120090
+DOUGLAS,Lawrence Precinct 30 S3,Kansas House of Representatives,10,Democratic,"Wilson, John",302,120100
+DOUGLAS,Lawrence Precinct 34 S2,Kansas House of Representatives,10,Democratic,"Wilson, John",394,120110
+DOUGLAS,Lawrence Precinct 34 S3,Kansas House of Representatives,10,Democratic,"Wilson, John",85,120120
+DOUGLAS,Lawrence Precinct 35 S2,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",574,120130
+DOUGLAS,Lawrence Precinct 35 S3,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",42,120140
+DOUGLAS,Lawrence Precinct 36 S2,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",453,120150
+DOUGLAS,Lawrence Precinct 37 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",669,120170
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",0,120190
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",15,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",4,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",1015,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",164,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",171,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",231,120260
+DOUGLAS,Lawrence Precinct 44 H44,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",267,120270
+DOUGLAS,Lawrence Precinct 44 H44,Kansas House of Representatives,44,Republican,"Lindsey, Michael",89,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",270,120280
+DOUGLAS,Lawrence Precinct 44 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",243,120280
+DOUGLAS,Lawrence Precinct 46 S19,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Kansas House of Representatives,45,Democratic,"Manies, Terry",729,120300
+DOUGLAS,Lawrence Precinct 46 S3,Kansas House of Representatives,45,Republican,"Sloan, Tom",633,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas House of Representatives,45,Democratic,"Manies, Terry",58,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas House of Representatives,45,Republican,"Sloan, Tom",88,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas House of Representatives,45,Democratic,"Manies, Terry",227,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas House of Representatives,45,Republican,"Sloan, Tom",267,120320
+DOUGLAS,Marion Township Precinct 59 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",116,120330
+DOUGLAS,Marion Township Precinct 59 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",167,120330
+DOUGLAS,Marion Township Precinct 59 H54,Kansas House of Representatives,54,Democratic,"Hansen, Renae",92,120340
+DOUGLAS,Marion Township Precinct 59 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",106,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",106,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",109,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",1,120360
+DOUGLAS,South Eudora Precinct 53 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",356,120370
+DOUGLAS,South Eudora Precinct 53 H42,Kansas House of Representatives,42,Democratic,"Reed, Kara",256,120380
+DOUGLAS,South Eudora Precinct 53 H42,Kansas House of Representatives,42,Republican,"Karleskint, Jim",290,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",186,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",77,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",130,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas House of Representatives,10,Democratic,"Wilson, John",128,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",1,120420
+DOUGLAS,Willow Springs Township S19 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",113,120430
+DOUGLAS,Willow Springs Township S19 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",195,120430
+DOUGLAS,Willow Springs Township S19 H54,Kansas House of Representatives,54,Democratic,"Hansen, Renae",138,120440
+DOUGLAS,Willow Springs Township S19 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",205,120440
+DOUGLAS,Willow Springs Township S3 H45,Kansas House of Representatives,45,Democratic,"Manies, Terry",40,120450
+DOUGLAS,Willow Springs Township S3 H45,Kansas House of Representatives,45,Republican,"Sloan, Tom",56,120450
+DOUGLAS,Willow Springs Township S3 H54,Kansas House of Representatives,54,Democratic,"Hansen, Renae",33,120460
+DOUGLAS,Willow Springs Township S3 H54,Kansas House of Representatives,54,Republican,"Corbet, Ken",42,120460
+DOUGLAS,Lawrence Precinct 75,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,160010
+DOUGLAS,Lawrence Precinct 75,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,160010
+DOUGLAS,Lawrence Precinct 76,Kansas House of Representatives,45,Democratic,"Manies, Terry",10,160020
+DOUGLAS,Lawrence Precinct 76,Kansas House of Representatives,45,Republican,"Sloan, Tom",5,160020
+DOUGLAS,Lawrence Precinct 77,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",469,160030
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas House of Representatives,10,Democratic,"Wilson, John",328,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400010
+DOUGLAS,Lawrence Precinct 47,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",327,400030
+DOUGLAS,Lawrence Precinct 47,Kansas House of Representatives,44,Republican,"Lindsey, Michael",137,400030
+DOUGLAS,Lawrence Precinct 48,Kansas House of Representatives,44,Democratic,"Ballard, Barbara W.",764,400040
+DOUGLAS,Lawrence Precinct 48,Kansas House of Representatives,44,Republican,"Lindsey, Michael",256,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas House of Representatives,42,Democratic,"Reed, Kara",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas House of Representatives,42,Republican,"Karleskint, Jim",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas House of Representatives,42,Democratic,"Reed, Kara",507,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas House of Representatives,42,Republican,"Karleskint, Jim",547,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas House of Representatives,42,Democratic,"Reed, Kara",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas House of Representatives,42,Republican,"Karleskint, Jim",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,400110
+DOUGLAS,Lawrence Precinct 68,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,900010
+DOUGLAS,Lawrence Precinct 68,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900010
+DOUGLAS,Lawrence Precinct 69,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900020
+DOUGLAS,Lawrence Precinct 70,Kansas House of Representatives,45,Democratic,"Manies, Terry",1,900040
+DOUGLAS,Lawrence Precinct 70,Kansas House of Representatives,45,Republican,"Sloan, Tom",10,900040
+DOUGLAS,Lawrence Precinct 71,Kansas House of Representatives,45,Democratic,"Manies, Terry",511,900050
+DOUGLAS,Lawrence Precinct 71,Kansas House of Representatives,45,Republican,"Sloan, Tom",529,900050
+DOUGLAS,Lawrence Precinct 72,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,900060
+DOUGLAS,Lawrence Precinct 72,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900060
+DOUGLAS,Lawrence Precinct 73,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,900070
+DOUGLAS,Lawrence Precinct 73,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900070
+DOUGLAS,Lawrence Precinct 74,Kansas House of Representatives,45,Democratic,"Manies, Terry",435,900080
+DOUGLAS,Lawrence Precinct 74,Kansas House of Representatives,45,Republican,"Sloan, Tom",578,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",25,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas House of Representatives,46,Democratic,"Highberger, Dennis ""Boog""",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas House of Representatives,10,Democratic,"Wilson, John",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas House of Representatives,45,Democratic,"Manies, Terry",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas House of Representatives,45,Republican,"Sloan, Tom",0,900170
+DOUGLAS,Big Springs Township,Kansas Senate,19,Democratic,"Hensley, Anthony",126,000010
+DOUGLAS,Big Springs Township,Kansas Senate,19,Republican,"Haney, Zach",87,000010
+DOUGLAS,Central Eudora,Kansas Senate,3,Democratic,"Holland, Tom",393,000020
+DOUGLAS,Central Eudora,Kansas Senate,3,Republican,"Van Meteren, Echo",362,000020
+DOUGLAS,Clinton Township,Kansas Senate,19,Democratic,"Hensley, Anthony",204,000030
+DOUGLAS,Clinton Township,Kansas Senate,19,Republican,"Haney, Zach",179,000030
+DOUGLAS,Lawrence Precinct 01,Kansas Senate,2,Democratic,"Francisco, Marci",467,00007A
+DOUGLAS,Lawrence Precinct 01,Kansas Senate,2,Republican,"Richey, Meredith",66,00007A
+DOUGLAS,Lawrence Precinct 02,Kansas Senate,2,Democratic,"Francisco, Marci",524,000080
+DOUGLAS,Lawrence Precinct 02,Kansas Senate,2,Republican,"Richey, Meredith",70,000080
+DOUGLAS,Lawrence Precinct 03,Kansas Senate,2,Democratic,"Francisco, Marci",528,000090
+DOUGLAS,Lawrence Precinct 03,Kansas Senate,2,Republican,"Richey, Meredith",75,000090
+DOUGLAS,Lawrence Precinct 04,Kansas Senate,2,Democratic,"Francisco, Marci",455,00010A
+DOUGLAS,Lawrence Precinct 04,Kansas Senate,2,Republican,"Richey, Meredith",94,00010A
+DOUGLAS,Lawrence Precinct 05,Kansas Senate,2,Democratic,"Francisco, Marci",350,000110
+DOUGLAS,Lawrence Precinct 05,Kansas Senate,2,Republican,"Richey, Meredith",180,000110
+DOUGLAS,Lawrence Precinct 06,Kansas Senate,2,Democratic,"Francisco, Marci",507,00012A
+DOUGLAS,Lawrence Precinct 06,Kansas Senate,2,Republican,"Richey, Meredith",250,00012A
+DOUGLAS,Lawrence Precinct 07,Kansas Senate,2,Democratic,"Francisco, Marci",262,000130
+DOUGLAS,Lawrence Precinct 07,Kansas Senate,2,Republican,"Richey, Meredith",29,000130
+DOUGLAS,Lawrence Precinct 08,Kansas Senate,2,Democratic,"Francisco, Marci",347,000140
+DOUGLAS,Lawrence Precinct 08,Kansas Senate,2,Republican,"Richey, Meredith",55,000140
+DOUGLAS,Lawrence Precinct 09,Kansas Senate,2,Democratic,"Francisco, Marci",337,000150
+DOUGLAS,Lawrence Precinct 09,Kansas Senate,2,Republican,"Richey, Meredith",40,000150
+DOUGLAS,Lawrence Precinct 10,Kansas Senate,2,Democratic,"Francisco, Marci",174,000160
+DOUGLAS,Lawrence Precinct 10,Kansas Senate,2,Republican,"Richey, Meredith",54,000160
+DOUGLAS,Lawrence Precinct 11,Kansas Senate,2,Democratic,"Francisco, Marci",450,000170
+DOUGLAS,Lawrence Precinct 11,Kansas Senate,2,Republican,"Richey, Meredith",123,000170
+DOUGLAS,Lawrence Precinct 12,Kansas Senate,2,Democratic,"Francisco, Marci",689,000180
+DOUGLAS,Lawrence Precinct 12,Kansas Senate,2,Republican,"Richey, Meredith",225,000180
+DOUGLAS,Lawrence Precinct 13,Kansas Senate,2,Democratic,"Francisco, Marci",595,000190
+DOUGLAS,Lawrence Precinct 13,Kansas Senate,2,Republican,"Richey, Meredith",182,000190
+DOUGLAS,Lawrence Precinct 14,Kansas Senate,3,Democratic,"Holland, Tom",931,000200
+DOUGLAS,Lawrence Precinct 14,Kansas Senate,3,Republican,"Van Meteren, Echo",333,000200
+DOUGLAS,Lawrence Precinct 15,Kansas Senate,2,Democratic,"Francisco, Marci",743,000210
+DOUGLAS,Lawrence Precinct 15,Kansas Senate,2,Republican,"Richey, Meredith",164,000210
+DOUGLAS,Lawrence Precinct 16,Kansas Senate,2,Democratic,"Francisco, Marci",532,000220
+DOUGLAS,Lawrence Precinct 16,Kansas Senate,2,Republican,"Richey, Meredith",184,000220
+DOUGLAS,Lawrence Precinct 17,Kansas Senate,3,Democratic,"Holland, Tom",765,000230
+DOUGLAS,Lawrence Precinct 17,Kansas Senate,3,Republican,"Van Meteren, Echo",305,000230
+DOUGLAS,Lawrence Precinct 18,Kansas Senate,2,Democratic,"Francisco, Marci",866,000240
+DOUGLAS,Lawrence Precinct 18,Kansas Senate,2,Republican,"Richey, Meredith",382,000240
+DOUGLAS,Lawrence Precinct 19,Kansas Senate,2,Democratic,"Francisco, Marci",618,000250
+DOUGLAS,Lawrence Precinct 19,Kansas Senate,2,Republican,"Richey, Meredith",343,000250
+DOUGLAS,Lawrence Precinct 20,Kansas Senate,2,Democratic,"Francisco, Marci",864,000260
+DOUGLAS,Lawrence Precinct 20,Kansas Senate,2,Republican,"Richey, Meredith",396,000260
+DOUGLAS,Lawrence Precinct 21,Kansas Senate,2,Democratic,"Francisco, Marci",326,000270
+DOUGLAS,Lawrence Precinct 21,Kansas Senate,2,Republican,"Richey, Meredith",91,000270
+DOUGLAS,Lawrence Precinct 22,Kansas Senate,3,Democratic,"Holland, Tom",533,000280
+DOUGLAS,Lawrence Precinct 22,Kansas Senate,3,Republican,"Van Meteren, Echo",193,000280
+DOUGLAS,Lawrence Precinct 23,Kansas Senate,2,Democratic,"Francisco, Marci",428,000290
+DOUGLAS,Lawrence Precinct 23,Kansas Senate,2,Republican,"Richey, Meredith",120,000290
+DOUGLAS,Lawrence Precinct 24,Kansas Senate,2,Democratic,"Francisco, Marci",381,000300
+DOUGLAS,Lawrence Precinct 24,Kansas Senate,2,Republican,"Richey, Meredith",163,000300
+DOUGLAS,Lawrence Precinct 25,Kansas Senate,2,Democratic,"Francisco, Marci",351,000310
+DOUGLAS,Lawrence Precinct 25,Kansas Senate,2,Republican,"Richey, Meredith",64,000310
+DOUGLAS,Lawrence Precinct 26,Kansas Senate,2,Democratic,"Francisco, Marci",511,000320
+DOUGLAS,Lawrence Precinct 26,Kansas Senate,2,Republican,"Richey, Meredith",78,000320
+DOUGLAS,Lawrence Precinct 27,Kansas Senate,2,Democratic,"Francisco, Marci",470,000330
+DOUGLAS,Lawrence Precinct 27,Kansas Senate,2,Republican,"Richey, Meredith",104,000330
+DOUGLAS,Lawrence Precinct 28,Kansas Senate,2,Democratic,"Francisco, Marci",306,000340
+DOUGLAS,Lawrence Precinct 28,Kansas Senate,2,Republican,"Richey, Meredith",62,000340
+DOUGLAS,Lawrence Precinct 29,Kansas Senate,3,Democratic,"Holland, Tom",421,000350
+DOUGLAS,Lawrence Precinct 29,Kansas Senate,3,Republican,"Van Meteren, Echo",94,000350
+DOUGLAS,Lawrence Precinct 31,Kansas Senate,3,Democratic,"Holland, Tom",580,000370
+DOUGLAS,Lawrence Precinct 31,Kansas Senate,3,Republican,"Van Meteren, Echo",189,000370
+DOUGLAS,Lawrence Precinct 32,Kansas Senate,3,Democratic,"Holland, Tom",367,000380
+DOUGLAS,Lawrence Precinct 32,Kansas Senate,3,Republican,"Van Meteren, Echo",102,000380
+DOUGLAS,Lawrence Precinct 33,Kansas Senate,2,Democratic,"Francisco, Marci",596,000400
+DOUGLAS,Lawrence Precinct 33,Kansas Senate,2,Republican,"Richey, Meredith",93,000400
+DOUGLAS,Lawrence Precinct 38,Kansas Senate,3,Democratic,"Holland, Tom",814,000450
+DOUGLAS,Lawrence Precinct 38,Kansas Senate,3,Republican,"Van Meteren, Echo",293,000450
+DOUGLAS,Lawrence Precinct 39,Kansas Senate,2,Democratic,"Francisco, Marci",634,000460
+DOUGLAS,Lawrence Precinct 39,Kansas Senate,2,Republican,"Richey, Meredith",53,000460
+DOUGLAS,Lawrence Precinct 40,Kansas Senate,2,Democratic,"Francisco, Marci",573,000470
+DOUGLAS,Lawrence Precinct 40,Kansas Senate,2,Republican,"Richey, Meredith",35,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas Senate,3,Democratic,"Holland, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,Kansas Senate,3,Republican,"Van Meteren, Echo",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas Senate,3,Democratic,"Holland, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,Kansas Senate,3,Republican,"Van Meteren, Echo",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas Senate,2,Democratic,"Francisco, Marci",350,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,Kansas Senate,2,Republican,"Richey, Meredith",149,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas Senate,2,Democratic,"Francisco, Marci",555,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,Kansas Senate,2,Republican,"Richey, Meredith",247,00050C
+DOUGLAS,Lawrence Precinct 45,Kansas Senate,2,Democratic,"Francisco, Marci",690,00052A
+DOUGLAS,Lawrence Precinct 45,Kansas Senate,2,Republican,"Richey, Meredith",410,00052A
+DOUGLAS,Lawrence Precinct 49,Kansas Senate,2,Democratic,"Francisco, Marci",707,000560
+DOUGLAS,Lawrence Precinct 49,Kansas Senate,2,Republican,"Richey, Meredith",493,000560
+DOUGLAS,North Eudora Precinct 52,Kansas Senate,3,Democratic,"Holland, Tom",241,000600
+DOUGLAS,North Eudora Precinct 52,Kansas Senate,3,Republican,"Van Meteren, Echo",196,000600
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas Senate,3,Democratic,"Holland, Tom",595,000620
+DOUGLAS,Northeast Baldwin Precinct 61,Kansas Senate,3,Republican,"Van Meteren, Echo",462,000620
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas Senate,3,Democratic,"Holland, Tom",447,000630
+DOUGLAS,Northwest Baldwin Precinct 60,Kansas Senate,3,Republican,"Van Meteren, Echo",287,000630
+DOUGLAS,South Baldwin Precinct 62,Kansas Senate,3,Democratic,"Holland, Tom",512,000640
+DOUGLAS,South Baldwin Precinct 62,Kansas Senate,3,Republican,"Van Meteren, Echo",438,000640
+DOUGLAS,Vinland Precinct 63,Kansas Senate,3,Democratic,"Holland, Tom",361,000660
+DOUGLAS,Vinland Precinct 63,Kansas Senate,3,Republican,"Van Meteren, Echo",313,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas Senate,3,Democratic,"Holland, Tom",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,Kansas Senate,3,Republican,"Van Meteren, Echo",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas Senate,3,Democratic,"Holland, Tom",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas Senate,3,Democratic,"Holland, Tom",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120030
+DOUGLAS,Grant Township S2 H45,Kansas Senate,2,Democratic,"Francisco, Marci",25,120040
+DOUGLAS,Grant Township S2 H45,Kansas Senate,2,Republican,"Richey, Meredith",10,120040
+DOUGLAS,Grant Township S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",84,120050
+DOUGLAS,Grant Township S3 H45,Kansas Senate,3,Republican,"Van Meteren, Echo",56,120050
+DOUGLAS,Grant Township S3 H46,Kansas Senate,3,Democratic,"Holland, Tom",29,120060
+DOUGLAS,Grant Township S3 H46,Kansas Senate,3,Republican,"Van Meteren, Echo",14,120060
+DOUGLAS,Kawaka Township S19,Kansas Senate,19,Democratic,"Hensley, Anthony",453,120070
+DOUGLAS,Kawaka Township S19,Kansas Senate,19,Republican,"Haney, Zach",371,120070
+DOUGLAS,Kawaka Township S2,Kansas Senate,2,Democratic,"Francisco, Marci",37,120080
+DOUGLAS,Kawaka Township S2,Kansas Senate,2,Republican,"Richey, Meredith",16,120080
+DOUGLAS,Lawrence Precinct 30 S2,Kansas Senate,2,Democratic,"Francisco, Marci",149,120090
+DOUGLAS,Lawrence Precinct 30 S2,Kansas Senate,2,Republican,"Richey, Meredith",53,120090
+DOUGLAS,Lawrence Precinct 30 S3,Kansas Senate,3,Democratic,"Holland, Tom",271,120100
+DOUGLAS,Lawrence Precinct 30 S3,Kansas Senate,3,Republican,"Van Meteren, Echo",53,120100
+DOUGLAS,Lawrence Precinct 34 S2,Kansas Senate,2,Democratic,"Francisco, Marci",365,120110
+DOUGLAS,Lawrence Precinct 34 S2,Kansas Senate,2,Republican,"Richey, Meredith",73,120110
+DOUGLAS,Lawrence Precinct 34 S3,Kansas Senate,3,Democratic,"Holland, Tom",83,120120
+DOUGLAS,Lawrence Precinct 34 S3,Kansas Senate,3,Republican,"Van Meteren, Echo",4,120120
+DOUGLAS,Lawrence Precinct 35 S2,Kansas Senate,2,Democratic,"Francisco, Marci",540,120130
+DOUGLAS,Lawrence Precinct 35 S2,Kansas Senate,2,Republican,"Richey, Meredith",86,120130
+DOUGLAS,Lawrence Precinct 35 S3,Kansas Senate,3,Democratic,"Holland, Tom",35,120140
+DOUGLAS,Lawrence Precinct 35 S3,Kansas Senate,3,Republican,"Van Meteren, Echo",15,120140
+DOUGLAS,Lawrence Precinct 36 S2,Kansas Senate,2,Democratic,"Francisco, Marci",399,120150
+DOUGLAS,Lawrence Precinct 36 S2,Kansas Senate,2,Republican,"Richey, Meredith",129,120150
+DOUGLAS,Lawrence Precinct 37 H10,Kansas Senate,3,Democratic,"Holland, Tom",558,120170
+DOUGLAS,Lawrence Precinct 37 H10,Kansas Senate,3,Republican,"Van Meteren, Echo",240,120170
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas Senate,3,Democratic,"Holland, Tom",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120190
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas Senate,2,Democratic,"Francisco, Marci",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,Kansas Senate,2,Republican,"Richey, Meredith",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas Senate,2,Democratic,"Francisco, Marci",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,Kansas Senate,2,Republican,"Richey, Meredith",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas Senate,2,Democratic,"Francisco, Marci",13,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,Kansas Senate,2,Republican,"Richey, Meredith",4,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",4,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas Senate,3,Democratic,"Holland, Tom",901,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,Kansas Senate,3,Republican,"Van Meteren, Echo",233,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas Senate,2,Democratic,"Francisco, Marci",243,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,Kansas Senate,2,Republican,"Richey, Meredith",96,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas Senate,2,Democratic,"Francisco, Marci",214,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,Kansas Senate,2,Republican,"Richey, Meredith",55,120260
+DOUGLAS,Lawrence Precinct 44 H44,Kansas Senate,2,Democratic,"Francisco, Marci",256,120270
+DOUGLAS,Lawrence Precinct 44 H44,Kansas Senate,2,Republican,"Richey, Meredith",104,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas Senate,2,Democratic,"Francisco, Marci",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,Kansas Senate,2,Republican,"Richey, Meredith",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,Kansas Senate,2,Democratic,"Francisco, Marci",343,120280
+DOUGLAS,Lawrence Precinct 44 H45,Kansas Senate,2,Republican,"Richey, Meredith",178,120280
+DOUGLAS,Lawrence Precinct 46 S19,Kansas Senate,19,Democratic,"Hensley, Anthony",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,Kansas Senate,19,Republican,"Haney, Zach",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,Kansas Senate,3,Democratic,"Holland, Tom",1024,120300
+DOUGLAS,Lawrence Precinct 46 S3,Kansas Senate,3,Republican,"Van Meteren, Echo",349,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas Senate,19,Democratic,"Hensley, Anthony",71,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,Kansas Senate,19,Republican,"Haney, Zach",73,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas Senate,2,Democratic,"Francisco, Marci",235,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,Kansas Senate,2,Republican,"Richey, Meredith",260,120320
+DOUGLAS,Marion Township Precinct 59 H45,Kansas Senate,19,Democratic,"Hensley, Anthony",157,120330
+DOUGLAS,Marion Township Precinct 59 H45,Kansas Senate,19,Republican,"Haney, Zach",127,120330
+DOUGLAS,Marion Township Precinct 59 H54,Kansas Senate,19,Democratic,"Hensley, Anthony",94,120340
+DOUGLAS,Marion Township Precinct 59 H54,Kansas Senate,19,Republican,"Haney, Zach",106,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas Senate,2,Democratic,"Francisco, Marci",155,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,Kansas Senate,2,Republican,"Richey, Meredith",61,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas Senate,2,Democratic,"Francisco, Marci",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,Kansas Senate,2,Republican,"Richey, Meredith",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,Kansas Senate,3,Democratic,"Holland, Tom",211,120370
+DOUGLAS,South Eudora Precinct 53 H10,Kansas Senate,3,Republican,"Van Meteren, Echo",306,120370
+DOUGLAS,South Eudora Precinct 53 H42,Kansas Senate,3,Democratic,"Holland, Tom",262,120380
+DOUGLAS,South Eudora Precinct 53 H42,Kansas Senate,3,Republican,"Van Meteren, Echo",290,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas Senate,19,Democratic,"Hensley, Anthony",133,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,Kansas Senate,19,Republican,"Haney, Zach",118,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,3,Democratic,"Holland, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,19,Democratic,"Hensley, Anthony",115,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,Kansas Senate,19,Republican,"Haney, Zach",92,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas Senate,3,Democratic,"Holland, Tom",94,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,Kansas Senate,3,Republican,"Van Meteren, Echo",75,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",3,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120420
+DOUGLAS,Willow Springs Township S19 H45,Kansas Senate,19,Democratic,"Hensley, Anthony",172,120430
+DOUGLAS,Willow Springs Township S19 H45,Kansas Senate,19,Republican,"Haney, Zach",131,120430
+DOUGLAS,Willow Springs Township S19 H54,Kansas Senate,19,Democratic,"Hensley, Anthony",144,120440
+DOUGLAS,Willow Springs Township S19 H54,Kansas Senate,19,Republican,"Haney, Zach",200,120440
+DOUGLAS,Willow Springs Township S3 H45,Kansas Senate,3,Democratic,"Holland, Tom",61,120450
+DOUGLAS,Willow Springs Township S3 H45,Kansas Senate,3,Republican,"Van Meteren, Echo",37,120450
+DOUGLAS,Willow Springs Township S3 H54,Kansas Senate,3,Democratic,"Holland, Tom",44,120460
+DOUGLAS,Willow Springs Township S3 H54,Kansas Senate,3,Republican,"Van Meteren, Echo",34,120460
+DOUGLAS,Lawrence Precinct 75,Kansas Senate,2,Democratic,"Francisco, Marci",0,160010
+DOUGLAS,Lawrence Precinct 75,Kansas Senate,2,Republican,"Richey, Meredith",0,160010
+DOUGLAS,Lawrence Precinct 76,Kansas Senate,3,Democratic,"Holland, Tom",11,160020
+DOUGLAS,Lawrence Precinct 76,Kansas Senate,3,Republican,"Van Meteren, Echo",4,160020
+DOUGLAS,Lawrence Precinct 77,Kansas Senate,3,Democratic,"Holland, Tom",403,160030
+DOUGLAS,Lawrence Precinct 77,Kansas Senate,3,Republican,"Van Meteren, Echo",147,160030
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas Senate,3,Democratic,"Holland, Tom",228,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,Kansas Senate,3,Republican,"Van Meteren, Echo",190,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas Senate,2,Democratic,"Francisco, Marci",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,Kansas Senate,2,Republican,"Richey, Meredith",0,400010
+DOUGLAS,Lawrence Precinct 47,Kansas Senate,2,Democratic,"Francisco, Marci",305,400030
+DOUGLAS,Lawrence Precinct 47,Kansas Senate,2,Republican,"Richey, Meredith",157,400030
+DOUGLAS,Lawrence Precinct 48,Kansas Senate,2,Democratic,"Francisco, Marci",726,400040
+DOUGLAS,Lawrence Precinct 48,Kansas Senate,2,Republican,"Richey, Meredith",309,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas Senate,3,Democratic,"Holland, Tom",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,Kansas Senate,3,Republican,"Van Meteren, Echo",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas Senate,2,Democratic,"Francisco, Marci",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,Kansas Senate,2,Republican,"Richey, Meredith",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas Senate,3,Democratic,"Holland, Tom",499,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,Kansas Senate,3,Republican,"Van Meteren, Echo",569,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas Senate,3,Democratic,"Holland, Tom",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,Kansas Senate,3,Republican,"Van Meteren, Echo",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas Senate,19,Democratic,"Hensley, Anthony",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,Kansas Senate,19,Republican,"Haney, Zach",0,400110
+DOUGLAS,Lawrence Precinct 68,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900010
+DOUGLAS,Lawrence Precinct 68,Kansas Senate,19,Republican,"Haney, Zach",0,900010
+DOUGLAS,Lawrence Precinct 69,Kansas Senate,3,Democratic,"Holland, Tom",0,900020
+DOUGLAS,Lawrence Precinct 69,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900020
+DOUGLAS,Lawrence Precinct 70,Kansas Senate,2,Democratic,"Francisco, Marci",4,900040
+DOUGLAS,Lawrence Precinct 70,Kansas Senate,2,Republican,"Richey, Meredith",7,900040
+DOUGLAS,Lawrence Precinct 71,Kansas Senate,2,Democratic,"Francisco, Marci",693,900050
+DOUGLAS,Lawrence Precinct 71,Kansas Senate,2,Republican,"Richey, Meredith",365,900050
+DOUGLAS,Lawrence Precinct 72,Kansas Senate,2,Democratic,"Francisco, Marci",0,900060
+DOUGLAS,Lawrence Precinct 72,Kansas Senate,2,Republican,"Richey, Meredith",0,900060
+DOUGLAS,Lawrence Precinct 73,Kansas Senate,2,Democratic,"Francisco, Marci",0,900070
+DOUGLAS,Lawrence Precinct 73,Kansas Senate,2,Republican,"Richey, Meredith",0,900070
+DOUGLAS,Lawrence Precinct 74,Kansas Senate,2,Democratic,"Francisco, Marci",647,900080
+DOUGLAS,Lawrence Precinct 74,Kansas Senate,2,Republican,"Richey, Meredith",365,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas Senate,2,Democratic,"Francisco, Marci",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,Kansas Senate,2,Republican,"Richey, Meredith",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas Senate,3,Democratic,"Holland, Tom",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas Senate,3,Democratic,"Holland, Tom",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas Senate,2,Democratic,"Francisco, Marci",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,Kansas Senate,2,Republican,"Richey, Meredith",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas Senate,3,Democratic,"Holland, Tom",26,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,Kansas Senate,3,Republican,"Van Meteren, Echo",4,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas Senate,3,Democratic,"Holland, Tom",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas Senate,2,Democratic,"Francisco, Marci",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,Kansas Senate,2,Republican,"Richey, Meredith",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas Senate,3,Democratic,"Holland, Tom",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas Senate,2,Democratic,"Francisco, Marci",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,Kansas Senate,2,Republican,"Richey, Meredith",0,900170
+DOUGLAS,Big Springs Township,President / Vice President,,independent,"Stein, Jill",2,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Castle, Darrell L",1,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000010
+DOUGLAS,Big Springs Township,President / Vice President,,Republican,"Trump, Donald J.",102,000010
+DOUGLAS,Central Eudora,President / Vice President,,independent,"Stein, Jill",28,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Hedges, James A",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"McMullin, Evan",3,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Perry, Darryl",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Smith, Mike",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Sood, Ajay",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+DOUGLAS,Central Eudora,President / Vice President,,Democratic,"Clinton, Hillary Rodham",296,000020
+DOUGLAS,Central Eudora,President / Vice President,,Libertarian,"Johnson, Gary",49,000020
+DOUGLAS,Central Eudora,President / Vice President,,Republican,"Trump, Donald J.",388,000020
+DOUGLAS,Clinton Township,President / Vice President,,independent,"Stein, Jill",2,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",1,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+DOUGLAS,Clinton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",179,000030
+DOUGLAS,Clinton Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000030
+DOUGLAS,Clinton Township,President / Vice President,,Republican,"Trump, Donald J.",195,000030
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,independent,"Stein, Jill",34,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",1,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"McMullin, Evan",3,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",420,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",17,00007A
+DOUGLAS,Lawrence Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",58,00007A
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,independent,"Stein, Jill",24,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"McMullin, Evan",2,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",492,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",18,000080
+DOUGLAS,Lawrence Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",55,000080
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,independent,"Stein, Jill",20,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"McMullin, Evan",2,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",492,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",22,000090
+DOUGLAS,Lawrence Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",61,000090
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,independent,"Stein, Jill",27,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"McMullin, Evan",4,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",397,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",29,00010A
+DOUGLAS,Lawrence Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",94,00010A
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,independent,"Stein, Jill",16,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"McMullin, Evan",3,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",327,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",22,000110
+DOUGLAS,Lawrence Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",160,000110
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,independent,"Stein, Jill",27,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"McMullin, Evan",6,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",460,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",53,00012A
+DOUGLAS,Lawrence Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",206,00012A
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,independent,"Stein, Jill",26,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"McMullin, Evan",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",233,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",8,000130
+DOUGLAS,Lawrence Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",26,000130
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,independent,"Stein, Jill",22,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Hedges, James A",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"McMullin, Evan",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Perry, Darryl",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Smith, Mike",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Sood, Ajay",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",319,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",18,000140
+DOUGLAS,Lawrence Precinct 08,President / Vice President,,Republican,"Trump, Donald J.",52,000140
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,independent,"Stein, Jill",8,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",1,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"McMullin, Evan",2,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",318,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",16,000150
+DOUGLAS,Lawrence Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",32,000150
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,independent,"Stein, Jill",6,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",1,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"McMullin, Evan",1,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",184,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",20,000160
+DOUGLAS,Lawrence Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",33,000160
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,independent,"Stein, Jill",24,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Hedges, James A",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"McMullin, Evan",7,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Perry, Darryl",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Smith, Mike",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Sood, Ajay",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",403,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",25,000170
+DOUGLAS,Lawrence Precinct 11,President / Vice President,,Republican,"Trump, Donald J.",113,000170
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,independent,"Stein, Jill",35,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Hedges, James A",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"McMullin, Evan",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Perry, Darryl",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Smith, Mike",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Sood, Ajay",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",620,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",47,000180
+DOUGLAS,Lawrence Precinct 12,President / Vice President,,Republican,"Trump, Donald J.",209,000180
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,independent,"Stein, Jill",13,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Hedges, James A",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"McMullin, Evan",2,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Perry, Darryl",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Smith, Mike",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Sood, Ajay",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",570,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",25,000190
+DOUGLAS,Lawrence Precinct 13,President / Vice President,,Republican,"Trump, Donald J.",158,000190
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,independent,"Stein, Jill",30,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Hedges, James A",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"McMullin, Evan",10,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Perry, Darryl",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Smith, Mike",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Sood, Ajay",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Democratic,"Clinton, Hillary Rodham",805,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",63,000200
+DOUGLAS,Lawrence Precinct 14,President / Vice President,,Republican,"Trump, Donald J.",353,000200
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,independent,"Stein, Jill",22,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Hedges, James A",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"McMullin, Evan",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Perry, Darryl",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Smith, Mike",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Sood, Ajay",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Democratic,"Clinton, Hillary Rodham",694,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",44,000210
+DOUGLAS,Lawrence Precinct 15,President / Vice President,,Republican,"Trump, Donald J.",144,000210
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,independent,"Stein, Jill",16,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Hedges, James A",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"McMullin, Evan",4,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Perry, Darryl",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Smith, Mike",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Sood, Ajay",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Democratic,"Clinton, Hillary Rodham",506,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",23,000220
+DOUGLAS,Lawrence Precinct 16,President / Vice President,,Republican,"Trump, Donald J.",165,000220
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,independent,"Stein, Jill",27,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Hedges, James A",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"McMullin, Evan",7,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Perry, Darryl",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Smith, Mike",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Sood, Ajay",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",702,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",39,000230
+DOUGLAS,Lawrence Precinct 17,President / Vice President,,Republican,"Trump, Donald J.",306,000230
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,independent,"Stein, Jill",17,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Hedges, James A",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"La Riva, Gloria",1,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"McMullin, Evan",7,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Perry, Darryl",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Smith, Mike",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Sood, Ajay",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",826,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",44,000240
+DOUGLAS,Lawrence Precinct 18,President / Vice President,,Republican,"Trump, Donald J.",332,000240
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,independent,"Stein, Jill",16,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Hedges, James A",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"McMullin, Evan",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Perry, Darryl",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Smith, Mike",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Sood, Ajay",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",612,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",35,000250
+DOUGLAS,Lawrence Precinct 19,President / Vice President,,Republican,"Trump, Donald J.",303,000250
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,independent,"Stein, Jill",20,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Hedges, James A",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"McMullin, Evan",9,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Perry, Darryl",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Smith, Mike",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Sood, Ajay",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Democratic,"Clinton, Hillary Rodham",840,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Libertarian,"Johnson, Gary",63,000260
+DOUGLAS,Lawrence Precinct 20,President / Vice President,,Republican,"Trump, Donald J.",322,000260
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,independent,"Stein, Jill",6,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Hedges, James A",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"McMullin, Evan",2,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Perry, Darryl",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Smith, Mike",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Sood, Ajay",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Democratic,"Clinton, Hillary Rodham",311,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Libertarian,"Johnson, Gary",14,000270
+DOUGLAS,Lawrence Precinct 21,President / Vice President,,Republican,"Trump, Donald J.",74,000270
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,independent,"Stein, Jill",21,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Hedges, James A",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"McMullin, Evan",4,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Perry, Darryl",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Smith, Mike",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Sood, Ajay",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Democratic,"Clinton, Hillary Rodham",464,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Libertarian,"Johnson, Gary",50,000280
+DOUGLAS,Lawrence Precinct 22,President / Vice President,,Republican,"Trump, Donald J.",193,000280
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,independent,"Stein, Jill",18,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Hedges, James A",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"McMullin, Evan",3,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Perry, Darryl",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Smith, Mike",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Sood, Ajay",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Democratic,"Clinton, Hillary Rodham",404,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Libertarian,"Johnson, Gary",15,000290
+DOUGLAS,Lawrence Precinct 23,President / Vice President,,Republican,"Trump, Donald J.",103,000290
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,independent,"Stein, Jill",12,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Hedges, James A",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"McMullin, Evan",4,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Perry, Darryl",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Smith, Mike",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Sood, Ajay",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Democratic,"Clinton, Hillary Rodham",356,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",38,000300
+DOUGLAS,Lawrence Precinct 24,President / Vice President,,Republican,"Trump, Donald J.",134,000300
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,independent,"Stein, Jill",14,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Hedges, James A",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"McMullin, Evan",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Perry, Darryl",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Smith, Mike",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Sood, Ajay",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Democratic,"Clinton, Hillary Rodham",329,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",22,000310
+DOUGLAS,Lawrence Precinct 25,President / Vice President,,Republican,"Trump, Donald J.",49,000310
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,independent,"Stein, Jill",25,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Hedges, James A",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"McMullin, Evan",1,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Perry, Darryl",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Smith, Mike",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Sood, Ajay",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Democratic,"Clinton, Hillary Rodham",473,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",12,000320
+DOUGLAS,Lawrence Precinct 26,President / Vice President,,Republican,"Trump, Donald J.",78,000320
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,independent,"Stein, Jill",37,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Hedges, James A",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"McMullin, Evan",1,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Perry, Darryl",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Smith, Mike",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Sood, Ajay",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Democratic,"Clinton, Hillary Rodham",428,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",25,000330
+DOUGLAS,Lawrence Precinct 27,President / Vice President,,Republican,"Trump, Donald J.",87,000330
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,independent,"Stein, Jill",10,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Hedges, James A",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"McMullin, Evan",1,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Perry, Darryl",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Smith, Mike",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Sood, Ajay",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Democratic,"Clinton, Hillary Rodham",280,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",12,000340
+DOUGLAS,Lawrence Precinct 28,President / Vice President,,Republican,"Trump, Donald J.",60,000340
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,independent,"Stein, Jill",15,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Castle, Darrell L",1,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Hedges, James A",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",1,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"McMullin, Evan",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Perry, Darryl",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Smith, Mike",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Sood, Ajay",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Democratic,"Clinton, Hillary Rodham",382,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",21,000350
+DOUGLAS,Lawrence Precinct 29,President / Vice President,,Republican,"Trump, Donald J.",94,000350
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,independent,"Stein, Jill",21,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Hedges, James A",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Maturen, Michael A",2,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"McMullin, Evan",2,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Perry, Darryl",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Smith, Mike",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Sood, Ajay",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Democratic,"Clinton, Hillary Rodham",515,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Libertarian,"Johnson, Gary",44,000370
+DOUGLAS,Lawrence Precinct 31,President / Vice President,,Republican,"Trump, Donald J.",181,000370
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,independent,"Stein, Jill",28,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Hedges, James A",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"McMullin, Evan",2,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Perry, Darryl",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Smith, Mike",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Sood, Ajay",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Democratic,"Clinton, Hillary Rodham",315,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",31,000380
+DOUGLAS,Lawrence Precinct 32,President / Vice President,,Republican,"Trump, Donald J.",110,000380
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,independent,"Stein, Jill",37,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Hedges, James A",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"McMullin, Evan",1,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Perry, Darryl",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Smith, Mike",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Sood, Ajay",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Democratic,"Clinton, Hillary Rodham",545,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Libertarian,"Johnson, Gary",21,000400
+DOUGLAS,Lawrence Precinct 33,President / Vice President,,Republican,"Trump, Donald J.",79,000400
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,independent,"Stein, Jill",24,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Castle, Darrell L",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Hedges, James A",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Maturen, Michael A",2,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"McMullin, Evan",6,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Perry, Darryl",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Smith, Mike",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Sood, Ajay",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Democratic,"Clinton, Hillary Rodham",715,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Libertarian,"Johnson, Gary",63,000450
+DOUGLAS,Lawrence Precinct 38,President / Vice President,,Republican,"Trump, Donald J.",292,000450
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,independent,"Stein, Jill",41,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Basiago, Andrew D.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Castle, Darrell L",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Giordani, Rocky",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Hedges, James A",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Kahn, Lynn",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"La Riva, Gloria",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Levinson, Michael S.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Maturen, Michael A",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"McMullin, Evan",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Moorehead, Monica G.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Perry, Darryl",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Schriner, Joe C",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Smith, Mike",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Sood, Ajay",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Sterling, Shawna",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Valdivia, Anthony J",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Democratic,"Clinton, Hillary Rodham",572,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Libertarian,"Johnson, Gary",27,000460
+DOUGLAS,Lawrence Precinct 39,President / Vice President,,Republican,"Trump, Donald J.",48,000460
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,independent,"Stein, Jill",37,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Basiago, Andrew D.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Castle, Darrell L",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Giordani, Rocky",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Hedges, James A",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Kahn, Lynn",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"La Riva, Gloria",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Levinson, Michael S.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Maturen, Michael A",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"McMullin, Evan",3,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Moorehead, Monica G.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Perry, Darryl",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Schriner, Joe C",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Smith, Mike",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Sood, Ajay",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Sterling, Shawna",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Valdivia, Anthony J",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Democratic,"Clinton, Hillary Rodham",521,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Libertarian,"Johnson, Gary",12,000470
+DOUGLAS,Lawrence Precinct 40,President / Vice President,,Republican,"Trump, Donald J.",37,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,independent,"Stein, Jill",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"McMullin, Evan",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,independent,"Stein, Jill",14,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Castle, Darrell L",1,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Giordani, Rocky",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Hedges, James A",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Kahn, Lynn",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"La Riva, Gloria",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Maturen, Michael A",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"McMullin, Evan",4,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Perry, Darryl",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Schriner, Joe C",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Smith, Mike",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Sood, Ajay",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Sterling, Shawna",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",296,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",19,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,President / Vice President,,Republican,"Trump, Donald J.",157,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,independent,"Stein, Jill",26,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Castle, Darrell L",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Giordani, Rocky",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Hedges, James A",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Kahn, Lynn",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"La Riva, Gloria",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Maturen, Michael A",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"McMullin, Evan",4,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Perry, Darryl",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Schriner, Joe C",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Smith, Mike",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Sood, Ajay",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Sterling, Shawna",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",516,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",37,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,President / Vice President,,Republican,"Trump, Donald J.",216,00050C
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,independent,"Stein, Jill",21,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Basiago, Andrew D.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Castle, Darrell L",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Giordani, Rocky",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Hedges, James A",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Hoefling, Tom",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Kahn, Lynn",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"La Riva, Gloria",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Levinson, Michael S.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Maturen, Michael A",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"McMullin, Evan",4,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Moorehead, Monica G.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Perry, Darryl",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Schriner, Joe C",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Smith, Mike",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Sood, Ajay",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Sterling, Shawna",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Valdivia, Anthony J",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",668,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Libertarian,"Johnson, Gary",47,00052A
+DOUGLAS,Lawrence Precinct 45,President / Vice President,,Republican,"Trump, Donald J.",363,00052A
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,independent,"Stein, Jill",26,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Basiago, Andrew D.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Castle, Darrell L",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Giordani, Rocky",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Hedges, James A",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Hoefling, Tom",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Kahn, Lynn",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"La Riva, Gloria",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Levinson, Michael S.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Maturen, Michael A",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"McMullin, Evan",10,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Moorehead, Monica G.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Perry, Darryl",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Schriner, Joe C",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Smith, Mike",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Sood, Ajay",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Sterling, Shawna",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Valdivia, Anthony J",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Democratic,"Clinton, Hillary Rodham",649,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Libertarian,"Johnson, Gary",66,000560
+DOUGLAS,Lawrence Precinct 49,President / Vice President,,Republican,"Trump, Donald J.",427,000560
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,independent,"Stein, Jill",14,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Basiago, Andrew D.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Castle, Darrell L",1,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Giordani, Rocky",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Hedges, James A",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Hoefling, Tom",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Kahn, Lynn",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"La Riva, Gloria",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Levinson, Michael S.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Maturen, Michael A",1,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"McMullin, Evan",2,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Moorehead, Monica G.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Perry, Darryl",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Schriner, Joe C",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Smith, Mike",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Sood, Ajay",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Sterling, Shawna",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Valdivia, Anthony J",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Democratic,"Clinton, Hillary Rodham",189,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Libertarian,"Johnson, Gary",24,000600
+DOUGLAS,North Eudora Precinct 52,President / Vice President,,Republican,"Trump, Donald J.",207,000600
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,independent,"Stein, Jill",25,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Basiago, Andrew D.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Castle, Darrell L",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Giordani, Rocky",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Hedges, James A",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Hoefling, Tom",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Kahn, Lynn",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"La Riva, Gloria",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Levinson, Michael S.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Maturen, Michael A",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"McMullin, Evan",2,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Moorehead, Monica G.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Perry, Darryl",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Schriner, Joe C",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Smith, Mike",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Sood, Ajay",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Sterling, Shawna",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Valdivia, Anthony J",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Democratic,"Clinton, Hillary Rodham",415,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Libertarian,"Johnson, Gary",68,000620
+DOUGLAS,Northeast Baldwin Precinct 61,President / Vice President,,Republican,"Trump, Donald J.",540,000620
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,independent,"Stein, Jill",16,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Basiago, Andrew D.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Castle, Darrell L",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Giordani, Rocky",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Hedges, James A",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Hoefling, Tom",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Kahn, Lynn",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"La Riva, Gloria",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Levinson, Michael S.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Maturen, Michael A",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"McMullin, Evan",2,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Moorehead, Monica G.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Perry, Darryl",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Schriner, Joe C",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Smith, Mike",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Sood, Ajay",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Sterling, Shawna",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Valdivia, Anthony J",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Democratic,"Clinton, Hillary Rodham",334,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Libertarian,"Johnson, Gary",40,000630
+DOUGLAS,Northwest Baldwin Precinct 60,President / Vice President,,Republican,"Trump, Donald J.",342,000630
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,independent,"Stein, Jill",23,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Basiago, Andrew D.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Castle, Darrell L",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Giordani, Rocky",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Hedges, James A",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Hoefling, Tom",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Kahn, Lynn",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"La Riva, Gloria",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Levinson, Michael S.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Maturen, Michael A",1,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"McMullin, Evan",3,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Moorehead, Monica G.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Perry, Darryl",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Schriner, Joe C",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Smith, Mike",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Sood, Ajay",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Sterling, Shawna",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Valdivia, Anthony J",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Democratic,"Clinton, Hillary Rodham",340,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Libertarian,"Johnson, Gary",62,000640
+DOUGLAS,South Baldwin Precinct 62,President / Vice President,,Republican,"Trump, Donald J.",513,000640
+DOUGLAS,Vinland Precinct 63,President / Vice President,,independent,"Stein, Jill",12,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Basiago, Andrew D.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Castle, Darrell L",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Giordani, Rocky",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Hedges, James A",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Hoefling, Tom",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Kahn, Lynn",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"La Riva, Gloria",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Levinson, Michael S.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Maturen, Michael A",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"McMullin, Evan",4,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Moorehead, Monica G.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Perry, Darryl",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Schriner, Joe C",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Smith, Mike",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Sood, Ajay",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Sterling, Shawna",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Valdivia, Anthony J",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Democratic,"Clinton, Hillary Rodham",289,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Libertarian,"Johnson, Gary",21,000660
+DOUGLAS,Vinland Precinct 63,President / Vice President,,Republican,"Trump, Donald J.",346,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,independent,"Stein, Jill",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Castle, Darrell L",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Giordani, Rocky",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Hedges, James A",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Kahn, Lynn",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"La Riva, Gloria",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Maturen, Michael A",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"McMullin, Evan",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Perry, Darryl",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Schriner, Joe C",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Smith, Mike",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Sood, Ajay",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Sterling, Shawna",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,President / Vice President,,Republican,"Trump, Donald J.",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,independent,"Stein, Jill",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Hedges, James A",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"McMullin, Evan",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Perry, Darryl",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Smith, Mike",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Sood, Ajay",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,President / Vice President,,Republican,"Trump, Donald J.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,independent,"Stein, Jill",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Hedges, James A",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"McMullin, Evan",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Perry, Darryl",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Smith, Mike",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Sood, Ajay",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,President / Vice President,,Republican,"Trump, Donald J.",0,120030
+DOUGLAS,Grant Township S2 H45,President / Vice President,,independent,"Stein, Jill",5,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Hedges, James A",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"McMullin, Evan",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Perry, Darryl",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Smith, Mike",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Sood, Ajay",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+DOUGLAS,Grant Township S2 H45,President / Vice President,,Republican,"Trump, Donald J.",8,120040
+DOUGLAS,Grant Township S3 H45,President / Vice President,,independent,"Stein, Jill",5,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Hedges, James A",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"McMullin, Evan",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Perry, Darryl",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Smith, Mike",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Sood, Ajay",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",11,120050
+DOUGLAS,Grant Township S3 H45,President / Vice President,,Republican,"Trump, Donald J.",53,120050
+DOUGLAS,Grant Township S3 H46,President / Vice President,,independent,"Stein, Jill",3,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Hedges, James A",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"McMullin, Evan",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Perry, Darryl",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Smith, Mike",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Sood, Ajay",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Libertarian,"Johnson, Gary",1,120060
+DOUGLAS,Grant Township S3 H46,President / Vice President,,Republican,"Trump, Donald J.",13,120060
+DOUGLAS,Kawaka Township S19,President / Vice President,,independent,"Stein, Jill",14,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",390,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Libertarian,"Johnson, Gary",51,120070
+DOUGLAS,Kawaka Township S19,President / Vice President,,Republican,"Trump, Donald J.",369,120070
+DOUGLAS,Kawaka Township S2,President / Vice President,,independent,"Stein, Jill",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Hedges, James A",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"McMullin, Evan",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Perry, Darryl",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Smith, Mike",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Sood, Ajay",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+DOUGLAS,Kawaka Township S2,President / Vice President,,Republican,"Trump, Donald J.",19,120080
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,independent,"Stein, Jill",8,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Hedges, James A",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"McMullin, Evan",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Perry, Darryl",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Smith, Mike",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Sood, Ajay",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",146,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Libertarian,"Johnson, Gary",11,120090
+DOUGLAS,Lawrence Precinct 30 S2,President / Vice President,,Republican,"Trump, Donald J.",41,120090
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,independent,"Stein, Jill",12,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Basiago, Andrew D.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Castle, Darrell L",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Giordani, Rocky",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Hedges, James A",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Kahn, Lynn",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"La Riva, Gloria",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Levinson, Michael S.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Maturen, Michael A",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"McMullin, Evan",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Moorehead, Monica G.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Perry, Darryl",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Schriner, Joe C",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Smith, Mike",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Sood, Ajay",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Sterling, Shawna",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Valdivia, Anthony J",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",255,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Libertarian,"Johnson, Gary",14,120100
+DOUGLAS,Lawrence Precinct 30 S3,President / Vice President,,Republican,"Trump, Donald J.",56,120100
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,independent,"Stein, Jill",25,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Castle, Darrell L",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Giordani, Rocky",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Hedges, James A",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Kahn, Lynn",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"La Riva, Gloria",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Levinson, Michael S.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Maturen, Michael A",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"McMullin, Evan",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Perry, Darryl",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Schriner, Joe C",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Smith, Mike",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Sood, Ajay",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Sterling, Shawna",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",333,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Libertarian,"Johnson, Gary",15,120110
+DOUGLAS,Lawrence Precinct 34 S2,President / Vice President,,Republican,"Trump, Donald J.",58,120110
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,independent,"Stein, Jill",5,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Basiago, Andrew D.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Castle, Darrell L",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Giordani, Rocky",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Hedges, James A",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Kahn, Lynn",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"La Riva, Gloria",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Levinson, Michael S.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Maturen, Michael A",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"McMullin, Evan",2,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Moorehead, Monica G.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Perry, Darryl",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Schriner, Joe C",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Smith, Mike",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Sood, Ajay",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Sterling, Shawna",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Valdivia, Anthony J",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",78,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Libertarian,"Johnson, Gary",1,120120
+DOUGLAS,Lawrence Precinct 34 S3,President / Vice President,,Republican,"Trump, Donald J.",2,120120
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,independent,"Stein, Jill",39,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Castle, Darrell L",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Giordani, Rocky",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Hedges, James A",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Kahn, Lynn",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"La Riva, Gloria",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Levinson, Michael S.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Maturen, Michael A",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"McMullin, Evan",1,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Perry, Darryl",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Schriner, Joe C",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Smith, Mike",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Sood, Ajay",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Sterling, Shawna",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",473,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Libertarian,"Johnson, Gary",18,120130
+DOUGLAS,Lawrence Precinct 35 S2,President / Vice President,,Republican,"Trump, Donald J.",100,120130
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,independent,"Stein, Jill",5,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Basiago, Andrew D.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Castle, Darrell L",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Giordani, Rocky",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Hedges, James A",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Kahn, Lynn",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"La Riva, Gloria",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Levinson, Michael S.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Maturen, Michael A",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"McMullin, Evan",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Moorehead, Monica G.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Perry, Darryl",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Schriner, Joe C",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Smith, Mike",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Sood, Ajay",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Sterling, Shawna",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Valdivia, Anthony J",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Libertarian,"Johnson, Gary",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,President / Vice President,,Republican,"Trump, Donald J.",17,120140
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,independent,"Stein, Jill",24,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Castle, Darrell L",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Giordani, Rocky",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Hedges, James A",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Kahn, Lynn",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"La Riva, Gloria",1,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Levinson, Michael S.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Maturen, Michael A",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"McMullin, Evan",2,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Perry, Darryl",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Schriner, Joe C",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Smith, Mike",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Sood, Ajay",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Sterling, Shawna",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",343,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Libertarian,"Johnson, Gary",25,120150
+DOUGLAS,Lawrence Precinct 36 S2,President / Vice President,,Republican,"Trump, Donald J.",124,120150
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,independent,"Stein, Jill",41,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Castle, Darrell L",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Giordani, Rocky",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Hedges, James A",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Kahn, Lynn",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"La Riva, Gloria",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Levinson, Michael S.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Maturen, Michael A",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"McMullin, Evan",6,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Perry, Darryl",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Schriner, Joe C",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Smith, Mike",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Sood, Ajay",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Sterling, Shawna",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",487,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Libertarian,"Johnson, Gary",52,120170
+DOUGLAS,Lawrence Precinct 37 H10,President / Vice President,,Republican,"Trump, Donald J.",218,120170
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,independent,"Stein, Jill",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Castle, Darrell L",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Giordani, Rocky",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Hedges, James A",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Kahn, Lynn",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"La Riva, Gloria",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Levinson, Michael S.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Maturen, Michael A",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"McMullin, Evan",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Perry, Darryl",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Schriner, Joe C",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Smith, Mike",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Sood, Ajay",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Sterling, Shawna",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Libertarian,"Johnson, Gary",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,President / Vice President,,Republican,"Trump, Donald J.",0,120190
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,independent,"Stein, Jill",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Castle, Darrell L",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Giordani, Rocky",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Hedges, James A",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Hoefling, Tom",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Kahn, Lynn",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"La Riva, Gloria",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Maturen, Michael A",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"McMullin, Evan",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Perry, Darryl",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Schriner, Joe C",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Smith, Mike",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Sood, Ajay",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Sterling, Shawna",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,President / Vice President,,Republican,"Trump, Donald J.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,independent,"Stein, Jill",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Hedges, James A",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"McMullin, Evan",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Perry, Darryl",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Smith, Mike",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Sood, Ajay",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,President / Vice President,,Republican,"Trump, Donald J.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,independent,"Stein, Jill",1,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Basiago, Andrew D.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Castle, Darrell L",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Giordani, Rocky",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Hedges, James A",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Kahn, Lynn",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"La Riva, Gloria",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Levinson, Michael S.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Maturen, Michael A",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"McMullin, Evan",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Moorehead, Monica G.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Perry, Darryl",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Schriner, Joe C",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Smith, Mike",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Sood, Ajay",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Sterling, Shawna",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Valdivia, Anthony J",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Libertarian,"Johnson, Gary",1,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,President / Vice President,,Republican,"Trump, Donald J.",3,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,independent,"Stein, Jill",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Hedges, James A",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"McMullin, Evan",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Perry, Darryl",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Smith, Mike",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Sood, Ajay",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,President / Vice President,,Republican,"Trump, Donald J.",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,independent,"Stein, Jill",59,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Basiago, Andrew D.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Castle, Darrell L",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Giordani, Rocky",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Hedges, James A",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Kahn, Lynn",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"La Riva, Gloria",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Levinson, Michael S.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Maturen, Michael A",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"McMullin, Evan",2,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Moorehead, Monica G.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Perry, Darryl",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Schriner, Joe C",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Smith, Mike",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Sood, Ajay",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Sterling, Shawna",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Valdivia, Anthony J",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Democratic,"Clinton, Hillary Rodham",795,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Libertarian,"Johnson, Gary",57,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,President / Vice President,,Republican,"Trump, Donald J.",232,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,independent,"Stein, Jill",3,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Hedges, James A",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"McMullin, Evan",5,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Perry, Darryl",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Smith, Mike",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Sood, Ajay",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",212,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Libertarian,"Johnson, Gary",20,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,President / Vice President,,Republican,"Trump, Donald J.",99,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,independent,"Stein, Jill",9,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Basiago, Andrew D.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Castle, Darrell L",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Giordani, Rocky",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Hedges, James A",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Kahn, Lynn",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"La Riva, Gloria",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Levinson, Michael S.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Maturen, Michael A",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"McMullin, Evan",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Moorehead, Monica G.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Perry, Darryl",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Schriner, Joe C",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Smith, Mike",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Sood, Ajay",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Sterling, Shawna",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Valdivia, Anthony J",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Democratic,"Clinton, Hillary Rodham",197,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Libertarian,"Johnson, Gary",8,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,President / Vice President,,Republican,"Trump, Donald J.",54,120260
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,independent,"Stein, Jill",10,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Basiago, Andrew D.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Castle, Darrell L",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Giordani, Rocky",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Hedges, James A",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Hoefling, Tom",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Kahn, Lynn",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"La Riva, Gloria",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Levinson, Michael S.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Maturen, Michael A",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"McMullin, Evan",2,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Moorehead, Monica G.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Perry, Darryl",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Schriner, Joe C",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Smith, Mike",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Sood, Ajay",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Sterling, Shawna",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Valdivia, Anthony J",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Democratic,"Clinton, Hillary Rodham",240,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Libertarian,"Johnson, Gary",22,120270
+DOUGLAS,Lawrence Precinct 44 H44,President / Vice President,,Republican,"Trump, Donald J.",81,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,independent,"Stein, Jill",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Castle, Darrell L",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Giordani, Rocky",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Hedges, James A",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Hoefling, Tom",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Kahn, Lynn",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"La Riva, Gloria",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Maturen, Michael A",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"McMullin, Evan",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Perry, Darryl",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Schriner, Joe C",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Smith, Mike",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Sood, Ajay",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Sterling, Shawna",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,President / Vice President,,Republican,"Trump, Donald J.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,independent,"Stein, Jill",13,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Hedges, James A",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"McMullin, Evan",2,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Perry, Darryl",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Smith, Mike",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Sood, Ajay",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",313,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Libertarian,"Johnson, Gary",28,120280
+DOUGLAS,Lawrence Precinct 44 H45,President / Vice President,,Republican,"Trump, Donald J.",169,120280
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,independent,"Stein, Jill",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Basiago, Andrew D.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Castle, Darrell L",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Giordani, Rocky",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Hedges, James A",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Hoefling, Tom",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Kahn, Lynn",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"La Riva, Gloria",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Levinson, Michael S.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Maturen, Michael A",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"McMullin, Evan",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Moorehead, Monica G.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Perry, Darryl",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Schriner, Joe C",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Smith, Mike",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Sood, Ajay",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Sterling, Shawna",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Valdivia, Anthony J",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Libertarian,"Johnson, Gary",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,President / Vice President,,Republican,"Trump, Donald J.",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,independent,"Stein, Jill",49,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Basiago, Andrew D.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Castle, Darrell L",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Giordani, Rocky",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Hedges, James A",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Hoefling, Tom",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Kahn, Lynn",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"La Riva, Gloria",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Levinson, Michael S.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Maturen, Michael A",1,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"McMullin, Evan",4,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Moorehead, Monica G.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Perry, Darryl",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Schriner, Joe C",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Smith, Mike",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Sood, Ajay",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Sterling, Shawna",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Valdivia, Anthony J",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",898,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Libertarian,"Johnson, Gary",84,120300
+DOUGLAS,Lawrence Precinct 46 S3,President / Vice President,,Republican,"Trump, Donald J.",364,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,independent,"Stein, Jill",3,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Basiago, Andrew D.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Castle, Darrell L",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Giordani, Rocky",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Hedges, James A",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Hoefling, Tom",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Kahn, Lynn",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"La Riva, Gloria",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Levinson, Michael S.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Maturen, Michael A",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"McMullin, Evan",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Moorehead, Monica G.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Perry, Darryl",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Schriner, Joe C",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Smith, Mike",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Sood, Ajay",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Sterling, Shawna",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Valdivia, Anthony J",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Libertarian,"Johnson, Gary",9,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,President / Vice President,,Republican,"Trump, Donald J.",82,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,independent,"Stein, Jill",15,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Castle, Darrell L",1,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Giordani, Rocky",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Hedges, James A",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Hoefling, Tom",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Kahn, Lynn",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"La Riva, Gloria",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Levinson, Michael S.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Maturen, Michael A",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"McMullin, Evan",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Perry, Darryl",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Schriner, Joe C",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Smith, Mike",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Sood, Ajay",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Sterling, Shawna",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",193,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Libertarian,"Johnson, Gary",30,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,President / Vice President,,Republican,"Trump, Donald J.",252,120320
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,independent,"Stein, Jill",10,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Hedges, James A",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"McMullin, Evan",2,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Perry, Darryl",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Smith, Mike",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Sood, Ajay",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",134,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Libertarian,"Johnson, Gary",20,120330
+DOUGLAS,Marion Township Precinct 59 H45,President / Vice President,,Republican,"Trump, Donald J.",119,120330
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,independent,"Stein, Jill",9,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Basiago, Andrew D.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Castle, Darrell L",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Giordani, Rocky",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Hedges, James A",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Hoefling, Tom",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Kahn, Lynn",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"La Riva, Gloria",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Levinson, Michael S.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Maturen, Michael A",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"McMullin, Evan",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Moorehead, Monica G.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Perry, Darryl",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Schriner, Joe C",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Smith, Mike",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Sood, Ajay",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Sterling, Shawna",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Valdivia, Anthony J",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Libertarian,"Johnson, Gary",11,120340
+DOUGLAS,Marion Township Precinct 59 H54,President / Vice President,,Republican,"Trump, Donald J.",126,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,independent,"Stein, Jill",4,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Hedges, James A",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"McMullin, Evan",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Perry, Darryl",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Smith, Mike",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Sood, Ajay",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",133,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Libertarian,"Johnson, Gary",11,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,President / Vice President,,Republican,"Trump, Donald J.",67,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,independent,"Stein, Jill",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Basiago, Andrew D.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Castle, Darrell L",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Giordani, Rocky",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Hedges, James A",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Hoefling, Tom",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Kahn, Lynn",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"La Riva, Gloria",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Levinson, Michael S.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Maturen, Michael A",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"McMullin, Evan",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Moorehead, Monica G.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Perry, Darryl",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Schriner, Joe C",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Smith, Mike",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Sood, Ajay",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Sterling, Shawna",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Valdivia, Anthony J",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Libertarian,"Johnson, Gary",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,President / Vice President,,Republican,"Trump, Donald J.",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,independent,"Stein, Jill",10,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Castle, Darrell L",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Giordani, Rocky",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Hedges, James A",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Kahn, Lynn",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"La Riva, Gloria",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Levinson, Michael S.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Maturen, Michael A",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"McMullin, Evan",3,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Perry, Darryl",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Schriner, Joe C",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Smith, Mike",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Sood, Ajay",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Sterling, Shawna",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",169,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Libertarian,"Johnson, Gary",30,120370
+DOUGLAS,South Eudora Precinct 53 H10,President / Vice President,,Republican,"Trump, Donald J.",305,120370
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,independent,"Stein, Jill",16,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Basiago, Andrew D.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Castle, Darrell L",2,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Giordani, Rocky",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Hedges, James A",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Hoefling, Tom",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Kahn, Lynn",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"La Riva, Gloria",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Levinson, Michael S.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Maturen, Michael A",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"McMullin, Evan",1,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Moorehead, Monica G.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Perry, Darryl",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Schriner, Joe C",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Smith, Mike",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Sood, Ajay",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Sterling, Shawna",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Valdivia, Anthony J",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Democratic,"Clinton, Hillary Rodham",196,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Libertarian,"Johnson, Gary",34,120380
+DOUGLAS,South Eudora Precinct 53 H42,President / Vice President,,Republican,"Trump, Donald J.",315,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,independent,"Stein, Jill",2,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Castle, Darrell L",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Giordani, Rocky",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Hedges, James A",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Kahn, Lynn",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"La Riva, Gloria",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Levinson, Michael S.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Maturen, Michael A",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"McMullin, Evan",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Perry, Darryl",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Schriner, Joe C",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Smith, Mike",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Sood, Ajay",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Sterling, Shawna",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Libertarian,"Johnson, Gary",15,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,President / Vice President,,Republican,"Trump, Donald J.",125,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,independent,"Stein, Jill",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Hedges, James A",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"McMullin, Evan",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Perry, Darryl",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Smith, Mike",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Sood, Ajay",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Republican,"Trump, Donald J.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,independent,"Stein, Jill",4,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Hedges, James A",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"McMullin, Evan",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Perry, Darryl",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Smith, Mike",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Sood, Ajay",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",99,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Libertarian,"Johnson, Gary",11,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,President / Vice President,,Republican,"Trump, Donald J.",92,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,independent,"Stein, Jill",4,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Castle, Darrell L",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Giordani, Rocky",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Hedges, James A",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Hoefling, Tom",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Kahn, Lynn",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"La Riva, Gloria",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Levinson, Michael S.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Maturen, Michael A",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"McMullin, Evan",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Perry, Darryl",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Schriner, Joe C",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Smith, Mike",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Sood, Ajay",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Sterling, Shawna",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Libertarian,"Johnson, Gary",6,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,President / Vice President,,Republican,"Trump, Donald J.",77,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,independent,"Stein, Jill",1,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Hedges, James A",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"McMullin, Evan",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Perry, Darryl",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Smith, Mike",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Sood, Ajay",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,President / Vice President,,Republican,"Trump, Donald J.",0,120420
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,independent,"Stein, Jill",9,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Hedges, James A",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"McMullin, Evan",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Perry, Darryl",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Smith, Mike",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Sood, Ajay",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",149,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Libertarian,"Johnson, Gary",16,120430
+DOUGLAS,Willow Springs Township S19 H45,President / Vice President,,Republican,"Trump, Donald J.",132,120430
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,independent,"Stein, Jill",7,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Basiago, Andrew D.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Castle, Darrell L",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Giordani, Rocky",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Hedges, James A",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Hoefling, Tom",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Kahn, Lynn",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"La Riva, Gloria",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Levinson, Michael S.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Maturen, Michael A",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"McMullin, Evan",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Moorehead, Monica G.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Perry, Darryl",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Schriner, Joe C",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Smith, Mike",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Sood, Ajay",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Sterling, Shawna",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Valdivia, Anthony J",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Democratic,"Clinton, Hillary Rodham",115,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Libertarian,"Johnson, Gary",17,120440
+DOUGLAS,Willow Springs Township S19 H54,President / Vice President,,Republican,"Trump, Donald J.",210,120440
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,independent,"Stein, Jill",3,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Basiago, Andrew D.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Castle, Darrell L",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Giordani, Rocky",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Hedges, James A",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Hoefling, Tom",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Kahn, Lynn",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"La Riva, Gloria",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Levinson, Michael S.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Maturen, Michael A",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"McMullin, Evan",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Moorehead, Monica G.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Perry, Darryl",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Schriner, Joe C",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Smith, Mike",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Sood, Ajay",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Sterling, Shawna",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Valdivia, Anthony J",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Libertarian,"Johnson, Gary",4,120450
+DOUGLAS,Willow Springs Township S3 H45,President / Vice President,,Republican,"Trump, Donald J.",41,120450
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,independent,"Stein, Jill",2,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Basiago, Andrew D.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Castle, Darrell L",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Giordani, Rocky",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Hedges, James A",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Hoefling, Tom",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Kahn, Lynn",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"La Riva, Gloria",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Levinson, Michael S.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Maturen, Michael A",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"McMullin, Evan",3,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Moorehead, Monica G.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Perry, Darryl",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Schriner, Joe C",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Smith, Mike",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Sood, Ajay",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Sterling, Shawna",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Valdivia, Anthony J",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Libertarian,"Johnson, Gary",6,120460
+DOUGLAS,Willow Springs Township S3 H54,President / Vice President,,Republican,"Trump, Donald J.",41,120460
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,independent,"Stein, Jill",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Basiago, Andrew D.",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Castle, Darrell L",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Giordani, Rocky",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Hedges, James A",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Hoefling, Tom",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Kahn, Lynn",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"La Riva, Gloria",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Levinson, Michael S.",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Maturen, Michael A",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"McMullin, Evan",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Moorehead, Monica G.",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Perry, Darryl",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Schoenke, Marshall R.",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Schriner, Joe C",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Smith, Mike",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Sood, Ajay",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Sterling, Shawna",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Valdivia, Anthony J",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,Libertarian,"Johnson, Gary",0,160010
+DOUGLAS,Lawrence Precinct 75,President / Vice President,,Republican,"Trump, Donald J.",0,160010
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,independent,"Stein, Jill",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Basiago, Andrew D.",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Castle, Darrell L",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Giordani, Rocky",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Hedges, James A",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Hoefling, Tom",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Kahn, Lynn",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"La Riva, Gloria",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Levinson, Michael S.",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Maturen, Michael A",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"McMullin, Evan",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Moorehead, Monica G.",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Perry, Darryl",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Schoenke, Marshall R.",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Schriner, Joe C",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Smith, Mike",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Sood, Ajay",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Sterling, Shawna",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Valdivia, Anthony J",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,Libertarian,"Johnson, Gary",1,160020
+DOUGLAS,Lawrence Precinct 76,President / Vice President,,Republican,"Trump, Donald J.",4,160020
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,independent,"Stein, Jill",26,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Basiago, Andrew D.",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Castle, Darrell L",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Giordani, Rocky",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Hedges, James A",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Hoefling, Tom",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Kahn, Lynn",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"La Riva, Gloria",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Levinson, Michael S.",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Maturen, Michael A",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"McMullin, Evan",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Moorehead, Monica G.",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Perry, Darryl",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Schoenke, Marshall R.",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Schriner, Joe C",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Smith, Mike",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Sood, Ajay",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Sterling, Shawna",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Valdivia, Anthony J",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,Democratic,"Clinton, Hillary Rodham",311,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,Libertarian,"Johnson, Gary",42,160030
+DOUGLAS,Lawrence Precinct 77,President / Vice President,,Republican,"Trump, Donald J.",178,160030
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,independent,"Stein, Jill",5,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Basiago, Andrew D.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Castle, Darrell L",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Giordani, Rocky",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Hedges, James A",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Kahn, Lynn",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"La Riva, Gloria",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Levinson, Michael S.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Maturen, Michael A",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"McMullin, Evan",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Moorehead, Monica G.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Perry, Darryl",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Schriner, Joe C",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Smith, Mike",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Sood, Ajay",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Sterling, Shawna",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Valdivia, Anthony J",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Democratic,"Clinton, Hillary Rodham",182,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Libertarian,"Johnson, Gary",20,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,President / Vice President,,Republican,"Trump, Donald J.",206,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,independent,"Stein, Jill",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Hedges, James A",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"McMullin, Evan",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Perry, Darryl",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Smith, Mike",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Sood, Ajay",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,President / Vice President,,Republican,"Trump, Donald J.",0,400010
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,independent,"Stein, Jill",11,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Basiago, Andrew D.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Castle, Darrell L",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Giordani, Rocky",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Hedges, James A",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Hoefling, Tom",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Kahn, Lynn",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"La Riva, Gloria",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Levinson, Michael S.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Maturen, Michael A",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"McMullin, Evan",3,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Moorehead, Monica G.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Perry, Darryl",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Schriner, Joe C",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Smith, Mike",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Sood, Ajay",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Sterling, Shawna",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Valdivia, Anthony J",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Democratic,"Clinton, Hillary Rodham",290,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Libertarian,"Johnson, Gary",16,400030
+DOUGLAS,Lawrence Precinct 47,President / Vice President,,Republican,"Trump, Donald J.",147,400030
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,independent,"Stein, Jill",23,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Basiago, Andrew D.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Castle, Darrell L",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Giordani, Rocky",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Hedges, James A",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Hoefling, Tom",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Kahn, Lynn",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"La Riva, Gloria",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Levinson, Michael S.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Maturen, Michael A",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"McMullin, Evan",8,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Moorehead, Monica G.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Perry, Darryl",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Schriner, Joe C",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Smith, Mike",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Sood, Ajay",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Sterling, Shawna",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Valdivia, Anthony J",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Democratic,"Clinton, Hillary Rodham",699,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Libertarian,"Johnson, Gary",41,400040
+DOUGLAS,Lawrence Precinct 48,President / Vice President,,Republican,"Trump, Donald J.",263,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,independent,"Stein, Jill",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Castle, Darrell L",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Giordani, Rocky",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Hedges, James A",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Kahn, Lynn",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"La Riva, Gloria",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Levinson, Michael S.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Maturen, Michael A",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"McMullin, Evan",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Perry, Darryl",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Schriner, Joe C",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Smith, Mike",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Sood, Ajay",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Sterling, Shawna",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,President / Vice President,,Republican,"Trump, Donald J.",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,independent,"Stein, Jill",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Castle, Darrell L",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Giordani, Rocky",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Hedges, James A",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Kahn, Lynn",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"La Riva, Gloria",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Levinson, Michael S.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Maturen, Michael A",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"McMullin, Evan",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Perry, Darryl",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Schriner, Joe C",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Smith, Mike",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Sood, Ajay",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Sterling, Shawna",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,President / Vice President,,Republican,"Trump, Donald J.",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,independent,"Stein, Jill",26,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Hedges, James A",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"McMullin, Evan",4,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Perry, Darryl",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Smith, Mike",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Sood, Ajay",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",388,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",86,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,President / Vice President,,Republican,"Trump, Donald J.",565,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,independent,"Stein, Jill",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Castle, Darrell L",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Giordani, Rocky",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Hedges, James A",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Kahn, Lynn",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"La Riva, Gloria",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Levinson, Michael S.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Maturen, Michael A",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"McMullin, Evan",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Perry, Darryl",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Schriner, Joe C",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Smith, Mike",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Sood, Ajay",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Sterling, Shawna",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,President / Vice President,,Republican,"Trump, Donald J.",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,independent,"Stein, Jill",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Hedges, James A",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"McMullin, Evan",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Perry, Darryl",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Smith, Mike",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Sood, Ajay",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,President / Vice President,,Republican,"Trump, Donald J.",0,400110
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,independent,"Stein, Jill",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Hedges, James A",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"McMullin, Evan",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Perry, Darryl",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Smith, Mike",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Sood, Ajay",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+DOUGLAS,Lawrence Precinct 68,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,independent,"Stein, Jill",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Hedges, James A",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"McMullin, Evan",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Perry, Darryl",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Smith, Mike",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Sood, Ajay",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+DOUGLAS,Lawrence Precinct 69,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,independent,"Stein, Jill",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Hedges, James A",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"McMullin, Evan",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Perry, Darryl",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Smith, Mike",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Sood, Ajay",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+DOUGLAS,Lawrence Precinct 70,President / Vice President,,Republican,"Trump, Donald J.",7,900040
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,independent,"Stein, Jill",27,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Hedges, James A",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"McMullin, Evan",6,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Perry, Darryl",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Smith, Mike",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Sood, Ajay",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Democratic,"Clinton, Hillary Rodham",646,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Libertarian,"Johnson, Gary",51,900050
+DOUGLAS,Lawrence Precinct 71,President / Vice President,,Republican,"Trump, Donald J.",313,900050
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,independent,"Stein, Jill",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Hedges, James A",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"McMullin, Evan",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Perry, Darryl",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Smith, Mike",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Sood, Ajay",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+DOUGLAS,Lawrence Precinct 72,President / Vice President,,Republican,"Trump, Donald J.",0,900060
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,independent,"Stein, Jill",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Basiago, Andrew D.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Castle, Darrell L",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Giordani, Rocky",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Hedges, James A",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Kahn, Lynn",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"La Riva, Gloria",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Levinson, Michael S.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Maturen, Michael A",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"McMullin, Evan",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Moorehead, Monica G.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Perry, Darryl",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Schriner, Joe C",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Smith, Mike",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Sood, Ajay",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Sterling, Shawna",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Valdivia, Anthony J",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+DOUGLAS,Lawrence Precinct 73,President / Vice President,,Republican,"Trump, Donald J.",0,900070
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,independent,"Stein, Jill",19,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Basiago, Andrew D.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Castle, Darrell L",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Giordani, Rocky",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Hedges, James A",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Kahn, Lynn",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"La Riva, Gloria",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Levinson, Michael S.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Maturen, Michael A",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"McMullin, Evan",6,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Moorehead, Monica G.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Perry, Darryl",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Schriner, Joe C",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Smith, Mike",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Sood, Ajay",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Sterling, Shawna",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Valdivia, Anthony J",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Democratic,"Clinton, Hillary Rodham",609,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Libertarian,"Johnson, Gary",44,900080
+DOUGLAS,Lawrence Precinct 74,President / Vice President,,Republican,"Trump, Donald J.",338,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,independent,"Stein, Jill",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Hedges, James A",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"McMullin, Evan",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Perry, Darryl",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Smith, Mike",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Sood, Ajay",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,President / Vice President,,Republican,"Trump, Donald J.",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,independent,"Stein, Jill",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Hedges, James A",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"McMullin, Evan",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Perry, Darryl",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Smith, Mike",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Sood, Ajay",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,President / Vice President,,Republican,"Trump, Donald J.",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,independent,"Stein, Jill",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Castle, Darrell L",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Giordani, Rocky",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Hedges, James A",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Kahn, Lynn",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"La Riva, Gloria",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Maturen, Michael A",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"McMullin, Evan",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Perry, Darryl",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Schriner, Joe C",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Smith, Mike",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Sood, Ajay",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Sterling, Shawna",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,President / Vice President,,Republican,"Trump, Donald J.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,independent,"Stein, Jill",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Hedges, James A",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"McMullin, Evan",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Perry, Darryl",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Smith, Mike",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Sood, Ajay",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,President / Vice President,,Republican,"Trump, Donald J.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,independent,"Stein, Jill",4,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Castle, Darrell L",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Giordani, Rocky",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Hedges, James A",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Hoefling, Tom",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Kahn, Lynn",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"La Riva, Gloria",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Levinson, Michael S.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Maturen, Michael A",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"McMullin, Evan",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Perry, Darryl",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Schriner, Joe C",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Smith, Mike",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Sood, Ajay",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Sterling, Shawna",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,President / Vice President,,Republican,"Trump, Donald J.",6,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,independent,"Stein, Jill",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Castle, Darrell L",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Giordani, Rocky",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Hedges, James A",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Hoefling, Tom",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Kahn, Lynn",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"La Riva, Gloria",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Levinson, Michael S.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Maturen, Michael A",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"McMullin, Evan",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Perry, Darryl",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Schriner, Joe C",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Smith, Mike",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Sood, Ajay",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Sterling, Shawna",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Libertarian,"Johnson, Gary",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,President / Vice President,,Republican,"Trump, Donald J.",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,independent,"Stein, Jill",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Castle, Darrell L",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Giordani, Rocky",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Hedges, James A",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Hoefling, Tom",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Kahn, Lynn",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"La Riva, Gloria",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Levinson, Michael S.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Maturen, Michael A",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"McMullin, Evan",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Perry, Darryl",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Schriner, Joe C",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Smith, Mike",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Sood, Ajay",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Sterling, Shawna",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,President / Vice President,,Republican,"Trump, Donald J.",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,independent,"Stein, Jill",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Castle, Darrell L",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Giordani, Rocky",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Hedges, James A",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Hoefling, Tom",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Kahn, Lynn",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"La Riva, Gloria",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Levinson, Michael S.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Maturen, Michael A",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"McMullin, Evan",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Perry, Darryl",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Schriner, Joe C",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Smith, Mike",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Sood, Ajay",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Sterling, Shawna",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,President / Vice President,,Republican,"Trump, Donald J.",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,independent,"Stein, Jill",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Castle, Darrell L",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Giordani, Rocky",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Hedges, James A",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Hoefling, Tom",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Kahn, Lynn",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"La Riva, Gloria",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Levinson, Michael S.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Maturen, Michael A",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"McMullin, Evan",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Perry, Darryl",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Schriner, Joe C",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Smith, Mike",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Sood, Ajay",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Sterling, Shawna",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Libertarian,"Johnson, Gary",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,President / Vice President,,Republican,"Trump, Donald J.",0,900170
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Democratic,"Potter, Britani",89,000010
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000010
+DOUGLAS,Big Springs Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",109,000010
+DOUGLAS,Central Eudora,United States House of Representatives,2,Democratic,"Potter, Britani",244,000020
+DOUGLAS,Central Eudora,United States House of Representatives,2,Libertarian,"Bales, James Houston",71,000020
+DOUGLAS,Central Eudora,United States House of Representatives,2,Republican,"Jenkins, Lynn",441,000020
+DOUGLAS,Clinton Township,United States House of Representatives,2,Democratic,"Potter, Britani",139,000030
+DOUGLAS,Clinton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,000030
+DOUGLAS,Clinton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",224,000030
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Democratic,"Potter, Britani",374,00007A
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Libertarian,"Bales, James Houston",84,00007A
+DOUGLAS,Lawrence Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",75,00007A
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Democratic,"Potter, Britani",451,000080
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Libertarian,"Bales, James Houston",60,000080
+DOUGLAS,Lawrence Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000080
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Democratic,"Potter, Britani",450,000090
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Libertarian,"Bales, James Houston",69,000090
+DOUGLAS,Lawrence Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",88,000090
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Democratic,"Potter, Britani",344,00010A
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Libertarian,"Bales, James Houston",103,00010A
+DOUGLAS,Lawrence Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,00010A
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Democratic,"Potter, Britani",277,000110
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Libertarian,"Bales, James Houston",65,000110
+DOUGLAS,Lawrence Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",192,000110
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Democratic,"Potter, Britani",380,00012A
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Libertarian,"Bales, James Houston",84,00012A
+DOUGLAS,Lawrence Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",293,00012A
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Democratic,"Potter, Britani",213,000130
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Libertarian,"Bales, James Houston",43,000130
+DOUGLAS,Lawrence Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",36,000130
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Democratic,"Potter, Britani",271,000140
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Libertarian,"Bales, James Houston",69,000140
+DOUGLAS,Lawrence Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,000140
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Democratic,"Potter, Britani",270,000150
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Libertarian,"Bales, James Houston",53,000150
+DOUGLAS,Lawrence Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000150
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Democratic,"Potter, Britani",131,000160
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Libertarian,"Bales, James Houston",42,000160
+DOUGLAS,Lawrence Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",61,000160
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Democratic,"Potter, Britani",342,000170
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Libertarian,"Bales, James Houston",84,000170
+DOUGLAS,Lawrence Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",146,000170
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Democratic,"Potter, Britani",552,000180
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Libertarian,"Bales, James Houston",109,000180
+DOUGLAS,Lawrence Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",258,000180
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Democratic,"Potter, Britani",471,000190
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Libertarian,"Bales, James Houston",56,000190
+DOUGLAS,Lawrence Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",246,000190
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Democratic,"Potter, Britani",662,000200
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Libertarian,"Bales, James Houston",183,000200
+DOUGLAS,Lawrence Precinct 14,United States House of Representatives,2,Republican,"Jenkins, Lynn",426,000200
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Democratic,"Potter, Britani",605,000210
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Libertarian,"Bales, James Houston",106,000210
+DOUGLAS,Lawrence Precinct 15,United States House of Representatives,2,Republican,"Jenkins, Lynn",201,000210
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Democratic,"Potter, Britani",415,000220
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Libertarian,"Bales, James Houston",98,000220
+DOUGLAS,Lawrence Precinct 16,United States House of Representatives,2,Republican,"Jenkins, Lynn",209,000220
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Democratic,"Potter, Britani",578,000230
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Libertarian,"Bales, James Houston",106,000230
+DOUGLAS,Lawrence Precinct 17,United States House of Representatives,2,Republican,"Jenkins, Lynn",398,000230
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Democratic,"Potter, Britani",608,000240
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Libertarian,"Bales, James Houston",141,000240
+DOUGLAS,Lawrence Precinct 18,United States House of Representatives,2,Republican,"Jenkins, Lynn",495,000240
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Democratic,"Potter, Britani",468,000250
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Libertarian,"Bales, James Houston",46,000250
+DOUGLAS,Lawrence Precinct 19,United States House of Representatives,2,Republican,"Jenkins, Lynn",458,000250
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Democratic,"Potter, Britani",662,000260
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Libertarian,"Bales, James Houston",147,000260
+DOUGLAS,Lawrence Precinct 20,United States House of Representatives,2,Republican,"Jenkins, Lynn",450,000260
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Democratic,"Potter, Britani",263,000270
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Libertarian,"Bales, James Houston",30,000270
+DOUGLAS,Lawrence Precinct 21,United States House of Representatives,2,Republican,"Jenkins, Lynn",124,000270
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Democratic,"Potter, Britani",375,000280
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Libertarian,"Bales, James Houston",106,000280
+DOUGLAS,Lawrence Precinct 22,United States House of Representatives,2,Republican,"Jenkins, Lynn",262,000280
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Democratic,"Potter, Britani",326,000290
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Libertarian,"Bales, James Houston",53,000290
+DOUGLAS,Lawrence Precinct 23,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000290
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Democratic,"Potter, Britani",280,000300
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Libertarian,"Bales, James Houston",50,000300
+DOUGLAS,Lawrence Precinct 24,United States House of Representatives,2,Republican,"Jenkins, Lynn",218,000300
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Democratic,"Potter, Britani",284,000310
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Libertarian,"Bales, James Houston",58,000310
+DOUGLAS,Lawrence Precinct 25,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000310
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Democratic,"Potter, Britani",415,000320
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Libertarian,"Bales, James Houston",74,000320
+DOUGLAS,Lawrence Precinct 26,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000320
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Democratic,"Potter, Britani",376,000330
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Libertarian,"Bales, James Houston",73,000330
+DOUGLAS,Lawrence Precinct 27,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,000330
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Democratic,"Potter, Britani",256,000340
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Libertarian,"Bales, James Houston",36,000340
+DOUGLAS,Lawrence Precinct 28,United States House of Representatives,2,Republican,"Jenkins, Lynn",76,000340
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Democratic,"Potter, Britani",317,000350
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Libertarian,"Bales, James Houston",75,000350
+DOUGLAS,Lawrence Precinct 29,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000350
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Democratic,"Potter, Britani",457,000370
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Libertarian,"Bales, James Houston",87,000370
+DOUGLAS,Lawrence Precinct 31,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,000370
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Democratic,"Potter, Britani",268,000380
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Libertarian,"Bales, James Houston",82,000380
+DOUGLAS,Lawrence Precinct 32,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000380
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Democratic,"Potter, Britani",509,000400
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Libertarian,"Bales, James Houston",69,000400
+DOUGLAS,Lawrence Precinct 33,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,000400
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Democratic,"Potter, Britani",590,000450
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Libertarian,"Bales, James Houston",123,000450
+DOUGLAS,Lawrence Precinct 38,United States House of Representatives,2,Republican,"Jenkins, Lynn",395,000450
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Democratic,"Potter, Britani",536,000460
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Libertarian,"Bales, James Houston",85,000460
+DOUGLAS,Lawrence Precinct 39,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000460
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Democratic,"Potter, Britani",467,000470
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Libertarian,"Bales, James Houston",85,000470
+DOUGLAS,Lawrence Precinct 40,United States House of Representatives,2,Republican,"Jenkins, Lynn",52,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Democratic,"Potter, Britani",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Democratic,"Potter, Britani",263,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",49,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",190,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Democratic,"Potter, Britani",405,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",94,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",302,00050C
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Democratic,"Potter, Britani",495,00052A
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Libertarian,"Bales, James Houston",89,00052A
+DOUGLAS,Lawrence Precinct 45,United States House of Representatives,2,Republican,"Jenkins, Lynn",522,00052A
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Democratic,"Potter, Britani",518,000560
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Libertarian,"Bales, James Houston",92,000560
+DOUGLAS,Lawrence Precinct 49,United States House of Representatives,2,Republican,"Jenkins, Lynn",591,000560
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Democratic,"Potter, Britani",152,000600
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Libertarian,"Bales, James Houston",55,000600
+DOUGLAS,North Eudora Precinct 52,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,000600
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Democratic,"Potter, Britani",347,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Libertarian,"Bales, James Houston",85,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States House of Representatives,2,Republican,"Jenkins, Lynn",617,000620
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Democratic,"Potter, Britani",295,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Libertarian,"Bales, James Houston",60,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States House of Representatives,2,Republican,"Jenkins, Lynn",379,000630
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Democratic,"Potter, Britani",300,000640
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Libertarian,"Bales, James Houston",92,000640
+DOUGLAS,South Baldwin Precinct 62,United States House of Representatives,2,Republican,"Jenkins, Lynn",562,000640
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Democratic,"Potter, Britani",251,000660
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Libertarian,"Bales, James Houston",49,000660
+DOUGLAS,Vinland Precinct 63,United States House of Representatives,2,Republican,"Jenkins, Lynn",374,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Democratic,"Potter, Britani",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Democratic,"Potter, Britani",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Democratic,"Potter, Britani",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Democratic,"Potter, Britani",21,120040
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,120040
+DOUGLAS,Grant Township S2 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",9,120040
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Democratic,"Potter, Britani",57,120050
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,120050
+DOUGLAS,Grant Township S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,120050
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Democratic,"Potter, Britani",18,120060
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,120060
+DOUGLAS,Grant Township S3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",19,120060
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Democratic,"Potter, Britani",325,120070
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Libertarian,"Bales, James Houston",78,120070
+DOUGLAS,Kawaka Township S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",437,120070
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Democratic,"Potter, Britani",27,120080
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,120080
+DOUGLAS,Kawaka Township S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",21,120080
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Democratic,"Potter, Britani",129,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,120090
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Democratic,"Potter, Britani",222,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Libertarian,"Bales, James Houston",46,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,120100
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Democratic,"Potter, Britani",314,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Libertarian,"Bales, James Houston",48,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,120110
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Democratic,"Potter, Britani",65,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",4,120120
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Democratic,"Potter, Britani",416,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Libertarian,"Bales, James Houston",98,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",112,120130
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Democratic,"Potter, Britani",23,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",17,120140
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Democratic,"Potter, Britani",292,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Libertarian,"Bales, James Houston",87,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",155,120150
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Democratic,"Potter, Britani",406,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Libertarian,"Bales, James Houston",122,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",277,120170
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Democratic,"Potter, Britani",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120190
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Democratic,"Potter, Britani",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Democratic,"Potter, Britani",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Democratic,"Potter, Britani",9,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",6,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Democratic,"Potter, Britani",3,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Democratic,"Potter, Britani",719,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Libertarian,"Bales, James Houston",158,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",263,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Democratic,"Potter, Britani",181,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",34,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Democratic,"Potter, Britani",158,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Libertarian,"Bales, James Houston",48,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,120260
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Democratic,"Potter, Britani",214,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Libertarian,"Bales, James Houston",37,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States House of Representatives,2,Republican,"Jenkins, Lynn",108,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Democratic,"Potter, Britani",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Democratic,"Potter, Britani",250,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",60,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",215,120280
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Democratic,"Potter, Britani",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Democratic,"Potter, Britani",748,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Libertarian,"Bales, James Houston",177,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States House of Representatives,2,Republican,"Jenkins, Lynn",458,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Democratic,"Potter, Britani",39,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States House of Representatives,2,Republican,"Jenkins, Lynn",98,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Democratic,"Potter, Britani",197,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Libertarian,"Bales, James Houston",41,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States House of Representatives,2,Republican,"Jenkins, Lynn",258,120320
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Democratic,"Potter, Britani",112,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",155,120330
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Democratic,"Potter, Britani",54,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Democratic,"Potter, Britani",120,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Democratic,"Potter, Britani",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Democratic,"Potter, Britani",135,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Libertarian,"Bales, James Houston",45,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",337,120370
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Democratic,"Potter, Britani",172,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Libertarian,"Bales, James Houston",62,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",323,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Democratic,"Potter, Britani",88,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Democratic,"Potter, Britani",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Democratic,"Potter, Britani",69,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Democratic,"Potter, Britani",59,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Democratic,"Potter, Britani",2,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120420
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Democratic,"Potter, Britani",132,120430
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,120430
+DOUGLAS,Willow Springs Township S19 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,120430
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Democratic,"Potter, Britani",103,120440
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Libertarian,"Bales, James Houston",31,120440
+DOUGLAS,Willow Springs Township S19 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",217,120440
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Democratic,"Potter, Britani",45,120450
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,120450
+DOUGLAS,Willow Springs Township S3 H45,United States House of Representatives,2,Republican,"Jenkins, Lynn",47,120450
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Democratic,"Potter, Britani",24,120460
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,120460
+DOUGLAS,Willow Springs Township S3 H54,United States House of Representatives,2,Republican,"Jenkins, Lynn",46,120460
+DOUGLAS,Lawrence Precinct 75,United States House of Representatives,2,Democratic,"Potter, Britani",0,160010
+DOUGLAS,Lawrence Precinct 75,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,160010
+DOUGLAS,Lawrence Precinct 75,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,160010
+DOUGLAS,Lawrence Precinct 76,United States House of Representatives,2,Democratic,"Potter, Britani",10,160020
+DOUGLAS,Lawrence Precinct 76,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,160020
+DOUGLAS,Lawrence Precinct 76,United States House of Representatives,2,Republican,"Jenkins, Lynn",4,160020
+DOUGLAS,Lawrence Precinct 77,United States House of Representatives,2,Democratic,"Potter, Britani",268,160030
+DOUGLAS,Lawrence Precinct 77,United States House of Representatives,2,Libertarian,"Bales, James Houston",104,160030
+DOUGLAS,Lawrence Precinct 77,United States House of Representatives,2,Republican,"Jenkins, Lynn",184,160030
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Democratic,"Potter, Britani",149,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Libertarian,"Bales, James Houston",40,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400010
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Democratic,"Potter, Britani",219,400030
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Libertarian,"Bales, James Houston",34,400030
+DOUGLAS,Lawrence Precinct 47,United States House of Representatives,2,Republican,"Jenkins, Lynn",213,400030
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Democratic,"Potter, Britani",535,400040
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Libertarian,"Bales, James Houston",78,400040
+DOUGLAS,Lawrence Precinct 48,United States House of Representatives,2,Republican,"Jenkins, Lynn",422,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Democratic,"Potter, Britani",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",330,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",126,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",616,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Democratic,"Potter, Britani",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,400110
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+DOUGLAS,Lawrence Precinct 68,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+DOUGLAS,Lawrence Precinct 69,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Democratic,"Potter, Britani",1,900040
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900040
+DOUGLAS,Lawrence Precinct 70,United States House of Representatives,2,Republican,"Jenkins, Lynn",10,900040
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Democratic,"Potter, Britani",524,900050
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Libertarian,"Bales, James Houston",98,900050
+DOUGLAS,Lawrence Precinct 71,United States House of Representatives,2,Republican,"Jenkins, Lynn",428,900050
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Democratic,"Potter, Britani",0,900060
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900060
+DOUGLAS,Lawrence Precinct 72,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Democratic,"Potter, Britani",0,900070
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900070
+DOUGLAS,Lawrence Precinct 73,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900070
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Democratic,"Potter, Britani",469,900080
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Libertarian,"Bales, James Houston",98,900080
+DOUGLAS,Lawrence Precinct 74,United States House of Representatives,2,Republican,"Jenkins, Lynn",444,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Democratic,"Potter, Britani",19,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",7,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Democratic,"Potter, Britani",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Democratic,"Potter, Britani",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Democratic,"Potter, Britani",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Democratic,"Potter, Britani",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900170
+DOUGLAS,Big Springs Township,United States Senate,,write - in,"Smith, DJ",0,000010
+DOUGLAS,Big Springs Township,United States Senate,,Democratic,"Wiesner, Patrick",95,000010
+DOUGLAS,Big Springs Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000010
+DOUGLAS,Big Springs Township,United States Senate,,Republican,"Moran, Jerry",112,000010
+DOUGLAS,Central Eudora,United States Senate,,write - in,"Smith, DJ",0,000020
+DOUGLAS,Central Eudora,United States Senate,,Democratic,"Wiesner, Patrick",307,000020
+DOUGLAS,Central Eudora,United States Senate,,Libertarian,"Garrard, Robert D.",46,000020
+DOUGLAS,Central Eudora,United States Senate,,Republican,"Moran, Jerry",403,000020
+DOUGLAS,Clinton Township,United States Senate,,write - in,"Smith, DJ",0,000030
+DOUGLAS,Clinton Township,United States Senate,,Democratic,"Wiesner, Patrick",160,000030
+DOUGLAS,Clinton Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000030
+DOUGLAS,Clinton Township,United States Senate,,Republican,"Moran, Jerry",220,000030
+DOUGLAS,Lawrence Precinct 01,United States Senate,,write - in,"Smith, DJ",0,00007A
+DOUGLAS,Lawrence Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",437,00007A
+DOUGLAS,Lawrence Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",27,00007A
+DOUGLAS,Lawrence Precinct 01,United States Senate,,Republican,"Moran, Jerry",72,00007A
+DOUGLAS,Lawrence Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000080
+DOUGLAS,Lawrence Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",490,000080
+DOUGLAS,Lawrence Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",19,000080
+DOUGLAS,Lawrence Precinct 02,United States Senate,,Republican,"Moran, Jerry",88,000080
+DOUGLAS,Lawrence Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000090
+DOUGLAS,Lawrence Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",498,000090
+DOUGLAS,Lawrence Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",21,000090
+DOUGLAS,Lawrence Precinct 03,United States Senate,,Republican,"Moran, Jerry",90,000090
+DOUGLAS,Lawrence Precinct 04,United States Senate,,write - in,"Smith, DJ",0,00010A
+DOUGLAS,Lawrence Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",423,00010A
+DOUGLAS,Lawrence Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",33,00010A
+DOUGLAS,Lawrence Precinct 04,United States Senate,,Republican,"Moran, Jerry",94,00010A
+DOUGLAS,Lawrence Precinct 05,United States Senate,,write - in,"Smith, DJ",0,000110
+DOUGLAS,Lawrence Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",317,000110
+DOUGLAS,Lawrence Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",22,000110
+DOUGLAS,Lawrence Precinct 05,United States Senate,,Republican,"Moran, Jerry",197,000110
+DOUGLAS,Lawrence Precinct 06,United States Senate,,write - in,"Smith, DJ",0,00012A
+DOUGLAS,Lawrence Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",458,00012A
+DOUGLAS,Lawrence Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",34,00012A
+DOUGLAS,Lawrence Precinct 06,United States Senate,,Republican,"Moran, Jerry",266,00012A
+DOUGLAS,Lawrence Precinct 07,United States Senate,,write - in,"Smith, DJ",0,000130
+DOUGLAS,Lawrence Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",243,000130
+DOUGLAS,Lawrence Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",16,000130
+DOUGLAS,Lawrence Precinct 07,United States Senate,,Republican,"Moran, Jerry",32,000130
+DOUGLAS,Lawrence Precinct 08,United States Senate,,write - in,"Smith, DJ",0,000140
+DOUGLAS,Lawrence Precinct 08,United States Senate,,Democratic,"Wiesner, Patrick",322,000140
+DOUGLAS,Lawrence Precinct 08,United States Senate,,Libertarian,"Garrard, Robert D.",17,000140
+DOUGLAS,Lawrence Precinct 08,United States Senate,,Republican,"Moran, Jerry",69,000140
+DOUGLAS,Lawrence Precinct 09,United States Senate,,write - in,"Smith, DJ",0,000150
+DOUGLAS,Lawrence Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",312,000150
+DOUGLAS,Lawrence Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",20,000150
+DOUGLAS,Lawrence Precinct 09,United States Senate,,Republican,"Moran, Jerry",50,000150
+DOUGLAS,Lawrence Precinct 10,United States Senate,,write - in,"Smith, DJ",0,000160
+DOUGLAS,Lawrence Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",154,000160
+DOUGLAS,Lawrence Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",19,000160
+DOUGLAS,Lawrence Precinct 10,United States Senate,,Republican,"Moran, Jerry",62,000160
+DOUGLAS,Lawrence Precinct 11,United States Senate,,write - in,"Smith, DJ",0,000170
+DOUGLAS,Lawrence Precinct 11,United States Senate,,Democratic,"Wiesner, Patrick",417,000170
+DOUGLAS,Lawrence Precinct 11,United States Senate,,Libertarian,"Garrard, Robert D.",25,000170
+DOUGLAS,Lawrence Precinct 11,United States Senate,,Republican,"Moran, Jerry",133,000170
+DOUGLAS,Lawrence Precinct 12,United States Senate,,write - in,"Smith, DJ",0,000180
+DOUGLAS,Lawrence Precinct 12,United States Senate,,Democratic,"Wiesner, Patrick",639,000180
+DOUGLAS,Lawrence Precinct 12,United States Senate,,Libertarian,"Garrard, Robert D.",38,000180
+DOUGLAS,Lawrence Precinct 12,United States Senate,,Republican,"Moran, Jerry",242,000180
+DOUGLAS,Lawrence Precinct 13,United States Senate,,write - in,"Smith, DJ",0,000190
+DOUGLAS,Lawrence Precinct 13,United States Senate,,Democratic,"Wiesner, Patrick",526,000190
+DOUGLAS,Lawrence Precinct 13,United States Senate,,Libertarian,"Garrard, Robert D.",15,000190
+DOUGLAS,Lawrence Precinct 13,United States Senate,,Republican,"Moran, Jerry",233,000190
+DOUGLAS,Lawrence Precinct 14,United States Senate,,write - in,"Smith, DJ",0,000200
+DOUGLAS,Lawrence Precinct 14,United States Senate,,Democratic,"Wiesner, Patrick",794,000200
+DOUGLAS,Lawrence Precinct 14,United States Senate,,Libertarian,"Garrard, Robert D.",81,000200
+DOUGLAS,Lawrence Precinct 14,United States Senate,,Republican,"Moran, Jerry",403,000200
+DOUGLAS,Lawrence Precinct 15,United States Senate,,write - in,"Smith, DJ",0,000210
+DOUGLAS,Lawrence Precinct 15,United States Senate,,Democratic,"Wiesner, Patrick",693,000210
+DOUGLAS,Lawrence Precinct 15,United States Senate,,Libertarian,"Garrard, Robert D.",34,000210
+DOUGLAS,Lawrence Precinct 15,United States Senate,,Republican,"Moran, Jerry",186,000210
+DOUGLAS,Lawrence Precinct 16,United States Senate,,write - in,"Smith, DJ",0,000220
+DOUGLAS,Lawrence Precinct 16,United States Senate,,Democratic,"Wiesner, Patrick",493,000220
+DOUGLAS,Lawrence Precinct 16,United States Senate,,Libertarian,"Garrard, Robert D.",29,000220
+DOUGLAS,Lawrence Precinct 16,United States Senate,,Republican,"Moran, Jerry",202,000220
+DOUGLAS,Lawrence Precinct 17,United States Senate,,write - in,"Smith, DJ",0,000230
+DOUGLAS,Lawrence Precinct 17,United States Senate,,Democratic,"Wiesner, Patrick",664,000230
+DOUGLAS,Lawrence Precinct 17,United States Senate,,Libertarian,"Garrard, Robert D.",44,000230
+DOUGLAS,Lawrence Precinct 17,United States Senate,,Republican,"Moran, Jerry",375,000230
+DOUGLAS,Lawrence Precinct 18,United States Senate,,write - in,"Smith, DJ",0,000240
+DOUGLAS,Lawrence Precinct 18,United States Senate,,Democratic,"Wiesner, Patrick",747,000240
+DOUGLAS,Lawrence Precinct 18,United States Senate,,Libertarian,"Garrard, Robert D.",34,000240
+DOUGLAS,Lawrence Precinct 18,United States Senate,,Republican,"Moran, Jerry",462,000240
+DOUGLAS,Lawrence Precinct 19,United States Senate,,write - in,"Smith, DJ",0,000250
+DOUGLAS,Lawrence Precinct 19,United States Senate,,Democratic,"Wiesner, Patrick",491,000250
+DOUGLAS,Lawrence Precinct 19,United States Senate,,Libertarian,"Garrard, Robert D.",19,000250
+DOUGLAS,Lawrence Precinct 19,United States Senate,,Republican,"Moran, Jerry",462,000250
+DOUGLAS,Lawrence Precinct 20,United States Senate,,write - in,"Smith, DJ",0,000260
+DOUGLAS,Lawrence Precinct 20,United States Senate,,Democratic,"Wiesner, Patrick",785,000260
+DOUGLAS,Lawrence Precinct 20,United States Senate,,Libertarian,"Garrard, Robert D.",56,000260
+DOUGLAS,Lawrence Precinct 20,United States Senate,,Republican,"Moran, Jerry",425,000260
+DOUGLAS,Lawrence Precinct 21,United States Senate,,write - in,"Smith, DJ",0,000270
+DOUGLAS,Lawrence Precinct 21,United States Senate,,Democratic,"Wiesner, Patrick",291,000270
+DOUGLAS,Lawrence Precinct 21,United States Senate,,Libertarian,"Garrard, Robert D.",8,000270
+DOUGLAS,Lawrence Precinct 21,United States Senate,,Republican,"Moran, Jerry",122,000270
+DOUGLAS,Lawrence Precinct 22,United States Senate,,write - in,"Smith, DJ",0,000280
+DOUGLAS,Lawrence Precinct 22,United States Senate,,Democratic,"Wiesner, Patrick",473,000280
+DOUGLAS,Lawrence Precinct 22,United States Senate,,Libertarian,"Garrard, Robert D.",39,000280
+DOUGLAS,Lawrence Precinct 22,United States Senate,,Republican,"Moran, Jerry",228,000280
+DOUGLAS,Lawrence Precinct 23,United States Senate,,write - in,"Smith, DJ",0,000290
+DOUGLAS,Lawrence Precinct 23,United States Senate,,Democratic,"Wiesner, Patrick",380,000290
+DOUGLAS,Lawrence Precinct 23,United States Senate,,Libertarian,"Garrard, Robert D.",18,000290
+DOUGLAS,Lawrence Precinct 23,United States Senate,,Republican,"Moran, Jerry",149,000290
+DOUGLAS,Lawrence Precinct 24,United States Senate,,write - in,"Smith, DJ",0,000300
+DOUGLAS,Lawrence Precinct 24,United States Senate,,Democratic,"Wiesner, Patrick",301,000300
+DOUGLAS,Lawrence Precinct 24,United States Senate,,Libertarian,"Garrard, Robert D.",30,000300
+DOUGLAS,Lawrence Precinct 24,United States Senate,,Republican,"Moran, Jerry",212,000300
+DOUGLAS,Lawrence Precinct 25,United States Senate,,write - in,"Smith, DJ",0,000310
+DOUGLAS,Lawrence Precinct 25,United States Senate,,Democratic,"Wiesner, Patrick",335,000310
+DOUGLAS,Lawrence Precinct 25,United States Senate,,Libertarian,"Garrard, Robert D.",22,000310
+DOUGLAS,Lawrence Precinct 25,United States Senate,,Republican,"Moran, Jerry",66,000310
+DOUGLAS,Lawrence Precinct 26,United States Senate,,write - in,"Smith, DJ",0,000320
+DOUGLAS,Lawrence Precinct 26,United States Senate,,Democratic,"Wiesner, Patrick",468,000320
+DOUGLAS,Lawrence Precinct 26,United States Senate,,Libertarian,"Garrard, Robert D.",26,000320
+DOUGLAS,Lawrence Precinct 26,United States Senate,,Republican,"Moran, Jerry",94,000320
+DOUGLAS,Lawrence Precinct 27,United States Senate,,write - in,"Smith, DJ",0,000330
+DOUGLAS,Lawrence Precinct 27,United States Senate,,Democratic,"Wiesner, Patrick",429,000330
+DOUGLAS,Lawrence Precinct 27,United States Senate,,Libertarian,"Garrard, Robert D.",26,000330
+DOUGLAS,Lawrence Precinct 27,United States Senate,,Republican,"Moran, Jerry",126,000330
+DOUGLAS,Lawrence Precinct 28,United States Senate,,write - in,"Smith, DJ",0,000340
+DOUGLAS,Lawrence Precinct 28,United States Senate,,Democratic,"Wiesner, Patrick",287,000340
+DOUGLAS,Lawrence Precinct 28,United States Senate,,Libertarian,"Garrard, Robert D.",15,000340
+DOUGLAS,Lawrence Precinct 28,United States Senate,,Republican,"Moran, Jerry",70,000340
+DOUGLAS,Lawrence Precinct 29,United States Senate,,write - in,"Smith, DJ",0,000350
+DOUGLAS,Lawrence Precinct 29,United States Senate,,Democratic,"Wiesner, Patrick",382,000350
+DOUGLAS,Lawrence Precinct 29,United States Senate,,Libertarian,"Garrard, Robert D.",21,000350
+DOUGLAS,Lawrence Precinct 29,United States Senate,,Republican,"Moran, Jerry",110,000350
+DOUGLAS,Lawrence Precinct 31,United States Senate,,write - in,"Smith, DJ",0,000370
+DOUGLAS,Lawrence Precinct 31,United States Senate,,Democratic,"Wiesner, Patrick",515,000370
+DOUGLAS,Lawrence Precinct 31,United States Senate,,Libertarian,"Garrard, Robert D.",38,000370
+DOUGLAS,Lawrence Precinct 31,United States Senate,,Republican,"Moran, Jerry",222,000370
+DOUGLAS,Lawrence Precinct 32,United States Senate,,write - in,"Smith, DJ",0,000380
+DOUGLAS,Lawrence Precinct 32,United States Senate,,Democratic,"Wiesner, Patrick",322,000380
+DOUGLAS,Lawrence Precinct 32,United States Senate,,Libertarian,"Garrard, Robert D.",30,000380
+DOUGLAS,Lawrence Precinct 32,United States Senate,,Republican,"Moran, Jerry",123,000380
+DOUGLAS,Lawrence Precinct 33,United States Senate,,write - in,"Smith, DJ",0,000400
+DOUGLAS,Lawrence Precinct 33,United States Senate,,Democratic,"Wiesner, Patrick",573,000400
+DOUGLAS,Lawrence Precinct 33,United States Senate,,Libertarian,"Garrard, Robert D.",18,000400
+DOUGLAS,Lawrence Precinct 33,United States Senate,,Republican,"Moran, Jerry",99,000400
+DOUGLAS,Lawrence Precinct 38,United States Senate,,write - in,"Smith, DJ",0,000450
+DOUGLAS,Lawrence Precinct 38,United States Senate,,Democratic,"Wiesner, Patrick",708,000450
+DOUGLAS,Lawrence Precinct 38,United States Senate,,Libertarian,"Garrard, Robert D.",54,000450
+DOUGLAS,Lawrence Precinct 38,United States Senate,,Republican,"Moran, Jerry",351,000450
+DOUGLAS,Lawrence Precinct 39,United States Senate,,write - in,"Smith, DJ",0,000460
+DOUGLAS,Lawrence Precinct 39,United States Senate,,Democratic,"Wiesner, Patrick",602,000460
+DOUGLAS,Lawrence Precinct 39,United States Senate,,Libertarian,"Garrard, Robert D.",29,000460
+DOUGLAS,Lawrence Precinct 39,United States Senate,,Republican,"Moran, Jerry",60,000460
+DOUGLAS,Lawrence Precinct 40,United States Senate,,write - in,"Smith, DJ",0,000470
+DOUGLAS,Lawrence Precinct 40,United States Senate,,Democratic,"Wiesner, Patrick",539,000470
+DOUGLAS,Lawrence Precinct 40,United States Senate,,Libertarian,"Garrard, Robert D.",22,000470
+DOUGLAS,Lawrence Precinct 40,United States Senate,,Republican,"Moran, Jerry",46,000470
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00048B
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,write - in,"Smith, DJ",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00048D
+DOUGLAS,Lawrence Precinct 41 Exclave C,United States Senate,,Republican,"Moran, Jerry",0,00048D
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,write - in,"Smith, DJ",0,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,Democratic,"Wiesner, Patrick",287,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,Libertarian,"Garrard, Robert D.",15,00050A
+DOUGLAS,Lawrence Precinct 43 Part 1,United States Senate,,Republican,"Moran, Jerry",198,00050A
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,write - in,"Smith, DJ",0,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,Democratic,"Wiesner, Patrick",476,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,Libertarian,"Garrard, Robert D.",33,00050C
+DOUGLAS,Lawrence Precinct 43 Part 3,United States Senate,,Republican,"Moran, Jerry",295,00050C
+DOUGLAS,Lawrence Precinct 45,United States Senate,,write - in,"Smith, DJ",0,00052A
+DOUGLAS,Lawrence Precinct 45,United States Senate,,Democratic,"Wiesner, Patrick",562,00052A
+DOUGLAS,Lawrence Precinct 45,United States Senate,,Libertarian,"Garrard, Robert D.",28,00052A
+DOUGLAS,Lawrence Precinct 45,United States Senate,,Republican,"Moran, Jerry",517,00052A
+DOUGLAS,Lawrence Precinct 49,United States Senate,,write - in,"Smith, DJ",0,000560
+DOUGLAS,Lawrence Precinct 49,United States Senate,,Democratic,"Wiesner, Patrick",582,000560
+DOUGLAS,Lawrence Precinct 49,United States Senate,,Libertarian,"Garrard, Robert D.",38,000560
+DOUGLAS,Lawrence Precinct 49,United States Senate,,Republican,"Moran, Jerry",576,000560
+DOUGLAS,North Eudora Precinct 52,United States Senate,,write - in,"Smith, DJ",0,000600
+DOUGLAS,North Eudora Precinct 52,United States Senate,,Democratic,"Wiesner, Patrick",200,000600
+DOUGLAS,North Eudora Precinct 52,United States Senate,,Libertarian,"Garrard, Robert D.",28,000600
+DOUGLAS,North Eudora Precinct 52,United States Senate,,Republican,"Moran, Jerry",206,000600
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,write - in,"Smith, DJ",0,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,Democratic,"Wiesner, Patrick",388,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,Libertarian,"Garrard, Robert D.",88,000620
+DOUGLAS,Northeast Baldwin Precinct 61,United States Senate,,Republican,"Moran, Jerry",571,000620
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,write - in,"Smith, DJ",0,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,Democratic,"Wiesner, Patrick",321,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,Libertarian,"Garrard, Robert D.",44,000630
+DOUGLAS,Northwest Baldwin Precinct 60,United States Senate,,Republican,"Moran, Jerry",365,000630
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,write - in,"Smith, DJ",0,000640
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,Democratic,"Wiesner, Patrick",333,000640
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,Libertarian,"Garrard, Robert D.",91,000640
+DOUGLAS,South Baldwin Precinct 62,United States Senate,,Republican,"Moran, Jerry",523,000640
+DOUGLAS,Vinland Precinct 63,United States Senate,,write - in,"Smith, DJ",0,000660
+DOUGLAS,Vinland Precinct 63,United States Senate,,Democratic,"Wiesner, Patrick",288,000660
+DOUGLAS,Vinland Precinct 63,United States Senate,,Libertarian,"Garrard, Robert D.",33,000660
+DOUGLAS,Vinland Precinct 63,United States Senate,,Republican,"Moran, Jerry",354,000660
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,write - in,"Smith, DJ",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,Democratic,"Wiesner, Patrick",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,00067B
+DOUGLAS,West Wakarusa Precinct 66 Part 3,United States Senate,,Republican,"Moran, Jerry",0,00067B
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,write - in,"Smith, DJ",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,Democratic,"Wiesner, Patrick",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,Libertarian,"Garrard, Robert D.",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H10,United States Senate,,Republican,"Moran, Jerry",0,120020
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,write - in,"Smith, DJ",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 3 H46,United States Senate,,Republican,"Moran, Jerry",0,120030
+DOUGLAS,Grant Township S2 H45,United States Senate,,write - in,"Smith, DJ",0,120040
+DOUGLAS,Grant Township S2 H45,United States Senate,,Democratic,"Wiesner, Patrick",25,120040
+DOUGLAS,Grant Township S2 H45,United States Senate,,Libertarian,"Garrard, Robert D.",1,120040
+DOUGLAS,Grant Township S2 H45,United States Senate,,Republican,"Moran, Jerry",11,120040
+DOUGLAS,Grant Township S3 H45,United States Senate,,write - in,"Smith, DJ",0,120050
+DOUGLAS,Grant Township S3 H45,United States Senate,,Democratic,"Wiesner, Patrick",77,120050
+DOUGLAS,Grant Township S3 H45,United States Senate,,Libertarian,"Garrard, Robert D.",6,120050
+DOUGLAS,Grant Township S3 H45,United States Senate,,Republican,"Moran, Jerry",56,120050
+DOUGLAS,Grant Township S3 H46,United States Senate,,write - in,"Smith, DJ",0,120060
+DOUGLAS,Grant Township S3 H46,United States Senate,,Democratic,"Wiesner, Patrick",30,120060
+DOUGLAS,Grant Township S3 H46,United States Senate,,Libertarian,"Garrard, Robert D.",1,120060
+DOUGLAS,Grant Township S3 H46,United States Senate,,Republican,"Moran, Jerry",14,120060
+DOUGLAS,Kawaka Township S19,United States Senate,,write - in,"Smith, DJ",0,120070
+DOUGLAS,Kawaka Township S19,United States Senate,,Democratic,"Wiesner, Patrick",367,120070
+DOUGLAS,Kawaka Township S19,United States Senate,,Libertarian,"Garrard, Robert D.",31,120070
+DOUGLAS,Kawaka Township S19,United States Senate,,Republican,"Moran, Jerry",443,120070
+DOUGLAS,Kawaka Township S2,United States Senate,,write - in,"Smith, DJ",0,120080
+DOUGLAS,Kawaka Township S2,United States Senate,,Democratic,"Wiesner, Patrick",32,120080
+DOUGLAS,Kawaka Township S2,United States Senate,,Libertarian,"Garrard, Robert D.",1,120080
+DOUGLAS,Kawaka Township S2,United States Senate,,Republican,"Moran, Jerry",19,120080
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,write - in,"Smith, DJ",0,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,Democratic,"Wiesner, Patrick",151,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,Libertarian,"Garrard, Robert D.",9,120090
+DOUGLAS,Lawrence Precinct 30 S2,United States Senate,,Republican,"Moran, Jerry",45,120090
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,write - in,"Smith, DJ",0,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,Democratic,"Wiesner, Patrick",255,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,Libertarian,"Garrard, Robert D.",19,120100
+DOUGLAS,Lawrence Precinct 30 S3,United States Senate,,Republican,"Moran, Jerry",56,120100
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,write - in,"Smith, DJ",0,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,Democratic,"Wiesner, Patrick",357,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,Libertarian,"Garrard, Robert D.",12,120110
+DOUGLAS,Lawrence Precinct 34 S2,United States Senate,,Republican,"Moran, Jerry",69,120110
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,write - in,"Smith, DJ",0,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,Democratic,"Wiesner, Patrick",78,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,Libertarian,"Garrard, Robert D.",6,120120
+DOUGLAS,Lawrence Precinct 34 S3,United States Senate,,Republican,"Moran, Jerry",4,120120
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,write - in,"Smith, DJ",0,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,Democratic,"Wiesner, Patrick",490,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,Libertarian,"Garrard, Robert D.",35,120130
+DOUGLAS,Lawrence Precinct 35 S2,United States Senate,,Republican,"Moran, Jerry",105,120130
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,write - in,"Smith, DJ",0,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,Democratic,"Wiesner, Patrick",30,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,Libertarian,"Garrard, Robert D.",4,120140
+DOUGLAS,Lawrence Precinct 35 S3,United States Senate,,Republican,"Moran, Jerry",17,120140
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,write - in,"Smith, DJ",0,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,Democratic,"Wiesner, Patrick",361,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,Libertarian,"Garrard, Robert D.",41,120150
+DOUGLAS,Lawrence Precinct 36 S2,United States Senate,,Republican,"Moran, Jerry",129,120150
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,write - in,"Smith, DJ",0,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,Democratic,"Wiesner, Patrick",503,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,Libertarian,"Garrard, Robert D.",43,120170
+DOUGLAS,Lawrence Precinct 37 H10,United States Senate,,Republican,"Moran, Jerry",262,120170
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,write - in,"Smith, DJ",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,Democratic,"Wiesner, Patrick",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,Libertarian,"Garrard, Robert D.",0,120190
+DOUGLAS,Lawrence Precinct 38 Part 2 H10,United States Senate,,Republican,"Moran, Jerry",0,120190
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,write - in,"Smith, DJ",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45 A,United States Senate,,Republican,"Moran, Jerry",0,12021A
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,write - in,"Smith, DJ",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,Democratic,"Wiesner, Patrick",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,Libertarian,"Garrard, Robert D.",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H45,United States Senate,,Republican,"Moran, Jerry",0,120210
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,write - in,"Smith, DJ",0,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,Democratic,"Wiesner, Patrick",11,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,Libertarian,"Garrard, Robert D.",1,120220
+DOUGLAS,Lawrence Precinct 41 S2 H46,United States Senate,,Republican,"Moran, Jerry",5,120220
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,write - in,"Smith, DJ",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,Democratic,"Wiesner, Patrick",3,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,Libertarian,"Garrard, Robert D.",1,120230
+DOUGLAS,Lawrence Precinct 41 S3 H45,United States Senate,,Republican,"Moran, Jerry",0,120230
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,write - in,"Smith, DJ",0,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,Democratic,"Wiesner, Patrick",840,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,Libertarian,"Garrard, Robert D.",68,120240
+DOUGLAS,Lawrence Precinct 41 S3 H46,United States Senate,,Republican,"Moran, Jerry",234,120240
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,write - in,"Smith, DJ",0,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,Democratic,"Wiesner, Patrick",210,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,Libertarian,"Garrard, Robert D.",15,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H45,United States Senate,,Republican,"Moran, Jerry",119,120250
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,write - in,"Smith, DJ",0,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,Democratic,"Wiesner, Patrick",197,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,Libertarian,"Garrard, Robert D.",15,120260
+DOUGLAS,Lawrence Precinct 42 Part 1 H46,United States Senate,,Republican,"Moran, Jerry",59,120260
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,write - in,"Smith, DJ",0,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,Democratic,"Wiesner, Patrick",241,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,Libertarian,"Garrard, Robert D.",10,120270
+DOUGLAS,Lawrence Precinct 44 H44,United States Senate,,Republican,"Moran, Jerry",104,120270
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,write - in,"Smith, DJ",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45 A,United States Senate,,Republican,"Moran, Jerry",0,12028A
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,write - in,"Smith, DJ",0,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,Democratic,"Wiesner, Patrick",301,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,Libertarian,"Garrard, Robert D.",24,120280
+DOUGLAS,Lawrence Precinct 44 H45,United States Senate,,Republican,"Moran, Jerry",193,120280
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,write - in,"Smith, DJ",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,Democratic,"Wiesner, Patrick",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,Libertarian,"Garrard, Robert D.",0,120290
+DOUGLAS,Lawrence Precinct 46 S19,United States Senate,,Republican,"Moran, Jerry",0,120290
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,write - in,"Smith, DJ",0,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,Democratic,"Wiesner, Patrick",882,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,Libertarian,"Garrard, Robert D.",75,120300
+DOUGLAS,Lawrence Precinct 46 S3,United States Senate,,Republican,"Moran, Jerry",435,120300
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,write - in,"Smith, DJ",0,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,Democratic,"Wiesner, Patrick",49,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,Libertarian,"Garrard, Robert D.",9,120310
+DOUGLAS,Lecompton Township Precinct 57 S19,United States Senate,,Republican,"Moran, Jerry",86,120310
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,write - in,"Smith, DJ",0,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,Democratic,"Wiesner, Patrick",208,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,Libertarian,"Garrard, Robert D.",28,120320
+DOUGLAS,Lecompton Township Precinct 57 S2,United States Senate,,Republican,"Moran, Jerry",255,120320
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,write - in,"Smith, DJ",0,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,Democratic,"Wiesner, Patrick",120,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,Libertarian,"Garrard, Robert D.",13,120330
+DOUGLAS,Marion Township Precinct 59 H45,United States Senate,,Republican,"Moran, Jerry",151,120330
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,write - in,"Smith, DJ",0,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,Democratic,"Wiesner, Patrick",51,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,Libertarian,"Garrard, Robert D.",11,120340
+DOUGLAS,Marion Township Precinct 59 H54,United States Senate,,Republican,"Moran, Jerry",137,120340
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,write - in,"Smith, DJ",0,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,Democratic,"Wiesner, Patrick",124,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,Libertarian,"Garrard, Robert D.",8,120350
+DOUGLAS,North Wakarusa Precinct 64 H45,United States Senate,,Republican,"Moran, Jerry",85,120350
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,write - in,"Smith, DJ",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,Democratic,"Wiesner, Patrick",1,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,Libertarian,"Garrard, Robert D.",0,120360
+DOUGLAS,North Wakarusa Precinct 64 H46,United States Senate,,Republican,"Moran, Jerry",0,120360
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,write - in,"Smith, DJ",0,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,Democratic,"Wiesner, Patrick",170,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,Libertarian,"Garrard, Robert D.",32,120370
+DOUGLAS,South Eudora Precinct 53 H10,United States Senate,,Republican,"Moran, Jerry",317,120370
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,write - in,"Smith, DJ",0,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,Democratic,"Wiesner, Patrick",199,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,Libertarian,"Garrard, Robert D.",35,120380
+DOUGLAS,South Eudora Precinct 53 H42,United States Senate,,Republican,"Moran, Jerry",323,120380
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,write - in,"Smith, DJ",0,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,Democratic,"Wiesner, Patrick",111,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,Libertarian,"Garrard, Robert D.",8,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H10,United States Senate,,Republican,"Moran, Jerry",145,120390
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,write - in,"Smith, DJ",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Democratic,"Wiesner, Patrick",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Libertarian,"Garrard, Robert D.",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Republican,"Moran, Jerry",0,120400
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,write - in,"Smith, DJ",0,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Democratic,"Wiesner, Patrick",88,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Libertarian,"Garrard, Robert D.",6,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S19 H45,United States Senate,,Republican,"Moran, Jerry",113,120401
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,write - in,"Smith, DJ",0,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,Democratic,"Wiesner, Patrick",76,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,Libertarian,"Garrard, Robert D.",6,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H10,United States Senate,,Republican,"Moran, Jerry",88,120410
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,write - in,"Smith, DJ",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,Democratic,"Wiesner, Patrick",3,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,Libertarian,"Garrard, Robert D.",0,120420
+DOUGLAS,West Wakarusa Precinct 66 Part 1 S3 H45,United States Senate,,Republican,"Moran, Jerry",0,120420
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,write - in,"Smith, DJ",0,120430
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,Democratic,"Wiesner, Patrick",145,120430
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,Libertarian,"Garrard, Robert D.",15,120430
+DOUGLAS,Willow Springs Township S19 H45,United States Senate,,Republican,"Moran, Jerry",151,120430
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,write - in,"Smith, DJ",0,120440
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,Democratic,"Wiesner, Patrick",104,120440
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,Libertarian,"Garrard, Robert D.",23,120440
+DOUGLAS,Willow Springs Township S19 H54,United States Senate,,Republican,"Moran, Jerry",218,120440
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,write - in,"Smith, DJ",0,120450
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,Democratic,"Wiesner, Patrick",49,120450
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,Libertarian,"Garrard, Robert D.",5,120450
+DOUGLAS,Willow Springs Township S3 H45,United States Senate,,Republican,"Moran, Jerry",45,120450
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,write - in,"Smith, DJ",0,120460
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,Democratic,"Wiesner, Patrick",26,120460
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,Libertarian,"Garrard, Robert D.",6,120460
+DOUGLAS,Willow Springs Township S3 H54,United States Senate,,Republican,"Moran, Jerry",46,120460
+DOUGLAS,Lawrence Precinct 75,United States Senate,,write - in,"Smith, DJ",0,160010
+DOUGLAS,Lawrence Precinct 75,United States Senate,,Democratic,"Wiesner, Patrick",0,160010
+DOUGLAS,Lawrence Precinct 75,United States Senate,,Libertarian,"Garrard, Robert D.",0,160010
+DOUGLAS,Lawrence Precinct 75,United States Senate,,Republican,"Moran, Jerry",0,160010
+DOUGLAS,Lawrence Precinct 76,United States Senate,,write - in,"Smith, DJ",0,160020
+DOUGLAS,Lawrence Precinct 76,United States Senate,,Democratic,"Wiesner, Patrick",11,160020
+DOUGLAS,Lawrence Precinct 76,United States Senate,,Libertarian,"Garrard, Robert D.",1,160020
+DOUGLAS,Lawrence Precinct 76,United States Senate,,Republican,"Moran, Jerry",3,160020
+DOUGLAS,Lawrence Precinct 77,United States Senate,,write - in,"Smith, DJ",0,160030
+DOUGLAS,Lawrence Precinct 77,United States Senate,,Democratic,"Wiesner, Patrick",349,160030
+DOUGLAS,Lawrence Precinct 77,United States Senate,,Libertarian,"Garrard, Robert D.",52,160030
+DOUGLAS,Lawrence Precinct 77,United States Senate,,Republican,"Moran, Jerry",161,160030
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,write - in,"Smith, DJ",0,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,Democratic,"Wiesner, Patrick",187,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,Libertarian,"Garrard, Robert D.",21,200010
+DOUGLAS,East Wakarusa H10 Precinct 65,United States Senate,,Republican,"Moran, Jerry",203,200010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,write - in,"Smith, DJ",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,Democratic,"Wiesner, Patrick",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,400010
+DOUGLAS,Lawrence Precinct 42 Part 2,United States Senate,,Republican,"Moran, Jerry",0,400010
+DOUGLAS,Lawrence Precinct 47,United States Senate,,write - in,"Smith, DJ",0,400030
+DOUGLAS,Lawrence Precinct 47,United States Senate,,Democratic,"Wiesner, Patrick",242,400030
+DOUGLAS,Lawrence Precinct 47,United States Senate,,Libertarian,"Garrard, Robert D.",12,400030
+DOUGLAS,Lawrence Precinct 47,United States Senate,,Republican,"Moran, Jerry",213,400030
+DOUGLAS,Lawrence Precinct 48,United States Senate,,write - in,"Smith, DJ",0,400040
+DOUGLAS,Lawrence Precinct 48,United States Senate,,Democratic,"Wiesner, Patrick",605,400040
+DOUGLAS,Lawrence Precinct 48,United States Senate,,Libertarian,"Garrard, Robert D.",19,400040
+DOUGLAS,Lawrence Precinct 48,United States Senate,,Republican,"Moran, Jerry",410,400040
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,write - in,"Smith, DJ",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,Democratic,"Wiesner, Patrick",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,400050
+DOUGLAS,West Eudora Precinct 50 Part 1,United States Senate,,Republican,"Moran, Jerry",0,400050
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,write - in,"Smith, DJ",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,Democratic,"Wiesner, Patrick",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,400080
+DOUGLAS,Lawrence Precinct 42 Part 3,United States Senate,,Republican,"Moran, Jerry",0,400080
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,write - in,"Smith, DJ",0,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,Democratic,"Wiesner, Patrick",385,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",82,400090
+DOUGLAS,West Eudora Precinct 50 Part 2,United States Senate,,Republican,"Moran, Jerry",602,400090
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,write - in,"Smith, DJ",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,Democratic,"Wiesner, Patrick",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,400100
+DOUGLAS,West Eudora Precinct 50 Part 3,United States Senate,,Republican,"Moran, Jerry",0,400100
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,write - in,"Smith, DJ",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,Democratic,"Wiesner, Patrick",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,400110
+DOUGLAS,West Wakarusa Precinct 66 Part 2,United States Senate,,Republican,"Moran, Jerry",0,400110
+DOUGLAS,Lawrence Precinct 68,United States Senate,,write - in,"Smith, DJ",0,900010
+DOUGLAS,Lawrence Precinct 68,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+DOUGLAS,Lawrence Precinct 68,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+DOUGLAS,Lawrence Precinct 68,United States Senate,,Republican,"Moran, Jerry",0,900010
+DOUGLAS,Lawrence Precinct 69,United States Senate,,write - in,"Smith, DJ",0,900020
+DOUGLAS,Lawrence Precinct 69,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+DOUGLAS,Lawrence Precinct 69,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+DOUGLAS,Lawrence Precinct 69,United States Senate,,Republican,"Moran, Jerry",0,900020
+DOUGLAS,Lawrence Precinct 70,United States Senate,,write - in,"Smith, DJ",0,900040
+DOUGLAS,Lawrence Precinct 70,United States Senate,,Democratic,"Wiesner, Patrick",1,900040
+DOUGLAS,Lawrence Precinct 70,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+DOUGLAS,Lawrence Precinct 70,United States Senate,,Republican,"Moran, Jerry",11,900040
+DOUGLAS,Lawrence Precinct 71,United States Senate,,write - in,"Smith, DJ",0,900050
+DOUGLAS,Lawrence Precinct 71,United States Senate,,Democratic,"Wiesner, Patrick",623,900050
+DOUGLAS,Lawrence Precinct 71,United States Senate,,Libertarian,"Garrard, Robert D.",29,900050
+DOUGLAS,Lawrence Precinct 71,United States Senate,,Republican,"Moran, Jerry",405,900050
+DOUGLAS,Lawrence Precinct 72,United States Senate,,write - in,"Smith, DJ",0,900060
+DOUGLAS,Lawrence Precinct 72,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+DOUGLAS,Lawrence Precinct 72,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+DOUGLAS,Lawrence Precinct 72,United States Senate,,Republican,"Moran, Jerry",0,900060
+DOUGLAS,Lawrence Precinct 73,United States Senate,,write - in,"Smith, DJ",0,900070
+DOUGLAS,Lawrence Precinct 73,United States Senate,,Democratic,"Wiesner, Patrick",0,900070
+DOUGLAS,Lawrence Precinct 73,United States Senate,,Libertarian,"Garrard, Robert D.",0,900070
+DOUGLAS,Lawrence Precinct 73,United States Senate,,Republican,"Moran, Jerry",0,900070
+DOUGLAS,Lawrence Precinct 74,United States Senate,,write - in,"Smith, DJ",0,900080
+DOUGLAS,Lawrence Precinct 74,United States Senate,,Democratic,"Wiesner, Patrick",539,900080
+DOUGLAS,Lawrence Precinct 74,United States Senate,,Libertarian,"Garrard, Robert D.",31,900080
+DOUGLAS,Lawrence Precinct 74,United States Senate,,Republican,"Moran, Jerry",449,900080
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,write - in,"Smith, DJ",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900090
+DOUGLAS,Lawrence Precinct 43 Part 2,United States Senate,,Republican,"Moran, Jerry",0,900090
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,write - in,"Smith, DJ",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900100
+DOUGLAS,East Wakarusa H10 Precinct 65 Part 2,United States Senate,,Republican,"Moran, Jerry",0,900100
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,write - in,"Smith, DJ",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 1,United States Senate,,Republican,"Moran, Jerry",0,900110
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,write - in,"Smith, DJ",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 2,United States Senate,,Republican,"Moran, Jerry",0,900120
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,write - in,"Smith, DJ",0,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,Democratic,"Wiesner, Patrick",22,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,Libertarian,"Garrard, Robert D.",1,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 4,United States Senate,,Republican,"Moran, Jerry",6,900130
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,write - in,"Smith, DJ",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,Democratic,"Wiesner, Patrick",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,900140
+DOUGLAS,East Wakarusa H38 Precinct 65 Part 5,United States Senate,,Republican,"Moran, Jerry",0,900140
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,write - in,"Smith, DJ",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,Democratic,"Wiesner, Patrick",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,Libertarian,"Garrard, Robert D.",0,900150
+DOUGLAS,Lawrence Precinct 42 Part 4,United States Senate,,Republican,"Moran, Jerry",0,900150
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,write - in,"Smith, DJ",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,Democratic,"Wiesner, Patrick",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,900160
+DOUGLAS,Lawrence Precinct 38 Part 3,United States Senate,,Republican,"Moran, Jerry",0,900160
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,write - in,"Smith, DJ",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,Democratic,"Wiesner, Patrick",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,900170
+DOUGLAS,Lawrence Precinct 42 Part 5,United States Senate,,Republican,"Moran, Jerry",0,900170

--- a/2016/20161108__ks__general__edwards__precinct.csv
+++ b/2016/20161108__ks__general__edwards__precinct.csv
@@ -1,522 +1,469 @@
-county,precinct,office,district,party,candidate,votes
-Edwards,01 Kinsley Ward 1,Voters,,Republican,Ballots,118
-Edwards,01 Kinsley Ward 1,Voters,,Democratic,Ballots,25
-Edwards,01 Kinsley Ward 1,U.S. Senate,,Republican,Jerry Moran,95
-Edwards,01 Kinsley Ward 1,U.S. Senate,,Republican,DJ Smith,17
-Edwards,01 Kinsley Ward 1,U.S. House,4,Republican,Michael Pompeo,102
-Edwards,01 Kinsley Ward 1,State Senate,33,Republican,Larry Salwans,61
-Edwards,01 Kinsley Ward 1,State Senate,33,Republican,Mary Jo Taylor,52
-Edwards,01 Kinsley Ward 1,State House,117,Republican,Leonard Mastroni,82
-Edwards,01 Kinsley Ward 1,U.S. Senate,,Democratic,Monique Singh,5
-Edwards,01 Kinsley Ward 1,U.S. Senate,,Democratic,Patrick Wiesner,14
-Edwards,01 Kinsley Ward 1,U.S. House,4,Democratic,Robert Tillman,14
-Edwards,01 Kinsley Ward 1,State Senate,33,Democratic,Daniel Giroux,6
-Edwards,01 Kinsley Ward 1,State Senate,33,Democratic,Matt Bristow,15
-Edwards,02 Kinsley Ward 2,Voters,,Republican,Ballots,129
-Edwards,02 Kinsley Ward 2,Voters,,Democratic,Ballots,20
-Edwards,02 Kinsley Ward 2,U.S. Senate,,Republican,Jerry Moran,98
-Edwards,02 Kinsley Ward 2,U.S. Senate,,Republican,DJ Smith,29
-Edwards,02 Kinsley Ward 2,U.S. House,4,Republican,Michael Pompeo,102
-Edwards,02 Kinsley Ward 2,State Senate,33,Republican,Larry Salwans,50
-Edwards,02 Kinsley Ward 2,State Senate,33,Republican,Mary Jo Taylor,79
-Edwards,02 Kinsley Ward 2,State House,117,Republican,Leonard Mastroni,95
-Edwards,02 Kinsley Ward 2,U.S. Senate,,Democratic,Monique Singh,2
-Edwards,02 Kinsley Ward 2,U.S. Senate,,Democratic,Patrick Wiesner,16
-Edwards,02 Kinsley Ward 2,U.S. House,4,Democratic,Robert Tillman,10
-Edwards,02 Kinsley Ward 2,State Senate,33,Democratic,Daniel Giroux,10
-Edwards,02 Kinsley Ward 2,State Senate,33,Democratic,Matt Bristow,15
-Edwards,03 Lewis City,Voters,,Republican,Ballots,50
-Edwards,03 Lewis City,Voters,,Democratic,Ballots,10
-Edwards,03 Lewis City,U.S. Senate,,Republican,Jerry Moran,44
-Edwards,03 Lewis City,U.S. Senate,,Republican,DJ Smith,5
-Edwards,03 Lewis City,U.S. House,4,Republican,Michael Pompeo,42
-Edwards,03 Lewis City,State Senate,33,Republican,Larry Salwans,28
-Edwards,03 Lewis City,State Senate,33,Republican,Mary Jo Taylor,22
-Edwards,03 Lewis City,State House,117,Republican,Leonard Mastroni,34
-Edwards,03 Lewis City,U.S. Senate,,Democratic,Monique Singh,4
-Edwards,03 Lewis City,U.S. Senate,,Democratic,Patrick Wiesner,6
-Edwards,03 Lewis City,U.S. House,4,Democratic,Robert Tillman,6
-Edwards,03 Lewis City,State Senate,33,Democratic,Daniel Giroux,4
-Edwards,03 Lewis City,State Senate,33,Democratic,Matt Bristow,8
-Edwards,04 Offerle City,Voters,,Republican,Ballots,43
-Edwards,04 Offerle City,Voters,,Democratic,Ballots,4
-Edwards,04 Offerle City,U.S. Senate,,Republican,Jerry Moran,40
-Edwards,04 Offerle City,U.S. Senate,,Republican,DJ Smith,2
-Edwards,04 Offerle City,U.S. House,4,Republican,Michael Pompeo,40
-Edwards,04 Offerle City,State Senate,33,Republican,Larry Salwans,32
-Edwards,04 Offerle City,State Senate,33,Republican,Mary Jo Taylor,10
-Edwards,04 Offerle City,State House,117,Republican,Leonard Mastroni,38
-Edwards,04 Offerle City,U.S. Senate,,Democratic,Monique Singh,0
-Edwards,04 Offerle City,U.S. Senate,,Democratic,Patrick Wiesner,4
-Edwards,04 Offerle City,U.S. House,4,Democratic,Robert Tillman,2
-Edwards,04 Offerle City,State Senate,33,Democratic,Daniel Giroux,2
-Edwards,04 Offerle City,State Senate,33,Democratic,Matt Bristow,4
-Edwards,05 Belpre City,Voters,,Republican,Ballots,12
-Edwards,05 Belpre City,Voters,,Democratic,Ballots,1
-Edwards,05 Belpre City,U.S. Senate,,Republican,Jerry Moran,9
-Edwards,05 Belpre City,U.S. Senate,,Republican,DJ Smith,3
-Edwards,05 Belpre City,U.S. House,4,Republican,Michael Pompeo,11
-Edwards,05 Belpre City,State Senate,33,Republican,Larry Salwans,7
-Edwards,05 Belpre City,State Senate,33,Republican,Mary Jo Taylor,5
-Edwards,05 Belpre City,State House,117,Republican,Leonard Mastroni,10
-Edwards,05 Belpre City,U.S. Senate,,Democratic,Monique Singh,0
-Edwards,05 Belpre City,U.S. Senate,,Democratic,Patrick Wiesner,1
-Edwards,05 Belpre City,U.S. House,4,Democratic,Robert Tillman,1
-Edwards,05 Belpre City,State Senate,33,Democratic,Daniel Giroux,0
-Edwards,05 Belpre City,State Senate,33,Democratic,Matt Bristow,1
-Edwards,06 Logan twp,Voters,,Republican,Ballots,7
-Edwards,06 Logan twp,Voters,,Democratic,Ballots,1
-Edwards,06 Logan twp,U.S. Senate,,Republican,Jerry Moran,7
-Edwards,06 Logan twp,U.S. Senate,,Republican,DJ Smith,0
-Edwards,06 Logan twp,U.S. House,4,Republican,Michael Pompeo,5
-Edwards,06 Logan twp,State Senate,33,Republican,Larry Salwans,5
-Edwards,06 Logan twp,State Senate,33,Republican,Mary Jo Taylor,2
-Edwards,06 Logan twp,State House,117,Republican,Leonard Mastroni,6
-Edwards,06 Logan twp,U.S. Senate,,Democratic,Monique Singh,0
-Edwards,06 Logan twp,U.S. Senate,,Democratic,Patrick Wiesner,0
-Edwards,06 Logan twp,U.S. House,4,Democratic,Robert Tillman,0
-Edwards,06 Logan twp,State Senate,33,Democratic,Daniel Giroux,1
-Edwards,06 Logan twp,State Senate,33,Democratic,Matt Bristow,1
-Edwards,07 Jackson twp,Voters,,Republican,Ballots,9
-Edwards,07 Jackson twp,Voters,,Democratic,Ballots,7
-Edwards,07 Jackson twp,U.S. Senate,,Republican,Jerry Moran,9
-Edwards,07 Jackson twp,U.S. Senate,,Republican,DJ Smith,0
-Edwards,07 Jackson twp,U.S. House,4,Republican,Michael Pompeo,9
-Edwards,07 Jackson twp,State Senate,33,Republican,Larry Salwans,8
-Edwards,07 Jackson twp,State Senate,33,Republican,Mary Jo Taylor,1
-Edwards,07 Jackson twp,State House,117,Republican,Leonard Mastroni,6
-Edwards,07 Jackson twp,U.S. Senate,,Democratic,Monique Singh,2
-Edwards,07 Jackson twp,U.S. Senate,,Democratic,Patrick Wiesner,4
-Edwards,07 Jackson twp,U.S. House,4,Democratic,Robert Tillman,4
-Edwards,07 Jackson twp,State Senate,33,Democratic,Daniel Giroux,2
-Edwards,07 Jackson twp,State Senate,33,Democratic,Matt Bristow,4
-Edwards,08 Kinsley twp,Voters,,Republican,Ballots,28
-Edwards,08 Kinsley twp,Voters,,Democratic,Ballots,5
-Edwards,08 Kinsley twp,U.S. Senate,,Republican,Jerry Moran,27
-Edwards,08 Kinsley twp,U.S. Senate,,Republican,DJ Smith,1
-Edwards,08 Kinsley twp,U.S. House,4,Republican,Michael Pompeo,25
-Edwards,08 Kinsley twp,State Senate,33,Republican,Larry Salwans,21
-Edwards,08 Kinsley twp,State Senate,33,Republican,Mary Jo Taylor,7
-Edwards,08 Kinsley twp,State House,117,Republican,Leonard Mastroni,18
-Edwards,08 Kinsley twp,U.S. Senate,,Democratic,Monique Singh,2
-Edwards,08 Kinsley twp,U.S. Senate,,Democratic,Patrick Wiesner,3
-Edwards,08 Kinsley twp,U.S. House,4,Democratic,Robert Tillman,1
-Edwards,08 Kinsley twp,State Senate,33,Democratic,Daniel Giroux,3
-Edwards,08 Kinsley twp,State Senate,33,Democratic,Matt Bristow,4
-Edwards,09 Wayne twp,Voters,,Republican,Ballots,30
-Edwards,09 Wayne twp,Voters,,Democratic,Ballots,2
-Edwards,09 Wayne twp,U.S. Senate,,Republican,Jerry Moran,26
-Edwards,09 Wayne twp,U.S. Senate,,Republican,DJ Smith,3
-Edwards,09 Wayne twp,U.S. House,4,Republican,Michael Pompeo,26
-Edwards,09 Wayne twp,State Senate,33,Republican,Larry Salwans,21
-Edwards,09 Wayne twp,State Senate,33,Republican,Mary Jo Taylor,8
-Edwards,09 Wayne twp,State House,117,Republican,Leonard Mastroni,26
-Edwards,09 Wayne twp,U.S. Senate,,Democratic,Monique Singh,1
-Edwards,09 Wayne twp,U.S. Senate,,Democratic,Patrick Wiesner,1
-Edwards,09 Wayne twp,U.S. House,4,Democratic,Robert Tillman,1
-Edwards,09 Wayne twp,State Senate,33,Democratic,Daniel Giroux,1
-Edwards,09 Wayne twp,State Senate,33,Democratic,Matt Bristow,2
-Edwards,09 Wayne twp,State House,117,Democratic,,1
-Edwards,10 Belpre twp,Voters,,Republican,Ballots,20
-Edwards,10 Belpre twp,Voters,,Democratic,Ballots,3
-Edwards,10 Belpre twp,U.S. Senate,,Republican,Jerry Moran,17
-Edwards,10 Belpre twp,U.S. Senate,,Republican,DJ Smith,3
-Edwards,10 Belpre twp,U.S. House,4,Republican,Michael Pompeo,18
-Edwards,10 Belpre twp,State Senate,33,Republican,Larry Salwans,11
-Edwards,10 Belpre twp,State Senate,33,Republican,Mary Jo Taylor,8
-Edwards,10 Belpre twp,State House,117,Republican,Leonard Mastroni,16
-Edwards,10 Belpre twp,U.S. Senate,,Democratic,Monique Singh,1
-Edwards,10 Belpre twp,U.S. Senate,,Democratic,Patrick Wiesner,2
-Edwards,10 Belpre twp,U.S. House,4,Democratic,Robert Tillman,1
-Edwards,10 Belpre twp,State Senate,33,Democratic,Daniel Giroux,2
-Edwards,10 Belpre twp,State Senate,33,Democratic,Matt Bristow,3
-Edwards,11 Lincoln twp,Voters,,Republican,Ballots,34
-Edwards,11 Lincoln twp,Voters,,Democratic,Ballots,3
-Edwards,11 Lincoln twp,U.S. Senate,,Republican,Jerry Moran,30
-Edwards,11 Lincoln twp,U.S. Senate,,Republican,DJ Smith,4
-Edwards,11 Lincoln twp,U.S. House,4,Republican,Michael Pompeo,33
-Edwards,11 Lincoln twp,State Senate,33,Republican,Larry Salwans,19
-Edwards,11 Lincoln twp,State Senate,33,Republican,Mary Jo Taylor,14
-Edwards,11 Lincoln twp,State House,117,Republican,Leonard Mastroni,21
-Edwards,11 Lincoln twp,U.S. Senate,,Democratic,Monique Singh,1
-Edwards,11 Lincoln twp,U.S. Senate,,Democratic,Patrick Wiesner,2
-Edwards,11 Lincoln twp,U.S. House,4,Democratic,Robert Tillman,0
-Edwards,11 Lincoln twp,State Senate,33,Democratic,Daniel Giroux,3
-Edwards,11 Lincoln twp,State Senate,33,Democratic,Matt Bristow,3
-Edwards,12 Franklin twp,Voters,,Republican,Ballots,21
-Edwards,12 Franklin twp,Voters,,Democratic,Ballots,0
-Edwards,12 Franklin twp,U.S. Senate,,Republican,Jerry Moran,17
-Edwards,12 Franklin twp,U.S. Senate,,Republican,DJ Smith,3
-Edwards,12 Franklin twp,U.S. House,4,Republican,Michael Pompeo,18
-Edwards,12 Franklin twp,State Senate,33,Republican,Larry Salwans,10
-Edwards,12 Franklin twp,State Senate,33,Republican,Mary Jo Taylor,10
-Edwards,12 Franklin twp,State House,117,Republican,Leonard Mastroni,16
-Edwards,12 Franklin twp,U.S. Senate,,Democratic,Monique Singh,0
-Edwards,12 Franklin twp,U.S. Senate,,Democratic,Patrick Wiesner,0
-Edwards,12 Franklin twp,U.S. House,4,Democratic,Robert Tillman,0
-Edwards,12 Franklin twp,State Senate,33,Democratic,Daniel Giroux,0
-Edwards,12 Franklin twp,State Senate,33,Democratic,Matt Bristow,0
-Edwards,13 N Brown twp,Voters,,Republican,Ballots,20
-Edwards,13 N Brown twp,Voters,,Democratic,Ballots,2
-Edwards,13 N Brown twp,U.S. Senate,,Republican,Jerry Moran,19
-Edwards,13 N Brown twp,U.S. Senate,,Republican,DJ Smith,1
-Edwards,13 N Brown twp,U.S. House,4,Republican,Michael Pompeo,18
-Edwards,13 N Brown twp,State Senate,33,Republican,Larry Salwans,11
-Edwards,13 N Brown twp,State Senate,33,Republican,Mary Jo Taylor,9
-Edwards,13 N Brown twp,State House,117,Republican,Leonard Mastroni,16
-Edwards,13 N Brown twp,U.S. Senate,,Democratic,Monique Singh,0
-Edwards,13 N Brown twp,U.S. Senate,,Democratic,Patrick Wiesner,0
-Edwards,13 N Brown twp,U.S. House,4,Democratic,Robert Tillman,0
-Edwards,13 N Brown twp,State Senate,33,Democratic,Daniel Giroux,0
-Edwards,13 N Brown twp,State Senate,33,Democratic,Matt Bristow,1
-Edwards,14 Trenton twp,Voters,,Republican,Ballots,20
-Edwards,14 Trenton twp,Voters,,Democratic,Ballots,1
-Edwards,14 Trenton twp,U.S. Senate,,Republican,Jerry Moran,16
-Edwards,14 Trenton twp,U.S. Senate,,Republican,DJ Smith,4
-Edwards,14 Trenton twp,U.S. House,4,Republican,Michael Pompeo,18
-Edwards,14 Trenton twp,State Senate,33,Republican,Larry Salwans,16
-Edwards,14 Trenton twp,State Senate,33,Republican,Mary Jo Taylor,4
-Edwards,14 Trenton twp,State House,117,Republican,Leonard Mastroni,18
-Edwards,14 Trenton twp,U.S. Senate,,Democratic,Monique Singh,0
-Edwards,14 Trenton twp,U.S. Senate,,Democratic,Patrick Wiesner,1
-Edwards,14 Trenton twp,U.S. House,4,Democratic,Robert Tillman,1
-Edwards,14 Trenton twp,State Senate,33,Democratic,Daniel Giroux,0
-Edwards,14 Trenton twp,State Senate,33,Democratic,Matt Bristow,1
-Edwards,15 S Brown twp,Voters,,Republican,Ballots,29
-Edwards,15 S Brown twp,Voters,,Democratic,Ballots,1
-Edwards,15 S Brown twp,U.S. Senate,,Republican,Jerry Moran,25
-Edwards,15 S Brown twp,U.S. Senate,,Republican,DJ Smith,3
-Edwards,15 S Brown twp,U.S. House,4,Republican,Michael Pompeo,26
-Edwards,15 S Brown twp,State Senate,33,Republican,Larry Salwans,14
-Edwards,15 S Brown twp,State Senate,33,Republican,Mary Jo Taylor,14
-Edwards,15 S Brown twp,State House,117,Republican,Leonard Mastroni,23
-Edwards,15 S Brown twp,U.S. Senate,,Democratic,Monique Singh,1
-Edwards,15 S Brown twp,U.S. Senate,,Democratic,Patrick Wiesner,0
-Edwards,15 S Brown twp,U.S. House,4,Democratic,Robert Tillman,1
-Edwards,15 S Brown twp,State Senate,33,Democratic,Daniel Giroux,0
-Edwards,15 S Brown twp,State Senate,33,Democratic,Matt Bristow,1
-Edwards,Belpre Township,President,,independent,"Stein, Jill  ",3
-Edwards,Belpre Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Belpre Township,President,,,"Castle, Darrell L ",0
-Edwards,Belpre Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Belpre Township,President,,,"Giordani, Rocky  ",0
-Edwards,Belpre Township,President,,,"Hedges, James A ",0
-Edwards,Belpre Township,President,,,"Hoefling, Tom  ",0
-Edwards,Belpre Township,President,,,"Kahn, Lynn  ",0
-Edwards,Belpre Township,President,,,"La Riva, Gloria  ",0
-Edwards,Belpre Township,President,,,"Levinson, Michael S. ",0
-Edwards,Belpre Township,President,,,"Maturen, Michael A ",0
-Edwards,Belpre Township,President,,,"McMullin, Evan  ",0
-Edwards,Belpre Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Belpre Township,President,,,"Perry, Darryl  ",0
-Edwards,Belpre Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Belpre Township,President,,,"Schriner, Joe C ",0
-Edwards,Belpre Township,President,,,"Smith, Mike  ",0
-Edwards,Belpre Township,President,,,"Sood, Ajay  ",0
-Edwards,Belpre Township,President,,,"Sterling, Shawna  ",0
-Edwards,Belpre Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Belpre Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Belpre Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Belpre Township,President,,Democratic,"Clinton, Hillary Rodham ",10
-Edwards,Belpre Township,President,,Libertarian,"Johnson, Gary  ",1
-Edwards,Belpre Township,President,,Republican,"Trump, Donald J. ",58
-Edwards,Franklin Township,President,,independent,"Stein, Jill  ",0
-Edwards,Franklin Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Franklin Township,President,,,"Castle, Darrell L ",0
-Edwards,Franklin Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Franklin Township,President,,,"Giordani, Rocky  ",0
-Edwards,Franklin Township,President,,,"Hedges, James A ",0
-Edwards,Franklin Township,President,,,"Hoefling, Tom  ",0
-Edwards,Franklin Township,President,,,"Kahn, Lynn  ",0
-Edwards,Franklin Township,President,,,"La Riva, Gloria  ",0
-Edwards,Franklin Township,President,,,"Levinson, Michael S. ",0
-Edwards,Franklin Township,President,,,"Maturen, Michael A ",0
-Edwards,Franklin Township,President,,,"McMullin, Evan  ",0
-Edwards,Franklin Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Franklin Township,President,,,"Perry, Darryl  ",0
-Edwards,Franklin Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Franklin Township,President,,,"Schriner, Joe C ",0
-Edwards,Franklin Township,President,,,"Smith, Mike  ",0
-Edwards,Franklin Township,President,,,"Sood, Ajay  ",0
-Edwards,Franklin Township,President,,,"Sterling, Shawna  ",0
-Edwards,Franklin Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Franklin Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Franklin Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Franklin Township,President,,Democratic,"Clinton, Hillary Rodham ",0
-Edwards,Franklin Township,President,,Libertarian,"Johnson, Gary  ",0
-Edwards,Franklin Township,President,,Republican,"Trump, Donald J. ",48
-Edwards,Jackson Township,President,,independent,"Stein, Jill  ",0
-Edwards,Jackson Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Jackson Township,President,,,"Castle, Darrell L ",0
-Edwards,Jackson Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Jackson Township,President,,,"Giordani, Rocky  ",0
-Edwards,Jackson Township,President,,,"Hedges, James A ",0
-Edwards,Jackson Township,President,,,"Hoefling, Tom  ",0
-Edwards,Jackson Township,President,,,"Kahn, Lynn  ",0
-Edwards,Jackson Township,President,,,"La Riva, Gloria  ",0
-Edwards,Jackson Township,President,,,"Levinson, Michael S. ",0
-Edwards,Jackson Township,President,,,"Maturen, Michael A ",0
-Edwards,Jackson Township,President,,,"McMullin, Evan  ",0
-Edwards,Jackson Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Jackson Township,President,,,"Perry, Darryl  ",0
-Edwards,Jackson Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Jackson Township,President,,,"Schriner, Joe C ",0
-Edwards,Jackson Township,President,,,"Smith, Mike  ",0
-Edwards,Jackson Township,President,,,"Sood, Ajay  ",0
-Edwards,Jackson Township,President,,,"Sterling, Shawna  ",0
-Edwards,Jackson Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Jackson Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Jackson Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Jackson Township,President,,Democratic,"Clinton, Hillary Rodham ",6
-Edwards,Jackson Township,President,,Libertarian,"Johnson, Gary  ",1
-Edwards,Jackson Township,President,,Republican,"Trump, Donald J. ",30
-Edwards,Kinsley Township,President,,independent,"Stein, Jill  ",2
-Edwards,Kinsley Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Kinsley Township,President,,,"Castle, Darrell L ",0
-Edwards,Kinsley Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Kinsley Township,President,,,"Giordani, Rocky  ",0
-Edwards,Kinsley Township,President,,,"Hedges, James A ",0
-Edwards,Kinsley Township,President,,,"Hoefling, Tom  ",0
-Edwards,Kinsley Township,President,,,"Kahn, Lynn  ",0
-Edwards,Kinsley Township,President,,,"La Riva, Gloria  ",0
-Edwards,Kinsley Township,President,,,"Levinson, Michael S. ",0
-Edwards,Kinsley Township,President,,,"Maturen, Michael A ",0
-Edwards,Kinsley Township,President,,,"McMullin, Evan  ",0
-Edwards,Kinsley Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Kinsley Township,President,,,"Perry, Darryl  ",0
-Edwards,Kinsley Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Kinsley Township,President,,,"Schriner, Joe C ",0
-Edwards,Kinsley Township,President,,,"Smith, Mike  ",0
-Edwards,Kinsley Township,President,,,"Sood, Ajay  ",0
-Edwards,Kinsley Township,President,,,"Sterling, Shawna  ",0
-Edwards,Kinsley Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Kinsley Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Kinsley Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Kinsley Township,President,,Democratic,"Clinton, Hillary Rodham ",10
-Edwards,Kinsley Township,President,,Libertarian,"Johnson, Gary  ",1
-Edwards,Kinsley Township,President,,Republican,"Trump, Donald J. ",55
-Edwards,Kinsley Ward 1,President,,independent,"Stein, Jill  ",11
-Edwards,Kinsley Ward 1,President,,,"Basiago, Andrew D. ",0
-Edwards,Kinsley Ward 1,President,,,"Castle, Darrell L ",0
-Edwards,Kinsley Ward 1,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Kinsley Ward 1,President,,,"Giordani, Rocky  ",0
-Edwards,Kinsley Ward 1,President,,,"Hedges, James A ",0
-Edwards,Kinsley Ward 1,President,,,"Hoefling, Tom  ",0
-Edwards,Kinsley Ward 1,President,,,"Kahn, Lynn  ",0
-Edwards,Kinsley Ward 1,President,,,"La Riva, Gloria  ",0
-Edwards,Kinsley Ward 1,President,,,"Levinson, Michael S. ",0
-Edwards,Kinsley Ward 1,President,,,"Maturen, Michael A ",0
-Edwards,Kinsley Ward 1,President,,,"McMullin, Evan  ",0
-Edwards,Kinsley Ward 1,President,,,"Moorehead, Monica G. ",0
-Edwards,Kinsley Ward 1,President,,,"Perry, Darryl  ",0
-Edwards,Kinsley Ward 1,President,,,"Schoenke, Marshall R. ",0
-Edwards,Kinsley Ward 1,President,,,"Schriner, Joe C ",0
-Edwards,Kinsley Ward 1,President,,,"Smith, Mike  ",0
-Edwards,Kinsley Ward 1,President,,,"Sood, Ajay  ",0
-Edwards,Kinsley Ward 1,President,,,"Sterling, Shawna  ",0
-Edwards,Kinsley Ward 1,President,,,"Valdivia, Anthony J ",0
-Edwards,Kinsley Ward 1,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Kinsley Ward 1,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Kinsley Ward 1,President,,Democratic,"Clinton, Hillary Rodham ",61
-Edwards,Kinsley Ward 1,President,,Libertarian,"Johnson, Gary  ",7
-Edwards,Kinsley Ward 1,President,,Republican,"Trump, Donald J. ",230
-Edwards,Kinsley Ward 2,President,,independent,"Stein, Jill  ",7
-Edwards,Kinsley Ward 2,President,,,"Basiago, Andrew D. ",0
-Edwards,Kinsley Ward 2,President,,,"Castle, Darrell L ",0
-Edwards,Kinsley Ward 2,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Kinsley Ward 2,President,,,"Giordani, Rocky  ",0
-Edwards,Kinsley Ward 2,President,,,"Hedges, James A ",0
-Edwards,Kinsley Ward 2,President,,,"Hoefling, Tom  ",0
-Edwards,Kinsley Ward 2,President,,,"Kahn, Lynn  ",0
-Edwards,Kinsley Ward 2,President,,,"La Riva, Gloria  ",0
-Edwards,Kinsley Ward 2,President,,,"Levinson, Michael S. ",0
-Edwards,Kinsley Ward 2,President,,,"Maturen, Michael A ",0
-Edwards,Kinsley Ward 2,President,,,"McMullin, Evan  ",0
-Edwards,Kinsley Ward 2,President,,,"Moorehead, Monica G. ",0
-Edwards,Kinsley Ward 2,President,,,"Perry, Darryl  ",0
-Edwards,Kinsley Ward 2,President,,,"Schoenke, Marshall R. ",0
-Edwards,Kinsley Ward 2,President,,,"Schriner, Joe C ",0
-Edwards,Kinsley Ward 2,President,,,"Smith, Mike  ",0
-Edwards,Kinsley Ward 2,President,,,"Sood, Ajay  ",0
-Edwards,Kinsley Ward 2,President,,,"Sterling, Shawna  ",0
-Edwards,Kinsley Ward 2,President,,,"Valdivia, Anthony J ",0
-Edwards,Kinsley Ward 2,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Kinsley Ward 2,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Kinsley Ward 2,President,,Democratic,"Clinton, Hillary Rodham ",69
-Edwards,Kinsley Ward 2,President,,Libertarian,"Johnson, Gary  ",11
-Edwards,Kinsley Ward 2,President,,Republican,"Trump, Donald J. ",217
-Edwards,Kinsley Ward 2 Exclave,President,,independent,"Stein, Jill  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Basiago, Andrew D. ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Castle, Darrell L ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Giordani, Rocky  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Hedges, James A ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Hoefling, Tom  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Kahn, Lynn  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"La Riva, Gloria  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Levinson, Michael S. ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Maturen, Michael A ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"McMullin, Evan  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Moorehead, Monica G. ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Perry, Darryl  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Schoenke, Marshall R. ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Schriner, Joe C ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Smith, Mike  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Sood, Ajay  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Sterling, Shawna  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Valdivia, Anthony J ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Kinsley Ward 2 Exclave,President,,Democratic,"Clinton, Hillary Rodham ",0
-Edwards,Kinsley Ward 2 Exclave,President,,Libertarian,"Johnson, Gary  ",0
-Edwards,Kinsley Ward 2 Exclave,President,,Republican,"Trump, Donald J. ",0
-Edwards,Lincoln Township,President,,independent,"Stein, Jill  ",2
-Edwards,Lincoln Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Lincoln Township,President,,,"Castle, Darrell L ",0
-Edwards,Lincoln Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Lincoln Township,President,,,"Giordani, Rocky  ",0
-Edwards,Lincoln Township,President,,,"Hedges, James A ",0
-Edwards,Lincoln Township,President,,,"Hoefling, Tom  ",0
-Edwards,Lincoln Township,President,,,"Kahn, Lynn  ",0
-Edwards,Lincoln Township,President,,,"La Riva, Gloria  ",0
-Edwards,Lincoln Township,President,,,"Levinson, Michael S. ",0
-Edwards,Lincoln Township,President,,,"Maturen, Michael A ",0
-Edwards,Lincoln Township,President,,,"McMullin, Evan  ",0
-Edwards,Lincoln Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Lincoln Township,President,,,"Perry, Darryl  ",0
-Edwards,Lincoln Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Lincoln Township,President,,,"Schriner, Joe C ",0
-Edwards,Lincoln Township,President,,,"Smith, Mike  ",0
-Edwards,Lincoln Township,President,,,"Sood, Ajay  ",0
-Edwards,Lincoln Township,President,,,"Sterling, Shawna  ",0
-Edwards,Lincoln Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Lincoln Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Lincoln Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Lincoln Township,President,,Democratic,"Clinton, Hillary Rodham ",7
-Edwards,Lincoln Township,President,,Libertarian,"Johnson, Gary  ",1
-Edwards,Lincoln Township,President,,Republican,"Trump, Donald J. ",60
-Edwards,Logan Township,President,,independent,"Stein, Jill  ",1
-Edwards,Logan Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Logan Township,President,,,"Castle, Darrell L ",0
-Edwards,Logan Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Logan Township,President,,,"Giordani, Rocky  ",0
-Edwards,Logan Township,President,,,"Hedges, James A ",0
-Edwards,Logan Township,President,,,"Hoefling, Tom  ",0
-Edwards,Logan Township,President,,,"Kahn, Lynn  ",0
-Edwards,Logan Township,President,,,"La Riva, Gloria  ",0
-Edwards,Logan Township,President,,,"Levinson, Michael S. ",0
-Edwards,Logan Township,President,,,"Maturen, Michael A ",0
-Edwards,Logan Township,President,,,"McMullin, Evan  ",0
-Edwards,Logan Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Logan Township,President,,,"Perry, Darryl  ",0
-Edwards,Logan Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Logan Township,President,,,"Schriner, Joe C ",0
-Edwards,Logan Township,President,,,"Smith, Mike  ",0
-Edwards,Logan Township,President,,,"Sood, Ajay  ",0
-Edwards,Logan Township,President,,,"Sterling, Shawna  ",0
-Edwards,Logan Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Logan Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Logan Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Logan Township,President,,Democratic,"Clinton, Hillary Rodham ",3
-Edwards,Logan Township,President,,Libertarian,"Johnson, Gary  ",1
-Edwards,Logan Township,President,,Republican,"Trump, Donald J. ",15
-Edwards,North Brown Township,President,,independent,"Stein, Jill  ",2
-Edwards,North Brown Township,President,,,"Basiago, Andrew D. ",0
-Edwards,North Brown Township,President,,,"Castle, Darrell L ",0
-Edwards,North Brown Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,North Brown Township,President,,,"Giordani, Rocky  ",0
-Edwards,North Brown Township,President,,,"Hedges, James A ",0
-Edwards,North Brown Township,President,,,"Hoefling, Tom  ",0
-Edwards,North Brown Township,President,,,"Kahn, Lynn  ",0
-Edwards,North Brown Township,President,,,"La Riva, Gloria  ",0
-Edwards,North Brown Township,President,,,"Levinson, Michael S. ",0
-Edwards,North Brown Township,President,,,"Maturen, Michael A ",0
-Edwards,North Brown Township,President,,,"McMullin, Evan  ",0
-Edwards,North Brown Township,President,,,"Moorehead, Monica G. ",0
-Edwards,North Brown Township,President,,,"Perry, Darryl  ",0
-Edwards,North Brown Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,North Brown Township,President,,,"Schriner, Joe C ",0
-Edwards,North Brown Township,President,,,"Smith, Mike  ",0
-Edwards,North Brown Township,President,,,"Sood, Ajay  ",0
-Edwards,North Brown Township,President,,,"Sterling, Shawna  ",0
-Edwards,North Brown Township,President,,,"Valdivia, Anthony J ",0
-Edwards,North Brown Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,North Brown Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,North Brown Township,President,,Democratic,"Clinton, Hillary Rodham ",2
-Edwards,North Brown Township,President,,Libertarian,"Johnson, Gary  ",3
-Edwards,North Brown Township,President,,Republican,"Trump, Donald J. ",24
-Edwards,South Brown Township,President,,independent,"Stein, Jill  ",0
-Edwards,South Brown Township,President,,,"Basiago, Andrew D. ",0
-Edwards,South Brown Township,President,,,"Castle, Darrell L ",0
-Edwards,South Brown Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,South Brown Township,President,,,"Giordani, Rocky  ",0
-Edwards,South Brown Township,President,,,"Hedges, James A ",0
-Edwards,South Brown Township,President,,,"Hoefling, Tom  ",0
-Edwards,South Brown Township,President,,,"Kahn, Lynn  ",0
-Edwards,South Brown Township,President,,,"La Riva, Gloria  ",0
-Edwards,South Brown Township,President,,,"Levinson, Michael S. ",0
-Edwards,South Brown Township,President,,,"Maturen, Michael A ",0
-Edwards,South Brown Township,President,,,"McMullin, Evan  ",0
-Edwards,South Brown Township,President,,,"Moorehead, Monica G. ",0
-Edwards,South Brown Township,President,,,"Perry, Darryl  ",0
-Edwards,South Brown Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,South Brown Township,President,,,"Schriner, Joe C ",0
-Edwards,South Brown Township,President,,,"Smith, Mike  ",0
-Edwards,South Brown Township,President,,,"Sood, Ajay  ",0
-Edwards,South Brown Township,President,,,"Sterling, Shawna  ",0
-Edwards,South Brown Township,President,,,"Valdivia, Anthony J ",0
-Edwards,South Brown Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,South Brown Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,South Brown Township,President,,Democratic,"Clinton, Hillary Rodham ",4
-Edwards,South Brown Township,President,,Libertarian,"Johnson, Gary  ",0
-Edwards,South Brown Township,President,,Republican,"Trump, Donald J. ",40
-Edwards,Trenton Township,President,,independent,"Stein, Jill  ",2
-Edwards,Trenton Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Trenton Township,President,,,"Castle, Darrell L ",1
-Edwards,Trenton Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Trenton Township,President,,,"Giordani, Rocky  ",0
-Edwards,Trenton Township,President,,,"Hedges, James A ",0
-Edwards,Trenton Township,President,,,"Hoefling, Tom  ",0
-Edwards,Trenton Township,President,,,"Kahn, Lynn  ",0
-Edwards,Trenton Township,President,,,"La Riva, Gloria  ",0
-Edwards,Trenton Township,President,,,"Levinson, Michael S. ",0
-Edwards,Trenton Township,President,,,"Maturen, Michael A ",0
-Edwards,Trenton Township,President,,,"McMullin, Evan  ",2
-Edwards,Trenton Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Trenton Township,President,,,"Perry, Darryl  ",0
-Edwards,Trenton Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Trenton Township,President,,,"Schriner, Joe C ",0
-Edwards,Trenton Township,President,,,"Smith, Mike  ",0
-Edwards,Trenton Township,President,,,"Sood, Ajay  ",0
-Edwards,Trenton Township,President,,,"Sterling, Shawna  ",0
-Edwards,Trenton Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Trenton Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Trenton Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Trenton Township,President,,Democratic,"Clinton, Hillary Rodham ",14
-Edwards,Trenton Township,President,,Libertarian,"Johnson, Gary  ",0
-Edwards,Trenton Township,President,,Republican,"Trump, Donald J. ",123
-Edwards,Wayne Township,President,,independent,"Stein, Jill  ",4
-Edwards,Wayne Township,President,,,"Basiago, Andrew D. ",0
-Edwards,Wayne Township,President,,,"Castle, Darrell L ",0
-Edwards,Wayne Township,President,,,"De La Fuente, ""Rocky"" Roque  ",0
-Edwards,Wayne Township,President,,,"Giordani, Rocky  ",0
-Edwards,Wayne Township,President,,,"Hedges, James A ",0
-Edwards,Wayne Township,President,,,"Hoefling, Tom  ",0
-Edwards,Wayne Township,President,,,"Kahn, Lynn  ",0
-Edwards,Wayne Township,President,,,"La Riva, Gloria  ",0
-Edwards,Wayne Township,President,,,"Levinson, Michael S. ",0
-Edwards,Wayne Township,President,,,"Maturen, Michael A ",0
-Edwards,Wayne Township,President,,,"McMullin, Evan  ",0
-Edwards,Wayne Township,President,,,"Moorehead, Monica G. ",0
-Edwards,Wayne Township,President,,,"Perry, Darryl  ",0
-Edwards,Wayne Township,President,,,"Schoenke, Marshall R. ",0
-Edwards,Wayne Township,President,,,"Schriner, Joe C ",0
-Edwards,Wayne Township,President,,,"Smith, Mike  ",0
-Edwards,Wayne Township,President,,,"Sood, Ajay  ",0
-Edwards,Wayne Township,President,,,"Sterling, Shawna  ",0
-Edwards,Wayne Township,President,,,"Valdivia, Anthony J ",0
-Edwards,Wayne Township,President,,,"Vogel-Walcutt, J.J.  ",0
-Edwards,Wayne Township,President,,,"Wysinger, Demetra Jefferson ",0
-Edwards,Wayne Township,President,,Democratic,"Clinton, Hillary Rodham ",26
-Edwards,Wayne Township,President,,Libertarian,"Johnson, Gary  ",7
-Edwards,Wayne Township,President,,Republican,"Trump, Donald J. ",137
+county,precinct,office,district,party,candidate,votes,vtd
+EDWARDS,Belpre Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",58,000010
+EDWARDS,Franklin Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",40,000020
+EDWARDS,Jackson Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",31,000030
+EDWARDS,Kinsley Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",47,000040
+EDWARDS,Kinsley Ward 1,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",251,000050
+EDWARDS,Kinsley Ward 2,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",255,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",0,00006B
+EDWARDS,Lincoln Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",56,000070
+EDWARDS,Logan Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",16,000080
+EDWARDS,North Brown Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",25,000090
+EDWARDS,South Brown Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",35,000100
+EDWARDS,Trenton Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",128,000110
+EDWARDS,Wayne Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",138,000120
+EDWARDS,Belpre Township,Kansas Senate,33,Democratic,"Bristow, Matt",13,000010
+EDWARDS,Belpre Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",54,000010
+EDWARDS,Franklin Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000020
+EDWARDS,Franklin Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",45,000020
+EDWARDS,Jackson Township,Kansas Senate,33,Democratic,"Bristow, Matt",5,000030
+EDWARDS,Jackson Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",30,000030
+EDWARDS,Kinsley Township,Kansas Senate,33,Democratic,"Bristow, Matt",13,000040
+EDWARDS,Kinsley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",51,000040
+EDWARDS,Kinsley Ward 1,Kansas Senate,33,Democratic,"Bristow, Matt",65,000050
+EDWARDS,Kinsley Ward 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",235,000050
+EDWARDS,Kinsley Ward 2,Kansas Senate,33,Democratic,"Bristow, Matt",56,00006A
+EDWARDS,Kinsley Ward 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",250,00006A
+EDWARDS,Kinsley Ward 2 Exclave,Kansas Senate,33,Democratic,"Bristow, Matt",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00006B
+EDWARDS,Lincoln Township,Kansas Senate,33,Democratic,"Bristow, Matt",8,000070
+EDWARDS,Lincoln Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",57,000070
+EDWARDS,Logan Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000080
+EDWARDS,Logan Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",18,000080
+EDWARDS,North Brown Township,Kansas Senate,33,Democratic,"Bristow, Matt",4,000090
+EDWARDS,North Brown Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",26,000090
+EDWARDS,South Brown Township,Kansas Senate,33,Democratic,"Bristow, Matt",0,000100
+EDWARDS,South Brown Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",39,000100
+EDWARDS,Trenton Township,Kansas Senate,33,Democratic,"Bristow, Matt",16,000110
+EDWARDS,Trenton Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",122,000110
+EDWARDS,Wayne Township,Kansas Senate,33,Democratic,"Bristow, Matt",33,000120
+EDWARDS,Wayne Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",132,000120
+EDWARDS,Belpre Township,President / Vice President,,independent,"Stein, Jill",3,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+EDWARDS,Belpre Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+EDWARDS,Belpre Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000010
+EDWARDS,Belpre Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+EDWARDS,Belpre Township,President / Vice President,,Republican,"Trump, Donald J.",58,000010
+EDWARDS,Franklin Township,President / Vice President,,independent,"Stein, Jill",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+EDWARDS,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+EDWARDS,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",48,000020
+EDWARDS,Jackson Township,President / Vice President,,independent,"Stein, Jill",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+EDWARDS,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+EDWARDS,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000030
+EDWARDS,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+EDWARDS,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",30,000030
+EDWARDS,Kinsley Township,President / Vice President,,independent,"Stein, Jill",2,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+EDWARDS,Kinsley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000040
+EDWARDS,Kinsley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+EDWARDS,Kinsley Township,President / Vice President,,Republican,"Trump, Donald J.",55,000040
+EDWARDS,Kinsley Ward 1,President / Vice President,,independent,"Stein, Jill",11,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+EDWARDS,Kinsley Ward 1,President / Vice President,,Republican,"Trump, Donald J.",230,000050
+EDWARDS,Kinsley Ward 2,President / Vice President,,independent,"Stein, Jill",7,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",11,00006A
+EDWARDS,Kinsley Ward 2,President / Vice President,,Republican,"Trump, Donald J.",217,00006A
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+EDWARDS,Lincoln Township,President / Vice President,,independent,"Stein, Jill",2,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+EDWARDS,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000070
+EDWARDS,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+EDWARDS,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",60,000070
+EDWARDS,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+EDWARDS,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+EDWARDS,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000080
+EDWARDS,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+EDWARDS,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",15,000080
+EDWARDS,North Brown Township,President / Vice President,,independent,"Stein, Jill",2,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+EDWARDS,North Brown Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+EDWARDS,North Brown Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000090
+EDWARDS,North Brown Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+EDWARDS,North Brown Township,President / Vice President,,Republican,"Trump, Donald J.",24,000090
+EDWARDS,South Brown Township,President / Vice President,,independent,"Stein, Jill",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+EDWARDS,South Brown Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+EDWARDS,South Brown Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000100
+EDWARDS,South Brown Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+EDWARDS,South Brown Township,President / Vice President,,Republican,"Trump, Donald J.",40,000100
+EDWARDS,Trenton Township,President / Vice President,,independent,"Stein, Jill",2,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Castle, Darrell L",1,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"McMullin, Evan",2,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+EDWARDS,Trenton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+EDWARDS,Trenton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000110
+EDWARDS,Trenton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+EDWARDS,Trenton Township,President / Vice President,,Republican,"Trump, Donald J.",123,000110
+EDWARDS,Wayne Township,President / Vice President,,independent,"Stein, Jill",4,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+EDWARDS,Wayne Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+EDWARDS,Wayne Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000120
+EDWARDS,Wayne Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000120
+EDWARDS,Wayne Township,President / Vice President,,Republican,"Trump, Donald J.",137,000120
+EDWARDS,Belpre Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000010
+EDWARDS,Belpre Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,000010
+EDWARDS,Belpre Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000010
+EDWARDS,Belpre Township,United States House of Representatives,4,Republican,"Pompeo, Michael",55,000010
+EDWARDS,Franklin Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000020
+EDWARDS,Franklin Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000020
+EDWARDS,Franklin Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000020
+EDWARDS,Franklin Township,United States House of Representatives,4,Republican,"Pompeo, Michael",45,000020
+EDWARDS,Jackson Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000030
+EDWARDS,Jackson Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000030
+EDWARDS,Jackson Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000030
+EDWARDS,Jackson Township,United States House of Representatives,4,Republican,"Pompeo, Michael",31,000030
+EDWARDS,Kinsley Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000040
+EDWARDS,Kinsley Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",10,000040
+EDWARDS,Kinsley Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000040
+EDWARDS,Kinsley Township,United States House of Representatives,4,Republican,"Pompeo, Michael",53,000040
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",28,000050
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",50,000050
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000050
+EDWARDS,Kinsley Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",227,000050
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",28,00006A
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",38,00006A
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,00006A
+EDWARDS,Kinsley Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",230,00006A
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00006B
+EDWARDS,Lincoln Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000070
+EDWARDS,Lincoln Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000070
+EDWARDS,Lincoln Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000070
+EDWARDS,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Michael",58,000070
+EDWARDS,Logan Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000080
+EDWARDS,Logan Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,000080
+EDWARDS,Logan Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000080
+EDWARDS,Logan Township,United States House of Representatives,4,Republican,"Pompeo, Michael",15,000080
+EDWARDS,North Brown Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000090
+EDWARDS,North Brown Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,000090
+EDWARDS,North Brown Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000090
+EDWARDS,North Brown Township,United States House of Representatives,4,Republican,"Pompeo, Michael",26,000090
+EDWARDS,South Brown Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000100
+EDWARDS,South Brown Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000100
+EDWARDS,South Brown Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000100
+EDWARDS,South Brown Township,United States House of Representatives,4,Republican,"Pompeo, Michael",39,000100
+EDWARDS,Trenton Township,United States House of Representatives,4,independent,"Allen, Miranda",15,000110
+EDWARDS,Trenton Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,000110
+EDWARDS,Trenton Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,000110
+EDWARDS,Trenton Township,United States House of Representatives,4,Republican,"Pompeo, Michael",111,000110
+EDWARDS,Wayne Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000120
+EDWARDS,Wayne Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",27,000120
+EDWARDS,Wayne Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000120
+EDWARDS,Wayne Township,United States House of Representatives,4,Republican,"Pompeo, Michael",126,000120
+EDWARDS,Belpre Township,United States Senate,,write - in,"Smith, DJ",0,000010
+EDWARDS,Belpre Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000010
+EDWARDS,Belpre Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000010
+EDWARDS,Belpre Township,United States Senate,,Republican,"Moran, Jerry",58,000010
+EDWARDS,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000020
+EDWARDS,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+EDWARDS,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+EDWARDS,Franklin Township,United States Senate,,Republican,"Moran, Jerry",47,000020
+EDWARDS,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000030
+EDWARDS,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000030
+EDWARDS,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+EDWARDS,Jackson Township,United States Senate,,Republican,"Moran, Jerry",32,000030
+EDWARDS,Kinsley Township,United States Senate,,write - in,"Smith, DJ",0,000040
+EDWARDS,Kinsley Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000040
+EDWARDS,Kinsley Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000040
+EDWARDS,Kinsley Township,United States Senate,,Republican,"Moran, Jerry",58,000040
+EDWARDS,Kinsley Ward 1,United States Senate,,write - in,"Smith, DJ",0,000050
+EDWARDS,Kinsley Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",51,000050
+EDWARDS,Kinsley Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",22,000050
+EDWARDS,Kinsley Ward 1,United States Senate,,Republican,"Moran, Jerry",237,000050
+EDWARDS,Kinsley Ward 2,United States Senate,,write - in,"Smith, DJ",0,00006A
+EDWARDS,Kinsley Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",51,00006A
+EDWARDS,Kinsley Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",23,00006A
+EDWARDS,Kinsley Ward 2,United States Senate,,Republican,"Moran, Jerry",234,00006A
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+EDWARDS,Kinsley Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00006B
+EDWARDS,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000070
+EDWARDS,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000070
+EDWARDS,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+EDWARDS,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",62,000070
+EDWARDS,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000080
+EDWARDS,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000080
+EDWARDS,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+EDWARDS,Logan Township,United States Senate,,Republican,"Moran, Jerry",17,000080
+EDWARDS,North Brown Township,United States Senate,,write - in,"Smith, DJ",0,000090
+EDWARDS,North Brown Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000090
+EDWARDS,North Brown Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000090
+EDWARDS,North Brown Township,United States Senate,,Republican,"Moran, Jerry",29,000090
+EDWARDS,South Brown Township,United States Senate,,write - in,"Smith, DJ",0,000100
+EDWARDS,South Brown Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000100
+EDWARDS,South Brown Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+EDWARDS,South Brown Township,United States Senate,,Republican,"Moran, Jerry",42,000100
+EDWARDS,Trenton Township,United States Senate,,write - in,"Smith, DJ",0,000110
+EDWARDS,Trenton Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000110
+EDWARDS,Trenton Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000110
+EDWARDS,Trenton Township,United States Senate,,Republican,"Moran, Jerry",124,000110
+EDWARDS,Wayne Township,United States Senate,,write - in,"Smith, DJ",0,000120
+EDWARDS,Wayne Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000120
+EDWARDS,Wayne Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000120
+EDWARDS,Wayne Township,United States Senate,,Republican,"Moran, Jerry",138,000120

--- a/2016/20161108__ks__general__elk__precinct.csv
+++ b/2016/20161108__ks__general__elk__precinct.csv
@@ -1,160 +1,364 @@
-county,precinct,office,district,party,candidate,election_day,votes,advance
-Elk,Elk Falls,President,,DEM,Clinton-Kaine,8,10,2
-Elk,Greenfield,President,,DEM,Clinton-Kaine,8,15,7
-Elk,Howard,President,,DEM,Clinton-Kaine,36,55,19
-Elk,Liberty,President,,DEM,Clinton-Kaine,3,4,1
-Elk,Longton,President,,DEM,Clinton-Kaine,14,17,3
-Elk,Oak Valley,President,,DEM,Clinton-Kaine,3,7,4
-Elk,Painterhood,President,,DEM,Clinton-Kaine,2,2,0
-Elk,Paw Paw,President,,DEM,Clinton-Kaine,3,4,1
-Elk,Union Center,President,,DEM,Clinton-Kaine,4,5,1
-Elk,Wild Cat,President,,DEM,Clinton-Kaine,28,41,13
-Elk,Total,President,,DEM,Clinton-Kaine,109,160,51
-Elk,Elk Falls,President,,LIB,Johnson-Weld,2,2,0
-Elk,Greenfield,President,,LIB,Johnson-Weld,4,6,2
-Elk,Howard,President,,LIB,Johnson-Weld,9,11,2
-Elk,Liberty,President,,LIB,Johnson-Weld,2,2,0
-Elk,Longton,President,,LIB,Johnson-Weld,4,4,0
-Elk,Oak Valley,President,,LIB,Johnson-Weld,1,1,0
-Elk,Painterhood,President,,LIB,Johnson-Weld,1,1,0
-Elk,Paw Paw,President,,LIB,Johnson-Weld,0,0,0
-Elk,Union Center,President,,LIB,Johnson-Weld,1,1,0
-Elk,Wild Cat,President,,LIB,Johnson-Weld,5,7,2
-Elk,Total,President,,LIB,Johnson-Weld,29,35,6
-Elk,Elk Falls,President,,IND,Stein-Baraka,1,1,0
-Elk,Greenfield,President,,IND,Stein-Baraka,0,0,0
-Elk,Howard,President,,IND,Stein-Baraka,2,6,4
-Elk,Liberty,President,,IND,Stein-Baraka,1,1,0
-Elk,Longton,President,,IND,Stein-Baraka,3,3,0
-Elk,Oak Valley,President,,IND,Stein-Baraka,0,0,0
-Elk,Painterhood,President,,IND,Stein-Baraka,0,0,0
-Elk,Paw Paw,President,,IND,Stein-Baraka,0,0,0
-Elk,Union Center,President,,IND,Stein-Baraka,0,0,0
-Elk,Wild Cat,President,,IND,Stein-Baraka,4,5,1
-Elk,Total,President,,IND,Stein-Baraka,11,16,5
-Elk,Elk Falls,President,,REP,Trump-Pence,57,86,29
-Elk,Greenfield,President,,REP,Trump-Pence,82,113,31
-Elk,Howard,President,,REP,Trump-Pence,273,329,56
-Elk,Liberty,President,,REP,Trump-Pence,19,37,18
-Elk,Longton,President,,REP,Trump-Pence,115,132,17
-Elk,Oak Valley,President,,REP,Trump-Pence,34,41,7
-Elk,Painterhood,President,,REP,Trump-Pence,15,20,5
-Elk,Paw Paw,President,,REP,Trump-Pence,43,49,6
-Elk,Union Center,President,,REP,Trump-Pence,34,41,7
-Elk,Wild Cat,President,,REP,Trump-Pence,180,200,20
-Elk,Total,President,,REP,Trump-Pence,852,1048,196
-Elk,Elk Falls,State House,12,REP,Doug Blex,46,72,26
-Elk,Longton,State House,12,REP,Doug Blex,90,104,14
-Elk,Oak Valley,State House,12,REP,Doug Blex,32,38,6
-Elk,Total,State House,12,REP,Doug Blex,168,214,46
-Elk,Elk Falls,State House,12,DEM,Jean Kurtis Schodorf,22,26,4
-Elk,Longton,State House,12,DEM,Jean Kurtis Schodorf,44,48,4
-Elk,Oak Valley,State House,12,DEM,Jean Kurtis Schodorf,9,14,5
-Elk,Total,State House,12,DEM,Jean Kurtis Schodorf,75,88,13
-Elk,Greenfield,State House,13,REP,Larry Hibbard,82,119,37
-Elk,Howard,State House,13,REP,Larry Hibbard,276,344,68
-Elk,Liberty,State House,13,REP,Larry Hibbard,23,37,14
-Elk,Painterhood,State House,13,REP,Larry Hibbard,18,23,5
-Elk,Paw Paw,State House,13,REP,Larry Hibbard,44,49,5
-Elk,Union Center,State House,13,REP,Larry Hibbard,34,41,7
-Elk,Wild Cat,State House,13,REP,Larry Hibbard,187,220,33
-Elk,Total,State House,13,REP,Larry Hibbard,664,833,169
-Elk,Elk Falls,State Senate,14,REP,Bruce Givens,52,80,28
-Elk,Greenfield,State Senate,14,REP,Bruce Givens,65,96,31
-Elk,Howard,State Senate,14,REP,Bruce Givens,241,294,53
-Elk,Liberty,State Senate,14,REP,Bruce Givens,20,30,10
-Elk,Longton,State Senate,14,REP,Bruce Givens,98,112,14
-Elk,Oak Valley,State Senate,14,REP,Bruce Givens,31,38,7
-Elk,Painterhood,State Senate,14,REP,Bruce Givens,11,16,5
-Elk,Paw Paw,State Senate,14,REP,Bruce Givens,38,43,5
-Elk,Union Center,State Senate,14,REP,Bruce Givens,27,33,6
-Elk,Wild Cat,State Senate,14,REP,Bruce Givens,160,181,21
-Elk,Total,State Senate,14,REP,Bruce Givens,743,923,180
-Elk,Elk Falls,State Senate,14,DEM,Mark Pringle,15,17,2
-Elk,Greenfield,State Senate,14,DEM,Mark Pringle,23,27,4
-Elk,Howard,State Senate,14,DEM,Mark Pringle,71,91,20
-Elk,Liberty,State Senate,14,DEM,Mark Pringle,4,10,6
-Elk,Longton,State Senate,14,DEM,Mark Pringle,35,40,5
-Elk,Oak Valley,State Senate,14,DEM,Mark Pringle,10,14,4
-Elk,Painterhood,State Senate,14,DEM,Mark Pringle,8,8,0
-Elk,Paw Paw,State Senate,14,DEM,Mark Pringle,8,9,1
-Elk,Union Center,State Senate,14,DEM,Mark Pringle,10,12,2
-Elk,Wild Cat,State Senate,14,DEM,Mark Pringle,50,67,17
-Elk,Total,State Senate,14,DEM,Mark Pringle,234,295,61
-Elk,Elk Falls,U.S. House,4,DEM,Daniel Giroux,7,8,1
-Elk,Greenfield,U.S. House,4,DEM,Daniel Giroux,14,19,5
-Elk,Howard,U.S. House,4,DEM,Daniel Giroux,43,53,10
-Elk,Liberty,U.S. House,4,DEM,Daniel Giroux,2,3,1
-Elk,Longton,U.S. House,4,DEM,Daniel Giroux,14,18,4
-Elk,Oak Valley,U.S. House,4,DEM,Daniel Giroux,5,9,4
-Elk,Painterhood,U.S. House,4,DEM,Daniel Giroux,2,2,0
-Elk,Paw Paw,U.S. House,4,DEM,Daniel Giroux,4,5,1
-Elk,Union Center,U.S. House,4,DEM,Daniel Giroux,5,6,1
-Elk,Wild Cat,U.S. House,4,DEM,Daniel Giroux,28,39,11
-Elk,Total,U.S. House,4,DEM,Daniel Giroux,124,162,38
-Elk,Elk Falls,U.S. House,4,LIB,Gorden Bakken,2,2,0
-Elk,Greenfield,U.S. House,4,LIB,Gorden Bakken,0,1,1
-Elk,Howard,U.S. House,4,LIB,Gorden Bakken,4,5,1
-Elk,Liberty,U.S. House,4,LIB,Gorden Bakken,0,0,0
-Elk,Longton,U.S. House,4,LIB,Gorden Bakken,10,12,2
-Elk,Oak Valley,U.S. House,4,LIB,Gorden Bakken,2,2,0
-Elk,Painterhood,U.S. House,4,LIB,Gorden Bakken,0,0,0
-Elk,Paw Paw,U.S. House,4,LIB,Gorden Bakken,1,1,0
-Elk,Union Center,U.S. House,4,LIB,Gorden Bakken,1,1,0
-Elk,Wild Cat,U.S. House,4,LIB,Gorden Bakken,5,6,1
-Elk,Total,U.S. House,4,LIB,Gorden Bakken,25,30,5
-Elk,Elk Falls,U.S. House,4,REP,Michael Pompeo,50,79,29
-Elk,Greenfield,U.S. House,4,REP,Michael Pompeo,73,105,32
-Elk,Howard,U.S. House,4,REP,Michael Pompeo,259,323,64
-Elk,Liberty,U.S. House,4,REP,Michael Pompeo,20,38,18
-Elk,Longton,U.S. House,4,REP,Michael Pompeo,103,115,12
-Elk,Oak Valley,U.S. House,4,REP,Michael Pompeo,29,36,7
-Elk,Painterhood,U.S. House,4,REP,Michael Pompeo,17,22,5
-Elk,Paw Paw,U.S. House,4,REP,Michael Pompeo,40,45,5
-Elk,Union Center,U.S. House,4,REP,Michael Pompeo,32,39,7
-Elk,Wild Cat,U.S. House,4,REP,Michael Pompeo,166,190,24
-Elk,Total,U.S. House,4,REP,Michael Pompeo,789,992,203
-Elk,Elk Falls,U.S. House,4,IND,Miranda Allen,7,7,0
-Elk,Greenfield,U.S. House,4,IND,Miranda Allen,5,7,2
-Elk,Howard,U.S. House,4,IND,Miranda Allen,18,24,6
-Elk,Liberty,U.S. House,4,IND,Miranda Allen,2,2,0
-Elk,Longton,U.S. House,4,IND,Miranda Allen,10,12,2
-Elk,Oak Valley,U.S. House,4,IND,Miranda Allen,5,5,0
-Elk,Painterhood,U.S. House,4,IND,Miranda Allen,1,1,0
-Elk,Paw Paw,U.S. House,4,IND,Miranda Allen,2,2,0
-Elk,Union Center,U.S. House,4,IND,Miranda Allen,1,1,0
-Elk,Wild Cat,U.S. House,4,IND,Miranda Allen,19,21,2
-Elk,Total,U.S. House,4,IND,Miranda Allen,70,82,12
-Elk,Elk Falls,U.S. Senate,,REP,Jerry Moran,57,85,28
-Elk,Greenfield,U.S. Senate,,REP,Jerry Moran,72,105,33
-Elk,Howard,U.S. Senate,,REP,Jerry Moran,261,325,64
-Elk,Liberty,U.S. Senate,,REP,Jerry Moran,19,37,18
-Elk,Longton,U.S. Senate,,REP,Jerry Moran,104,117,13
-Elk,Oak Valley,U.S. Senate,,REP,Jerry Moran,30,37,7
-Elk,Painterhood,U.S. Senate,,REP,Jerry Moran,14,19,5
-Elk,Paw Paw,U.S. Senate,,REP,Jerry Moran,38,43,5
-Elk,Union Center,U.S. Senate,,REP,Jerry Moran,35,42,7
-Elk,Wild Cat,U.S. Senate,,REP,Jerry Moran,179,202,23
-Elk,Total,U.S. Senate,,REP,Jerry Moran,809,1012,203
-Elk,Elk Falls,U.S. Senate,,DEM,Patrick Wiesner,6,7,378
-Elk,Greenfield,U.S. Senate,,DEM,Patrick Wiesner,16,21,5
-Elk,Howard,U.S. Senate,,DEM,Patrick Wiesner,39,53,14
-Elk,Liberty,U.S. Senate,,DEM,Patrick Wiesner,3,4,1
-Elk,Longton,U.S. Senate,,DEM,Patrick Wiesner,13,16,3
-Elk,Oak Valley,U.S. Senate,,DEM,Patrick Wiesner,3,7,4
-Elk,Painterhood,U.S. Senate,,DEM,Patrick Wiesner,4,4,0
-Elk,Paw Paw,U.S. Senate,,DEM,Patrick Wiesner,3,4,1
-Elk,Union Center,U.S. Senate,,DEM,Patrick Wiesner,1,2,1
-Elk,Wild Cat,U.S. Senate,,DEM,Patrick Wiesner,25,36,11
-Elk,Total,U.S. Senate,,DEM,Patrick Wiesner,113,154,41
-Elk,Elk Falls,U.S. Senate,,LIB,Robert Garrard,5,5,0
-Elk,Greenfield,U.S. Senate,,LIB,Robert Garrard,3,4,1
-Elk,Howard,U.S. Senate,,LIB,Robert Garrard,21,24,3
-Elk,Liberty,U.S. Senate,,LIB,Robert Garrard,0,0,0
-Elk,Longton,U.S. Senate,,LIB,Robert Garrard,15,19,4
-Elk,Oak Valley,U.S. Senate,,LIB,Robert Garrard,7,7,0
-Elk,Painterhood,U.S. Senate,,LIB,Robert Garrard,2,2,0
-Elk,Paw Paw,U.S. Senate,,LIB,Robert Garrard,5,5,0
-Elk,Union Center,U.S. Senate,,LIB,Robert Garrard,3,3,0
-Elk,Wild Cat,U.S. Senate,,LIB,Robert Garrard,11,14,3
-Elk,Total,U.S. Senate,,LIB,Robert Garrard,72,83,11
+county,precinct,office,district,party,candidate,votes,vtd
+ELK,Elk Falls Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",26,000010
+ELK,Elk Falls Township,Kansas House of Representatives,12,Republican,"Blex, Doug",72,000010
+ELK,Greenfield Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",119,000020
+ELK,Howard Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",344,000030
+ELK,Liberty Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",37,000040
+ELK,Longton Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",48,000050
+ELK,Longton Township,Kansas House of Representatives,12,Republican,"Blex, Doug",104,000050
+ELK,Oak Valley Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",14,000060
+ELK,Oak Valley Township,Kansas House of Representatives,12,Republican,"Blex, Doug",38,000060
+ELK,Painterhood Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",23,000070
+ELK,Paw Paw Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",49,000080
+ELK,Union Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",41,000090
+ELK,Wildcat Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",220,000100
+ELK,Elk Falls Township,Kansas Senate,14,Democratic,"Pringle, Mark",17,000010
+ELK,Elk Falls Township,Kansas Senate,14,Republican,"Givens, Bruce",80,000010
+ELK,Greenfield Township,Kansas Senate,14,Democratic,"Pringle, Mark",27,000020
+ELK,Greenfield Township,Kansas Senate,14,Republican,"Givens, Bruce",96,000020
+ELK,Howard Township,Kansas Senate,14,Democratic,"Pringle, Mark",91,000030
+ELK,Howard Township,Kansas Senate,14,Republican,"Givens, Bruce",294,000030
+ELK,Liberty Township,Kansas Senate,14,Democratic,"Pringle, Mark",10,000040
+ELK,Liberty Township,Kansas Senate,14,Republican,"Givens, Bruce",30,000040
+ELK,Longton Township,Kansas Senate,14,Democratic,"Pringle, Mark",40,000050
+ELK,Longton Township,Kansas Senate,14,Republican,"Givens, Bruce",112,000050
+ELK,Oak Valley Township,Kansas Senate,14,Democratic,"Pringle, Mark",14,000060
+ELK,Oak Valley Township,Kansas Senate,14,Republican,"Givens, Bruce",38,000060
+ELK,Painterhood Township,Kansas Senate,14,Democratic,"Pringle, Mark",8,000070
+ELK,Painterhood Township,Kansas Senate,14,Republican,"Givens, Bruce",16,000070
+ELK,Paw Paw Township,Kansas Senate,14,Democratic,"Pringle, Mark",9,000080
+ELK,Paw Paw Township,Kansas Senate,14,Republican,"Givens, Bruce",43,000080
+ELK,Union Center Township,Kansas Senate,14,Democratic,"Pringle, Mark",12,000090
+ELK,Union Center Township,Kansas Senate,14,Republican,"Givens, Bruce",33,000090
+ELK,Wildcat Township,Kansas Senate,14,Democratic,"Pringle, Mark",67,000100
+ELK,Wildcat Township,Kansas Senate,14,Republican,"Givens, Bruce",181,000100
+ELK,Elk Falls Township,President / Vice President,,independent,"Stein, Jill",1,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+ELK,Elk Falls Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+ELK,Elk Falls Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000010
+ELK,Elk Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+ELK,Elk Falls Township,President / Vice President,,Republican,"Trump, Donald J.",86,000010
+ELK,Greenfield Township,President / Vice President,,independent,"Stein, Jill",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+ELK,Greenfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+ELK,Greenfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000020
+ELK,Greenfield Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+ELK,Greenfield Township,President / Vice President,,Republican,"Trump, Donald J.",113,000020
+ELK,Howard Township,President / Vice President,,independent,"Stein, Jill",6,000030
+ELK,Howard Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ELK,Howard Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ELK,Howard Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000030
+ELK,Howard Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000030
+ELK,Howard Township,President / Vice President,,Republican,"Trump, Donald J.",329,000030
+ELK,Liberty Township,President / Vice President,,independent,"Stein, Jill",1,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ELK,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ELK,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000040
+ELK,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+ELK,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",37,000040
+ELK,Longton Township,President / Vice President,,independent,"Stein, Jill",3,000050
+ELK,Longton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+ELK,Longton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+ELK,Longton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000050
+ELK,Longton Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+ELK,Longton Township,President / Vice President,,Republican,"Trump, Donald J.",132,000050
+ELK,Oak Valley Township,President / Vice President,,independent,"Stein, Jill",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+ELK,Oak Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+ELK,Oak Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000060
+ELK,Oak Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+ELK,Oak Valley Township,President / Vice President,,Republican,"Trump, Donald J.",41,000060
+ELK,Painterhood Township,President / Vice President,,independent,"Stein, Jill",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+ELK,Painterhood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+ELK,Painterhood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000070
+ELK,Painterhood Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+ELK,Painterhood Township,President / Vice President,,Republican,"Trump, Donald J.",20,000070
+ELK,Paw Paw Township,President / Vice President,,independent,"Stein, Jill",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+ELK,Paw Paw Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+ELK,Paw Paw Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000080
+ELK,Paw Paw Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+ELK,Paw Paw Township,President / Vice President,,Republican,"Trump, Donald J.",49,000080
+ELK,Union Center Township,President / Vice President,,independent,"Stein, Jill",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+ELK,Union Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+ELK,Union Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000090
+ELK,Union Center Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+ELK,Union Center Township,President / Vice President,,Republican,"Trump, Donald J.",41,000090
+ELK,Wildcat Township,President / Vice President,,independent,"Stein, Jill",5,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+ELK,Wildcat Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+ELK,Wildcat Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000100
+ELK,Wildcat Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000100
+ELK,Wildcat Township,President / Vice President,,Republican,"Trump, Donald J.",200,000100
+ELK,Elk Falls Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000010
+ELK,Elk Falls Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000010
+ELK,Elk Falls Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000010
+ELK,Elk Falls Township,United States House of Representatives,4,Republican,"Pompeo, Michael",79,000010
+ELK,Greenfield Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000020
+ELK,Greenfield Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,000020
+ELK,Greenfield Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000020
+ELK,Greenfield Township,United States House of Representatives,4,Republican,"Pompeo, Michael",105,000020
+ELK,Howard Township,United States House of Representatives,4,independent,"Allen, Miranda",24,000030
+ELK,Howard Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",53,000030
+ELK,Howard Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000030
+ELK,Howard Township,United States House of Representatives,4,Republican,"Pompeo, Michael",323,000030
+ELK,Liberty Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000040
+ELK,Liberty Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000040
+ELK,Liberty Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000040
+ELK,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Michael",38,000040
+ELK,Longton Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000050
+ELK,Longton Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",18,000050
+ELK,Longton Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,000050
+ELK,Longton Township,United States House of Representatives,4,Republican,"Pompeo, Michael",115,000050
+ELK,Oak Valley Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000060
+ELK,Oak Valley Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",9,000060
+ELK,Oak Valley Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000060
+ELK,Oak Valley Township,United States House of Representatives,4,Republican,"Pompeo, Michael",36,000060
+ELK,Painterhood Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000070
+ELK,Painterhood Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,000070
+ELK,Painterhood Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000070
+ELK,Painterhood Township,United States House of Representatives,4,Republican,"Pompeo, Michael",22,000070
+ELK,Paw Paw Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000080
+ELK,Paw Paw Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000080
+ELK,Paw Paw Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000080
+ELK,Paw Paw Township,United States House of Representatives,4,Republican,"Pompeo, Michael",45,000080
+ELK,Union Center Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000090
+ELK,Union Center Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000090
+ELK,Union Center Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000090
+ELK,Union Center Township,United States House of Representatives,4,Republican,"Pompeo, Michael",39,000090
+ELK,Wildcat Township,United States House of Representatives,4,independent,"Allen, Miranda",21,000100
+ELK,Wildcat Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",39,000100
+ELK,Wildcat Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000100
+ELK,Wildcat Township,United States House of Representatives,4,Republican,"Pompeo, Michael",190,000100
+ELK,Elk Falls Township,United States Senate,,write - in,"Smith, DJ",0,000010
+ELK,Elk Falls Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000010
+ELK,Elk Falls Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000010
+ELK,Elk Falls Township,United States Senate,,Republican,"Moran, Jerry",85,000010
+ELK,Greenfield Township,United States Senate,,write - in,"Smith, DJ",0,000020
+ELK,Greenfield Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000020
+ELK,Greenfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+ELK,Greenfield Township,United States Senate,,Republican,"Moran, Jerry",105,000020
+ELK,Howard Township,United States Senate,,write - in,"Smith, DJ",0,000030
+ELK,Howard Township,United States Senate,,Democratic,"Wiesner, Patrick",53,000030
+ELK,Howard Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000030
+ELK,Howard Township,United States Senate,,Republican,"Moran, Jerry",325,000030
+ELK,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000040
+ELK,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000040
+ELK,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+ELK,Liberty Township,United States Senate,,Republican,"Moran, Jerry",37,000040
+ELK,Longton Township,United States Senate,,write - in,"Smith, DJ",0,000050
+ELK,Longton Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000050
+ELK,Longton Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000050
+ELK,Longton Township,United States Senate,,Republican,"Moran, Jerry",117,000050
+ELK,Oak Valley Township,United States Senate,,write - in,"Smith, DJ",0,000060
+ELK,Oak Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000060
+ELK,Oak Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000060
+ELK,Oak Valley Township,United States Senate,,Republican,"Moran, Jerry",37,000060
+ELK,Painterhood Township,United States Senate,,write - in,"Smith, DJ",0,000070
+ELK,Painterhood Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000070
+ELK,Painterhood Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+ELK,Painterhood Township,United States Senate,,Republican,"Moran, Jerry",19,000070
+ELK,Paw Paw Township,United States Senate,,write - in,"Smith, DJ",0,000080
+ELK,Paw Paw Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+ELK,Paw Paw Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000080
+ELK,Paw Paw Township,United States Senate,,Republican,"Moran, Jerry",43,000080
+ELK,Union Center Township,United States Senate,,write - in,"Smith, DJ",0,000090
+ELK,Union Center Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000090
+ELK,Union Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+ELK,Union Center Township,United States Senate,,Republican,"Moran, Jerry",42,000090
+ELK,Wildcat Township,United States Senate,,write - in,"Smith, DJ",0,000100
+ELK,Wildcat Township,United States Senate,,Democratic,"Wiesner, Patrick",36,000100
+ELK,Wildcat Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000100
+ELK,Wildcat Township,United States Senate,,Republican,"Moran, Jerry",202,000100

--- a/2016/20161108__ks__general__ellis__precinct.csv
+++ b/2016/20161108__ks__general__ellis__precinct.csv
@@ -1,571 +1,1581 @@
-county,precinct,office,district,party,candidate,votes
-Ellis,Hays W1P1,President,,LBT,Gary Johnson,27
-Ellis,Hays W1P2,President,,LBT,Gary Johnson,16
-Ellis,Hays W2P1,President,,LBT,Gary Johnson,23
-Ellis,Hays W2P2,President,,LBT,Gary Johnson,19
-Ellis,Hays W2P3,President,,LBT,Gary Johnson,13
-Ellis,Hays W2P4,President,,LBT,Gary Johnson,14
-Ellis,Hays W2P5,President,,LBT,Gary Johnson,11
-Ellis,Hays W3P1,President,,LBT,Gary Johnson,21
-Ellis,Hays W3P2,President,,LBT,Gary Johnson,21
-Ellis,Hays W3P3,President,,LBT,Gary Johnson,18
-Ellis,Hays W3P4,President,,LBT,Gary Johnson,33
-Ellis,Hays W4P1,President,,LBT,Gary Johnson,18
-Ellis,Hays W4P2,President,,LBT,Gary Johnson,25
-Ellis,Hays W4P3,President,,LBT,Gary Johnson,16
-Ellis,Hays W4P4,President,,LBT,Gary Johnson,37
-Ellis,Hays W4P5,President,,LBT,Gary Johnson,29
-Ellis,Ellis W1,President,,LBT,Gary Johnson,7
-Ellis,Ellis W2,President,,LBT,Gary Johnson,7
-Ellis,Ellis W3,President,,LBT,Gary Johnson,10
-Ellis,E Big Creek,President,,LBT,Gary Johnson,18
-Ellis,N Big Creek twp 110,President,,LBT,Gary Johnson,3
-Ellis,N Big Creek twp 111,President,,LBT,Gary Johnson,6
-Ellis,W Big Creek 111,President,,LBT,Gary Johnson,0
-Ellis,W Big Creek 110,President,,LBT,Gary Johnson,2
-Ellis,Buckeye twp,President,,LBT,Gary Johnson,6
-Ellis,Catherine twp,President,,LBT,Gary Johnson,11
-Ellis,Ellis twp,President,,LBT,Gary Johnson,3
-Ellis,Freedom twp,President,,LBT,Gary Johnson,0
-Ellis,Herzog twp 110,President,,LBT,Gary Johnson,3
-Ellis,Herzog twp 111,President,,LBT,Gary Johnson,10
-Ellis,N Lookout twp 110,President,,LBT,Gary Johnson,1
-Ellis,N Lookout twp 111,President,,LBT,Gary Johnson,6
-Ellis,S Lookout twp,President,,LBT,Gary Johnson,3
-Ellis,Victoria twp,President,,LBT,Gary Johnson,20
-Ellis,Wheatland twp,President,,LBT,Gary Johnson,7
-Ellis,Hays W1P1,President,,IND,Jill Stein,12
-Ellis,Hays W1P2,President,,IND,Jill Stein,5
-Ellis,Hays W2P1,President,,IND,Jill Stein,11
-Ellis,Hays W2P2,President,,IND,Jill Stein,8
-Ellis,Hays W2P3,President,,IND,Jill Stein,4
-Ellis,Hays W2P4,President,,IND,Jill Stein,11
-Ellis,Hays W2P5,President,,IND,Jill Stein,5
-Ellis,Hays W3P1,President,,IND,Jill Stein,5
-Ellis,Hays W3P2,President,,IND,Jill Stein,12
-Ellis,Hays W3P3,President,,IND,Jill Stein,14
-Ellis,Hays W3P4,President,,IND,Jill Stein,19
-Ellis,Hays W4P1,President,,IND,Jill Stein,12
-Ellis,Hays W4P2,President,,IND,Jill Stein,17
-Ellis,Hays W4P3,President,,IND,Jill Stein,6
-Ellis,Hays W4P4,President,,IND,Jill Stein,16
-Ellis,Hays W4P5,President,,IND,Jill Stein,12
-Ellis,Ellis W1,President,,IND,Jill Stein,6
-Ellis,Ellis W2,President,,IND,Jill Stein,3
-Ellis,Ellis W3,President,,IND,Jill Stein,8
-Ellis,E Big Creek,President,,IND,Jill Stein,5
-Ellis,N Big Creek twp 110,President,,IND,Jill Stein,1
-Ellis,N Big Creek twp 111,President,,IND,Jill Stein,8
-Ellis,W Big Creek 111,President,,IND,Jill Stein,0
-Ellis,W Big Creek 110,President,,IND,Jill Stein,0
-Ellis,Buckeye twp,President,,IND,Jill Stein,5
-Ellis,Catherine twp,President,,IND,Jill Stein,1
-Ellis,Ellis twp,President,,IND,Jill Stein,6
-Ellis,Freedom twp,President,,IND,Jill Stein,2
-Ellis,Herzog twp 110,President,,IND,Jill Stein,0
-Ellis,Herzog twp 111,President,,IND,Jill Stein,3
-Ellis,N Lookout twp 110,President,,IND,Jill Stein,2
-Ellis,N Lookout twp 111,President,,IND,Jill Stein,1
-Ellis,S Lookout twp,President,,IND,Jill Stein,2
-Ellis,Victoria twp,President,,IND,Jill Stein,11
-Ellis,Wheatland twp,President,,IND,Jill Stein,4
-Ellis,Hays W1P1,President,,R,Donald Trump,96
-Ellis,Hays W1P2,President,,R,Donald Trump,128
-Ellis,Hays W2P1,President,,R,Donald Trump,298
-Ellis,Hays W2P2,President,,R,Donald Trump,192
-Ellis,Hays W2P3,President,,R,Donald Trump,163
-Ellis,Hays W2P4,President,,R,Donald Trump,210
-Ellis,Hays W2P5,President,,R,Donald Trump,175
-Ellis,Hays W3P1,President,,R,Donald Trump,254
-Ellis,Hays W3P2,President,,R,Donald Trump,393
-Ellis,Hays W3P3,President,,R,Donald Trump,498
-Ellis,Hays W3P4,President,,R,Donald Trump,904
-Ellis,Hays W4P1,President,,R,Donald Trump,322
-Ellis,Hays W4P2,President,,R,Donald Trump,358
-Ellis,Hays W4P3,President,,R,Donald Trump,339
-Ellis,Hays W4P4,President,,R,Donald Trump,627
-Ellis,Hays W4P5,President,,R,Donald Trump,513
-Ellis,Ellis W1,President,,R,Donald Trump,213
-Ellis,Ellis W2,President,,R,Donald Trump,318
-Ellis,Ellis W3,President,,R,Donald Trump,148
-Ellis,E Big Creek,President,,R,Donald Trump,343
-Ellis,N Big Creek twp 110,President,,R,Donald Trump,79
-Ellis,N Big Creek twp 111,President,,R,Donald Trump,215
-Ellis,W Big Creek 111,President,,R,Donald Trump,35
-Ellis,W Big Creek 110,President,,R,Donald Trump,32
-Ellis,Buckeye twp,President,,R,Donald Trump,179
-Ellis,Catherine twp,President,,R,Donald Trump,139
-Ellis,Ellis twp,President,,R,Donald Trump,187
-Ellis,Freedom twp,President,,R,Donald Trump,44
-Ellis,Herzog twp 110,President,,R,Donald Trump,119
-Ellis,Herzog twp 111,President,,R,Donald Trump,201
-Ellis,N Lookout twp 110,President,,R,Donald Trump,71
-Ellis,N Lookout twp 111,President,,R,Donald Trump,77
-Ellis,S Lookout twp,President,,R,Donald Trump,106
-Ellis,Victoria twp,President,,R,Donald Trump,328
-Ellis,Wheatland twp,President,,R,Donald Trump,161
-Ellis,Hays W1P1,President,,D,Hillary Clinton,106
-Ellis,Hays W1P2,President,,D,Hillary Clinton,61
-Ellis,Hays W2P1,President,,D,Hillary Clinton,135
-Ellis,Hays W2P2,President,,D,Hillary Clinton,154
-Ellis,Hays W2P3,President,,D,Hillary Clinton,88
-Ellis,Hays W2P4,President,,D,Hillary Clinton,111
-Ellis,Hays W2P5,President,,D,Hillary Clinton,86
-Ellis,Hays W3P1,President,,D,Hillary Clinton,97
-Ellis,Hays W3P2,President,,D,Hillary Clinton,160
-Ellis,Hays W3P3,President,,D,Hillary Clinton,136
-Ellis,Hays W3P4,President,,D,Hillary Clinton,311
-Ellis,Hays W4P1,President,,D,Hillary Clinton,119
-Ellis,Hays W4P2,President,,D,Hillary Clinton,140
-Ellis,Hays W4P3,President,,D,Hillary Clinton,101
-Ellis,Hays W4P4,President,,D,Hillary Clinton,198
-Ellis,Hays W4P5,President,,D,Hillary Clinton,142
-Ellis,Ellis W1,President,,D,Hillary Clinton,56
-Ellis,Ellis W2,President,,D,Hillary Clinton,91
-Ellis,Ellis W3,President,,D,Hillary Clinton,51
-Ellis,E Big Creek,President,,D,Hillary Clinton,60
-Ellis,N Big Creek twp 110,President,,D,Hillary Clinton,16
-Ellis,N Big Creek twp 111,President,,D,Hillary Clinton,50
-Ellis,W Big Creek 111,President,,D,Hillary Clinton,3
-Ellis,W Big Creek 110,President,,D,Hillary Clinton,7
-Ellis,Buckeye twp,President,,D,Hillary Clinton,26
-Ellis,Catherine twp,President,,D,Hillary Clinton,17
-Ellis,Ellis twp,President,,D,Hillary Clinton,35
-Ellis,Freedom twp,President,,D,Hillary Clinton,8
-Ellis,Herzog twp 110,President,,D,Hillary Clinton,9
-Ellis,Herzog twp 111,President,,D,Hillary Clinton,39
-Ellis,N Lookout twp 110,President,,D,Hillary Clinton,8
-Ellis,N Lookout twp 111,President,,D,Hillary Clinton,10
-Ellis,S Lookout twp,President,,D,Hillary Clinton,19
-Ellis,Victoria twp,President,,D,Hillary Clinton,65
-Ellis,Wheatland twp,President,,D,Hillary Clinton,26
-Ellis,Herzog H110,President,,,Darrell Castle,1
-Ellis,Hays W2P5,President,,,Darrell Castle,1
-Ellis,Hays W3P3,President,,,Darrell Castle,5
-Ellis,Hays W2P1,President,,,Evan McMullin,1
-Ellis,Hays W4P2,President,,,Evan McMullin,2
-Ellis,Victoria twp,President,,,Evan McMullin,1
-Ellis,Wheatland twp,President,,,Evan McMullin,1
-Ellis,Hays W1P1,President,,,Evan McMullin,1
-Ellis,Hays W2P2,President,,,Evan McMullin,1
-Ellis,Hays W2P3,President,,,Evan McMullin,1
-Ellis,Hays W2P4,President,,,Evan McMullin,2
-Ellis,Hays W3P1,President,,,Evan McMullin,3
-Ellis,Hays W3P4,President,,,Evan McMullin,1
-Ellis,Hays W4P4,President,,,Evan McMullin,3
-Ellis,N Lookout twp 111,President,,,Evan McMullin,1
-Ellis,Victoria twp,President,,,Evan McMullin,1
-Ellis,Wheatland twp,President,,,Evan McMullin,1
-Ellis,Hays W1P1,President,,,Write-ins,7
-Ellis,Hays W1P2,President,,,Write-ins,4
-Ellis,Hays W2P1,President,,,Write-ins,3
-Ellis,Hays W2P2,President,,,Write-ins,3
-Ellis,Hays W2P3,President,,,Write-ins,2
-Ellis,Hays W2P4,President,,,Write-ins,1
-Ellis,Hays W2P5,President,,,Write-ins,2
-Ellis,Hays W3P1,President,,,Write-ins,5
-Ellis,Hays W3P2,President,,,Write-ins,7
-Ellis,Hays W3P3,President,,,Write-ins,3
-Ellis,Hays W3P4,President,,,Write-ins,14
-Ellis,Hays W4P1,President,,,Write-ins,6
-Ellis,Hays W4P2,President,,,Write-ins,8
-Ellis,Hays W4P3,President,,,Write-ins,7
-Ellis,Hays W4P4,President,,,Write-ins,12
-Ellis,Hays W4P5,President,,,Write-ins,5
-Ellis,Ellis W1,President,,,Write-ins,4
-Ellis,Ellis W2,President,,,Write-ins,3
-Ellis,Ellis W3,President,,,Write-ins,1
-Ellis,E Big Creek,President,,,Write-ins,4
-Ellis,N Big Creek twp 110,President,,,Write-ins,4
-Ellis,N Big Creek twp 111,President,,,Write-ins,5
-Ellis,W Big Creek 111,President,,,Write-ins,0
-Ellis,W Big Creek 110,President,,,Write-ins,0
-Ellis,Buckeye twp,President,,,Write-ins,1
-Ellis,Catherine twp,President,,,Write-ins,0
-Ellis,Ellis twp,President,,,Write-ins,0
-Ellis,Freedom twp,President,,,Write-ins,0
-Ellis,Herzog twp 110,President,,,Write-ins,0
-Ellis,Herzog twp 111,President,,,Write-ins,2
-Ellis,N Lookout twp 110,President,,,Write-ins,0
-Ellis,N Lookout twp 111,President,,,Write-ins,2
-Ellis,S Lookout twp,President,,,Write-ins,2
-Ellis,Victoria twp,President,,,Write-ins,5
-Ellis,Wheatland twp,President,,,Write-ins,3
-Ellis,Hays W1P1,U.S. Senate,,LBT,Robert Garrard,22
-Ellis,Hays W1P2,U.S. Senate,,LBT,Robert Garrard,13
-Ellis,Hays W2P1,U.S. Senate,,LBT,Robert Garrard,19
-Ellis,Hays W2P2,U.S. Senate,,LBT,Robert Garrard,18
-Ellis,Hays W2P3,U.S. Senate,,LBT,Robert Garrard,15
-Ellis,Hays W2P4,U.S. Senate,,LBT,Robert Garrard,21
-Ellis,Hays W2P5,U.S. Senate,,LBT,Robert Garrard,14
-Ellis,Hays W3P1,U.S. Senate,,LBT,Robert Garrard,13
-Ellis,Hays W3P2,U.S. Senate,,LBT,Robert Garrard,10
-Ellis,Hays W3P3,U.S. Senate,,LBT,Robert Garrard,23
-Ellis,Hays W3P4,U.S. Senate,,LBT,Robert Garrard,45
-Ellis,Hays W4P1,U.S. Senate,,LBT,Robert Garrard,21
-Ellis,Hays W4P2,U.S. Senate,,LBT,Robert Garrard,31
-Ellis,Hays W4P3,U.S. Senate,,LBT,Robert Garrard,14
-Ellis,Hays W4P4,U.S. Senate,,LBT,Robert Garrard,25
-Ellis,Hays W4P5,U.S. Senate,,LBT,Robert Garrard,17
-Ellis,Ellis W1,U.S. Senate,,LBT,Robert Garrard,19
-Ellis,Ellis W2,U.S. Senate,,LBT,Robert Garrard,13
-Ellis,Ellis W3,U.S. Senate,,LBT,Robert Garrard,10
-Ellis,E Big Creek,U.S. Senate,,LBT,Robert Garrard,16
-Ellis,N Big Creek twp 110,U.S. Senate,,LBT,Robert Garrard,4
-Ellis,N Big Creek twp 111,U.S. Senate,,LBT,Robert Garrard,8
-Ellis,W Big Creek 111,U.S. Senate,,LBT,Robert Garrard,0
-Ellis,W Big Creek 110,U.S. Senate,,LBT,Robert Garrard,4
-Ellis,Buckeye twp,U.S. Senate,,LBT,Robert Garrard,6
-Ellis,Catherine twp,U.S. Senate,,LBT,Robert Garrard,12
-Ellis,Ellis twp,U.S. Senate,,LBT,Robert Garrard,5
-Ellis,Freedom twp,U.S. Senate,,LBT,Robert Garrard,1
-Ellis,Herzog twp 110,U.S. Senate,,LBT,Robert Garrard,4
-Ellis,Herzog twp 111,U.S. Senate,,LBT,Robert Garrard,10
-Ellis,N Lookout twp 110,U.S. Senate,,LBT,Robert Garrard,0
-Ellis,N Lookout twp 111,U.S. Senate,,LBT,Robert Garrard,2
-Ellis,S Lookout twp,U.S. Senate,,LBT,Robert Garrard,4
-Ellis,Victoria twp,U.S. Senate,,LBT,Robert Garrard,14
-Ellis,Wheatland twp,U.S. Senate,,LBT,Robert Garrard,5
-Ellis,Hays W1P1,U.S. Senate,,R,Jerry Moran,126
-Ellis,Hays W1P2,U.S. Senate,,R,Jerry Moran,136
-Ellis,Hays W2P1,U.S. Senate,,R,Jerry Moran,334
-Ellis,Hays W2P2,U.S. Senate,,R,Jerry Moran,243
-Ellis,Hays W2P3,U.S. Senate,,R,Jerry Moran,178
-Ellis,Hays W2P4,U.S. Senate,,R,Jerry Moran,242
-Ellis,Hays W2P5,U.S. Senate,,R,Jerry Moran,191
-Ellis,Hays W3P1,U.S. Senate,,R,Jerry Moran,311
-Ellis,Hays W3P2,U.S. Senate,,R,Jerry Moran,468
-Ellis,Hays W3P3,U.S. Senate,,R,Jerry Moran,555
-Ellis,Hays W3P4,U.S. Senate,,R,Jerry Moran,1038
-Ellis,Hays W4P1,U.S. Senate,,R,Jerry Moran,359
-Ellis,Hays W4P2,U.S. Senate,,R,Jerry Moran,410
-Ellis,Hays W4P3,U.S. Senate,,R,Jerry Moran,375
-Ellis,Hays W4P4,U.S. Senate,,R,Jerry Moran,704
-Ellis,Hays W4P5,U.S. Senate,,R,Jerry Moran,589
-Ellis,Ellis W1,U.S. Senate,,R,Jerry Moran,188
-Ellis,Ellis W2,U.S. Senate,,R,Jerry Moran,312
-Ellis,Ellis W3,U.S. Senate,,R,Jerry Moran,151
-Ellis,E Big Creek,U.S. Senate,,R,Jerry Moran,371
-Ellis,N Big Creek twp 110,U.S. Senate,,R,Jerry Moran,87
-Ellis,N Big Creek twp 111,U.S. Senate,,R,Jerry Moran,239
-Ellis,W Big Creek 111,U.S. Senate,,R,Jerry Moran,33
-Ellis,W Big Creek 110,U.S. Senate,,R,Jerry Moran,33
-Ellis,Buckeye twp,U.S. Senate,,R,Jerry Moran,190
-Ellis,Catherine twp,U.S. Senate,,R,Jerry Moran,127
-Ellis,Ellis twp,U.S. Senate,,R,Jerry Moran,179
-Ellis,Freedom twp,U.S. Senate,,R,Jerry Moran,45
-Ellis,Herzog twp 110,U.S. Senate,,R,Jerry Moran,118
-Ellis,Herzog twp 111,U.S. Senate,,R,Jerry Moran,207
-Ellis,N Lookout twp 110,U.S. Senate,,R,Jerry Moran,68
-Ellis,N Lookout twp 111,U.S. Senate,,R,Jerry Moran,83
-Ellis,S Lookout twp,U.S. Senate,,R,Jerry Moran,105
-Ellis,Victoria twp,U.S. Senate,,R,Jerry Moran,354
-Ellis,Wheatland twp,U.S. Senate,,R,Jerry Moran,170
-Ellis,Hays W1P1,U.S. Senate,,D,Patrick Wiesner,93
-Ellis,Hays W1P2,U.S. Senate,,D,Patrick Wiesner,64
-Ellis,Hays W2P1,U.S. Senate,,D,Patrick Wiesner,119
-Ellis,Hays W2P2,U.S. Senate,,D,Patrick Wiesner,115
-Ellis,Hays W2P3,U.S. Senate,,D,Patrick Wiesner,74
-Ellis,Hays W2P4,U.S. Senate,,D,Patrick Wiesner,84
-Ellis,Hays W2P5,U.S. Senate,,D,Patrick Wiesner,71
-Ellis,Hays W3P1,U.S. Senate,,D,Patrick Wiesner,63
-Ellis,Hays W3P2,U.S. Senate,,D,Patrick Wiesner,118
-Ellis,Hays W3P3,U.S. Senate,,D,Patrick Wiesner,90
-Ellis,Hays W3P4,U.S. Senate,,D,Patrick Wiesner,210
-Ellis,Hays W4P1,U.S. Senate,,D,Patrick Wiesner,98
-Ellis,Hays W4P2,U.S. Senate,,D,Patrick Wiesner,102
-Ellis,Hays W4P3,U.S. Senate,,D,Patrick Wiesner,74
-Ellis,Hays W4P4,U.S. Senate,,D,Patrick Wiesner,166
-Ellis,Hays W4P5,U.S. Senate,,D,Patrick Wiesner,86
-Ellis,Ellis W1,U.S. Senate,,D,Patrick Wiesner,74
-Ellis,Ellis W2,U.S. Senate,,D,Patrick Wiesner,93
-Ellis,Ellis W3,U.S. Senate,,D,Patrick Wiesner,56
-Ellis,E Big Creek,U.S. Senate,,D,Patrick Wiesner,39
-Ellis,N Big Creek twp 110,U.S. Senate,,D,Patrick Wiesner,11
-Ellis,N Big Creek twp 111,U.S. Senate,,D,Patrick Wiesner,36
-Ellis,W Big Creek 111,U.S. Senate,,D,Patrick Wiesner,3
-Ellis,W Big Creek 110,U.S. Senate,,D,Patrick Wiesner,4
-Ellis,Buckeye twp,U.S. Senate,,D,Patrick Wiesner,22
-Ellis,Catherine twp,U.S. Senate,,D,Patrick Wiesner,28
-Ellis,Ellis twp,U.S. Senate,,D,Patrick Wiesner,47
-Ellis,Freedom twp,U.S. Senate,,D,Patrick Wiesner,6
-Ellis,Herzog twp 110,U.S. Senate,,D,Patrick Wiesner,8
-Ellis,Herzog twp 111,U.S. Senate,,D,Patrick Wiesner,31
-Ellis,N Lookout twp 110,U.S. Senate,,D,Patrick Wiesner,12
-Ellis,N Lookout twp 111,U.S. Senate,,D,Patrick Wiesner,12
-Ellis,S Lookout twp,U.S. Senate,,D,Patrick Wiesner,19
-Ellis,Victoria twp,U.S. Senate,,D,Patrick Wiesner,57
-Ellis,Wheatland twp,U.S. Senate,,D,Patrick Wiesner,26
-Ellis,Hays W3P4,U.S. Senate,,,Write-ins,1
-Ellis,N Lookout twp 110,U.S. Senate,,,Tim Huelskamp,2
-Ellis,Hays W1P1,U.S. House,1,LBT,Kerry Burt,40
-Ellis,Hays W1P2,U.S. House,1,LBT,Kerry Burt,23
-Ellis,Hays W2P1,U.S. House,1,LBT,Kerry Burt,35
-Ellis,Hays W2P2,U.S. House,1,LBT,Kerry Burt,30
-Ellis,Hays W2P3,U.S. House,1,LBT,Kerry Burt,19
-Ellis,Hays W2P4,U.S. House,1,LBT,Kerry Burt,17
-Ellis,Hays W2P5,U.S. House,1,LBT,Kerry Burt,21
-Ellis,Hays W3P1,U.S. House,1,LBT,Kerry Burt,13
-Ellis,Hays W3P2,U.S. House,1,LBT,Kerry Burt,32
-Ellis,Hays W3P3,U.S. House,1,LBT,Kerry Burt,17
-Ellis,Hays W3P4,U.S. House,1,LBT,Kerry Burt,57
-Ellis,Hays W4P1,U.S. House,1,LBT,Kerry Burt,22
-Ellis,Hays W4P2,U.S. House,1,LBT,Kerry Burt,32
-Ellis,Hays W4P3,U.S. House,1,LBT,Kerry Burt,13
-Ellis,Hays W4P4,U.S. House,1,LBT,Kerry Burt,24
-Ellis,Hays W4P5,U.S. House,1,LBT,Kerry Burt,24
-Ellis,Ellis W1,U.S. House,1,LBT,Kerry Burt,13
-Ellis,Ellis W2,U.S. House,1,LBT,Kerry Burt,14
-Ellis,Ellis W3,U.S. House,1,LBT,Kerry Burt,17
-Ellis,E Big Creek,U.S. House,1,LBT,Kerry Burt,15
-Ellis,N Big Creek twp 110,U.S. House,1,LBT,Kerry Burt,2
-Ellis,N Big Creek twp 111,U.S. House,1,LBT,Kerry Burt,7
-Ellis,W Big Creek 111,U.S. House,1,LBT,Kerry Burt,2
-Ellis,W Big Creek 110,U.S. House,1,LBT,Kerry Burt,2
-Ellis,Buckeye twp,U.S. House,1,LBT,Kerry Burt,4
-Ellis,Catherine twp,U.S. House,1,LBT,Kerry Burt,9
-Ellis,Ellis twp,U.S. House,1,LBT,Kerry Burt,8
-Ellis,Freedom twp,U.S. House,1,LBT,Kerry Burt,0
-Ellis,Herzog twp 110,U.S. House,1,LBT,Kerry Burt,2
-Ellis,Herzog twp 111,U.S. House,1,LBT,Kerry Burt,10
-Ellis,N Lookout twp 110,U.S. House,1,LBT,Kerry Burt,0
-Ellis,N Lookout twp 111,U.S. House,1,LBT,Kerry Burt,5
-Ellis,S Lookout twp,U.S. House,1,LBT,Kerry Burt,6
-Ellis,Victoria twp,U.S. House,1,LBT,Kerry Burt,11
-Ellis,Wheatland twp,U.S. House,1,LBT,Kerry Burt,5
-Ellis,Hays W1P1,U.S. House,1,IND,Alan LaPolice,91
-Ellis,Hays W1P2,U.S. House,1,IND,Alan LaPolice,70
-Ellis,Hays W2P1,U.S. House,1,IND,Alan LaPolice,147
-Ellis,Hays W2P2,U.S. House,1,IND,Alan LaPolice,126
-Ellis,Hays W2P3,U.S. House,1,IND,Alan LaPolice,90
-Ellis,Hays W2P4,U.S. House,1,IND,Alan LaPolice,128
-Ellis,Hays W2P5,U.S. House,1,IND,Alan LaPolice,86
-Ellis,Hays W3P1,U.S. House,1,IND,Alan LaPolice,121
-Ellis,Hays W3P2,U.S. House,1,IND,Alan LaPolice,173
-Ellis,Hays W3P3,U.S. House,1,IND,Alan LaPolice,162
-Ellis,Hays W3P4,U.S. House,1,IND,Alan LaPolice,272
-Ellis,Hays W4P1,U.S. House,1,IND,Alan LaPolice,149
-Ellis,Hays W4P2,U.S. House,1,IND,Alan LaPolice,136
-Ellis,Hays W4P3,U.S. House,1,IND,Alan LaPolice,149
-Ellis,Hays W4P4,U.S. House,1,IND,Alan LaPolice,242
-Ellis,Hays W4P5,U.S. House,1,IND,Alan LaPolice,173
-Ellis,Ellis W1,U.S. House,1,IND,Alan LaPolice,65
-Ellis,Ellis W2,U.S. House,1,IND,Alan LaPolice,100
-Ellis,Ellis W3,U.S. House,1,IND,Alan LaPolice,52
-Ellis,E Big Creek,U.S. House,1,IND,Alan LaPolice,91
-Ellis,N Big Creek twp 110,U.S. House,1,IND,Alan LaPolice,16
-Ellis,N Big Creek twp 111,U.S. House,1,IND,Alan LaPolice,63
-Ellis,W Big Creek 111,U.S. House,1,IND,Alan LaPolice,5
-Ellis,W Big Creek 110,U.S. House,1,IND,Alan LaPolice,16
-Ellis,Buckeye twp,U.S. House,1,IND,Alan LaPolice,44
-Ellis,Catherine twp,U.S. House,1,IND,Alan LaPolice,40
-Ellis,Ellis twp,U.S. House,1,IND,Alan LaPolice,50
-Ellis,Freedom twp,U.S. House,1,IND,Alan LaPolice,8
-Ellis,Herzog twp 110,U.S. House,1,IND,Alan LaPolice,31
-Ellis,Herzog twp 111,U.S. House,1,IND,Alan LaPolice,59
-Ellis,N Lookout twp 110,U.S. House,1,IND,Alan LaPolice,28
-Ellis,N Lookout twp 111,U.S. House,1,IND,Alan LaPolice,22
-Ellis,S Lookout twp,U.S. House,1,IND,Alan LaPolice,27
-Ellis,Victoria twp,U.S. House,1,IND,Alan LaPolice,102
-Ellis,Wheatland twp,U.S. House,1,IND,Alan LaPolice,49
-Ellis,Hays W1P1,U.S. House,1,R,Roger Marshall,98
-Ellis,Hays W1P2,U.S. House,1,R,Roger Marshall,109
-Ellis,Hays W2P1,U.S. House,1,R,Roger Marshall,274
-Ellis,Hays W2P2,U.S. House,1,R,Roger Marshall,195
-Ellis,Hays W2P3,U.S. House,1,R,Roger Marshall,154
-Ellis,Hays W2P4,U.S. House,1,R,Roger Marshall,192
-Ellis,Hays W2P5,U.S. House,1,R,Roger Marshall,159
-Ellis,Hays W3P1,U.S. House,1,R,Roger Marshall,232
-Ellis,Hays W3P2,U.S. House,1,R,Roger Marshall,372
-Ellis,Hays W3P3,U.S. House,1,R,Roger Marshall,470
-Ellis,Hays W3P4,U.S. House,1,R,Roger Marshall,895
-Ellis,Hays W4P1,U.S. House,1,R,Roger Marshall,294
-Ellis,Hays W4P2,U.S. House,1,R,Roger Marshall,361
-Ellis,Hays W4P3,U.S. House,1,R,Roger Marshall,287
-Ellis,Hays W4P4,U.S. House,1,R,Roger Marshall,594
-Ellis,Hays W4P5,U.S. House,1,R,Roger Marshall,465
-Ellis,Ellis W1,U.S. House,1,R,Roger Marshall,194
-Ellis,Ellis W2,U.S. House,1,R,Roger Marshall,291
-Ellis,Ellis W3,U.S. House,1,R,Roger Marshall,138
-Ellis,E Big Creek,U.S. House,1,R,Roger Marshall,310
-Ellis,N Big Creek twp 110,U.S. House,1,R,Roger Marshall,83
-Ellis,N Big Creek twp 111,U.S. House,1,R,Roger Marshall,205
-Ellis,W Big Creek 111,U.S. House,1,R,Roger Marshall,30
-Ellis,W Big Creek 110,U.S. House,1,R,Roger Marshall,22
-Ellis,Buckeye twp,U.S. House,1,R,Roger Marshall,162
-Ellis,Catherine twp,U.S. House,1,R,Roger Marshall,110
-Ellis,Ellis twp,U.S. House,1,R,Roger Marshall,171
-Ellis,Freedom twp,U.S. House,1,R,Roger Marshall,40
-Ellis,Herzog twp 110,U.S. House,1,R,Roger Marshall,94
-Ellis,Herzog twp 111,U.S. House,1,R,Roger Marshall,175
-Ellis,N Lookout twp 110,U.S. House,1,R,Roger Marshall,50
-Ellis,N Lookout twp 111,U.S. House,1,R,Roger Marshall,66
-Ellis,S Lookout twp,U.S. House,1,R,Roger Marshall,94
-Ellis,Victoria twp,U.S. House,1,R,Roger Marshall,294
-Ellis,Wheatland twp,U.S. House,1,R,Roger Marshall,139
-Ellis,Hays W1P1,U.S. House,1,,Write-ins,1
-Ellis,Hays W1P2,U.S. House,1,,Write-ins,0
-Ellis,Hays W2P1,U.S. House,1,,Write-ins,0
-Ellis,Hays W2P2,U.S. House,1,,Write-ins,2
-Ellis,Hays W2P3,U.S. House,1,,Write-ins,0
-Ellis,Hays W2P4,U.S. House,1,,Write-ins,2
-Ellis,Hays W2P5,U.S. House,1,,Write-ins,0
-Ellis,Hays W3P1,U.S. House,1,,Write-ins,0
-Ellis,Hays W3P2,U.S. House,1,,Write-ins,3
-Ellis,Hays W3P3,U.S. House,1,,Write-ins,2
-Ellis,Hays W3P4,U.S. House,1,,Write-ins,4
-Ellis,Hays W4P1,U.S. House,1,,Write-ins,0
-Ellis,Hays W4P2,U.S. House,1,,Write-ins,0
-Ellis,Hays W4P3,U.S. House,1,,Write-ins,0
-Ellis,Hays W4P4,U.S. House,1,,Write-ins,3
-Ellis,Hays W4P5,U.S. House,1,,Write-ins,1
-Ellis,Ellis W1,U.S. House,1,,Write-ins,3
-Ellis,Ellis W2,U.S. House,1,,Write-ins,1
-Ellis,Ellis W3,U.S. House,1,,Write-ins,0
-Ellis,Herzog twp 111,U.S. House,1,,Write-ins,1
-Ellis,N Lookout twp 110,U.S. House,1,,Write-ins,2
-Ellis,Hays W1P1,State Senate,40,R,Rick Billinger,82
-Ellis,Hays W1P2,State Senate,40,R,Rick Billinger,86
-Ellis,Hays W2P1,State Senate,40,R,Rick Billinger,238
-Ellis,Hays W2P2,State Senate,40,R,Rick Billinger,166
-Ellis,Hays W2P3,State Senate,40,R,Rick Billinger,132
-Ellis,Hays W2P4,State Senate,40,R,Rick Billinger,160
-Ellis,Hays W2P5,State Senate,40,R,Rick Billinger,129
-Ellis,Hays W3P1,State Senate,40,R,Rick Billinger,205
-Ellis,Hays W3P2,State Senate,40,R,Rick Billinger,320
-Ellis,Hays W3P3,State Senate,40,R,Rick Billinger,384
-Ellis,Hays W3P4,State Senate,40,R,Rick Billinger,753
-Ellis,Hays W4P1,State Senate,40,R,Rick Billinger,255
-Ellis,Hays W4P2,State Senate,40,R,Rick Billinger,275
-Ellis,Hays W4P3,State Senate,40,R,Rick Billinger,266
-Ellis,Hays W4P4,State Senate,40,R,Rick Billinger,470
-Ellis,Hays W4P5,State Senate,40,R,Rick Billinger,410
-Ellis,Ellis W1,State Senate,40,R,Rick Billinger,168
-Ellis,Ellis W2,State Senate,40,R,Rick Billinger,236
-Ellis,Ellis W3,State Senate,40,R,Rick Billinger,102
-Ellis,E Big Creek,State Senate,40,R,Rick Billinger,279
-Ellis,N Big Creek twp 110,State Senate,40,R,Rick Billinger,69
-Ellis,N Big Creek twp 111,State Senate,40,R,Rick Billinger,177
-Ellis,W Big Creek 111,State Senate,40,R,Rick Billinger,28
-Ellis,W Big Creek 110,State Senate,40,R,Rick Billinger,25
-Ellis,Buckeye twp,State Senate,40,R,Rick Billinger,145
-Ellis,Catherine twp,State Senate,40,R,Rick Billinger,96
-Ellis,Ellis twp,State Senate,40,R,Rick Billinger,145
-Ellis,Freedom twp,State Senate,40,R,Rick Billinger,34
-Ellis,Herzog twp 110,State Senate,40,R,Rick Billinger,91
-Ellis,Herzog twp 111,State Senate,40,R,Rick Billinger,144
-Ellis,N Lookout twp 110,State Senate,40,R,Rick Billinger,54
-Ellis,N Lookout twp 111,State Senate,40,R,Rick Billinger,52
-Ellis,S Lookout twp,State Senate,40,R,Rick Billinger,82
-Ellis,Victoria twp,State Senate,40,R,Rick Billinger,266
-Ellis,Wheatland twp,State Senate,40,R,Rick Billinger,122
-Ellis,Hays W1P1,State Senate,40,D,Alex Herman,152
-Ellis,Hays W1P2,State Senate,40,D,Alex Herman,118
-Ellis,Hays W2P1,State Senate,40,D,Alex Herman,222
-Ellis,Hays W2P2,State Senate,40,D,Alex Herman,204
-Ellis,Hays W2P3,State Senate,40,D,Alex Herman,134
-Ellis,Hays W2P4,State Senate,40,D,Alex Herman,184
-Ellis,Hays W2P5,State Senate,40,D,Alex Herman,145
-Ellis,Hays W3P1,State Senate,40,D,Alex Herman,173
-Ellis,Hays W3P2,State Senate,40,D,Alex Herman,268
-Ellis,Hays W3P3,State Senate,40,D,Alex Herman,270
-Ellis,Hays W3P4,State Senate,40,D,Alex Herman,497
-Ellis,Hays W4P1,State Senate,40,D,Alex Herman,216
-Ellis,Hays W4P2,State Senate,40,D,Alex Herman,261
-Ellis,Hays W4P3,State Senate,40,D,Alex Herman,186
-Ellis,Hays W4P4,State Senate,40,D,Alex Herman,403
-Ellis,Hays W4P5,State Senate,40,D,Alex Herman,267
-Ellis,Ellis W1,State Senate,40,D,Alex Herman,108
-Ellis,Ellis W2,State Senate,40,D,Alex Herman,170
-Ellis,Ellis W3,State Senate,40,D,Alex Herman,107
-Ellis,E Big Creek,State Senate,40,D,Alex Herman,132
-Ellis,N Big Creek twp 110,State Senate,40,D,Alex Herman,30
-Ellis,N Big Creek twp 111,State Senate,40,D,Alex Herman,97
-Ellis,W Big Creek 111,State Senate,40,D,Alex Herman,9
-Ellis,W Big Creek 110,State Senate,40,D,Alex Herman,14
-Ellis,Buckeye twp,State Senate,40,D,Alex Herman,65
-Ellis,Catherine twp,State Senate,40,D,Alex Herman,59
-Ellis,Ellis twp,State Senate,40,D,Alex Herman,80
-Ellis,Freedom twp,State Senate,40,D,Alex Herman,17
-Ellis,Herzog twp 110,State Senate,40,D,Alex Herman,37
-Ellis,Herzog twp 111,State Senate,40,D,Alex Herman,105
-Ellis,N Lookout twp 110,State Senate,40,D,Alex Herman,27
-Ellis,N Lookout twp 111,State Senate,40,D,Alex Herman,43
-Ellis,S Lookout twp,State Senate,40,D,Alex Herman,50
-Ellis,Victoria twp,State Senate,40,D,Alex Herman,153
-Ellis,Wheatland twp,State Senate,40,D,Alex Herman,80
-Ellis,Hays W3P4,State Senate,40,,Write-ins,2
-Ellis,Ellis W1,State Senate,40,,Write-ins,1
-Ellis,Hays W1P1,State House,111,R,Sue Ellen Boldra,86
-Ellis,Hays W1P2,State House,111,R,Sue Ellen Boldra,92
-Ellis,Hays W2P1,State House,111,R,Sue Ellen Boldra,202
-Ellis,Hays W2P2,State House,111,R,Sue Ellen Boldra,144
-Ellis,Hays W2P3,State House,111,R,Sue Ellen Boldra,114
-Ellis,Hays W2P4,State House,111,R,Sue Ellen Boldra,135
-Ellis,Hays W2P5,State House,111,R,Sue Ellen Boldra,108
-Ellis,Hays W3P1,State House,111,R,Sue Ellen Boldra,173
-Ellis,Hays W3P2,State House,111,R,Sue Ellen Boldra,266
-Ellis,Hays W3P3,State House,111,R,Sue Ellen Boldra,302
-Ellis,Hays W3P4,State House,111,R,Sue Ellen Boldra,646
-Ellis,Hays W4P1,State House,111,R,Sue Ellen Boldra,233
-Ellis,Hays W4P2,State House,111,R,Sue Ellen Boldra,220
-Ellis,Hays W4P3,State House,111,R,Sue Ellen Boldra,205
-Ellis,Hays W4P4,State House,111,R,Sue Ellen Boldra,393
-Ellis,Hays W4P5,State House,111,R,Sue Ellen Boldra,319
-Ellis,Ellis W1,State House,110,R,Ken Rahjes,237
-Ellis,Ellis W2,State House,110,R,Ken Rahjes,352
-Ellis,Ellis W3,State House,110,R,Ken Rahjes,176
-Ellis,E Big Creek,State House,111,R,Sue Ellen Boldra,250
-Ellis,N Big Creek twp 110,State House,110,R,Ken Rahjes,89
-Ellis,N Big Creek twp 111,State House,111,R,Sue Ellen Boldra,148
-Ellis,W Big Creek 111,State House,111,R,Sue Ellen Boldra,23
-Ellis,W Big Creek 110,State House,110,R,Ken Rahjes,33
-Ellis,Buckeye twp,State House,110,R,Ken Rahjes,180
-Ellis,Catherine twp,State House,110,R,Ken Rahjes,107
-Ellis,Ellis twp,State House,110,R,Ken Rahjes,194
-Ellis,Freedom twp,State House,111,R,Sue Ellen Boldra,32
-Ellis,Herzog twp 110,State House,110,R,Ken Rahjes,114
-Ellis,Herzog twp 111,State House,111,R,Sue Ellen Boldra,117
-Ellis,N Lookout twp 110,State House,110,R,Ken Rahjes,76
-Ellis,N Lookout twp 111,State House,111,R,Sue Ellen Boldra,52
-Ellis,S Lookout twp,State House,110,R,Ken Rahjes,96
-Ellis,Victoria twp,State House,111,R,Sue Ellen Boldra,222
-Ellis,Wheatland twp,State House,111,R,Sue Ellen Boldra,116
-Ellis,Hays W1P1,State House,111,D,Eber Phelps,149
-Ellis,Hays W1P2,State House,111,D,Eber Phelps,114
-Ellis,Hays W2P1,State House,111,D,Eber Phelps,266
-Ellis,Hays W2P2,State House,111,D,Eber Phelps,224
-Ellis,Hays W2P3,State House,111,D,Eber Phelps,155
-Ellis,Hays W2P4,State House,111,D,Eber Phelps,204
-Ellis,Hays W2P5,State House,111,D,Eber Phelps,166
-Ellis,Hays W3P1,State House,111,D,Eber Phelps,210
-Ellis,Hays W3P2,State House,111,D,Eber Phelps,328
-Ellis,Hays W3P3,State House,111,D,Eber Phelps,365
-Ellis,Hays W3P4,State House,111,D,Eber Phelps,631
-Ellis,Hays W4P1,State House,111,D,Eber Phelps,241
-Ellis,Hays W4P2,State House,111,D,Eber Phelps,328
-Ellis,Hays W4P3,State House,111,D,Eber Phelps,257
-Ellis,Hays W4P4,State House,111,D,Eber Phelps,500
-Ellis,Hays W4P5,State House,111,D,Eber Phelps,369
-Ellis,E Big Creek,State House,111,D,Eber Phelps,168
-Ellis,N Big Creek twp 111,State House,111,D,Eber Phelps,132
-Ellis,W Big Creek 111,State House,111,D,Eber Phelps,14
-Ellis,Freedom twp,State House,111,D,Eber Phelps,21
-Ellis,Herzog twp 111,State House,111,D,Eber Phelps,128
-Ellis,N Lookout twp 111,State House,111,D,Eber Phelps,45
-Ellis,Victoria twp,State House,111,D,Eber Phelps,206
-Ellis,Wheatland twp,State House,111,D,Eber Phelps,87
-Ellis,Victoria twp,State House,111,,Write-ins,1
-Ellis,Hays W3P2,State House,111,,Write-ins,2
-Ellis,Hays W3P3,State House,111,,Write-ins,2
-Ellis,Hays W3P4,State House,111,,Write-ins,1
-Ellis,Hays W4P1,State House,111,,Write-ins,1
-Ellis,Hays W4P2,State House,111,,Write-ins,1
-Ellis,Hays W4P3,State House,111,,Write-ins,2
-Ellis,Hays W4P5,State House,111,,Write-ins,1
-Ellis,Ellis W1,State House,110,,Write-ins,3
-Ellis,Ellis W2,State House,110,,Write-ins,4
-Ellis,Ellis W3,State House,110,,Write-ins,3
-Ellis,N Big Creek twp 110,State House,110,,Write-ins,1
-Ellis,Catherine twp,State House,110,,Write-ins,1
-Ellis,Victoria twp,State House,110,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+ELLIS,Buckeye Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",180,000010
+ELLIS,Catherine Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",107,000020
+ELLIS,East Big Creek Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber",168,000030
+ELLIS,East Big Creek Township,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",250,000030
+ELLIS,Ellis Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",194,000040
+ELLIS,Ellis Ward 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",237,000050
+ELLIS,Ellis Ward 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",352,000060
+ELLIS,Ellis Ward 3,Kansas House of Representatives,110,Republican,"Rahjes, Ken",176,000070
+ELLIS,Freedom Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber",21,000080
+ELLIS,Freedom Township,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",32,000080
+ELLIS,Hays Ward 1 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",149,000090
+ELLIS,Hays Ward 1 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",86,000090
+ELLIS,Hays Ward 1 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",114,00010A
+ELLIS,Hays Ward 1 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",92,00010A
+ELLIS,Hays Ward 2 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",266,000110
+ELLIS,Hays Ward 2 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",202,000110
+ELLIS,Hays Ward 2 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",224,000120
+ELLIS,Hays Ward 2 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",144,000120
+ELLIS,Hays Ward 2 Precinct 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber",155,000130
+ELLIS,Hays Ward 2 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",114,000130
+ELLIS,Hays Ward 2 Precinct 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber",204,000140
+ELLIS,Hays Ward 2 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",135,000140
+ELLIS,Hays Ward 2 Precinct 5,Kansas House of Representatives,111,Democratic,"Phelps, Eber",166,000150
+ELLIS,Hays Ward 2 Precinct 5,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",108,000150
+ELLIS,Hays Ward 3 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",210,00016A
+ELLIS,Hays Ward 3 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",173,00016A
+ELLIS,Hays Ward 3 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",328,000170
+ELLIS,Hays Ward 3 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",266,000170
+ELLIS,Hays Ward 3 Precinct 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber",365,000180
+ELLIS,Hays Ward 3 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",302,000180
+ELLIS,Hays Ward 3 Precinct 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber",631,00019A
+ELLIS,Hays Ward 3 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",646,00019A
+ELLIS,Hays Ward 4 Precinct 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",241,000200
+ELLIS,Hays Ward 4 Precinct 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",233,000200
+ELLIS,Hays Ward 4 Precinct 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",328,00021A
+ELLIS,Hays Ward 4 Precinct 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",220,00021A
+ELLIS,Hays Ward 4 Precinct 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber",257,000220
+ELLIS,Hays Ward 4 Precinct 3,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",205,000220
+ELLIS,Hays Ward 4 Precinct 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber",500,000230
+ELLIS,Hays Ward 4 Precinct 4,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",393,000230
+ELLIS,Hays Ward 4 Precinct 5,Kansas House of Representatives,111,Democratic,"Phelps, Eber",369,000240
+ELLIS,Hays Ward 4 Precinct 5,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",319,000240
+ELLIS,South Lookout Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",96,000280
+ELLIS,Victoria Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber",206,000290
+ELLIS,Victoria Township,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",222,000290
+ELLIS,Wheatland Township,Kansas House of Representatives,111,Democratic,"Phelps, Eber",87,000310
+ELLIS,Wheatland Township,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",116,000310
+ELLIS,Herzog Township H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",114,120020
+ELLIS,Herzog Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber",128,120030
+ELLIS,Herzog Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",117,120030
+ELLIS,North Big Creek Township H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",89,120040
+ELLIS,North Big Creek Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber",132,120050
+ELLIS,North Big Creek Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",148,120050
+ELLIS,North Lookout Township H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",76,120060
+ELLIS,North Lookout Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber",45,120070
+ELLIS,North Lookout Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",52,120070
+ELLIS,West Big Creek Township H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",33,120080
+ELLIS,West Big Creek Township H111,Kansas House of Representatives,111,Democratic,"Phelps, Eber",14,120090
+ELLIS,West Big Creek Township H111,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",23,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900040
+ELLIS,North Big Creek Township Enclave 1,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900050
+ELLIS,North Big Creek Township Enclave 1,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900050
+ELLIS,North Big Creek Township Enclave 2,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900060
+ELLIS,North Big Creek Township Enclave 2,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900060
+ELLIS,North Big Creek Township Enclave 3,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900070
+ELLIS,North Big Creek Township Enclave 3,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900070
+ELLIS,North Big Creek Township Enclave 4,Kansas House of Representatives,111,Democratic,"Phelps, Eber",0,900080
+ELLIS,North Big Creek Township Enclave 4,Kansas House of Representatives,111,Republican,"Boldra, Sue Ellen",0,900080
+ELLIS,Buckeye Township,Kansas Senate,40,Democratic,"Herman, Alex",65,000010
+ELLIS,Buckeye Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",145,000010
+ELLIS,Catherine Township,Kansas Senate,40,Democratic,"Herman, Alex",59,000020
+ELLIS,Catherine Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",96,000020
+ELLIS,East Big Creek Township,Kansas Senate,40,Democratic,"Herman, Alex",132,000030
+ELLIS,East Big Creek Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",279,000030
+ELLIS,Ellis Township,Kansas Senate,40,Democratic,"Herman, Alex",80,000040
+ELLIS,Ellis Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",145,000040
+ELLIS,Ellis Ward 1,Kansas Senate,40,Democratic,"Herman, Alex",108,000050
+ELLIS,Ellis Ward 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",168,000050
+ELLIS,Ellis Ward 2,Kansas Senate,40,Democratic,"Herman, Alex",170,000060
+ELLIS,Ellis Ward 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",236,000060
+ELLIS,Ellis Ward 3,Kansas Senate,40,Democratic,"Herman, Alex",107,000070
+ELLIS,Ellis Ward 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",102,000070
+ELLIS,Freedom Township,Kansas Senate,40,Democratic,"Herman, Alex",17,000080
+ELLIS,Freedom Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",34,000080
+ELLIS,Hays Ward 1 Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",152,000090
+ELLIS,Hays Ward 1 Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",82,000090
+ELLIS,Hays Ward 1 Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",118,00010A
+ELLIS,Hays Ward 1 Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",86,00010A
+ELLIS,Hays Ward 2 Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",222,000110
+ELLIS,Hays Ward 2 Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",238,000110
+ELLIS,Hays Ward 2 Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",204,000120
+ELLIS,Hays Ward 2 Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",166,000120
+ELLIS,Hays Ward 2 Precinct 3,Kansas Senate,40,Democratic,"Herman, Alex",134,000130
+ELLIS,Hays Ward 2 Precinct 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",132,000130
+ELLIS,Hays Ward 2 Precinct 4,Kansas Senate,40,Democratic,"Herman, Alex",184,000140
+ELLIS,Hays Ward 2 Precinct 4,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",160,000140
+ELLIS,Hays Ward 2 Precinct 5,Kansas Senate,40,Democratic,"Herman, Alex",145,000150
+ELLIS,Hays Ward 2 Precinct 5,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",129,000150
+ELLIS,Hays Ward 3 Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",173,00016A
+ELLIS,Hays Ward 3 Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",205,00016A
+ELLIS,Hays Ward 3 Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",268,000170
+ELLIS,Hays Ward 3 Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",320,000170
+ELLIS,Hays Ward 3 Precinct 3,Kansas Senate,40,Democratic,"Herman, Alex",270,000180
+ELLIS,Hays Ward 3 Precinct 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",384,000180
+ELLIS,Hays Ward 3 Precinct 4,Kansas Senate,40,Democratic,"Herman, Alex",497,00019A
+ELLIS,Hays Ward 3 Precinct 4,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",753,00019A
+ELLIS,Hays Ward 4 Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",216,000200
+ELLIS,Hays Ward 4 Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",255,000200
+ELLIS,Hays Ward 4 Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",261,00021A
+ELLIS,Hays Ward 4 Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",275,00021A
+ELLIS,Hays Ward 4 Precinct 3,Kansas Senate,40,Democratic,"Herman, Alex",186,000220
+ELLIS,Hays Ward 4 Precinct 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",266,000220
+ELLIS,Hays Ward 4 Precinct 4,Kansas Senate,40,Democratic,"Herman, Alex",403,000230
+ELLIS,Hays Ward 4 Precinct 4,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",470,000230
+ELLIS,Hays Ward 4 Precinct 5,Kansas Senate,40,Democratic,"Herman, Alex",267,000240
+ELLIS,Hays Ward 4 Precinct 5,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",410,000240
+ELLIS,South Lookout Township,Kansas Senate,40,Democratic,"Herman, Alex",50,000280
+ELLIS,South Lookout Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",82,000280
+ELLIS,Victoria Township,Kansas Senate,40,Democratic,"Herman, Alex",153,000290
+ELLIS,Victoria Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",266,000290
+ELLIS,Wheatland Township,Kansas Senate,40,Democratic,"Herman, Alex",80,000310
+ELLIS,Wheatland Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",122,000310
+ELLIS,Herzog Township H110,Kansas Senate,40,Democratic,"Herman, Alex",37,120020
+ELLIS,Herzog Township H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",91,120020
+ELLIS,Herzog Township H111,Kansas Senate,40,Democratic,"Herman, Alex",105,120030
+ELLIS,Herzog Township H111,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",144,120030
+ELLIS,North Big Creek Township H110,Kansas Senate,40,Democratic,"Herman, Alex",30,120040
+ELLIS,North Big Creek Township H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",69,120040
+ELLIS,North Big Creek Township H111,Kansas Senate,40,Democratic,"Herman, Alex",97,120050
+ELLIS,North Big Creek Township H111,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",177,120050
+ELLIS,North Lookout Township H110,Kansas Senate,40,Democratic,"Herman, Alex",27,120060
+ELLIS,North Lookout Township H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",54,120060
+ELLIS,North Lookout Township H111,Kansas Senate,40,Democratic,"Herman, Alex",43,120070
+ELLIS,North Lookout Township H111,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",52,120070
+ELLIS,West Big Creek Township H110,Kansas Senate,40,Democratic,"Herman, Alex",14,120080
+ELLIS,West Big Creek Township H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",25,120080
+ELLIS,West Big Creek Township H111,Kansas Senate,40,Democratic,"Herman, Alex",9,120090
+ELLIS,West Big Creek Township H111,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",28,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas Senate,40,Democratic,"Herman, Alex",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas Senate,40,Democratic,"Herman, Alex",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas Senate,40,Democratic,"Herman, Alex",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas Senate,40,Democratic,"Herman, Alex",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900040
+ELLIS,North Big Creek Township Enclave 1,Kansas Senate,40,Democratic,"Herman, Alex",0,900050
+ELLIS,North Big Creek Township Enclave 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900050
+ELLIS,North Big Creek Township Enclave 2,Kansas Senate,40,Democratic,"Herman, Alex",0,900060
+ELLIS,North Big Creek Township Enclave 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900060
+ELLIS,North Big Creek Township Enclave 3,Kansas Senate,40,Democratic,"Herman, Alex",0,900070
+ELLIS,North Big Creek Township Enclave 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900070
+ELLIS,North Big Creek Township Enclave 4,Kansas Senate,40,Democratic,"Herman, Alex",0,900080
+ELLIS,North Big Creek Township Enclave 4,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900080
+ELLIS,Buckeye Township,President / Vice President,,independent,"Stein, Jill",5,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+ELLIS,Buckeye Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+ELLIS,Buckeye Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000010
+ELLIS,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+ELLIS,Buckeye Township,President / Vice President,,Republican,"Trump, Donald J.",179,000010
+ELLIS,Catherine Township,President / Vice President,,independent,"Stein, Jill",1,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+ELLIS,Catherine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+ELLIS,Catherine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000020
+ELLIS,Catherine Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000020
+ELLIS,Catherine Township,President / Vice President,,Republican,"Trump, Donald J.",139,000020
+ELLIS,East Big Creek Township,President / Vice President,,independent,"Stein, Jill",5,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ELLIS,East Big Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000030
+ELLIS,East Big Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000030
+ELLIS,East Big Creek Township,President / Vice President,,Republican,"Trump, Donald J.",343,000030
+ELLIS,Ellis Township,President / Vice President,,independent,"Stein, Jill",6,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ELLIS,Ellis Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ELLIS,Ellis Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000040
+ELLIS,Ellis Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+ELLIS,Ellis Township,President / Vice President,,Republican,"Trump, Donald J.",187,000040
+ELLIS,Ellis Ward 1,President / Vice President,,independent,"Stein, Jill",6,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+ELLIS,Ellis Ward 1,President / Vice President,,Republican,"Trump, Donald J.",213,000050
+ELLIS,Ellis Ward 2,President / Vice President,,independent,"Stein, Jill",3,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",91,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+ELLIS,Ellis Ward 2,President / Vice President,,Republican,"Trump, Donald J.",318,000060
+ELLIS,Ellis Ward 3,President / Vice President,,independent,"Stein, Jill",8,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000070
+ELLIS,Ellis Ward 3,President / Vice President,,Republican,"Trump, Donald J.",148,000070
+ELLIS,Freedom Township,President / Vice President,,independent,"Stein, Jill",2,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+ELLIS,Freedom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+ELLIS,Freedom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000080
+ELLIS,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+ELLIS,Freedom Township,President / Vice President,,Republican,"Trump, Donald J.",44,000080
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",12,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",27,000090
+ELLIS,Hays Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",97,000090
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",5,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",16,00010A
+ELLIS,Hays Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",128,00010A
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",11,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",135,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",23,000110
+ELLIS,Hays Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",298,000110
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",154,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",19,000120
+ELLIS,Hays Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",192,000120
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",4,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",1,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+ELLIS,Hays Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",163,000130
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,independent,"Stein, Jill",11,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",2,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",111,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",14,000140
+ELLIS,Hays Ward 2 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",210,000140
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,independent,"Stein, Jill",5,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",11,000150
+ELLIS,Hays Ward 2 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",175,000150
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",3,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",21,00016A
+ELLIS,Hays Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",254,00016A
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",12,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",160,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",21,000170
+ELLIS,Hays Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",393,000170
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,independent,"Stein, Jill",14,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",5,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",136,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",18,000180
+ELLIS,Hays Ward 3 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",498,000180
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,independent,"Stein, Jill",19,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",1,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",2,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",311,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",33,00019A
+ELLIS,Hays Ward 3 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",904,00019A
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",12,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",119,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",18,000200
+ELLIS,Hays Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",322,000200
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",17,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",140,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",25,00021A
+ELLIS,Hays Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",358,00021A
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",6,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",1,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",102,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",16,000220
+ELLIS,Hays Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",339,000220
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,independent,"Stein, Jill",16,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",3,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",198,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",37,000230
+ELLIS,Hays Ward 4 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",627,000230
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,independent,"Stein, Jill",12,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",142,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",29,000240
+ELLIS,Hays Ward 4 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",513,000240
+ELLIS,South Lookout Township,President / Vice President,,independent,"Stein, Jill",2,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+ELLIS,South Lookout Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+ELLIS,South Lookout Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000280
+ELLIS,South Lookout Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000280
+ELLIS,South Lookout Township,President / Vice President,,Republican,"Trump, Donald J.",106,000280
+ELLIS,Victoria Township,President / Vice President,,independent,"Stein, Jill",11,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"McMullin, Evan",5,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+ELLIS,Victoria Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+ELLIS,Victoria Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000290
+ELLIS,Victoria Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000290
+ELLIS,Victoria Township,President / Vice President,,Republican,"Trump, Donald J.",328,000290
+ELLIS,Wheatland Township,President / Vice President,,independent,"Stein, Jill",4,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"McMullin, Evan",2,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+ELLIS,Wheatland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+ELLIS,Wheatland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000310
+ELLIS,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000310
+ELLIS,Wheatland Township,President / Vice President,,Republican,"Trump, Donald J.",161,000310
+ELLIS,Herzog Township H110,President / Vice President,,independent,"Stein, Jill",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Castle, Darrell L",1,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Hedges, James A",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"McMullin, Evan",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Perry, Darryl",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Smith, Mike",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Sood, Ajay",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+ELLIS,Herzog Township H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,120020
+ELLIS,Herzog Township H110,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+ELLIS,Herzog Township H110,President / Vice President,,Republican,"Trump, Donald J.",119,120020
+ELLIS,Herzog Township H111,President / Vice President,,independent,"Stein, Jill",3,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Hedges, James A",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"McMullin, Evan",2,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Perry, Darryl",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Smith, Mike",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Sood, Ajay",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+ELLIS,Herzog Township H111,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,120030
+ELLIS,Herzog Township H111,President / Vice President,,Libertarian,"Johnson, Gary",10,120030
+ELLIS,Herzog Township H111,President / Vice President,,Republican,"Trump, Donald J.",201,120030
+ELLIS,North Big Creek Township H110,President / Vice President,,independent,"Stein, Jill",1,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Hedges, James A",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"McMullin, Evan",1,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Perry, Darryl",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Smith, Mike",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Sood, Ajay",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Libertarian,"Johnson, Gary",3,120040
+ELLIS,North Big Creek Township H110,President / Vice President,,Republican,"Trump, Donald J.",79,120040
+ELLIS,North Big Creek Township H111,President / Vice President,,independent,"Stein, Jill",8,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Hedges, James A",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"McMullin, Evan",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Perry, Darryl",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Smith, Mike",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Sood, Ajay",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Libertarian,"Johnson, Gary",6,120050
+ELLIS,North Big Creek Township H111,President / Vice President,,Republican,"Trump, Donald J.",215,120050
+ELLIS,North Lookout Township H110,President / Vice President,,independent,"Stein, Jill",2,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Hedges, James A",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"McMullin, Evan",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Perry, Darryl",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Smith, Mike",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Sood, Ajay",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Libertarian,"Johnson, Gary",1,120060
+ELLIS,North Lookout Township H110,President / Vice President,,Republican,"Trump, Donald J.",71,120060
+ELLIS,North Lookout Township H111,President / Vice President,,independent,"Stein, Jill",1,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Hedges, James A",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"McMullin, Evan",1,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Perry, Darryl",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Smith, Mike",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Sood, Ajay",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Libertarian,"Johnson, Gary",6,120070
+ELLIS,North Lookout Township H111,President / Vice President,,Republican,"Trump, Donald J.",77,120070
+ELLIS,West Big Creek Township H110,President / Vice President,,independent,"Stein, Jill",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Hedges, James A",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"McMullin, Evan",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Perry, Darryl",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Smith, Mike",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Sood, Ajay",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Libertarian,"Johnson, Gary",2,120080
+ELLIS,West Big Creek Township H110,President / Vice President,,Republican,"Trump, Donald J.",32,120080
+ELLIS,West Big Creek Township H111,President / Vice President,,independent,"Stein, Jill",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Hedges, James A",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"McMullin, Evan",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Perry, Darryl",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Smith, Mike",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Sood, Ajay",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+ELLIS,West Big Creek Township H111,President / Vice President,,Republican,"Trump, Donald J.",35,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+ELLIS,North Big Creek Township Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900050
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+ELLIS,North Big Creek Township Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900060
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,independent,"Stein, Jill",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Castle, Darrell L",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Giordani, Rocky",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Hedges, James A",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Kahn, Lynn",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"La Riva, Gloria",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Levinson, Michael S.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Maturen, Michael A",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"McMullin, Evan",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Perry, Darryl",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Schriner, Joe C",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Smith, Mike",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Sood, Ajay",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Sterling, Shawna",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+ELLIS,North Big Creek Township Enclave 3,President / Vice President,,Republican,"Trump, Donald J.",0,900070
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,independent,"Stein, Jill",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Castle, Darrell L",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Giordani, Rocky",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Hedges, James A",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Kahn, Lynn",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"La Riva, Gloria",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Levinson, Michael S.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Maturen, Michael A",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"McMullin, Evan",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Perry, Darryl",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Schriner, Joe C",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Smith, Mike",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Sood, Ajay",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Sterling, Shawna",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+ELLIS,North Big Creek Township Enclave 4,President / Vice President,,Republican,"Trump, Donald J.",0,900080
+ELLIS,Buckeye Township,United States House of Representatives,1,independent,"LaPolice, Alan",44,000010
+ELLIS,Buckeye Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+ELLIS,Buckeye Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000010
+ELLIS,Buckeye Township,United States House of Representatives,1,Republican,"Marshall, Roger",162,000010
+ELLIS,Catherine Township,United States House of Representatives,1,independent,"LaPolice, Alan",40,000020
+ELLIS,Catherine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+ELLIS,Catherine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000020
+ELLIS,Catherine Township,United States House of Representatives,1,Republican,"Marshall, Roger",110,000020
+ELLIS,East Big Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",91,000030
+ELLIS,East Big Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+ELLIS,East Big Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000030
+ELLIS,East Big Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",310,000030
+ELLIS,Ellis Township,United States House of Representatives,1,independent,"LaPolice, Alan",50,000040
+ELLIS,Ellis Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+ELLIS,Ellis Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000040
+ELLIS,Ellis Township,United States House of Representatives,1,Republican,"Marshall, Roger",171,000040
+ELLIS,Ellis Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",65,000050
+ELLIS,Ellis Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+ELLIS,Ellis Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000050
+ELLIS,Ellis Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",194,000050
+ELLIS,Ellis Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",100,000060
+ELLIS,Ellis Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+ELLIS,Ellis Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000060
+ELLIS,Ellis Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",291,000060
+ELLIS,Ellis Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",52,000070
+ELLIS,Ellis Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+ELLIS,Ellis Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000070
+ELLIS,Ellis Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",138,000070
+ELLIS,Freedom Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000080
+ELLIS,Freedom Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+ELLIS,Freedom Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+ELLIS,Freedom Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000080
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",91,000090
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",40,000090
+ELLIS,Hays Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",98,000090
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",70,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",109,00010A
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",147,000110
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000110
+ELLIS,Hays Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",274,000110
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",126,000120
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000120
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,000120
+ELLIS,Hays Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",195,000120
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",90,000130
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000130
+ELLIS,Hays Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",154,000130
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",128,000140
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000140
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000140
+ELLIS,Hays Ward 2 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",192,000140
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,independent,"LaPolice, Alan",86,000150
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,000150
+ELLIS,Hays Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Marshall, Roger",159,000150
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",121,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",232,00016A
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",173,000170
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,000170
+ELLIS,Hays Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",372,000170
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",162,000180
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000180
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000180
+ELLIS,Hays Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",470,000180
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",272,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",57,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",895,00019A
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",149,000200
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000200
+ELLIS,Hays Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",294,000200
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",136,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",361,00021A
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",149,000220
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000220
+ELLIS,Hays Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",287,000220
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",242,000230
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000230
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000230
+ELLIS,Hays Ward 4 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",594,000230
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,independent,"LaPolice, Alan",173,000240
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000240
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000240
+ELLIS,Hays Ward 4 Precinct 5,United States House of Representatives,1,Republican,"Marshall, Roger",465,000240
+ELLIS,South Lookout Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000280
+ELLIS,South Lookout Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+ELLIS,South Lookout Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000280
+ELLIS,South Lookout Township,United States House of Representatives,1,Republican,"Marshall, Roger",94,000280
+ELLIS,Victoria Township,United States House of Representatives,1,independent,"LaPolice, Alan",102,000290
+ELLIS,Victoria Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+ELLIS,Victoria Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000290
+ELLIS,Victoria Township,United States House of Representatives,1,Republican,"Marshall, Roger",294,000290
+ELLIS,Wheatland Township,United States House of Representatives,1,independent,"LaPolice, Alan",49,000310
+ELLIS,Wheatland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+ELLIS,Wheatland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000310
+ELLIS,Wheatland Township,United States House of Representatives,1,Republican,"Marshall, Roger",139,000310
+ELLIS,Herzog Township H110,United States House of Representatives,1,independent,"LaPolice, Alan",31,120020
+ELLIS,Herzog Township H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+ELLIS,Herzog Township H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120020
+ELLIS,Herzog Township H110,United States House of Representatives,1,Republican,"Marshall, Roger",94,120020
+ELLIS,Herzog Township H111,United States House of Representatives,1,independent,"LaPolice, Alan",59,120030
+ELLIS,Herzog Township H111,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,120030
+ELLIS,Herzog Township H111,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,120030
+ELLIS,Herzog Township H111,United States House of Representatives,1,Republican,"Marshall, Roger",175,120030
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,independent,"LaPolice, Alan",16,120040
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120040
+ELLIS,North Big Creek Township H110,United States House of Representatives,1,Republican,"Marshall, Roger",83,120040
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,independent,"LaPolice, Alan",63,120050
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120050
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,120050
+ELLIS,North Big Creek Township H111,United States House of Representatives,1,Republican,"Marshall, Roger",205,120050
+ELLIS,North Lookout Township H110,United States House of Representatives,1,independent,"LaPolice, Alan",28,120060
+ELLIS,North Lookout Township H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,120060
+ELLIS,North Lookout Township H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120060
+ELLIS,North Lookout Township H110,United States House of Representatives,1,Republican,"Marshall, Roger",50,120060
+ELLIS,North Lookout Township H111,United States House of Representatives,1,independent,"LaPolice, Alan",22,120070
+ELLIS,North Lookout Township H111,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120070
+ELLIS,North Lookout Township H111,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,120070
+ELLIS,North Lookout Township H111,United States House of Representatives,1,Republican,"Marshall, Roger",66,120070
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,independent,"LaPolice, Alan",16,120080
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120080
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120080
+ELLIS,West Big Creek Township H110,United States House of Representatives,1,Republican,"Marshall, Roger",22,120080
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,independent,"LaPolice, Alan",5,120090
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120090
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120090
+ELLIS,West Big Creek Township H111,United States House of Representatives,1,Republican,"Marshall, Roger",30,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900040
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900050
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900060
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,independent,"LaPolice, Alan",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States House of Representatives,1,Republican,"Marshall, Roger",0,900070
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,independent,"LaPolice, Alan",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States House of Representatives,1,Republican,"Marshall, Roger",0,900080
+ELLIS,Buckeye Township,United States Senate,,write - in,"Smith, DJ",0,000010
+ELLIS,Buckeye Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000010
+ELLIS,Buckeye Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000010
+ELLIS,Buckeye Township,United States Senate,,Republican,"Moran, Jerry",190,000010
+ELLIS,Catherine Township,United States Senate,,write - in,"Smith, DJ",0,000020
+ELLIS,Catherine Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000020
+ELLIS,Catherine Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000020
+ELLIS,Catherine Township,United States Senate,,Republican,"Moran, Jerry",127,000020
+ELLIS,East Big Creek Township,United States Senate,,write - in,"Smith, DJ",0,000030
+ELLIS,East Big Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000030
+ELLIS,East Big Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000030
+ELLIS,East Big Creek Township,United States Senate,,Republican,"Moran, Jerry",371,000030
+ELLIS,Ellis Township,United States Senate,,write - in,"Smith, DJ",0,000040
+ELLIS,Ellis Township,United States Senate,,Democratic,"Wiesner, Patrick",47,000040
+ELLIS,Ellis Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000040
+ELLIS,Ellis Township,United States Senate,,Republican,"Moran, Jerry",179,000040
+ELLIS,Ellis Ward 1,United States Senate,,write - in,"Smith, DJ",0,000050
+ELLIS,Ellis Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",74,000050
+ELLIS,Ellis Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000050
+ELLIS,Ellis Ward 1,United States Senate,,Republican,"Moran, Jerry",188,000050
+ELLIS,Ellis Ward 2,United States Senate,,write - in,"Smith, DJ",0,000060
+ELLIS,Ellis Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",93,000060
+ELLIS,Ellis Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",13,000060
+ELLIS,Ellis Ward 2,United States Senate,,Republican,"Moran, Jerry",312,000060
+ELLIS,Ellis Ward 3,United States Senate,,write - in,"Smith, DJ",0,000070
+ELLIS,Ellis Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",56,000070
+ELLIS,Ellis Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",10,000070
+ELLIS,Ellis Ward 3,United States Senate,,Republican,"Moran, Jerry",151,000070
+ELLIS,Freedom Township,United States Senate,,write - in,"Smith, DJ",0,000080
+ELLIS,Freedom Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000080
+ELLIS,Freedom Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+ELLIS,Freedom Township,United States Senate,,Republican,"Moran, Jerry",45,000080
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000090
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",93,000090
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",22,000090
+ELLIS,Hays Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",126,000090
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",64,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",13,00010A
+ELLIS,Hays Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",136,00010A
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000110
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",119,000110
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000110
+ELLIS,Hays Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",334,000110
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000120
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",115,000120
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,000120
+ELLIS,Hays Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",243,000120
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000130
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",74,000130
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",15,000130
+ELLIS,Hays Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",178,000130
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000140
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",84,000140
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",21,000140
+ELLIS,Hays Ward 2 Precinct 4,United States Senate,,Republican,"Moran, Jerry",242,000140
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,000150
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",71,000150
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",14,000150
+ELLIS,Hays Ward 2 Precinct 5,United States Senate,,Republican,"Moran, Jerry",191,000150
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",63,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",13,00016A
+ELLIS,Hays Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",311,00016A
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000170
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",118,000170
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",10,000170
+ELLIS,Hays Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",468,000170
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000180
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",90,000180
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",23,000180
+ELLIS,Hays Ward 3 Precinct 3,United States Senate,,Republican,"Moran, Jerry",555,000180
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",210,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",45,00019A
+ELLIS,Hays Ward 3 Precinct 4,United States Senate,,Republican,"Moran, Jerry",1038,00019A
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000200
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",98,000200
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",21,000200
+ELLIS,Hays Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",359,000200
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",102,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",31,00021A
+ELLIS,Hays Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",410,00021A
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000220
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",74,000220
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",14,000220
+ELLIS,Hays Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",375,000220
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000230
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",166,000230
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",25,000230
+ELLIS,Hays Ward 4 Precinct 4,United States Senate,,Republican,"Moran, Jerry",704,000230
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,000240
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",86,000240
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",17,000240
+ELLIS,Hays Ward 4 Precinct 5,United States Senate,,Republican,"Moran, Jerry",589,000240
+ELLIS,South Lookout Township,United States Senate,,write - in,"Smith, DJ",0,000280
+ELLIS,South Lookout Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000280
+ELLIS,South Lookout Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000280
+ELLIS,South Lookout Township,United States Senate,,Republican,"Moran, Jerry",105,000280
+ELLIS,Victoria Township,United States Senate,,write - in,"Smith, DJ",0,000290
+ELLIS,Victoria Township,United States Senate,,Democratic,"Wiesner, Patrick",57,000290
+ELLIS,Victoria Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000290
+ELLIS,Victoria Township,United States Senate,,Republican,"Moran, Jerry",354,000290
+ELLIS,Wheatland Township,United States Senate,,write - in,"Smith, DJ",0,000310
+ELLIS,Wheatland Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000310
+ELLIS,Wheatland Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000310
+ELLIS,Wheatland Township,United States Senate,,Republican,"Moran, Jerry",170,000310
+ELLIS,Herzog Township H110,United States Senate,,write - in,"Smith, DJ",0,120020
+ELLIS,Herzog Township H110,United States Senate,,Democratic,"Wiesner, Patrick",8,120020
+ELLIS,Herzog Township H110,United States Senate,,Libertarian,"Garrard, Robert D.",4,120020
+ELLIS,Herzog Township H110,United States Senate,,Republican,"Moran, Jerry",118,120020
+ELLIS,Herzog Township H111,United States Senate,,write - in,"Smith, DJ",0,120030
+ELLIS,Herzog Township H111,United States Senate,,Democratic,"Wiesner, Patrick",31,120030
+ELLIS,Herzog Township H111,United States Senate,,Libertarian,"Garrard, Robert D.",10,120030
+ELLIS,Herzog Township H111,United States Senate,,Republican,"Moran, Jerry",207,120030
+ELLIS,North Big Creek Township H110,United States Senate,,write - in,"Smith, DJ",0,120040
+ELLIS,North Big Creek Township H110,United States Senate,,Democratic,"Wiesner, Patrick",11,120040
+ELLIS,North Big Creek Township H110,United States Senate,,Libertarian,"Garrard, Robert D.",4,120040
+ELLIS,North Big Creek Township H110,United States Senate,,Republican,"Moran, Jerry",87,120040
+ELLIS,North Big Creek Township H111,United States Senate,,write - in,"Smith, DJ",0,120050
+ELLIS,North Big Creek Township H111,United States Senate,,Democratic,"Wiesner, Patrick",36,120050
+ELLIS,North Big Creek Township H111,United States Senate,,Libertarian,"Garrard, Robert D.",8,120050
+ELLIS,North Big Creek Township H111,United States Senate,,Republican,"Moran, Jerry",239,120050
+ELLIS,North Lookout Township H110,United States Senate,,write - in,"Smith, DJ",0,120060
+ELLIS,North Lookout Township H110,United States Senate,,Democratic,"Wiesner, Patrick",12,120060
+ELLIS,North Lookout Township H110,United States Senate,,Libertarian,"Garrard, Robert D.",0,120060
+ELLIS,North Lookout Township H110,United States Senate,,Republican,"Moran, Jerry",68,120060
+ELLIS,North Lookout Township H111,United States Senate,,write - in,"Smith, DJ",0,120070
+ELLIS,North Lookout Township H111,United States Senate,,Democratic,"Wiesner, Patrick",12,120070
+ELLIS,North Lookout Township H111,United States Senate,,Libertarian,"Garrard, Robert D.",2,120070
+ELLIS,North Lookout Township H111,United States Senate,,Republican,"Moran, Jerry",83,120070
+ELLIS,West Big Creek Township H110,United States Senate,,write - in,"Smith, DJ",0,120080
+ELLIS,West Big Creek Township H110,United States Senate,,Democratic,"Wiesner, Patrick",4,120080
+ELLIS,West Big Creek Township H110,United States Senate,,Libertarian,"Garrard, Robert D.",4,120080
+ELLIS,West Big Creek Township H110,United States Senate,,Republican,"Moran, Jerry",33,120080
+ELLIS,West Big Creek Township H111,United States Senate,,write - in,"Smith, DJ",0,120090
+ELLIS,West Big Creek Township H111,United States Senate,,Democratic,"Wiesner, Patrick",3,120090
+ELLIS,West Big Creek Township H111,United States Senate,,Libertarian,"Garrard, Robert D.",0,120090
+ELLIS,West Big Creek Township H111,United States Senate,,Republican,"Moran, Jerry",33,120090
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+ELLIS,Hays Ward 1 Precinct 2 Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900020
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900030
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+ELLIS,Hays Ward 3 Precinct 4 Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900040
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+ELLIS,North Big Creek Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900050
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+ELLIS,North Big Creek Township Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900060
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,write - in,"Smith, DJ",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,Democratic,"Wiesner, Patrick",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,900070
+ELLIS,North Big Creek Township Enclave 3,United States Senate,,Republican,"Moran, Jerry",0,900070
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,write - in,"Smith, DJ",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,Democratic,"Wiesner, Patrick",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,Libertarian,"Garrard, Robert D.",0,900080
+ELLIS,North Big Creek Township Enclave 4,United States Senate,,Republican,"Moran, Jerry",0,900080

--- a/2016/20161108__ks__general__ellsworth__precinct.csv
+++ b/2016/20161108__ks__general__ellsworth__precinct.csv
@@ -1,516 +1,926 @@
-county,precinct,office,district,party,candidate,votes
-Ellsworth,Ash Creek,President,,D,Hillary Clinton,2
-Ellsworth,Ash Creek,President,,LBT,Gary Johnson,3
-Ellsworth,Ash Creek,President,,IND,Jill Stein,1
-Ellsworth,Ash Creek,President,,R,Donald J Trump,31
-Ellsworth,Ash Creek,President,,,Write-ins,0
-Ellsworth,Ash Creek,U.S. Senate,,R,Jerry Moran,30
-Ellsworth,Ash Creek,U.S. Senate,,D,Patrick Wiesner,4
-Ellsworth,Ash Creek,U.S. Senate,,LBT,Robert Garrard,2
-Ellsworth,Ash Creek,U.S. Senate,,,Write-ins,0
-Ellsworth,Ash Creek,U.S. House,1,LBT,Kerry Burt,1
-Ellsworth,Ash Creek,U.S. House,1,IND,Alan LaPolice,8
-Ellsworth,Ash Creek,U.S. House,1,R,Roger Marshall,27
-Ellsworth,Ash Creek,U.S. House,1,,Write-ins,0
-Ellsworth,Ash Creek,State Senate,35,D,Levi Morris,8
-Ellsworth,Ash Creek,State Senate,35,R,Richard Wilborn,24
-Ellsworth,Ash Creek,State Senate,35,,Write-ins,0
-Ellsworth,Ash Creek,State House,108,R,Steven Johnson,30
-Ellsworth,Ash Creek,State House,108,D,Kelley Menke,5
-Ellsworth,Ash Creek,State House,108,,Write-ins,0
-Ellsworth,Black Wolf,President,,D,Hillary Clinton,13
-Ellsworth,Black Wolf,President,,LBT,Gary Johnson,0
-Ellsworth,Black Wolf,President,,IND,Jill Stein,2
-Ellsworth,Black Wolf,President,,R,Donald J Trump,39
-Ellsworth,Black Wolf,President,,,Write-ins,1
-Ellsworth,Black Wolf,U.S. Senate,,R,Jerry Moran,45
-Ellsworth,Black Wolf,U.S. Senate,,D,Patrick Wiesner,8
-Ellsworth,Black Wolf,U.S. Senate,,LBT,Robert Garrard,2
-Ellsworth,Black Wolf,U.S. Senate,,,Write-ins,0
-Ellsworth,Black Wolf,U.S. House,1,LBT,Kerry Burt,0
-Ellsworth,Black Wolf,U.S. House,1,IND,Alan LaPolice,20
-Ellsworth,Black Wolf,U.S. House,1,R,Roger Marshall,35
-Ellsworth,Black Wolf,U.S. House,1,,Write-ins,0
-Ellsworth,Black Wolf,State Senate,35,D,Levi Morris,16
-Ellsworth,Black Wolf,State Senate,35,R,Richard Wilborn,38
-Ellsworth,Black Wolf,State Senate,35,,Write-ins,0
-Ellsworth,Black Wolf,State House,108,R,Steven Johnson,41
-Ellsworth,Black Wolf,State House,108,D,Kelley Menke,12
-Ellsworth,Black Wolf,State House,108,,Write-ins,0
-Ellsworth,Carneiro,President,,D,Hillary Clinton,2
-Ellsworth,Carneiro,President,,LBT,Gary Johnson,0
-Ellsworth,Carneiro,President,,IND,Jill Stein,1
-Ellsworth,Carneiro,President,,R,Donald J Trump,25
-Ellsworth,Carneiro,President,,,Write-ins,0
-Ellsworth,Carneiro,U.S. Senate,,R,Jerry Moran,25
-Ellsworth,Carneiro,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Carneiro,U.S. Senate,,LBT,Robert Garrard,0
-Ellsworth,Carneiro,U.S. Senate,,,Write-ins,0
-Ellsworth,Carneiro,U.S. House,1,LBT,Kerry Burt,0
-Ellsworth,Carneiro,U.S. House,1,IND,Alan LaPolice,11
-Ellsworth,Carneiro,U.S. House,1,R,Roger Marshall,15
-Ellsworth,Carneiro,U.S. House,1,,Write-ins,0
-Ellsworth,Carneiro,State Senate,35,D,Levi Morris,5
-Ellsworth,Carneiro,State Senate,35,R,Richard Wilborn,22
-Ellsworth,Carneiro,State Senate,35,,Write-ins,0
-Ellsworth,Carneiro,State House,108,R,Steven Johnson,24
-Ellsworth,Carneiro,State House,108,D,Kelley Menke,3
-Ellsworth,Carneiro,State House,108,,Write-ins,0
-Ellsworth,Clear Creek,President,,D,Hillary Clinton,7
-Ellsworth,Clear Creek,President,,LBT,Gary Johnson,4
-Ellsworth,Clear Creek,President,,IND,Jill Stein,0
-Ellsworth,Clear Creek,President,,R,Donald J Trump,54
-Ellsworth,Clear Creek,President,,,Write-ins,0
-Ellsworth,Clear Creek,U.S. Senate,,R,Jerry Moran,52
-Ellsworth,Clear Creek,U.S. Senate,,D,Patrick Wiesner,9
-Ellsworth,Clear Creek,U.S. Senate,,LBT,Robert Garrard,2
-Ellsworth,Clear Creek,U.S. Senate,,,Write-ins,0
-Ellsworth,Clear Creek,U.S. House,1,LBT,Kerry Burt,2
-Ellsworth,Clear Creek,U.S. House,1,IND,Alan LaPolice,22
-Ellsworth,Clear Creek,U.S. House,1,R,Roger Marshall,39
-Ellsworth,Clear Creek,U.S. House,1,,Write-ins,0
-Ellsworth,Clear Creek,State Senate,35,D,Levi Morris,18
-Ellsworth,Clear Creek,State Senate,35,R,Richard Wilborn,41
-Ellsworth,Clear Creek,State Senate,35,,Write-ins,1
-Ellsworth,Clear Creek,State House,108,R,Steven Johnson,50
-Ellsworth,Clear Creek,State House,108,D,Kelley Menke,13
-Ellsworth,Clear Creek,State House,108,,Write-ins,1
-Ellsworth,Columbia,President,,D,Hillary Clinton,1
-Ellsworth,Columbia,President,,LBT,Gary Johnson,3
-Ellsworth,Columbia,President,,IND,Jill Stein,1
-Ellsworth,Columbia,President,,R,Donald J Trump,29
-Ellsworth,Columbia,President,,,Write-ins,0
-Ellsworth,Columbia,U.S. Senate,,R,Jerry Moran,31
-Ellsworth,Columbia,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Columbia,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Columbia,U.S. Senate,,,Write-ins,0
-Ellsworth,Columbia,U.S. House,1,LBT,Kerry Burt,3
-Ellsworth,Columbia,U.S. House,1,IND,Alan LaPolice,4
-Ellsworth,Columbia,U.S. House,1,R,Roger Marshall,25
-Ellsworth,Columbia,U.S. House,1,,Write-ins,0
-Ellsworth,Columbia,State Senate,35,D,Levi Morris,5
-Ellsworth,Columbia,State Senate,35,R,Richard Wilborn,27
-Ellsworth,Columbia,State Senate,35,,Write-ins,0
-Ellsworth,Columbia,State House,108,R,Steven Johnson,27
-Ellsworth,Columbia,State House,108,D,Kelley Menke,5
-Ellsworth,Columbia,State House,108,,Write-ins,0
-Ellsworth,Ellsworth twp,President,,D,Hillary Clinton,21
-Ellsworth,Ellsworth twp,President,,LBT,Gary Johnson,4
-Ellsworth,Ellsworth twp,President,,IND,Jill Stein,1
-Ellsworth,Ellsworth twp,President,,R,Donald J Trump,65
-Ellsworth,Ellsworth twp,President,,WRI,Mike Maturen,1
-Ellsworth,Ellsworth twp,U.S. Senate,,R,Jerry Moran,75
-Ellsworth,Ellsworth twp,U.S. Senate,,D,Patrick Wiesner,12
-Ellsworth,Ellsworth twp,U.S. Senate,,LBT,Robert Garrard,5
-Ellsworth,Ellsworth twp,U.S. Senate,,,Write-ins,0
-Ellsworth,Ellsworth twp,U.S. House,1,LBT,Kerry Burt,6
-Ellsworth,Ellsworth twp,U.S. House,1,IND,Alan LaPolice,26
-Ellsworth,Ellsworth twp,U.S. House,1,R,Roger Marshall,56
-Ellsworth,Ellsworth twp,U.S. House,1,,Write-ins,0
-Ellsworth,Ellsworth twp,State Senate,35,D,Levi Morris,26
-Ellsworth,Ellsworth twp,State Senate,35,R,Richard Wilborn,61
-Ellsworth,Ellsworth twp,State Senate,35,,Write-ins,0
-Ellsworth,Ellsworth twp,State House,108,R,Steven Johnson,69
-Ellsworth,Ellsworth twp,State House,108,D,Kelley Menke,21
-Ellsworth,Ellsworth twp,State House,108,,Write-ins,0
-Ellsworth,Buckeye,President,,D,Hillary Clinton,3
-Ellsworth,Buckeye,President,,LBT,Gary Johnson,2
-Ellsworth,Buckeye,President,,IND,Jill Stein,2
-Ellsworth,Buckeye,President,,R,Donald J Trump,22
-Ellsworth,Buckeye,President,,,Write-ins,0
-Ellsworth,Buckeye,U.S. Senate,,R,Jerry Moran,27
-Ellsworth,Buckeye,U.S. Senate,,D,Patrick Wiesner,3
-Ellsworth,Buckeye,U.S. Senate,,LBT,Robert Garrard,0
-Ellsworth,Buckeye,U.S. Senate,,,Write-ins,0
-Ellsworth,Buckeye,U.S. House,1,LBT,Kerry Burt,0
-Ellsworth,Buckeye,U.S. House,1,IND,Alan LaPolice,5
-Ellsworth,Buckeye,U.S. House,1,R,Roger Marshall,24
-Ellsworth,Buckeye,U.S. House,1,,Write-ins,0
-Ellsworth,Buckeye,State Senate,35,D,Levi Morris,9
-Ellsworth,Buckeye,State Senate,35,R,Richard Wilborn,19
-Ellsworth,Buckeye,State Senate,35,,Write-ins,0
-Ellsworth,Buckeye,State House,108,R,Steven Johnson,28
-Ellsworth,Buckeye,State House,108,D,Kelley Menke,1
-Ellsworth,Buckeye,State House,108,,Write-ins,0
-Ellsworth,Venango,President,,D,Hillary Clinton,11
-Ellsworth,Venango,President,,LBT,Gary Johnson,1
-Ellsworth,Venango,President,,IND,Jill Stein,1
-Ellsworth,Venango,President,,R,Donald J Trump,49
-Ellsworth,Venango,President,,WRI,Evan McMullin,1
-Ellsworth,Venango,President,,,Write-ins,1
-Ellsworth,Venango,U.S. Senate,,R,Jerry Moran,50
-Ellsworth,Venango,U.S. Senate,,D,Patrick Wiesner,7
-Ellsworth,Venango,U.S. Senate,,LBT,Robert Garrard,7
-Ellsworth,Venango,U.S. Senate,,,Write-ins,0
-Ellsworth,Venango,U.S. House,1,LBT,Kerry Burt,4
-Ellsworth,Venango,U.S. House,1,IND,Alan LaPolice,12
-Ellsworth,Venango,U.S. House,1,R,Roger Marshall,42
-Ellsworth,Venango,U.S. House,1,,Write-ins,1
-Ellsworth,Venango,State Senate,35,D,Levi Morris,19
-Ellsworth,Venango,State Senate,35,R,Richard Wilborn,44
-Ellsworth,Venango,State Senate,35,,Write-ins,0
-Ellsworth,Venango,State House,108,R,Steven Johnson,43
-Ellsworth,Venango,State House,108,D,Kelley Menke,21
-Ellsworth,Venango,State House,108,,Write-ins,0
-Ellsworth,Garfield 9,President,,D,Hillary Clinton,3
-Ellsworth,Garfield 9,President,,LBT,Gary Johnson,0
-Ellsworth,Garfield 9,President,,IND,Jill Stein,0
-Ellsworth,Garfield 9,President,,R,Donald J Trump,26
-Ellsworth,Garfield 9,President,,,Write-ins,0
-Ellsworth,Garfield 9,U.S. Senate,,R,Jerry Moran,25
-Ellsworth,Garfield 9,U.S. Senate,,D,Patrick Wiesner,3
-Ellsworth,Garfield 9,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Garfield 9,U.S. Senate,,,Write-ins,0
-Ellsworth,Garfield 9,U.S. House,1,LBT,Kerry Burt,2
-Ellsworth,Garfield 9,U.S. House,1,IND,Alan LaPolice,5
-Ellsworth,Garfield 9,U.S. House,1,R,Roger Marshall,22
-Ellsworth,Garfield 9,U.S. House,1,,Write-ins,0
-Ellsworth,Garfield 9,State Senate,35,D,Levi Morris,4
-Ellsworth,Garfield 9,State Senate,35,R,Richard Wilborn,25
-Ellsworth,Garfield 9,State Senate,35,,Write-ins,0
-Ellsworth,Garfield 9,State House,108,R,Steven Johnson,29
-Ellsworth,Garfield 9,State House,108,D,Kelley Menke,0
-Ellsworth,Garfield 9,State House,108,,Write-ins,0
-Ellsworth,Langley,President,,D,Hillary Clinton,4
-Ellsworth,Langley,President,,LBT,Gary Johnson,0
-Ellsworth,Langley,President,,IND,Jill Stein,0
-Ellsworth,Langley,President,,R,Donald J Trump,40
-Ellsworth,Langley,President,,,Write-ins,2
-Ellsworth,Langley,U.S. Senate,,R,Jerry Moran,41
-Ellsworth,Langley,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Langley,U.S. Senate,,LBT,Robert Garrard,3
-Ellsworth,Langley,U.S. Senate,,,Write-ins,0
-Ellsworth,Langley,U.S. House,1,LBT,Kerry Burt,2
-Ellsworth,Langley,U.S. House,1,IND,Alan LaPolice,14
-Ellsworth,Langley,U.S. House,1,R,Roger Marshall,28
-Ellsworth,Langley,U.S. House,1,,Write-ins,1
-Ellsworth,Langley,State Senate,35,D,Levi Morris,6
-Ellsworth,Langley,State Senate,35,R,Richard Wilborn,38
-Ellsworth,Langley,State Senate,35,,Write-ins,0
-Ellsworth,Langley,State House,108,R,Steven Johnson,33
-Ellsworth,Langley,State House,108,D,Kelley Menke,11
-Ellsworth,Langley,State House,108,,Write-ins,0
-Ellsworth,Lincoln,President,,D,Hillary Clinton,2
-Ellsworth,Lincoln,President,,LBT,Gary Johnson,0
-Ellsworth,Lincoln,President,,IND,Jill Stein,0
-Ellsworth,Lincoln,President,,R,Donald J Trump,27
-Ellsworth,Lincoln,President,,,Write-ins,0
-Ellsworth,Lincoln,U.S. Senate,,R,Jerry Moran,25
-Ellsworth,Lincoln,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Lincoln,U.S. Senate,,LBT,Robert Garrard,2
-Ellsworth,Lincoln,U.S. Senate,,,Write-ins,0
-Ellsworth,Lincoln,U.S. House,1,LBT,Kerry Burt,3
-Ellsworth,Lincoln,U.S. House,1,IND,Alan LaPolice,5
-Ellsworth,Lincoln,U.S. House,1,R,Roger Marshall,18
-Ellsworth,Lincoln,U.S. House,1,,Write-ins,0
-Ellsworth,Lincoln,State Senate,35,D,Levi Morris,6
-Ellsworth,Lincoln,State Senate,35,R,Richard Wilborn,21
-Ellsworth,Lincoln,State Senate,35,,Write-ins,0
-Ellsworth,Lincoln,State House,108,R,Steven Johnson,21
-Ellsworth,Lincoln,State House,108,D,Kelley Menke,6
-Ellsworth,Lincoln,State House,108,,Write-ins,0
-Ellsworth,Mulberry,President,,D,Hillary Clinton,1
-Ellsworth,Mulberry,President,,LBT,Gary Johnson,0
-Ellsworth,Mulberry,President,,IND,Jill Stein,0
-Ellsworth,Mulberry,President,,R,Donald J Trump,16
-Ellsworth,Mulberry,President,,WRI,Evan McMullin,2
-Ellsworth,Mulberry,U.S. Senate,,R,Jerry Moran,15
-Ellsworth,Mulberry,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Mulberry,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Mulberry,U.S. Senate,,,Write-ins,0
-Ellsworth,Mulberry,U.S. House,1,LBT,Kerry Burt,0
-Ellsworth,Mulberry,U.S. House,1,IND,Alan LaPolice,8
-Ellsworth,Mulberry,U.S. House,1,R,Roger Marshall,10
-Ellsworth,Mulberry,U.S. House,1,,Write-ins,0
-Ellsworth,Mulberry,State Senate,35,D,Levi Morris,2
-Ellsworth,Mulberry,State Senate,35,R,Richard Wilborn,16
-Ellsworth,Mulberry,State Senate,35,,Write-ins,0
-Ellsworth,Mulberry,State House,108,R,Steven Johnson,17
-Ellsworth,Mulberry,State House,108,D,Kelley Menke,1
-Ellsworth,Mulberry,State House,108,,Write-ins,0
-Ellsworth,Noble,President,,D,Hillary Clinton,6
-Ellsworth,Noble,President,,LBT,Gary Johnson,3
-Ellsworth,Noble,President,,IND,Jill Stein,1
-Ellsworth,Noble,President,,R,Donald J Trump,30
-Ellsworth,Noble,President,,,Write-ins,1
-Ellsworth,Noble,U.S. Senate,,R,Jerry Moran,34
-Ellsworth,Noble,U.S. Senate,,D,Patrick Wiesner,4
-Ellsworth,Noble,U.S. Senate,,LBT,Robert Garrard,3
-Ellsworth,Noble,U.S. Senate,,,Write-ins,0
-Ellsworth,Noble,U.S. House,1,LBT,Kerry Burt,1
-Ellsworth,Noble,U.S. House,1,IND,Alan LaPolice,10
-Ellsworth,Noble,U.S. House,1,R,Roger Marshall,27
-Ellsworth,Noble,U.S. House,1,,Write-ins,2
-Ellsworth,Noble,State Senate,35,D,Levi Morris,8
-Ellsworth,Noble,State Senate,35,R,Richard Wilborn,32
-Ellsworth,Noble,State Senate,35,,Write-ins,0
-Ellsworth,Noble,State House,108,R,Steven Johnson,32
-Ellsworth,Noble,State House,108,D,Kelley Menke,9
-Ellsworth,Noble,State House,108,,Write-ins,0
-Ellsworth,Palacky,President,,D,Hillary Clinton,4
-Ellsworth,Palacky,President,,LBT,Gary Johnson,1
-Ellsworth,Palacky,President,,IND,Jill Stein,0
-Ellsworth,Palacky,President,,R,Donald J Trump,29
-Ellsworth,Palacky,President,,,Write-ins,0
-Ellsworth,Palacky,U.S. Senate,,R,Jerry Moran,31
-Ellsworth,Palacky,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Palacky,U.S. Senate,,LBT,Robert Garrard,0
-Ellsworth,Palacky,U.S. Senate,,,Write-ins,0
-Ellsworth,Palacky,U.S. House,1,LBT,Kerry Burt,2
-Ellsworth,Palacky,U.S. House,1,IND,Alan LaPolice,11
-Ellsworth,Palacky,U.S. House,1,R,Roger Marshall,21
-Ellsworth,Palacky,U.S. House,1,,Write-ins,0
-Ellsworth,Palacky,State Senate,35,D,Levi Morris,5
-Ellsworth,Palacky,State Senate,35,R,Richard Wilborn,27
-Ellsworth,Palacky,State Senate,35,,Write-ins,0
-Ellsworth,Palacky,State House,108,R,Steven Johnson,25
-Ellsworth,Palacky,State House,108,D,Kelley Menke,8
-Ellsworth,Palacky,State House,108,,Write-ins,0
-Ellsworth,Sherman,President,,D,Hillary Clinton,2
-Ellsworth,Sherman,President,,LBT,Gary Johnson,1
-Ellsworth,Sherman,President,,IND,Jill Stein,0
-Ellsworth,Sherman,President,,R,Donald J Trump,34
-Ellsworth,Sherman,President,,,Write-ins,0
-Ellsworth,Sherman,U.S. Senate,,R,Jerry Moran,34
-Ellsworth,Sherman,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Sherman,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Sherman,U.S. Senate,,,Write-ins,0
-Ellsworth,Sherman,U.S. House,1,LBT,Kerry Burt,0
-Ellsworth,Sherman,U.S. House,1,IND,Alan LaPolice,8
-Ellsworth,Sherman,U.S. House,1,R,Roger Marshall,28
-Ellsworth,Sherman,U.S. House,1,,Write-ins,0
-Ellsworth,Sherman,State Senate,35,D,Levi Morris,8
-Ellsworth,Sherman,State Senate,35,R,Richard Wilborn,28
-Ellsworth,Sherman,State Senate,35,,Write-ins,0
-Ellsworth,Sherman,State House,108,R,Steven Johnson,32
-Ellsworth,Sherman,State House,108,D,Kelley Menke,4
-Ellsworth,Sherman,State House,108,,Write-ins,0
-Ellsworth,Thomas,President,,D,Hillary Clinton,4
-Ellsworth,Thomas,President,,LBT,Gary Johnson,2
-Ellsworth,Thomas,President,,IND,Jill Stein,1
-Ellsworth,Thomas,President,,R,Donald J Trump,31
-Ellsworth,Thomas,President,,,Write-ins,0
-Ellsworth,Thomas,U.S. Senate,,R,Jerry Moran,34
-Ellsworth,Thomas,U.S. Senate,,D,Patrick Wiesner,2
-Ellsworth,Thomas,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Thomas,U.S. Senate,,,Write-ins,0
-Ellsworth,Thomas,U.S. House,1,LBT,Kerry Burt,0
-Ellsworth,Thomas,U.S. House,1,IND,Alan LaPolice,13
-Ellsworth,Thomas,U.S. House,1,R,Roger Marshall,25
-Ellsworth,Thomas,U.S. House,1,,Write-ins,0
-Ellsworth,Thomas,State Senate,35,D,Levi Morris,9
-Ellsworth,Thomas,State Senate,35,R,Richard Wilborn,24
-Ellsworth,Thomas,State Senate,35,,Write-ins,0
-Ellsworth,Thomas,State House,108,R,Steven Johnson,28
-Ellsworth,Thomas,State House,108,D,Kelley Menke,7
-Ellsworth,Thomas,State House,108,,Write-ins,0
-Ellsworth,Trivoli,President,,D,Hillary Clinton,4
-Ellsworth,Trivoli,President,,LBT,Gary Johnson,0
-Ellsworth,Trivoli,President,,IND,Jill Stein,0
-Ellsworth,Trivoli,President,,R,Donald J Trump,29
-Ellsworth,Trivoli,President,,,Write-ins,0
-Ellsworth,Trivoli,U.S. Senate,,R,Jerry Moran,24
-Ellsworth,Trivoli,U.S. Senate,,D,Patrick Wiesner,4
-Ellsworth,Trivoli,U.S. Senate,,LBT,Robert Garrard,3
-Ellsworth,Trivoli,U.S. Senate,,,Write-ins,0
-Ellsworth,Trivoli,U.S. House,1,LBT,Kerry Burt,1
-Ellsworth,Trivoli,U.S. House,1,IND,Alan LaPolice,6
-Ellsworth,Trivoli,U.S. House,1,R,Roger Marshall,25
-Ellsworth,Trivoli,U.S. House,1,,Write-ins,0
-Ellsworth,Trivoli,State Senate,35,D,Levi Morris,5
-Ellsworth,Trivoli,State Senate,35,R,Richard Wilborn,25
-Ellsworth,Trivoli,State Senate,35,,Write-ins,0
-Ellsworth,Trivoli,State House,108,R,Steven Johnson,26
-Ellsworth,Trivoli,State House,108,D,Kelley Menke,5
-Ellsworth,Trivoli,State House,108,,Write-ins,0
-Ellsworth,E Ellsworth 1,President,,D,Hillary Clinton,66
-Ellsworth,E Ellsworth 1,President,,LBT,Gary Johnson,13
-Ellsworth,E Ellsworth 1,President,,IND,Jill Stein,10
-Ellsworth,E Ellsworth 1,President,,R,Donald J Trump,222
-Ellsworth,E Ellsworth 1,President,,,Write-ins,2
-Ellsworth,E Ellsworth 1,U.S. Senate,,R,Jerry Moran,251
-Ellsworth,E Ellsworth 1,U.S. Senate,,D,Patrick Wiesner,50
-Ellsworth,E Ellsworth 1,U.S. Senate,,LBT,Robert Garrard,14
-Ellsworth,E Ellsworth 1,U.S. Senate,,,Write-ins,0
-Ellsworth,E Ellsworth 1,U.S. House,1,LBT,Kerry Burt,16
-Ellsworth,E Ellsworth 1,U.S. House,1,IND,Alan LaPolice,92
-Ellsworth,E Ellsworth 1,U.S. House,1,R,Roger Marshall,206
-Ellsworth,E Ellsworth 1,U.S. House,1,,Write-ins,0
-Ellsworth,E Ellsworth 1,State Senate,35,D,Levi Morris,120
-Ellsworth,E Ellsworth 1,State Senate,35,R,Richard Wilborn,182
-Ellsworth,E Ellsworth 1,State Senate,35,,Write-ins,0
-Ellsworth,E Ellsworth 1,State House,108,R,Steven Johnson,220
-Ellsworth,E Ellsworth 1,State House,108,D,Kelley Menke,87
-Ellsworth,E Ellsworth 1,State House,108,,Write-ins,0
-Ellsworth,E Ellsworth 2,President,,D,Hillary Clinton,77
-Ellsworth,E Ellsworth 2,President,,LBT,Gary Johnson,13
-Ellsworth,E Ellsworth 2,President,,IND,Jill Stein,16
-Ellsworth,E Ellsworth 2,President,,R,Donald J Trump,212
-Ellsworth,E Ellsworth 2,President,,,Write-ins,5
-Ellsworth,E Ellsworth 2,U.S. Senate,,R,Jerry Moran,271
-Ellsworth,E Ellsworth 2,U.S. Senate,,D,Patrick Wiesner,41
-Ellsworth,E Ellsworth 2,U.S. Senate,,LBT,Robert Garrard,11
-Ellsworth,E Ellsworth 2,U.S. Senate,,,Write-ins,0
-Ellsworth,E Ellsworth 2,U.S. House,1,LBT,Kerry Burt,11
-Ellsworth,E Ellsworth 2,U.S. House,1,IND,Alan LaPolice,120
-Ellsworth,E Ellsworth 2,U.S. House,1,R,Roger Marshall,189
-Ellsworth,E Ellsworth 2,U.S. House,1,,Write-ins,1
-Ellsworth,E Ellsworth 2,State Senate,35,D,Levi Morris,131
-Ellsworth,E Ellsworth 2,State Senate,35,R,Richard Wilborn,183
-Ellsworth,E Ellsworth 2,State Senate,35,,Write-ins,0
-Ellsworth,E Ellsworth 2,State House,108,R,Steven Johnson,218
-Ellsworth,E Ellsworth 2,State House,108,D,Kelley Menke,96
-Ellsworth,E Ellsworth 2,State House,108,,Write-ins,0
-Ellsworth,W Ellsworth,President,,D,Hillary Clinton,76
-Ellsworth,W Ellsworth,President,,LBT,Gary Johnson,17
-Ellsworth,W Ellsworth,President,,IND,Jill Stein,3
-Ellsworth,W Ellsworth,President,,R,Donald J Trump,265
-Ellsworth,W Ellsworth,President,,WRI,Evan McMullin,4
-Ellsworth,W Ellsworth,President,,,Write-ins,3
-Ellsworth,W Ellsworth,U.S. Senate,,R,Jerry Moran,305
-Ellsworth,W Ellsworth,U.S. Senate,,D,Patrick Wiesner,48
-Ellsworth,W Ellsworth,U.S. Senate,,LBT,Robert Garrard,13
-Ellsworth,W Ellsworth,U.S. Senate,,,Write-ins,0
-Ellsworth,W Ellsworth,U.S. House,1,LBT,Kerry Burt,14
-Ellsworth,W Ellsworth,U.S. House,1,IND,Alan LaPolice,123
-Ellsworth,W Ellsworth,U.S. House,1,R,Roger Marshall,221
-Ellsworth,W Ellsworth,U.S. House,1,,Write-ins,2
-Ellsworth,W Ellsworth,State Senate,35,D,Levi Morris,130
-Ellsworth,W Ellsworth,State Senate,35,R,Richard Wilborn,219
-Ellsworth,W Ellsworth,State Senate,35,,Write-ins,0
-Ellsworth,W Ellsworth,State House,108,R,Steven Johnson,247
-Ellsworth,W Ellsworth,State House,108,D,Kelley Menke,103
-Ellsworth,W Ellsworth,State House,108,,Write-ins,0
-Ellsworth,Holyrood,President,,D,Hillary Clinton,54
-Ellsworth,Holyrood,President,,LBT,Gary Johnson,6
-Ellsworth,Holyrood,President,,IND,Jill Stein,8
-Ellsworth,Holyrood,President,,R,Donald J Trump,184
-Ellsworth,Holyrood,President,,,Write-ins,1
-Ellsworth,Holyrood,U.S. Senate,,R,Jerry Moran,199
-Ellsworth,Holyrood,U.S. Senate,,D,Patrick Wiesner,45
-Ellsworth,Holyrood,U.S. Senate,,LBT,Robert Garrard,6
-Ellsworth,Holyrood,U.S. Senate,,,Write-ins,0
-Ellsworth,Holyrood,U.S. House,1,LBT,Kerry Burt,6
-Ellsworth,Holyrood,U.S. House,1,IND,Alan LaPolice,60
-Ellsworth,Holyrood,U.S. House,1,R,Roger Marshall,180
-Ellsworth,Holyrood,U.S. House,1,,Write-ins,0
-Ellsworth,Holyrood,State Senate,35,D,Levi Morris,79
-Ellsworth,Holyrood,State Senate,35,R,Richard Wilborn,168
-Ellsworth,Holyrood,State Senate,35,,Write-ins,0
-Ellsworth,Holyrood,State House,108,R,Steven Johnson,175
-Ellsworth,Holyrood,State House,108,D,Kelley Menke,75
-Ellsworth,Holyrood,State House,108,,Write-ins,0
-Ellsworth,Kanopolis,President,,D,Hillary Clinton,55
-Ellsworth,Kanopolis,President,,LBT,Gary Johnson,12
-Ellsworth,Kanopolis,President,,IND,Jill Stein,7
-Ellsworth,Kanopolis,President,,R,Donald J Trump,158
-Ellsworth,Kanopolis,President,,,Write-ins,3
-Ellsworth,Kanopolis,U.S. Senate,,R,Jerry Moran,172
-Ellsworth,Kanopolis,U.S. Senate,,D,Patrick Wiesner,53
-Ellsworth,Kanopolis,U.S. Senate,,LBT,Robert Garrard,11
-Ellsworth,Kanopolis,U.S. Senate,,,Write-ins,0
-Ellsworth,Kanopolis,U.S. House,1,LBT,Kerry Burt,14
-Ellsworth,Kanopolis,U.S. House,1,IND,Alan LaPolice,78
-Ellsworth,Kanopolis,U.S. House,1,R,Roger Marshall,141
-Ellsworth,Kanopolis,U.S. House,1,,Write-ins,0
-Ellsworth,Kanopolis,State Senate,35,D,Levi Morris,103
-Ellsworth,Kanopolis,State Senate,35,R,Richard Wilborn,129
-Ellsworth,Kanopolis,State Senate,35,,Write-ins,0
-Ellsworth,Kanopolis,State House,108,R,Steven Johnson,148
-Ellsworth,Kanopolis,State House,108,D,Kelley Menke,88
-Ellsworth,Kanopolis,State House,108,,Write-ins,0
-Ellsworth,Lorraine,President,,D,Hillary Clinton,17
-Ellsworth,Lorraine,President,,LBT,Gary Johnson,7
-Ellsworth,Lorraine,President,,IND,Jill Stein,4
-Ellsworth,Lorraine,President,,R,Donald J Trump,57
-Ellsworth,Lorraine,President,,,Write-ins,5
-Ellsworth,Lorraine,U.S. Senate,,R,Jerry Moran,69
-Ellsworth,Lorraine,U.S. Senate,,D,Patrick Wiesner,15
-Ellsworth,Lorraine,U.S. Senate,,LBT,Robert Garrard,5
-Ellsworth,Lorraine,U.S. Senate,,,Write-ins,1
-Ellsworth,Lorraine,U.S. House,1,LBT,Kerry Burt,5
-Ellsworth,Lorraine,U.S. House,1,IND,Alan LaPolice,23
-Ellsworth,Lorraine,U.S. House,1,R,Roger Marshall,56
-Ellsworth,Lorraine,U.S. House,1,,Write-ins,0
-Ellsworth,Lorraine,State Senate,35,D,Levi Morris,28
-Ellsworth,Lorraine,State Senate,35,R,Richard Wilborn,58
-Ellsworth,Lorraine,State Senate,35,,Write-ins,0
-Ellsworth,Lorraine,State House,108,R,Steven Johnson,65
-Ellsworth,Lorraine,State House,108,D,Kelley Menke,23
-Ellsworth,Lorraine,State House,108,,Write-ins,0
-Ellsworth,Wilson,President,,D,Hillary Clinton,8
-Ellsworth,Wilson,President,,LBT,Gary Johnson,2
-Ellsworth,Wilson,President,,IND,Jill Stein,1
-Ellsworth,Wilson,President,,R,Donald J Trump,30
-Ellsworth,Wilson,President,,,Write-ins,1
-Ellsworth,Wilson,U.S. Senate,,R,Jerry Moran,38
-Ellsworth,Wilson,U.S. Senate,,D,Patrick Wiesner,4
-Ellsworth,Wilson,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Wilson,U.S. Senate,,,Write-ins,1
-Ellsworth,Wilson,U.S. House,1,LBT,Kerry Burt,1
-Ellsworth,Wilson,U.S. House,1,IND,Alan LaPolice,14
-Ellsworth,Wilson,U.S. House,1,R,Roger Marshall,28
-Ellsworth,Wilson,U.S. House,1,,Write-ins,1
-Ellsworth,Wilson,State Senate,35,D,Levi Morris,15
-Ellsworth,Wilson,State Senate,35,R,Richard Wilborn,28
-Ellsworth,Wilson,State Senate,35,,Write-ins,1
-Ellsworth,Wilson,State House,108,R,Steven Johnson,28
-Ellsworth,Wilson,State House,108,D,Kelley Menke,15
-Ellsworth,Wilson,State House,108,,Write-ins,1
-Ellsworth,Canren,President,,D,Hillary Clinton,14
-Ellsworth,Canren,President,,LBT,Gary Johnson,0
-Ellsworth,Canren,President,,IND,Jill Stein,0
-Ellsworth,Canren,President,,R,Donald J Trump,16
-Ellsworth,Canren,President,,,Write-ins,0
-Ellsworth,Canren,U.S. Senate,,R,Jerry Moran,21
-Ellsworth,Canren,U.S. Senate,,D,Patrick Wiesner,8
-Ellsworth,Canren,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Canren,U.S. Senate,,,Write-ins,0
-Ellsworth,Canren,U.S. House,1,LBT,Kerry Burt,2
-Ellsworth,Canren,U.S. House,1,IND,Alan LaPolice,8
-Ellsworth,Canren,U.S. House,1,R,Roger Marshall,20
-Ellsworth,Canren,U.S. House,1,,Write-ins,0
-Ellsworth,Canren,State Senate,35,D,Levi Morris,14
-Ellsworth,Canren,State Senate,35,R,Richard Wilborn,16
-Ellsworth,Canren,State Senate,35,,Write-ins,0
-Ellsworth,Canren,State House,108,R,Steven Johnson,21
-Ellsworth,Canren,State House,108,D,Kelley Menke,9
-Ellsworth,Canren,State House,108,,Write-ins,0
-Ellsworth,Wilson City,President,,D,Hillary Clinton,64
-Ellsworth,Wilson City,President,,LBT,Gary Johnson,13
-Ellsworth,Wilson City,President,,IND,Jill Stein,14
-Ellsworth,Wilson City,President,,R,Donald J Trump,249
-Ellsworth,Wilson City,President,,,Write-ins,2
-Ellsworth,Wilson City,U.S. Senate,,R,Jerry Moran,275
-Ellsworth,Wilson City,U.S. Senate,,D,Patrick Wiesner,50
-Ellsworth,Wilson City,U.S. Senate,,LBT,Robert Garrard,16
-Ellsworth,Wilson City,U.S. Senate,,,Write-ins,0
-Ellsworth,Wilson City,U.S. House,1,LBT,Kerry Burt,7
-Ellsworth,Wilson City,U.S. House,1,IND,Alan LaPolice,107
-Ellsworth,Wilson City,U.S. House,1,R,Roger Marshall,216
-Ellsworth,Wilson City,U.S. House,1,,Write-ins,1
-Ellsworth,Wilson City,State Senate,35,D,Levi Morris,121
-Ellsworth,Wilson City,State Senate,35,R,Richard Wilborn,209
-Ellsworth,Wilson City,State Senate,35,,Write-ins,0
-Ellsworth,Wilson City,State House,108,R,Steven Johnson,223
-Ellsworth,Wilson City,State House,108,D,Kelley Menke,106
-Ellsworth,Wilson City,State House,108,,Write-ins,0
-Ellsworth,Wilson twp,President,,D,Hillary Clinton,8
-Ellsworth,Wilson twp,President,,LBT,Gary Johnson,3
-Ellsworth,Wilson twp,President,,IND,Jill Stein,1
-Ellsworth,Wilson twp,President,,R,Donald J Trump,30
-Ellsworth,Wilson twp,President,,,Write-ins,0
-Ellsworth,Wilson twp,U.S. Senate,,R,Jerry Moran,38
-Ellsworth,Wilson twp,U.S. Senate,,D,Patrick Wiesner,4
-Ellsworth,Wilson twp,U.S. Senate,,LBT,Robert Garrard,1
-Ellsworth,Wilson twp,U.S. Senate,,,Write-ins,0
-Ellsworth,Wilson twp,U.S. House,1,LBT,Kerry Burt,1
-Ellsworth,Wilson twp,U.S. House,1,IND,Alan LaPolice,14
-Ellsworth,Wilson twp,U.S. House,1,R,Roger Marshall,28
-Ellsworth,Wilson twp,U.S. House,1,,Write-ins,0
-Ellsworth,Wilson twp,State Senate,35,D,Levi Morris,15
-Ellsworth,Wilson twp,State Senate,35,R,Richard Wilborn,28
-Ellsworth,Wilson twp,State Senate,35,,Write-ins,0
-Ellsworth,Wilson twp,State House,108,R,Steven Johnson,28
-Ellsworth,Wilson twp,State House,108,D,Kelley Menke,15
-Ellsworth,Wilson twp,State House,108,,Write-ins,0
+county,precinct,office,district,party,candidate,votes,vtd
+ELLSWORTH,Ash Creek Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",5,000010
+ELLSWORTH,Ash Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",30,000010
+ELLSWORTH,Black Wolf Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",12,000020
+ELLSWORTH,Black Wolf Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",41,000020
+ELLSWORTH,Buckeye Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",1,000030
+ELLSWORTH,Buckeye Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",28,000030
+ELLSWORTH,Carneiro Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",3,000040
+ELLSWORTH,Carneiro Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",24,000040
+ELLSWORTH,Clear Creek Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",13,000050
+ELLSWORTH,Clear Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",50,000050
+ELLSWORTH,Columbia Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",5,000060
+ELLSWORTH,Columbia Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",27,000060
+ELLSWORTH,Ellsworth City East Ward 1,Kansas House of Representatives,108,Democratic,"Menke, Kelley",87,000070
+ELLSWORTH,Ellsworth City East Ward 1,Kansas House of Representatives,108,Republican,"Johnson, Steven",220,000070
+ELLSWORTH,Ellsworth City East Ward 2,Kansas House of Representatives,108,Democratic,"Menke, Kelley",96,000080
+ELLSWORTH,Ellsworth City East Ward 2,Kansas House of Representatives,108,Republican,"Johnson, Steven",218,000080
+ELLSWORTH,Ellsworth City West,Kansas House of Representatives,108,Democratic,"Menke, Kelley",103,00009A
+ELLSWORTH,Ellsworth City West,Kansas House of Representatives,108,Republican,"Johnson, Steven",247,00009A
+ELLSWORTH,Canren Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",9,00009B
+ELLSWORTH,Canren Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",21,00009B
+ELLSWORTH,Ellsworth Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",21,000100
+ELLSWORTH,Ellsworth Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",69,000100
+ELLSWORTH,Garfield Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",0,000110
+ELLSWORTH,Garfield Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",29,000110
+ELLSWORTH,Green Garden Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",23,000120
+ELLSWORTH,Green Garden Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",65,000120
+ELLSWORTH,Kanopolis Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",88,000130
+ELLSWORTH,Kanopolis Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",148,000130
+ELLSWORTH,Langley Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",11,000140
+ELLSWORTH,Langley Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",33,000140
+ELLSWORTH,Lincoln Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",6,000150
+ELLSWORTH,Lincoln Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",21,000150
+ELLSWORTH,Mulberry Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",1,000160
+ELLSWORTH,Mulberry Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",17,000160
+ELLSWORTH,Noble Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",9,000170
+ELLSWORTH,Noble Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",32,000170
+ELLSWORTH,Palacky Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",8,000180
+ELLSWORTH,Palacky Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",25,000180
+ELLSWORTH,Sherman Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",4,000190
+ELLSWORTH,Sherman Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",32,000190
+ELLSWORTH,Thomas Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",7,000200
+ELLSWORTH,Thomas Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",28,000200
+ELLSWORTH,Trivoli Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",5,000210
+ELLSWORTH,Trivoli Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",26,000210
+ELLSWORTH,Valley Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",75,000220
+ELLSWORTH,Valley Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",172,000220
+ELLSWORTH,Venango Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",21,000230
+ELLSWORTH,Venango Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",43,000230
+ELLSWORTH,Wilson Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",121,000240
+ELLSWORTH,Wilson Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",251,000240
+ELLSWORTH,Ash Creek Township,Kansas Senate,35,Democratic,"Morris, Levi",8,000010
+ELLSWORTH,Ash Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",24,000010
+ELLSWORTH,Black Wolf Township,Kansas Senate,35,Democratic,"Morris, Levi",16,000020
+ELLSWORTH,Black Wolf Township,Kansas Senate,35,Republican,"Wilborn, Richard",38,000020
+ELLSWORTH,Buckeye Township,Kansas Senate,35,Democratic,"Morris, Levi",9,000030
+ELLSWORTH,Buckeye Township,Kansas Senate,35,Republican,"Wilborn, Richard",19,000030
+ELLSWORTH,Carneiro Township,Kansas Senate,35,Democratic,"Morris, Levi",5,000040
+ELLSWORTH,Carneiro Township,Kansas Senate,35,Republican,"Wilborn, Richard",22,000040
+ELLSWORTH,Clear Creek Township,Kansas Senate,35,Democratic,"Morris, Levi",18,000050
+ELLSWORTH,Clear Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",41,000050
+ELLSWORTH,Columbia Township,Kansas Senate,35,Democratic,"Morris, Levi",5,000060
+ELLSWORTH,Columbia Township,Kansas Senate,35,Republican,"Wilborn, Richard",27,000060
+ELLSWORTH,Ellsworth City East Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",120,000070
+ELLSWORTH,Ellsworth City East Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",182,000070
+ELLSWORTH,Ellsworth City East Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",131,000080
+ELLSWORTH,Ellsworth City East Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",183,000080
+ELLSWORTH,Ellsworth City West,Kansas Senate,35,Democratic,"Morris, Levi",130,00009A
+ELLSWORTH,Ellsworth City West,Kansas Senate,35,Republican,"Wilborn, Richard",219,00009A
+ELLSWORTH,Canren Township,Kansas Senate,35,Democratic,"Morris, Levi",14,00009B
+ELLSWORTH,Canren Township,Kansas Senate,35,Republican,"Wilborn, Richard",16,00009B
+ELLSWORTH,Ellsworth Township,Kansas Senate,35,Democratic,"Morris, Levi",26,000100
+ELLSWORTH,Ellsworth Township,Kansas Senate,35,Republican,"Wilborn, Richard",61,000100
+ELLSWORTH,Garfield Township,Kansas Senate,35,Democratic,"Morris, Levi",4,000110
+ELLSWORTH,Garfield Township,Kansas Senate,35,Republican,"Wilborn, Richard",25,000110
+ELLSWORTH,Green Garden Township,Kansas Senate,35,Democratic,"Morris, Levi",28,000120
+ELLSWORTH,Green Garden Township,Kansas Senate,35,Republican,"Wilborn, Richard",58,000120
+ELLSWORTH,Kanopolis Township,Kansas Senate,35,Democratic,"Morris, Levi",103,000130
+ELLSWORTH,Kanopolis Township,Kansas Senate,35,Republican,"Wilborn, Richard",129,000130
+ELLSWORTH,Langley Township,Kansas Senate,35,Democratic,"Morris, Levi",6,000140
+ELLSWORTH,Langley Township,Kansas Senate,35,Republican,"Wilborn, Richard",38,000140
+ELLSWORTH,Lincoln Township,Kansas Senate,35,Democratic,"Morris, Levi",6,000150
+ELLSWORTH,Lincoln Township,Kansas Senate,35,Republican,"Wilborn, Richard",21,000150
+ELLSWORTH,Mulberry Township,Kansas Senate,35,Democratic,"Morris, Levi",2,000160
+ELLSWORTH,Mulberry Township,Kansas Senate,35,Republican,"Wilborn, Richard",16,000160
+ELLSWORTH,Noble Township,Kansas Senate,35,Democratic,"Morris, Levi",8,000170
+ELLSWORTH,Noble Township,Kansas Senate,35,Republican,"Wilborn, Richard",32,000170
+ELLSWORTH,Palacky Township,Kansas Senate,35,Democratic,"Morris, Levi",5,000180
+ELLSWORTH,Palacky Township,Kansas Senate,35,Republican,"Wilborn, Richard",27,000180
+ELLSWORTH,Sherman Township,Kansas Senate,35,Democratic,"Morris, Levi",8,000190
+ELLSWORTH,Sherman Township,Kansas Senate,35,Republican,"Wilborn, Richard",28,000190
+ELLSWORTH,Thomas Township,Kansas Senate,35,Democratic,"Morris, Levi",9,000200
+ELLSWORTH,Thomas Township,Kansas Senate,35,Republican,"Wilborn, Richard",24,000200
+ELLSWORTH,Trivoli Township,Kansas Senate,35,Democratic,"Morris, Levi",5,000210
+ELLSWORTH,Trivoli Township,Kansas Senate,35,Republican,"Wilborn, Richard",25,000210
+ELLSWORTH,Valley Township,Kansas Senate,35,Democratic,"Morris, Levi",79,000220
+ELLSWORTH,Valley Township,Kansas Senate,35,Republican,"Wilborn, Richard",168,000220
+ELLSWORTH,Venango Township,Kansas Senate,35,Democratic,"Morris, Levi",19,000230
+ELLSWORTH,Venango Township,Kansas Senate,35,Republican,"Wilborn, Richard",44,000230
+ELLSWORTH,Wilson Township,Kansas Senate,35,Democratic,"Morris, Levi",136,000240
+ELLSWORTH,Wilson Township,Kansas Senate,35,Republican,"Wilborn, Richard",237,000240
+ELLSWORTH,Ash Creek Township,President / Vice President,,independent,"Stein, Jill",1,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+ELLSWORTH,Ash Creek Township,President / Vice President,,Republican,"Trump, Donald J.",31,000010
+ELLSWORTH,Black Wolf Township,President / Vice President,,independent,"Stein, Jill",2,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+ELLSWORTH,Black Wolf Township,President / Vice President,,Republican,"Trump, Donald J.",39,000020
+ELLSWORTH,Buckeye Township,President / Vice President,,independent,"Stein, Jill",2,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+ELLSWORTH,Buckeye Township,President / Vice President,,Republican,"Trump, Donald J.",22,000030
+ELLSWORTH,Carneiro Township,President / Vice President,,independent,"Stein, Jill",1,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+ELLSWORTH,Carneiro Township,President / Vice President,,Republican,"Trump, Donald J.",25,000040
+ELLSWORTH,Clear Creek Township,President / Vice President,,independent,"Stein, Jill",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+ELLSWORTH,Clear Creek Township,President / Vice President,,Republican,"Trump, Donald J.",54,000050
+ELLSWORTH,Columbia Township,President / Vice President,,independent,"Stein, Jill",1,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+ELLSWORTH,Columbia Township,President / Vice President,,Republican,"Trump, Donald J.",29,000060
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,independent,"Stein, Jill",10,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000070
+ELLSWORTH,Ellsworth City East Ward 1,President / Vice President,,Republican,"Trump, Donald J.",222,000070
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,independent,"Stein, Jill",16,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+ELLSWORTH,Ellsworth City East Ward 2,President / Vice President,,Republican,"Trump, Donald J.",212,000080
+ELLSWORTH,Ellsworth City West,President / Vice President,,independent,"Stein, Jill",3,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Castle, Darrell L",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Giordani, Rocky",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Hedges, James A",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Kahn, Lynn",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"La Riva, Gloria",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Levinson, Michael S.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Maturen, Michael A",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"McMullin, Evan",4,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Perry, Darryl",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Schriner, Joe C",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Smith, Mike",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Sood, Ajay",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Sterling, Shawna",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Libertarian,"Johnson, Gary",17,00009A
+ELLSWORTH,Ellsworth City West,President / Vice President,,Republican,"Trump, Donald J.",265,00009A
+ELLSWORTH,Canren Township,President / Vice President,,independent,"Stein, Jill",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Castle, Darrell L",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Giordani, Rocky",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Hedges, James A",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Kahn, Lynn",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"La Riva, Gloria",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Maturen, Michael A",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"McMullin, Evan",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Perry, Darryl",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Schriner, Joe C",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Smith, Mike",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Sood, Ajay",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Sterling, Shawna",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+ELLSWORTH,Canren Township,President / Vice President,,Republican,"Trump, Donald J.",16,00009B
+ELLSWORTH,Ellsworth Township,President / Vice President,,independent,"Stein, Jill",1,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Maturen, Michael A",1,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+ELLSWORTH,Ellsworth Township,President / Vice President,,Republican,"Trump, Donald J.",65,000100
+ELLSWORTH,Garfield Township,President / Vice President,,independent,"Stein, Jill",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+ELLSWORTH,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",26,000110
+ELLSWORTH,Green Garden Township,President / Vice President,,independent,"Stein, Jill",4,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000120
+ELLSWORTH,Green Garden Township,President / Vice President,,Republican,"Trump, Donald J.",57,000120
+ELLSWORTH,Kanopolis Township,President / Vice President,,independent,"Stein, Jill",7,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000130
+ELLSWORTH,Kanopolis Township,President / Vice President,,Republican,"Trump, Donald J.",158,000130
+ELLSWORTH,Langley Township,President / Vice President,,independent,"Stein, Jill",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000140
+ELLSWORTH,Langley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+ELLSWORTH,Langley Township,President / Vice President,,Republican,"Trump, Donald J.",40,000140
+ELLSWORTH,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+ELLSWORTH,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",27,000150
+ELLSWORTH,Mulberry Township,President / Vice President,,independent,"Stein, Jill",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"McMullin, Evan",2,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+ELLSWORTH,Mulberry Township,President / Vice President,,Republican,"Trump, Donald J.",16,000160
+ELLSWORTH,Noble Township,President / Vice President,,independent,"Stein, Jill",1,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+ELLSWORTH,Noble Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000170
+ELLSWORTH,Noble Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+ELLSWORTH,Noble Township,President / Vice President,,Republican,"Trump, Donald J.",30,000170
+ELLSWORTH,Palacky Township,President / Vice President,,independent,"Stein, Jill",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+ELLSWORTH,Palacky Township,President / Vice President,,Republican,"Trump, Donald J.",29,000180
+ELLSWORTH,Sherman Township,President / Vice President,,independent,"Stein, Jill",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+ELLSWORTH,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",34,000190
+ELLSWORTH,Thomas Township,President / Vice President,,independent,"Stein, Jill",1,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+ELLSWORTH,Thomas Township,President / Vice President,,Republican,"Trump, Donald J.",31,000200
+ELLSWORTH,Trivoli Township,President / Vice President,,independent,"Stein, Jill",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+ELLSWORTH,Trivoli Township,President / Vice President,,Republican,"Trump, Donald J.",29,000210
+ELLSWORTH,Valley Township,President / Vice President,,independent,"Stein, Jill",8,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+ELLSWORTH,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000220
+ELLSWORTH,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000220
+ELLSWORTH,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",184,000220
+ELLSWORTH,Venango Township,President / Vice President,,independent,"Stein, Jill",1,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"McMullin, Evan",1,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+ELLSWORTH,Venango Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000230
+ELLSWORTH,Venango Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+ELLSWORTH,Venango Township,President / Vice President,,Republican,"Trump, Donald J.",49,000230
+ELLSWORTH,Wilson Township,President / Vice President,,independent,"Stein, Jill",15,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",72,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000240
+ELLSWORTH,Wilson Township,President / Vice President,,Republican,"Trump, Donald J.",279,000240
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000010
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+ELLSWORTH,Ash Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000010
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000020
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+ELLSWORTH,Black Wolf Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000020
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000030
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+ELLSWORTH,Buckeye Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000030
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000040
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+ELLSWORTH,Carneiro Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000040
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000050
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000050
+ELLSWORTH,Clear Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",39,000050
+ELLSWORTH,Columbia Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000060
+ELLSWORTH,Columbia Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+ELLSWORTH,Columbia Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000060
+ELLSWORTH,Columbia Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000060
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",92,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",206,000070
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",120,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",189,000080
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,independent,"LaPolice, Alan",123,00009A
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00009A
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,00009A
+ELLSWORTH,Ellsworth City West,United States House of Representatives,1,Republican,"Marshall, Roger",221,00009A
+ELLSWORTH,Canren Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,00009B
+ELLSWORTH,Canren Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00009B
+ELLSWORTH,Canren Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,00009B
+ELLSWORTH,Canren Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,00009B
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000100
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000100
+ELLSWORTH,Ellsworth Township,United States House of Representatives,1,Republican,"Marshall, Roger",56,000100
+ELLSWORTH,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000110
+ELLSWORTH,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+ELLSWORTH,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000110
+ELLSWORTH,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000110
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000120
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000120
+ELLSWORTH,Green Garden Township,United States House of Representatives,1,Republican,"Marshall, Roger",56,000120
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,independent,"LaPolice, Alan",78,000130
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000130
+ELLSWORTH,Kanopolis Township,United States House of Representatives,1,Republican,"Marshall, Roger",141,000130
+ELLSWORTH,Langley Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000140
+ELLSWORTH,Langley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000140
+ELLSWORTH,Langley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000140
+ELLSWORTH,Langley Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000140
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000150
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000150
+ELLSWORTH,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000150
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000160
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000160
+ELLSWORTH,Mulberry Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000160
+ELLSWORTH,Noble Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000170
+ELLSWORTH,Noble Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000170
+ELLSWORTH,Noble Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000170
+ELLSWORTH,Noble Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000170
+ELLSWORTH,Palacky Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000180
+ELLSWORTH,Palacky Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+ELLSWORTH,Palacky Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000180
+ELLSWORTH,Palacky Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000180
+ELLSWORTH,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000190
+ELLSWORTH,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+ELLSWORTH,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000190
+ELLSWORTH,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000190
+ELLSWORTH,Thomas Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000200
+ELLSWORTH,Thomas Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+ELLSWORTH,Thomas Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000200
+ELLSWORTH,Thomas Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000200
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000210
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000210
+ELLSWORTH,Trivoli Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000210
+ELLSWORTH,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",60,000220
+ELLSWORTH,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+ELLSWORTH,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000220
+ELLSWORTH,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",180,000220
+ELLSWORTH,Venango Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000230
+ELLSWORTH,Venango Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000230
+ELLSWORTH,Venango Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000230
+ELLSWORTH,Venango Township,United States House of Representatives,1,Republican,"Marshall, Roger",42,000230
+ELLSWORTH,Wilson Township,United States House of Representatives,1,independent,"LaPolice, Alan",121,000240
+ELLSWORTH,Wilson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+ELLSWORTH,Wilson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000240
+ELLSWORTH,Wilson Township,United States House of Representatives,1,Republican,"Marshall, Roger",244,000240
+ELLSWORTH,Ash Creek Township,United States Senate,,write - in,"Smith, DJ",0,000010
+ELLSWORTH,Ash Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000010
+ELLSWORTH,Ash Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+ELLSWORTH,Ash Creek Township,United States Senate,,Republican,"Moran, Jerry",30,000010
+ELLSWORTH,Black Wolf Township,United States Senate,,write - in,"Smith, DJ",0,000020
+ELLSWORTH,Black Wolf Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000020
+ELLSWORTH,Black Wolf Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+ELLSWORTH,Black Wolf Township,United States Senate,,Republican,"Moran, Jerry",45,000020
+ELLSWORTH,Buckeye Township,United States Senate,,write - in,"Smith, DJ",0,000030
+ELLSWORTH,Buckeye Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000030
+ELLSWORTH,Buckeye Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+ELLSWORTH,Buckeye Township,United States Senate,,Republican,"Moran, Jerry",27,000030
+ELLSWORTH,Carneiro Township,United States Senate,,write - in,"Smith, DJ",0,000040
+ELLSWORTH,Carneiro Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000040
+ELLSWORTH,Carneiro Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+ELLSWORTH,Carneiro Township,United States Senate,,Republican,"Moran, Jerry",25,000040
+ELLSWORTH,Clear Creek Township,United States Senate,,write - in,"Smith, DJ",0,000050
+ELLSWORTH,Clear Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000050
+ELLSWORTH,Clear Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+ELLSWORTH,Clear Creek Township,United States Senate,,Republican,"Moran, Jerry",52,000050
+ELLSWORTH,Columbia Township,United States Senate,,write - in,"Smith, DJ",0,000060
+ELLSWORTH,Columbia Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000060
+ELLSWORTH,Columbia Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+ELLSWORTH,Columbia Township,United States Senate,,Republican,"Moran, Jerry",31,000060
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,write - in,"Smith, DJ",0,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",50,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000070
+ELLSWORTH,Ellsworth City East Ward 1,United States Senate,,Republican,"Moran, Jerry",251,000070
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,write - in,"Smith, DJ",0,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",41,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,000080
+ELLSWORTH,Ellsworth City East Ward 2,United States Senate,,Republican,"Moran, Jerry",271,000080
+ELLSWORTH,Ellsworth City West,United States Senate,,write - in,"Smith, DJ",0,00009A
+ELLSWORTH,Ellsworth City West,United States Senate,,Democratic,"Wiesner, Patrick",48,00009A
+ELLSWORTH,Ellsworth City West,United States Senate,,Libertarian,"Garrard, Robert D.",13,00009A
+ELLSWORTH,Ellsworth City West,United States Senate,,Republican,"Moran, Jerry",305,00009A
+ELLSWORTH,Canren Township,United States Senate,,write - in,"Smith, DJ",0,00009B
+ELLSWORTH,Canren Township,United States Senate,,Democratic,"Wiesner, Patrick",8,00009B
+ELLSWORTH,Canren Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,00009B
+ELLSWORTH,Canren Township,United States Senate,,Republican,"Moran, Jerry",21,00009B
+ELLSWORTH,Ellsworth Township,United States Senate,,write - in,"Smith, DJ",0,000100
+ELLSWORTH,Ellsworth Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000100
+ELLSWORTH,Ellsworth Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000100
+ELLSWORTH,Ellsworth Township,United States Senate,,Republican,"Moran, Jerry",75,000100
+ELLSWORTH,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000110
+ELLSWORTH,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000110
+ELLSWORTH,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+ELLSWORTH,Garfield Township,United States Senate,,Republican,"Moran, Jerry",25,000110
+ELLSWORTH,Green Garden Township,United States Senate,,write - in,"Smith, DJ",0,000120
+ELLSWORTH,Green Garden Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000120
+ELLSWORTH,Green Garden Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000120
+ELLSWORTH,Green Garden Township,United States Senate,,Republican,"Moran, Jerry",69,000120
+ELLSWORTH,Kanopolis Township,United States Senate,,write - in,"Smith, DJ",0,000130
+ELLSWORTH,Kanopolis Township,United States Senate,,Democratic,"Wiesner, Patrick",53,000130
+ELLSWORTH,Kanopolis Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000130
+ELLSWORTH,Kanopolis Township,United States Senate,,Republican,"Moran, Jerry",172,000130
+ELLSWORTH,Langley Township,United States Senate,,write - in,"Smith, DJ",0,000140
+ELLSWORTH,Langley Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000140
+ELLSWORTH,Langley Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000140
+ELLSWORTH,Langley Township,United States Senate,,Republican,"Moran, Jerry",41,000140
+ELLSWORTH,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000150
+ELLSWORTH,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000150
+ELLSWORTH,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000150
+ELLSWORTH,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",25,000150
+ELLSWORTH,Mulberry Township,United States Senate,,write - in,"Smith, DJ",0,000160
+ELLSWORTH,Mulberry Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000160
+ELLSWORTH,Mulberry Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+ELLSWORTH,Mulberry Township,United States Senate,,Republican,"Moran, Jerry",15,000160
+ELLSWORTH,Noble Township,United States Senate,,write - in,"Smith, DJ",0,000170
+ELLSWORTH,Noble Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000170
+ELLSWORTH,Noble Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+ELLSWORTH,Noble Township,United States Senate,,Republican,"Moran, Jerry",34,000170
+ELLSWORTH,Palacky Township,United States Senate,,write - in,"Smith, DJ",0,000180
+ELLSWORTH,Palacky Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000180
+ELLSWORTH,Palacky Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+ELLSWORTH,Palacky Township,United States Senate,,Republican,"Moran, Jerry",31,000180
+ELLSWORTH,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000190
+ELLSWORTH,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000190
+ELLSWORTH,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+ELLSWORTH,Sherman Township,United States Senate,,Republican,"Moran, Jerry",34,000190
+ELLSWORTH,Thomas Township,United States Senate,,write - in,"Smith, DJ",0,000200
+ELLSWORTH,Thomas Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000200
+ELLSWORTH,Thomas Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000200
+ELLSWORTH,Thomas Township,United States Senate,,Republican,"Moran, Jerry",34,000200
+ELLSWORTH,Trivoli Township,United States Senate,,write - in,"Smith, DJ",0,000210
+ELLSWORTH,Trivoli Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000210
+ELLSWORTH,Trivoli Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000210
+ELLSWORTH,Trivoli Township,United States Senate,,Republican,"Moran, Jerry",24,000210
+ELLSWORTH,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000220
+ELLSWORTH,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000220
+ELLSWORTH,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000220
+ELLSWORTH,Valley Township,United States Senate,,Republican,"Moran, Jerry",199,000220
+ELLSWORTH,Venango Township,United States Senate,,write - in,"Smith, DJ",0,000230
+ELLSWORTH,Venango Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000230
+ELLSWORTH,Venango Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000230
+ELLSWORTH,Venango Township,United States Senate,,Republican,"Moran, Jerry",50,000230
+ELLSWORTH,Wilson Township,United States Senate,,write - in,"Smith, DJ",0,000240
+ELLSWORTH,Wilson Township,United States Senate,,Democratic,"Wiesner, Patrick",54,000240
+ELLSWORTH,Wilson Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000240
+ELLSWORTH,Wilson Township,United States Senate,,Republican,"Moran, Jerry",313,000240

--- a/2016/20161108__ks__general__finney__precinct.csv
+++ b/2016/20161108__ks__general__finney__precinct.csv
@@ -1,1002 +1,1002 @@
-county,precinct,office,district,candidate,party,votes
-Finney,Friend Township,President,,"Stein, Jill  ",independent,0
-Finney,Friend Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Friend Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Friend Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Friend Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Friend Township,President,,"Hedges, James A ",write - in,0
-Finney,Friend Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Friend Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Friend Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Friend Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Friend Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Friend Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Friend Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Friend Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Friend Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Friend Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Friend Township,President,,"Smith, Mike  ",write - in,0
-Finney,Friend Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Friend Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Friend Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Friend Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Friend Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Friend Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Finney,Friend Township,President,,"Johnson, Gary  ",Libertarian,5
-Finney,Friend Township,President,,"Trump, Donald J. ",Republican,47
-Finney,Garden City Ward 3,President,,"Stein, Jill  ",independent,19
-Finney,Garden City Ward 3,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 3,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 3,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 3,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 3,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 3,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 3,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 3,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 3,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 3,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 3,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 3,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 3,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 3,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 3,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 3,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 3,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 3,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,184
-Finney,Garden City Ward 3,President,,"Johnson, Gary  ",Libertarian,24
-Finney,Garden City Ward 3,President,,"Trump, Donald J. ",Republican,283
-Finney,Garden City Ward 5,President,,"Stein, Jill  ",independent,4
-Finney,Garden City Ward 5,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 5,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 5,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 5,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 5,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 5,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 5,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 5,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 5,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 5,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 5,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 5,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 5,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 5,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 5,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 5,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 5,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 5,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 5,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 5,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 5,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 5,President,,"Clinton, Hillary Rodham ",Democratic,108
-Finney,Garden City Ward 5,President,,"Johnson, Gary  ",Libertarian,16
-Finney,Garden City Ward 5,President,,"Trump, Donald J. ",Republican,196
-Finney,Garden City Ward 6,President,,"Stein, Jill  ",independent,5
-Finney,Garden City Ward 6,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 6,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 6,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 6,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 6,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 6,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 6,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 6,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 6,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 6,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 6,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 6,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 6,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 6,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 6,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 6,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 6,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 6,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 6,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 6,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 6,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 6,President,,"Clinton, Hillary Rodham ",Democratic,221
-Finney,Garden City Ward 6,President,,"Johnson, Gary  ",Libertarian,23
-Finney,Garden City Ward 6,President,,"Trump, Donald J. ",Republican,243
-Finney,Garden City Ward 7,President,,"Stein, Jill  ",independent,9
-Finney,Garden City Ward 7,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 7,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 7,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 7,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 7,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 7,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 7,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 7,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 7,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 7,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 7,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 7,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 7,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 7,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 7,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 7,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 7,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 7,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 7,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 7,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 7,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 7,President,,"Clinton, Hillary Rodham ",Democratic,128
-Finney,Garden City Ward 7,President,,"Johnson, Gary  ",Libertarian,15
-Finney,Garden City Ward 7,President,,"Trump, Donald J. ",Republican,160
-Finney,Garden City Ward 8,President,,"Stein, Jill  ",independent,10
-Finney,Garden City Ward 8,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 8,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 8,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 8,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 8,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 8,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 8,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 8,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 8,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 8,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 8,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 8,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 8,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 8,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 8,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 8,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 8,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 8,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 8,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 8,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 8,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 8,President,,"Clinton, Hillary Rodham ",Democratic,309
-Finney,Garden City Ward 8,President,,"Johnson, Gary  ",Libertarian,21
-Finney,Garden City Ward 8,President,,"Trump, Donald J. ",Republican,243
-Finney,Garden City Ward 9,President,,"Stein, Jill  ",independent,8
-Finney,Garden City Ward 9,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 9,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 9,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 9,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 9,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 9,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 9,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 9,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 9,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 9,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 9,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 9,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 9,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 9,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 9,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 9,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 9,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 9,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 9,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 9,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 9,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 9,President,,"Clinton, Hillary Rodham ",Democratic,154
-Finney,Garden City Ward 9,President,,"Johnson, Gary  ",Libertarian,22
-Finney,Garden City Ward 9,President,,"Trump, Donald J. ",Republican,171
-Finney,Garden City Ward 10,President,,"Stein, Jill  ",independent,11
-Finney,Garden City Ward 10,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 10,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 10,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 10,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 10,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 10,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 10,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 10,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 10,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 10,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 10,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 10,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 10,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 10,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 10,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 10,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 10,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 10,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 10,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 10,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 10,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 10,President,,"Clinton, Hillary Rodham ",Democratic,118
-Finney,Garden City Ward 10,President,,"Johnson, Gary  ",Libertarian,17
-Finney,Garden City Ward 10,President,,"Trump, Donald J. ",Republican,201
-Finney,Garden City Ward 11,President,,"Stein, Jill  ",independent,5
-Finney,Garden City Ward 11,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 11,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 11,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 11,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 11,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 11,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 11,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 11,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 11,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 11,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 11,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 11,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 11,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 11,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 11,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 11,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 11,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 11,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 11,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 11,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 11,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 11,President,,"Clinton, Hillary Rodham ",Democratic,156
-Finney,Garden City Ward 11,President,,"Johnson, Gary  ",Libertarian,20
-Finney,Garden City Ward 11,President,,"Trump, Donald J. ",Republican,347
-Finney,Garden City Ward 12,President,,"Stein, Jill  ",independent,3
-Finney,Garden City Ward 12,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 12,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 12,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 12,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 12,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 12,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 12,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 12,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 12,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 12,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 12,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 12,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 12,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 12,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 12,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 12,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 12,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 12,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 12,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 12,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 12,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 12,President,,"Clinton, Hillary Rodham ",Democratic,132
-Finney,Garden City Ward 12,President,,"Johnson, Gary  ",Libertarian,23
-Finney,Garden City Ward 12,President,,"Trump, Donald J. ",Republican,383
-Finney,Garden City Ward 13,President,,"Stein, Jill  ",independent,4
-Finney,Garden City Ward 13,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 13,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 13,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 13,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 13,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 13,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 13,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 13,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 13,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 13,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 13,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 13,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 13,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 13,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 13,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 13,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 13,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 13,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 13,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 13,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 13,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 13,President,,"Clinton, Hillary Rodham ",Democratic,95
-Finney,Garden City Ward 13,President,,"Johnson, Gary  ",Libertarian,13
-Finney,Garden City Ward 13,President,,"Trump, Donald J. ",Republican,342
-Finney,Garden City Ward 16,President,,"Stein, Jill  ",independent,14
-Finney,Garden City Ward 16,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 16,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 16,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 16,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 16,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 16,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 16,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 16,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 16,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 16,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 16,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 16,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 16,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 16,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 16,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 16,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 16,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 16,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 16,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 16,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 16,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 16,President,,"Clinton, Hillary Rodham ",Democratic,165
-Finney,Garden City Ward 16,President,,"Johnson, Gary  ",Libertarian,23
-Finney,Garden City Ward 16,President,,"Trump, Donald J. ",Republican,380
-Finney,Holcomb Township,President,,"Stein, Jill  ",independent,21
-Finney,Holcomb Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Holcomb Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Holcomb Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Holcomb Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Holcomb Township,President,,"Hedges, James A ",write - in,0
-Finney,Holcomb Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Holcomb Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Holcomb Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Holcomb Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Holcomb Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Holcomb Township,President,,"McMullin, Evan  ",write - in,1
-Finney,Holcomb Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Holcomb Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Holcomb Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Holcomb Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Holcomb Township,President,,"Smith, Mike  ",write - in,0
-Finney,Holcomb Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Holcomb Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Holcomb Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Holcomb Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Holcomb Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Holcomb Township,President,,"Clinton, Hillary Rodham ",Democratic,154
-Finney,Holcomb Township,President,,"Johnson, Gary  ",Libertarian,33
-Finney,Holcomb Township,President,,"Trump, Donald J. ",Republican,682
-Finney,Huffman Township,President,,"Stein, Jill  ",independent,4
-Finney,Huffman Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Huffman Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Huffman Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Huffman Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Huffman Township,President,,"Hedges, James A ",write - in,0
-Finney,Huffman Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Huffman Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Huffman Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Huffman Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Huffman Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Huffman Township,President,,"McMullin, Evan  ",write - in,1
-Finney,Huffman Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Huffman Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Huffman Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Huffman Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Huffman Township,President,,"Smith, Mike  ",write - in,0
-Finney,Huffman Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Huffman Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Huffman Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Huffman Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Huffman Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Huffman Township,President,,"Clinton, Hillary Rodham ",Democratic,83
-Finney,Huffman Township,President,,"Johnson, Gary  ",Libertarian,11
-Finney,Huffman Township,President,,"Trump, Donald J. ",Republican,172
-Finney,Jennie Barker Township,President,,"Stein, Jill  ",independent,6
-Finney,Jennie Barker Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Jennie Barker Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Jennie Barker Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Jennie Barker Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Jennie Barker Township,President,,"Hedges, James A ",write - in,0
-Finney,Jennie Barker Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Jennie Barker Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Jennie Barker Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Jennie Barker Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Jennie Barker Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Jennie Barker Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Jennie Barker Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Jennie Barker Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Jennie Barker Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Jennie Barker Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Jennie Barker Township,President,,"Smith, Mike  ",write - in,0
-Finney,Jennie Barker Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Jennie Barker Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Jennie Barker Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Jennie Barker Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Jennie Barker Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Jennie Barker Township,President,,"Clinton, Hillary Rodham ",Democratic,104
-Finney,Jennie Barker Township,President,,"Johnson, Gary  ",Libertarian,25
-Finney,Jennie Barker Township,President,,"Trump, Donald J. ",Republican,361
-Finney,Kalvesta Township,President,,"Stein, Jill  ",independent,0
-Finney,Kalvesta Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Kalvesta Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Kalvesta Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Kalvesta Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Kalvesta Township,President,,"Hedges, James A ",write - in,0
-Finney,Kalvesta Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Kalvesta Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Kalvesta Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Kalvesta Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Kalvesta Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Kalvesta Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Kalvesta Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Kalvesta Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Kalvesta Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Kalvesta Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Kalvesta Township,President,,"Smith, Mike  ",write - in,0
-Finney,Kalvesta Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Kalvesta Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Kalvesta Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Kalvesta Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Kalvesta Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Kalvesta Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Finney,Kalvesta Township,President,,"Johnson, Gary  ",Libertarian,0
-Finney,Kalvesta Township,President,,"Trump, Donald J. ",Republican,51
-Finney,Mack Township,President,,"Stein, Jill  ",independent,2
-Finney,Mack Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Mack Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Mack Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Mack Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Mack Township,President,,"Hedges, James A ",write - in,0
-Finney,Mack Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Mack Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Mack Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Mack Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Mack Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Mack Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Mack Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Mack Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Mack Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Mack Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Mack Township,President,,"Smith, Mike  ",write - in,0
-Finney,Mack Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Mack Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Mack Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Mack Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Mack Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Mack Township,President,,"Clinton, Hillary Rodham ",Democratic,109
-Finney,Mack Township,President,,"Johnson, Gary  ",Libertarian,6
-Finney,Mack Township,President,,"Trump, Donald J. ",Republican,112
-Finney,Pleasant Valley Township,President,,"Stein, Jill  ",independent,1
-Finney,Pleasant Valley Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Pleasant Valley Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Pleasant Valley Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Hedges, James A ",write - in,0
-Finney,Pleasant Valley Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Pleasant Valley Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Pleasant Valley Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Pleasant Valley Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Pleasant Valley Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Pleasant Valley Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Pleasant Valley Township,President,,"Smith, Mike  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Pleasant Valley Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Pleasant Valley Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Pleasant Valley Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-Finney,Pleasant Valley Township,President,,"Johnson, Gary  ",Libertarian,0
-Finney,Pleasant Valley Township,President,,"Trump, Donald J. ",Republican,67
-Finney,Plymell Township,President,,"Stein, Jill  ",independent,2
-Finney,Plymell Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Plymell Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Plymell Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Plymell Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Plymell Township,President,,"Hedges, James A ",write - in,0
-Finney,Plymell Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Plymell Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Plymell Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Plymell Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Plymell Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Plymell Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Plymell Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Plymell Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Plymell Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Plymell Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Plymell Township,President,,"Smith, Mike  ",write - in,0
-Finney,Plymell Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Plymell Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Plymell Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Plymell Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Plymell Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Plymell Township,President,,"Clinton, Hillary Rodham ",Democratic,26
-Finney,Plymell Township,President,,"Johnson, Gary  ",Libertarian,0
-Finney,Plymell Township,President,,"Trump, Donald J. ",Republican,132
-Finney,Theoni Township,President,,"Stein, Jill  ",independent,1
-Finney,Theoni Township,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Theoni Township,President,,"Castle, Darrell L ",write - in,0
-Finney,Theoni Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Theoni Township,President,,"Giordani, Rocky  ",write - in,0
-Finney,Theoni Township,President,,"Hedges, James A ",write - in,0
-Finney,Theoni Township,President,,"Hoefling, Tom  ",write - in,0
-Finney,Theoni Township,President,,"Kahn, Lynn  ",write - in,0
-Finney,Theoni Township,President,,"La Riva, Gloria  ",write - in,0
-Finney,Theoni Township,President,,"Levinson, Michael S. ",write - in,0
-Finney,Theoni Township,President,,"Maturen, Michael A ",write - in,0
-Finney,Theoni Township,President,,"McMullin, Evan  ",write - in,0
-Finney,Theoni Township,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Theoni Township,President,,"Perry, Darryl  ",write - in,0
-Finney,Theoni Township,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Theoni Township,President,,"Schriner, Joe C ",write - in,0
-Finney,Theoni Township,President,,"Smith, Mike  ",write - in,0
-Finney,Theoni Township,President,,"Sood, Ajay  ",write - in,0
-Finney,Theoni Township,President,,"Sterling, Shawna  ",write - in,0
-Finney,Theoni Township,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Theoni Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Theoni Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Theoni Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Finney,Theoni Township,President,,"Johnson, Gary  ",Libertarian,0
-Finney,Theoni Township,President,,"Trump, Donald J. ",Republican,51
-Finney,Garden City Ward 1,President,,"Stein, Jill  ",independent,3
-Finney,Garden City Ward 1,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 1,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 1,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 1,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 1,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 1,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 1,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 1,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 1,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 1,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 1,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 1,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 1,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 1,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 1,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 1,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 1,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 1,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,149
-Finney,Garden City Ward 1,President,,"Johnson, Gary  ",Libertarian,14
-Finney,Garden City Ward 1,President,,"Trump, Donald J. ",Republican,70
-Finney,Garden City Ward 2,President,,"Stein, Jill  ",independent,16
-Finney,Garden City Ward 2,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 2,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 2,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 2,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 2,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 2,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 2,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 2,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 2,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 2,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 2,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 2,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 2,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 2,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 2,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 2,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 2,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 2,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,256
-Finney,Garden City Ward 2,President,,"Johnson, Gary  ",Libertarian,22
-Finney,Garden City Ward 2,President,,"Trump, Donald J. ",Republican,169
-Finney,Garden City Ward 4,President,,"Stein, Jill  ",independent,4
-Finney,Garden City Ward 4,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 4,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 4,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 4,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 4,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 4,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 4,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 4,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 4,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 4,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 4,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 4,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 4,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 4,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 4,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 4,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 4,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 4,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 4,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 4,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 4,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 4,President,,"Clinton, Hillary Rodham ",Democratic,91
-Finney,Garden City Ward 4,President,,"Johnson, Gary  ",Libertarian,16
-Finney,Garden City Ward 4,President,,"Trump, Donald J. ",Republican,207
-Finney,Garden City Ward 14 H122,President,,"Stein, Jill  ",independent,11
-Finney,Garden City Ward 14 H122,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 14 H122,President,,"Clinton, Hillary Rodham ",Democratic,162
-Finney,Garden City Ward 14 H122,President,,"Johnson, Gary  ",Libertarian,21
-Finney,Garden City Ward 14 H122,President,,"Trump, Donald J. ",Republican,300
-Finney,Garden City Ward 15 H122,President,,"Stein, Jill  ",independent,14
-Finney,Garden City Ward 15 H122,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Castle, Darrell L ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Giordani, Rocky  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Hedges, James A ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Hoefling, Tom  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Kahn, Lynn  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"La Riva, Gloria  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Levinson, Michael S. ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Maturen, Michael A ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"McMullin, Evan  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Perry, Darryl  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Schriner, Joe C ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Smith, Mike  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Sood, Ajay  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Sterling, Shawna  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Garden City Ward 15 H122,President,,"Clinton, Hillary Rodham ",Democratic,151
-Finney,Garden City Ward 15 H122,President,,"Johnson, Gary  ",Libertarian,35
-Finney,Garden City Ward 15 H122,President,,"Trump, Donald J. ",Republican,407
-Finney,Pierceville Precinct,President,,"Stein, Jill  ",independent,1
-Finney,Pierceville Precinct,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Pierceville Precinct,President,,"Castle, Darrell L ",write - in,0
-Finney,Pierceville Precinct,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Pierceville Precinct,President,,"Giordani, Rocky  ",write - in,0
-Finney,Pierceville Precinct,President,,"Hedges, James A ",write - in,0
-Finney,Pierceville Precinct,President,,"Hoefling, Tom  ",write - in,0
-Finney,Pierceville Precinct,President,,"Kahn, Lynn  ",write - in,0
-Finney,Pierceville Precinct,President,,"La Riva, Gloria  ",write - in,0
-Finney,Pierceville Precinct,President,,"Levinson, Michael S. ",write - in,0
-Finney,Pierceville Precinct,President,,"Maturen, Michael A ",write - in,0
-Finney,Pierceville Precinct,President,,"McMullin, Evan  ",write - in,0
-Finney,Pierceville Precinct,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Pierceville Precinct,President,,"Perry, Darryl  ",write - in,0
-Finney,Pierceville Precinct,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Pierceville Precinct,President,,"Schriner, Joe C ",write - in,0
-Finney,Pierceville Precinct,President,,"Smith, Mike  ",write - in,0
-Finney,Pierceville Precinct,President,,"Sood, Ajay  ",write - in,0
-Finney,Pierceville Precinct,President,,"Sterling, Shawna  ",write - in,0
-Finney,Pierceville Precinct,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Pierceville Precinct,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Pierceville Precinct,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Pierceville Precinct,President,,"Clinton, Hillary Rodham ",Democratic,22
-Finney,Pierceville Precinct,President,,"Johnson, Gary  ",Libertarian,4
-Finney,Pierceville Precinct,President,,"Trump, Donald J. ",Republican,140
-Finney,Pierceville Precinct H122,President,,"Stein, Jill  ",independent,0
-Finney,Pierceville Precinct H122,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Castle, Darrell L ",write - in,0
-Finney,Pierceville Precinct H122,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Giordani, Rocky  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Hedges, James A ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Hoefling, Tom  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Kahn, Lynn  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"La Riva, Gloria  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Levinson, Michael S. ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Maturen, Michael A ",write - in,0
-Finney,Pierceville Precinct H122,President,,"McMullin, Evan  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Perry, Darryl  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Schriner, Joe C ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Smith, Mike  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Sood, Ajay  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Sterling, Shawna  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Pierceville Precinct H122,President,,"Clinton, Hillary Rodham ",Democratic,0
-Finney,Pierceville Precinct H122,President,,"Johnson, Gary  ",Libertarian,0
-Finney,Pierceville Precinct H122,President,,"Trump, Donald J. ",Republican,0
-Finney,Riverside Precinct H122,President,,"Stein, Jill  ",independent,2
-Finney,Riverside Precinct H122,President,,"Basiago, Andrew D. ",write - in,0
-Finney,Riverside Precinct H122,President,,"Castle, Darrell L ",write - in,0
-Finney,Riverside Precinct H122,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Giordani, Rocky  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Hedges, James A ",write - in,0
-Finney,Riverside Precinct H122,President,,"Hoefling, Tom  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Kahn, Lynn  ",write - in,0
-Finney,Riverside Precinct H122,President,,"La Riva, Gloria  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Levinson, Michael S. ",write - in,0
-Finney,Riverside Precinct H122,President,,"Maturen, Michael A ",write - in,0
-Finney,Riverside Precinct H122,President,,"McMullin, Evan  ",write - in,8
-Finney,Riverside Precinct H122,President,,"Moorehead, Monica G. ",write - in,0
-Finney,Riverside Precinct H122,President,,"Perry, Darryl  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Schoenke, Marshall R. ",write - in,0
-Finney,Riverside Precinct H122,President,,"Schriner, Joe C ",write - in,0
-Finney,Riverside Precinct H122,President,,"Smith, Mike  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Sood, Ajay  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Sterling, Shawna  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Valdivia, Anthony J ",write - in,0
-Finney,Riverside Precinct H122,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Finney,Riverside Precinct H122,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Finney,Riverside Precinct H122,President,,"Clinton, Hillary Rodham ",Democratic,100
-Finney,Riverside Precinct H122,President,,"Johnson, Gary  ",Libertarian,15
-Finney,Riverside Precinct H122,President,,"Trump, Donald J. ",Republican,433
-Finney,Friend Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Friend Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Finney,Friend Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Finney,Friend Township,U.S. Senate,,"Moran, Jerry  ",Republican,53
-Finney,Garden City Ward 3,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,133
-Finney,Garden City Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,34
-Finney,Garden City Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,335
-Finney,Garden City Ward 5,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 5,U.S. Senate,,"Wiesner, Patrick  ",Democratic,80
-Finney,Garden City Ward 5,U.S. Senate,,"Garrard, Robert D. ",Libertarian,17
-Finney,Garden City Ward 5,U.S. Senate,,"Moran, Jerry  ",Republican,221
-Finney,Garden City Ward 6,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 6,U.S. Senate,,"Wiesner, Patrick  ",Democratic,158
-Finney,Garden City Ward 6,U.S. Senate,,"Garrard, Robert D. ",Libertarian,27
-Finney,Garden City Ward 6,U.S. Senate,,"Moran, Jerry  ",Republican,294
-Finney,Garden City Ward 7,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 7,U.S. Senate,,"Wiesner, Patrick  ",Democratic,97
-Finney,Garden City Ward 7,U.S. Senate,,"Garrard, Robert D. ",Libertarian,18
-Finney,Garden City Ward 7,U.S. Senate,,"Moran, Jerry  ",Republican,186
-Finney,Garden City Ward 8,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 8,U.S. Senate,,"Wiesner, Patrick  ",Democratic,240
-Finney,Garden City Ward 8,U.S. Senate,,"Garrard, Robert D. ",Libertarian,27
-Finney,Garden City Ward 8,U.S. Senate,,"Moran, Jerry  ",Republican,304
-Finney,Garden City Ward 9,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 9,U.S. Senate,,"Wiesner, Patrick  ",Democratic,118
-Finney,Garden City Ward 9,U.S. Senate,,"Garrard, Robert D. ",Libertarian,33
-Finney,Garden City Ward 9,U.S. Senate,,"Moran, Jerry  ",Republican,199
-Finney,Garden City Ward 10,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 10,U.S. Senate,,"Wiesner, Patrick  ",Democratic,80
-Finney,Garden City Ward 10,U.S. Senate,,"Garrard, Robert D. ",Libertarian,14
-Finney,Garden City Ward 10,U.S. Senate,,"Moran, Jerry  ",Republican,249
-Finney,Garden City Ward 11,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 11,U.S. Senate,,"Wiesner, Patrick  ",Democratic,108
-Finney,Garden City Ward 11,U.S. Senate,,"Garrard, Robert D. ",Libertarian,25
-Finney,Garden City Ward 11,U.S. Senate,,"Moran, Jerry  ",Republican,390
-Finney,Garden City Ward 12,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 12,U.S. Senate,,"Wiesner, Patrick  ",Democratic,80
-Finney,Garden City Ward 12,U.S. Senate,,"Garrard, Robert D. ",Libertarian,20
-Finney,Garden City Ward 12,U.S. Senate,,"Moran, Jerry  ",Republican,445
-Finney,Garden City Ward 13,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 13,U.S. Senate,,"Wiesner, Patrick  ",Democratic,58
-Finney,Garden City Ward 13,U.S. Senate,,"Garrard, Robert D. ",Libertarian,15
-Finney,Garden City Ward 13,U.S. Senate,,"Moran, Jerry  ",Republican,381
-Finney,Garden City Ward 16,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 16,U.S. Senate,,"Wiesner, Patrick  ",Democratic,111
-Finney,Garden City Ward 16,U.S. Senate,,"Garrard, Robert D. ",Libertarian,23
-Finney,Garden City Ward 16,U.S. Senate,,"Moran, Jerry  ",Republican,444
-Finney,Holcomb Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Holcomb Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,122
-Finney,Holcomb Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,41
-Finney,Holcomb Township,U.S. Senate,,"Moran, Jerry  ",Republican,725
-Finney,Huffman Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Huffman Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,69
-Finney,Huffman Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,25
-Finney,Huffman Township,U.S. Senate,,"Moran, Jerry  ",Republican,171
-Finney,Jennie Barker Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Jennie Barker Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,91
-Finney,Jennie Barker Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,28
-Finney,Jennie Barker Township,U.S. Senate,,"Moran, Jerry  ",Republican,371
-Finney,Kalvesta Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Kalvesta Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Finney,Kalvesta Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Finney,Kalvesta Township,U.S. Senate,,"Moran, Jerry  ",Republican,47
-Finney,Mack Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Mack Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,89
-Finney,Mack Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Finney,Mack Township,U.S. Senate,,"Moran, Jerry  ",Republican,117
-Finney,Pleasant Valley Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Pleasant Valley Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Finney,Pleasant Valley Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Finney,Pleasant Valley Township,U.S. Senate,,"Moran, Jerry  ",Republican,64
-Finney,Plymell Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Plymell Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,20
-Finney,Plymell Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Finney,Plymell Township,U.S. Senate,,"Moran, Jerry  ",Republican,133
-Finney,Theoni Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Theoni Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Finney,Theoni Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Finney,Theoni Township,U.S. Senate,,"Moran, Jerry  ",Republican,53
-Finney,Garden City Ward 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,106
-Finney,Garden City Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,29
-Finney,Garden City Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,95
-Finney,Garden City Ward 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,204
-Finney,Garden City Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,33
-Finney,Garden City Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,218
-Finney,Garden City Ward 4,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City Ward 4,U.S. Senate,,"Wiesner, Patrick  ",Democratic,70
-Finney,Garden City Ward 4,U.S. Senate,,"Garrard, Robert D. ",Libertarian,10
-Finney,Garden City Ward 4,U.S. Senate,,"Moran, Jerry  ",Republican,238
-Finney,Garden City ward 14 H123,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City ward 14 H123,U.S. Senate,,"Wiesner, Patrick  ",Democratic,117
-Finney,Garden City ward 14 H123,U.S. Senate,,"Garrard, Robert D. ",Libertarian,31
-Finney,Garden City ward 14 H123,U.S. Senate,,"Moran, Jerry  ",Republican,346
-Finney,Garden City ward 15 H123,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Garden City ward 15 H123,U.S. Senate,,"Wiesner, Patrick  ",Democratic,111
-Finney,Garden City ward 15 H123,U.S. Senate,,"Garrard, Robert D. ",Libertarian,32
-Finney,Garden City ward 15 H123,U.S. Senate,,"Moran, Jerry  ",Republican,471
-Finney,Pierceville Precinct,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Pierceville Precinct,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Finney,Pierceville Precinct,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Finney,Pierceville Precinct,U.S. Senate,,"Moran, Jerry  ",Republican,147
-Finney,Riverside Precinct H122,U.S. Senate,,"Smith, DJ  ",write - in,0
-Finney,Riverside Precinct H122,U.S. Senate,,"Wiesner, Patrick  ",Democratic,64
-Finney,Riverside Precinct H122,U.S. Senate,,"Garrard, Robert D. ",Libertarian,23
-Finney,Riverside Precinct H122,U.S. Senate,,"Moran, Jerry  ",Republican,468
-Finney,Friend Township,U.S. House,1,"LaPolice, Alan  ",independent,8
-Finney,Friend Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Friend Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Finney,Friend Township,U.S. House,1,"Marshall, Roger  ",Republican,46
-Finney,Garden City Ward 3,U.S. House,1,"LaPolice, Alan  ",independent,124
-Finney,Garden City Ward 3,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-Finney,Garden City Ward 3,U.S. House,1,"Burt, Kerry  ",Libertarian,65
-Finney,Garden City Ward 3,U.S. House,1,"Marshall, Roger  ",Republican,297
-Finney,Garden City Ward 5,U.S. House,1,"LaPolice, Alan  ",independent,72
-Finney,Garden City Ward 5,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Finney,Garden City Ward 5,U.S. House,1,"Burt, Kerry  ",Libertarian,51
-Finney,Garden City Ward 5,U.S. House,1,"Marshall, Roger  ",Republican,184
-Finney,Garden City Ward 6,U.S. House,1,"LaPolice, Alan  ",independent,98
-Finney,Garden City Ward 6,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 6,U.S. House,1,"Burt, Kerry  ",Libertarian,91
-Finney,Garden City Ward 6,U.S. House,1,"Marshall, Roger  ",Republican,269
-Finney,Garden City Ward 7,U.S. House,1,"LaPolice, Alan  ",independent,65
-Finney,Garden City Ward 7,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 7,U.S. House,1,"Burt, Kerry  ",Libertarian,38
-Finney,Garden City Ward 7,U.S. House,1,"Marshall, Roger  ",Republican,197
-Finney,Garden City Ward 8,U.S. House,1,"LaPolice, Alan  ",independent,153
-Finney,Garden City Ward 8,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 8,U.S. House,1,"Burt, Kerry  ",Libertarian,84
-Finney,Garden City Ward 8,U.S. House,1,"Marshall, Roger  ",Republican,291
-Finney,Garden City Ward 9,U.S. House,1,"LaPolice, Alan  ",independent,80
-Finney,Garden City Ward 9,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 9,U.S. House,1,"Burt, Kerry  ",Libertarian,63
-Finney,Garden City Ward 9,U.S. House,1,"Marshall, Roger  ",Republican,191
-Finney,Garden City Ward 10,U.S. House,1,"LaPolice, Alan  ",independent,83
-Finney,Garden City Ward 10,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 10,U.S. House,1,"Burt, Kerry  ",Libertarian,29
-Finney,Garden City Ward 10,U.S. House,1,"Marshall, Roger  ",Republican,223
-Finney,Garden City Ward 11,U.S. House,1,"LaPolice, Alan  ",independent,111
-Finney,Garden City Ward 11,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-Finney,Garden City Ward 11,U.S. House,1,"Burt, Kerry  ",Libertarian,48
-Finney,Garden City Ward 11,U.S. House,1,"Marshall, Roger  ",Republican,340
-Finney,Garden City Ward 12,U.S. House,1,"LaPolice, Alan  ",independent,118
-Finney,Garden City Ward 12,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Finney,Garden City Ward 12,U.S. House,1,"Burt, Kerry  ",Libertarian,27
-Finney,Garden City Ward 12,U.S. House,1,"Marshall, Roger  ",Republican,386
-Finney,Garden City Ward 13,U.S. House,1,"LaPolice, Alan  ",independent,93
-Finney,Garden City Ward 13,U.S. House,1,"Huelskamp, Tim  ",write - in,3
-Finney,Garden City Ward 13,U.S. House,1,"Burt, Kerry  ",Libertarian,19
-Finney,Garden City Ward 13,U.S. House,1,"Marshall, Roger  ",Republican,326
-Finney,Garden City Ward 16,U.S. House,1,"LaPolice, Alan  ",independent,106
-Finney,Garden City Ward 16,U.S. House,1,"Huelskamp, Tim  ",write - in,3
-Finney,Garden City Ward 16,U.S. House,1,"Burt, Kerry  ",Libertarian,50
-Finney,Garden City Ward 16,U.S. House,1,"Marshall, Roger  ",Republican,406
-Finney,Holcomb Township,U.S. House,1,"LaPolice, Alan  ",independent,165
-Finney,Holcomb Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Holcomb Township,U.S. House,1,"Burt, Kerry  ",Libertarian,72
-Finney,Holcomb Township,U.S. House,1,"Marshall, Roger  ",Republican,647
-Finney,Huffman Township,U.S. House,1,"LaPolice, Alan  ",independent,53
-Finney,Huffman Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Huffman Township,U.S. House,1,"Burt, Kerry  ",Libertarian,37
-Finney,Huffman Township,U.S. House,1,"Marshall, Roger  ",Republican,166
-Finney,Jennie Barker Township,U.S. House,1,"LaPolice, Alan  ",independent,74
-Finney,Jennie Barker Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Jennie Barker Township,U.S. House,1,"Burt, Kerry  ",Libertarian,49
-Finney,Jennie Barker Township,U.S. House,1,"Marshall, Roger  ",Republican,356
-Finney,Kalvesta Township,U.S. House,1,"LaPolice, Alan  ",independent,10
-Finney,Kalvesta Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Kalvesta Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Finney,Kalvesta Township,U.S. House,1,"Marshall, Roger  ",Republican,42
-Finney,Mack Township,U.S. House,1,"LaPolice, Alan  ",independent,53
-Finney,Mack Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Mack Township,U.S. House,1,"Burt, Kerry  ",Libertarian,39
-Finney,Mack Township,U.S. House,1,"Marshall, Roger  ",Republican,116
-Finney,Pleasant Valley Township,U.S. House,1,"LaPolice, Alan  ",independent,8
-Finney,Pleasant Valley Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Pleasant Valley Township,U.S. House,1,"Burt, Kerry  ",Libertarian,8
-Finney,Pleasant Valley Township,U.S. House,1,"Marshall, Roger  ",Republican,53
-Finney,Plymell Township,U.S. House,1,"LaPolice, Alan  ",independent,26
-Finney,Plymell Township,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Finney,Plymell Township,U.S. House,1,"Burt, Kerry  ",Libertarian,10
-Finney,Plymell Township,U.S. House,1,"Marshall, Roger  ",Republican,116
-Finney,Theoni Township,U.S. House,1,"LaPolice, Alan  ",independent,8
-Finney,Theoni Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Theoni Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Finney,Theoni Township,U.S. House,1,"Marshall, Roger  ",Republican,50
-Finney,Garden City Ward 1,U.S. House,1,"LaPolice, Alan  ",independent,67
-Finney,Garden City Ward 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 1,U.S. House,1,"Burt, Kerry  ",Libertarian,43
-Finney,Garden City Ward 1,U.S. House,1,"Marshall, Roger  ",Republican,105
-Finney,Garden City Ward 2,U.S. House,1,"LaPolice, Alan  ",independent,120
-Finney,Garden City Ward 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Garden City Ward 2,U.S. House,1,"Burt, Kerry  ",Libertarian,85
-Finney,Garden City Ward 2,U.S. House,1,"Marshall, Roger  ",Republican,224
-Finney,Garden City Ward 4,U.S. House,1,"LaPolice, Alan  ",independent,74
-Finney,Garden City Ward 4,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-Finney,Garden City Ward 4,U.S. House,1,"Burt, Kerry  ",Libertarian,27
-Finney,Garden City Ward 4,U.S. House,1,"Marshall, Roger  ",Republican,205
-Finney,Garden City ward 14 H123,U.S. House,1,"LaPolice, Alan  ",independent,113
-Finney,Garden City ward 14 H123,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-Finney,Garden City ward 14 H123,U.S. House,1,"Burt, Kerry  ",Libertarian,57
-Finney,Garden City ward 14 H123,U.S. House,1,"Marshall, Roger  ",Republican,308
-Finney,Garden City ward 15 H123,U.S. House,1,"LaPolice, Alan  ",independent,99
-Finney,Garden City ward 15 H123,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-Finney,Garden City ward 15 H123,U.S. House,1,"Burt, Kerry  ",Libertarian,70
-Finney,Garden City ward 15 H123,U.S. House,1,"Marshall, Roger  ",Republican,426
-Finney,Pierceville Precinct,U.S. House,1,"LaPolice, Alan  ",independent,32
-Finney,Pierceville Precinct,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Finney,Pierceville Precinct,U.S. House,1,"Burt, Kerry  ",Libertarian,6
-Finney,Pierceville Precinct,U.S. House,1,"Marshall, Roger  ",Republican,123
-Finney,Riverside Precinct H122,U.S. House,1,"LaPolice, Alan  ",independent,73
-Finney,Riverside Precinct H122,U.S. House,1,"Huelskamp, Tim  ",write - in,4
-Finney,Riverside Precinct H122,U.S. House,1,"Burt, Kerry  ",Libertarian,30
-Finney,Riverside Precinct H122,U.S. House,1,"Marshall, Roger  ",Republican,438
-Finney,Friend Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,8
-Finney,Friend Township,State Senate,39,"Doll, John  ",Republican,47
-Finney,Garden City Ward 3,State Senate,39,"Worf, A. Zacheriah ",Democratic,117
-Finney,Garden City Ward 3,State Senate,39,"Doll, John  ",Republican,383
-Finney,Garden City Ward 5,State Senate,39,"Worf, A. Zacheriah ",Democratic,64
-Finney,Garden City Ward 5,State Senate,39,"Doll, John  ",Republican,251
-Finney,Garden City Ward 6,State Senate,39,"Worf, A. Zacheriah ",Democratic,122
-Finney,Garden City Ward 6,State Senate,39,"Doll, John  ",Republican,349
-Finney,Garden City Ward 7,State Senate,39,"Worf, A. Zacheriah ",Democratic,81
-Finney,Garden City Ward 7,State Senate,39,"Doll, John  ",Republican,229
-Finney,Garden City Ward 8,State Senate,39,"Worf, A. Zacheriah ",Democratic,188
-Finney,Garden City Ward 8,State Senate,39,"Doll, John  ",Republican,372
-Finney,Garden City Ward 9,State Senate,39,"Worf, A. Zacheriah ",Democratic,115
-Finney,Garden City Ward 9,State Senate,39,"Doll, John  ",Republican,236
-Finney,Garden City Ward 10,State Senate,39,"Worf, A. Zacheriah ",Democratic,64
-Finney,Garden City Ward 10,State Senate,39,"Doll, John  ",Republican,288
-Finney,Garden City Ward 11,State Senate,39,"Worf, A. Zacheriah ",Democratic,107
-Finney,Garden City Ward 11,State Senate,39,"Doll, John  ",Republican,398
-Finney,Garden City Ward 12,State Senate,39,"Worf, A. Zacheriah ",Democratic,67
-Finney,Garden City Ward 12,State Senate,39,"Doll, John  ",Republican,463
-Finney,Garden City Ward 13,State Senate,39,"Worf, A. Zacheriah ",Democratic,40
-Finney,Garden City Ward 13,State Senate,39,"Doll, John  ",Republican,396
-Finney,Garden City Ward 16,State Senate,39,"Worf, A. Zacheriah ",Democratic,81
-Finney,Garden City Ward 16,State Senate,39,"Doll, John  ",Republican,490
-Finney,Holcomb Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,164
-Finney,Holcomb Township,State Senate,39,"Doll, John  ",Republican,707
-Finney,Huffman Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,63
-Finney,Huffman Township,State Senate,39,"Doll, John  ",Republican,202
-Finney,Jennie Barker Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,84
-Finney,Jennie Barker Township,State Senate,39,"Doll, John  ",Republican,397
-Finney,Kalvesta Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,9
-Finney,Kalvesta Township,State Senate,39,"Doll, John  ",Republican,42
-Finney,Mack Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,79
-Finney,Mack Township,State Senate,39,"Doll, John  ",Republican,139
-Finney,Pleasant Valley Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,9
-Finney,Pleasant Valley Township,State Senate,39,"Doll, John  ",Republican,56
-Finney,Plymell Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,18
-Finney,Plymell Township,State Senate,39,"Doll, John  ",Republican,139
-Finney,Theoni Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,7
-Finney,Theoni Township,State Senate,39,"Doll, John  ",Republican,50
-Finney,Garden City Ward 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,85
-Finney,Garden City Ward 1,State Senate,39,"Doll, John  ",Republican,135
-Finney,Garden City Ward 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,169
-Finney,Garden City Ward 2,State Senate,39,"Doll, John  ",Republican,278
-Finney,Garden City Ward 4,State Senate,39,"Worf, A. Zacheriah ",Democratic,56
-Finney,Garden City Ward 4,State Senate,39,"Doll, John  ",Republican,259
-Finney,Garden City ward 14 H123,State Senate,39,"Worf, A. Zacheriah ",Democratic,103
-Finney,Garden City ward 14 H123,State Senate,39,"Doll, John  ",Republican,381
-Finney,Garden City ward 15 H123,State Senate,39,"Worf, A. Zacheriah ",Democratic,75
-Finney,Garden City ward 15 H123,State Senate,39,"Doll, John  ",Republican,531
-Finney,Pierceville Precinct,State Senate,39,"Worf, A. Zacheriah ",Democratic,0
-Finney,Pierceville Precinct,State Senate,39,"Doll, John  ",Republican,0
-Finney,Pierceville Precinct H122,State Senate,39,"Worf, A. Zacheriah ",Democratic,15
-Finney,Pierceville Precinct H122,State Senate,39,"Doll, John  ",Republican,145
-Finney,Riverside Precinct H122,State Senate,39,"Worf, A. Zacheriah ",Democratic,63
-Finney,Riverside Precinct H122,State Senate,39,"Doll, John  ",Republican,478
-Finney,Friend Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,53
-Finney,Garden City Ward 3,State House,123,"Wheeler, John P. Jr.",Republican,448
-Finney,Garden City Ward 5,State House,123,"Wheeler, John P. Jr.",Republican,291
-Finney,Garden City Ward 6,State House,123,"Wheeler, John P. Jr.",Republican,420
-Finney,Garden City Ward 7,State House,123,"Wheeler, John P. Jr.",Republican,277
-Finney,Garden City Ward 8,State House,123,"Wheeler, John P. Jr.",Republican,491
-Finney,Garden City Ward 9,State House,123,"Wheeler, John P. Jr.",Republican,312
-Finney,Garden City Ward 10,State House,123,"Wheeler, John P. Jr.",Republican,320
-Finney,Garden City Ward 11,State House,123,"Wheeler, John P. Jr.",Republican,467
-Finney,Garden City Ward 12,State House,123,"Wheeler, John P. Jr.",Republican,507
-Finney,Garden City Ward 13,State House,123,"Wheeler, John P. Jr.",Republican,427
-Finney,Garden City Ward 16,State House,123,"Wheeler, John P. Jr.",Republican,529
-Finney,Holcomb Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,828
-Finney,Huffman Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,228
-Finney,Jennie Barker Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,449
-Finney,Kalvesta Township,State House,117,"Mastroni, Leonard A. ",Republican,42
-Finney,Mack Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,190
-Finney,Pleasant Valley Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,63
-Finney,Plymell Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,138
-Finney,Theoni Township,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,56
-Finney,Garden City Ward 1,State House,123,"Wheeler, John P. Jr.",Republican,192
-Finney,Garden City Ward 2,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,356
-Finney,Garden City Ward 4,State House,123,"Wheeler, John P. Jr.",Republican,287
-Finney,Garden City Ward 14 H122,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,155
-Finney,Garden City ward 14 H123,State House,123,"Wheeler, John P. Jr.",Republican,282
-Finney,Garden City Ward 15 H122,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,234
-Finney,Garden City ward 15 H123,State House,123,"Wheeler, John P. Jr.",Republican,327
-Finney,Pierceville Precinct H122,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,156
-Finney,Riverside Precinct H122,State House,122,"Jennings, J. Russell ""Russ"" ",Republican,520
+county,precinct,office,district,party,candidate,votes,vtd
+FINNEY,Friend Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",53,000010
+FINNEY,Garden City Ward 3,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",448,000040
+FINNEY,Garden City Ward 5,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",291,000060
+FINNEY,Garden City Ward 6,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",420,000070
+FINNEY,Garden City Ward 7,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",277,000080
+FINNEY,Garden City Ward 8,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",491,00009A
+FINNEY,Garden City Ward 9,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",312,000100
+FINNEY,Garden City Ward 10,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",320,000110
+FINNEY,Garden City Ward 11,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",467,000120
+FINNEY,Garden City Ward 12,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",507,000130
+FINNEY,Garden City Ward 13,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",427,000140
+FINNEY,Garden City Ward 16,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",529,000170
+FINNEY,Holcomb Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",828,000190
+FINNEY,Huffman Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",228,000200
+FINNEY,Jennie Barker Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",449,00021A
+FINNEY,Kalvesta Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",42,000220
+FINNEY,Mack Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",190,000230
+FINNEY,Pleasant Valley Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",63,000250
+FINNEY,Plymell Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",138,000260
+FINNEY,Theoni Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",56,000280
+FINNEY,Garden City Ward 1,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",192,120030
+FINNEY,Garden City Ward 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",356,140010
+FINNEY,Garden City Ward 4,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",287,140020
+FINNEY,Garden City Ward 14 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",155,140030
+FINNEY,Garden City ward 14 H123,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",282,140040
+FINNEY,Garden City Ward 15 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",234,140050
+FINNEY,Garden City ward 15 H123,Kansas House of Representatives,123,Republican,"Wheeler, John P. Jr.",327,140060
+FINNEY,Pierceville Precinct H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",156,200040
+FINNEY,Riverside Precinct H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",520,200060
+FINNEY,Friend Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",8,000010
+FINNEY,Friend Township,Kansas Senate,39,Republican,"Doll, John",47,000010
+FINNEY,Garden City Ward 3,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",117,000040
+FINNEY,Garden City Ward 3,Kansas Senate,39,Republican,"Doll, John",383,000040
+FINNEY,Garden City Ward 5,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",64,000060
+FINNEY,Garden City Ward 5,Kansas Senate,39,Republican,"Doll, John",251,000060
+FINNEY,Garden City Ward 6,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",122,000070
+FINNEY,Garden City Ward 6,Kansas Senate,39,Republican,"Doll, John",349,000070
+FINNEY,Garden City Ward 7,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",81,000080
+FINNEY,Garden City Ward 7,Kansas Senate,39,Republican,"Doll, John",229,000080
+FINNEY,Garden City Ward 8,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",188,00009A
+FINNEY,Garden City Ward 8,Kansas Senate,39,Republican,"Doll, John",372,00009A
+FINNEY,Garden City Ward 9,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",115,000100
+FINNEY,Garden City Ward 9,Kansas Senate,39,Republican,"Doll, John",236,000100
+FINNEY,Garden City Ward 10,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",64,000110
+FINNEY,Garden City Ward 10,Kansas Senate,39,Republican,"Doll, John",288,000110
+FINNEY,Garden City Ward 11,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",107,000120
+FINNEY,Garden City Ward 11,Kansas Senate,39,Republican,"Doll, John",398,000120
+FINNEY,Garden City Ward 12,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",67,000130
+FINNEY,Garden City Ward 12,Kansas Senate,39,Republican,"Doll, John",463,000130
+FINNEY,Garden City Ward 13,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",40,000140
+FINNEY,Garden City Ward 13,Kansas Senate,39,Republican,"Doll, John",396,000140
+FINNEY,Garden City Ward 16,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",81,000170
+FINNEY,Garden City Ward 16,Kansas Senate,39,Republican,"Doll, John",490,000170
+FINNEY,Holcomb Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",164,000190
+FINNEY,Holcomb Township,Kansas Senate,39,Republican,"Doll, John",707,000190
+FINNEY,Huffman Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",63,000200
+FINNEY,Huffman Township,Kansas Senate,39,Republican,"Doll, John",202,000200
+FINNEY,Jennie Barker Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",84,00021A
+FINNEY,Jennie Barker Township,Kansas Senate,39,Republican,"Doll, John",397,00021A
+FINNEY,Kalvesta Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",9,000220
+FINNEY,Kalvesta Township,Kansas Senate,39,Republican,"Doll, John",42,000220
+FINNEY,Mack Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",79,000230
+FINNEY,Mack Township,Kansas Senate,39,Republican,"Doll, John",139,000230
+FINNEY,Pleasant Valley Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",9,000250
+FINNEY,Pleasant Valley Township,Kansas Senate,39,Republican,"Doll, John",56,000250
+FINNEY,Plymell Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",18,000260
+FINNEY,Plymell Township,Kansas Senate,39,Republican,"Doll, John",139,000260
+FINNEY,Theoni Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",7,000280
+FINNEY,Theoni Township,Kansas Senate,39,Republican,"Doll, John",50,000280
+FINNEY,Garden City Ward 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",85,120030
+FINNEY,Garden City Ward 1,Kansas Senate,39,Republican,"Doll, John",135,120030
+FINNEY,Garden City Ward 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",169,140010
+FINNEY,Garden City Ward 2,Kansas Senate,39,Republican,"Doll, John",278,140010
+FINNEY,Garden City Ward 4,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",56,140020
+FINNEY,Garden City Ward 4,Kansas Senate,39,Republican,"Doll, John",259,140020
+FINNEY,Garden City ward 14 H123,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",103,140040
+FINNEY,Garden City ward 14 H123,Kansas Senate,39,Republican,"Doll, John",381,140040
+FINNEY,Garden City ward 15 H123,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",75,140060
+FINNEY,Garden City ward 15 H123,Kansas Senate,39,Republican,"Doll, John",531,140060
+FINNEY,Pierceville Precinct,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,140070
+FINNEY,Pierceville Precinct,Kansas Senate,39,Republican,"Doll, John",0,140070
+FINNEY,Pierceville Precinct H122,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",15,200040
+FINNEY,Pierceville Precinct H122,Kansas Senate,39,Republican,"Doll, John",145,200040
+FINNEY,Riverside Precinct H122,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",63,200060
+FINNEY,Riverside Precinct H122,Kansas Senate,39,Republican,"Doll, John",478,200060
+FINNEY,Friend Township,President / Vice President,,independent,"Stein, Jill",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+FINNEY,Friend Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+FINNEY,Friend Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000010
+FINNEY,Friend Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+FINNEY,Friend Township,President / Vice President,,Republican,"Trump, Donald J.",47,000010
+FINNEY,Garden City Ward 3,President / Vice President,,independent,"Stein, Jill",19,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",184,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",24,000040
+FINNEY,Garden City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",283,000040
+FINNEY,Garden City Ward 5,President / Vice President,,independent,"Stein, Jill",4,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Hedges, James A",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Smith, Mike",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",108,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",16,000060
+FINNEY,Garden City Ward 5,President / Vice President,,Republican,"Trump, Donald J.",196,000060
+FINNEY,Garden City Ward 6,President / Vice President,,independent,"Stein, Jill",5,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Hedges, James A",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"McMullin, Evan",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Perry, Darryl",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Smith, Mike",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Sood, Ajay",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",221,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Libertarian,"Johnson, Gary",23,000070
+FINNEY,Garden City Ward 6,President / Vice President,,Republican,"Trump, Donald J.",243,000070
+FINNEY,Garden City Ward 7,President / Vice President,,independent,"Stein, Jill",9,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Hedges, James A",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"McMullin, Evan",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Perry, Darryl",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Smith, Mike",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Sood, Ajay",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",128,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Libertarian,"Johnson, Gary",15,000080
+FINNEY,Garden City Ward 7,President / Vice President,,Republican,"Trump, Donald J.",160,000080
+FINNEY,Garden City Ward 8,President / Vice President,,independent,"Stein, Jill",10,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Castle, Darrell L",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Giordani, Rocky",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Hedges, James A",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Kahn, Lynn",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"La Riva, Gloria",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Levinson, Michael S.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Maturen, Michael A",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"McMullin, Evan",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Perry, Darryl",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Schriner, Joe C",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Smith, Mike",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Sood, Ajay",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Sterling, Shawna",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Democratic,"Clinton, Hillary Rodham",309,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Libertarian,"Johnson, Gary",21,00009A
+FINNEY,Garden City Ward 8,President / Vice President,,Republican,"Trump, Donald J.",243,00009A
+FINNEY,Garden City Ward 9,President / Vice President,,independent,"Stein, Jill",8,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Hedges, James A",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"McMullin, Evan",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Perry, Darryl",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Smith, Mike",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Sood, Ajay",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Democratic,"Clinton, Hillary Rodham",154,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Libertarian,"Johnson, Gary",22,000100
+FINNEY,Garden City Ward 9,President / Vice President,,Republican,"Trump, Donald J.",171,000100
+FINNEY,Garden City Ward 10,President / Vice President,,independent,"Stein, Jill",11,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Hedges, James A",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"McMullin, Evan",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Perry, Darryl",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Smith, Mike",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Sood, Ajay",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",118,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Libertarian,"Johnson, Gary",17,000110
+FINNEY,Garden City Ward 10,President / Vice President,,Republican,"Trump, Donald J.",201,000110
+FINNEY,Garden City Ward 11,President / Vice President,,independent,"Stein, Jill",5,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Hedges, James A",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"McMullin, Evan",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Perry, Darryl",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Smith, Mike",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Sood, Ajay",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",156,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Libertarian,"Johnson, Gary",20,000120
+FINNEY,Garden City Ward 11,President / Vice President,,Republican,"Trump, Donald J.",347,000120
+FINNEY,Garden City Ward 12,President / Vice President,,independent,"Stein, Jill",3,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Hedges, James A",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"McMullin, Evan",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Perry, Darryl",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Smith, Mike",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Sood, Ajay",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",132,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Libertarian,"Johnson, Gary",23,000130
+FINNEY,Garden City Ward 12,President / Vice President,,Republican,"Trump, Donald J.",383,000130
+FINNEY,Garden City Ward 13,President / Vice President,,independent,"Stein, Jill",4,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Hedges, James A",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"McMullin, Evan",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Perry, Darryl",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Smith, Mike",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Sood, Ajay",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Libertarian,"Johnson, Gary",13,000140
+FINNEY,Garden City Ward 13,President / Vice President,,Republican,"Trump, Donald J.",342,000140
+FINNEY,Garden City Ward 16,President / Vice President,,independent,"Stein, Jill",14,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Hedges, James A",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"McMullin, Evan",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Perry, Darryl",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Smith, Mike",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Sood, Ajay",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Democratic,"Clinton, Hillary Rodham",165,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Libertarian,"Johnson, Gary",23,000170
+FINNEY,Garden City Ward 16,President / Vice President,,Republican,"Trump, Donald J.",380,000170
+FINNEY,Holcomb Township,President / Vice President,,independent,"Stein, Jill",21,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"McMullin, Evan",1,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+FINNEY,Holcomb Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+FINNEY,Holcomb Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",154,000190
+FINNEY,Holcomb Township,President / Vice President,,Libertarian,"Johnson, Gary",33,000190
+FINNEY,Holcomb Township,President / Vice President,,Republican,"Trump, Donald J.",682,000190
+FINNEY,Huffman Township,President / Vice President,,independent,"Stein, Jill",4,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"McMullin, Evan",1,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+FINNEY,Huffman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+FINNEY,Huffman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000200
+FINNEY,Huffman Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000200
+FINNEY,Huffman Township,President / Vice President,,Republican,"Trump, Donald J.",172,000200
+FINNEY,Jennie Barker Township,President / Vice President,,independent,"Stein, Jill",6,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Castle, Darrell L",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Giordani, Rocky",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Hedges, James A",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Hoefling, Tom",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Kahn, Lynn",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"La Riva, Gloria",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Maturen, Michael A",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"McMullin, Evan",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Perry, Darryl",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Schriner, Joe C",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Smith, Mike",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Sood, Ajay",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Sterling, Shawna",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",104,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Libertarian,"Johnson, Gary",25,00021A
+FINNEY,Jennie Barker Township,President / Vice President,,Republican,"Trump, Donald J.",361,00021A
+FINNEY,Kalvesta Township,President / Vice President,,independent,"Stein, Jill",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000220
+FINNEY,Kalvesta Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+FINNEY,Kalvesta Township,President / Vice President,,Republican,"Trump, Donald J.",51,000220
+FINNEY,Mack Township,President / Vice President,,independent,"Stein, Jill",2,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+FINNEY,Mack Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+FINNEY,Mack Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",109,000230
+FINNEY,Mack Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000230
+FINNEY,Mack Township,President / Vice President,,Republican,"Trump, Donald J.",112,000230
+FINNEY,Pleasant Valley Township,President / Vice President,,independent,"Stein, Jill",1,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+FINNEY,Pleasant Valley Township,President / Vice President,,Republican,"Trump, Donald J.",67,000250
+FINNEY,Plymell Township,President / Vice President,,independent,"Stein, Jill",2,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+FINNEY,Plymell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+FINNEY,Plymell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000260
+FINNEY,Plymell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+FINNEY,Plymell Township,President / Vice President,,Republican,"Trump, Donald J.",132,000260
+FINNEY,Theoni Township,President / Vice President,,independent,"Stein, Jill",1,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+FINNEY,Theoni Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+FINNEY,Theoni Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000280
+FINNEY,Theoni Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+FINNEY,Theoni Township,President / Vice President,,Republican,"Trump, Donald J.",51,000280
+FINNEY,Garden City Ward 1,President / Vice President,,independent,"Stein, Jill",3,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+FINNEY,Garden City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",149,120030
+FINNEY,Garden City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",14,120030
+FINNEY,Garden City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",70,120030
+FINNEY,Garden City Ward 2,President / Vice President,,independent,"Stein, Jill",16,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+FINNEY,Garden City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",256,140010
+FINNEY,Garden City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",22,140010
+FINNEY,Garden City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",169,140010
+FINNEY,Garden City Ward 4,President / Vice President,,independent,"Stein, Jill",4,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140020
+FINNEY,Garden City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",91,140020
+FINNEY,Garden City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",16,140020
+FINNEY,Garden City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",207,140020
+FINNEY,Garden City Ward 14 H122,President / Vice President,,independent,"Stein, Jill",11,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Castle, Darrell L",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Giordani, Rocky",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Hedges, James A",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Hoefling, Tom",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Kahn, Lynn",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"La Riva, Gloria",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Levinson, Michael S.",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Maturen, Michael A",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"McMullin, Evan",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Perry, Darryl",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Schriner, Joe C",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Smith, Mike",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Sood, Ajay",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Sterling, Shawna",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",162,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,Libertarian,"Johnson, Gary",21,140030
+FINNEY,Garden City Ward 14 H122,President / Vice President,,Republican,"Trump, Donald J.",300,140030
+FINNEY,Garden City Ward 15 H122,President / Vice President,,independent,"Stein, Jill",14,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Castle, Darrell L",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Giordani, Rocky",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Hedges, James A",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Hoefling, Tom",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Kahn, Lynn",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"La Riva, Gloria",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Levinson, Michael S.",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Maturen, Michael A",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"McMullin, Evan",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Perry, Darryl",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Schriner, Joe C",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Smith, Mike",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Sood, Ajay",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Sterling, Shawna",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",151,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,Libertarian,"Johnson, Gary",35,140050
+FINNEY,Garden City Ward 15 H122,President / Vice President,,Republican,"Trump, Donald J.",407,140050
+FINNEY,Pierceville Precinct,President / Vice President,,independent,"Stein, Jill",1,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Hedges, James A",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"McMullin, Evan",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Perry, Darryl",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Smith, Mike",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Sood, Ajay",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140070
+FINNEY,Pierceville Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,140070
+FINNEY,Pierceville Precinct,President / Vice President,,Libertarian,"Johnson, Gary",4,140070
+FINNEY,Pierceville Precinct,President / Vice President,,Republican,"Trump, Donald J.",140,140070
+FINNEY,Pierceville Precinct H122,President / Vice President,,independent,"Stein, Jill",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Castle, Darrell L",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Giordani, Rocky",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Hedges, James A",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Hoefling, Tom",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Kahn, Lynn",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"La Riva, Gloria",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Levinson, Michael S.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Maturen, Michael A",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"McMullin, Evan",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Perry, Darryl",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Schriner, Joe C",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Smith, Mike",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Sood, Ajay",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Sterling, Shawna",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Libertarian,"Johnson, Gary",0,200040
+FINNEY,Pierceville Precinct H122,President / Vice President,,Republican,"Trump, Donald J.",0,200040
+FINNEY,Riverside Precinct H122,President / Vice President,,independent,"Stein, Jill",2,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Castle, Darrell L",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Giordani, Rocky",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Hedges, James A",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Hoefling, Tom",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Kahn, Lynn",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"La Riva, Gloria",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Levinson, Michael S.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Maturen, Michael A",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"McMullin, Evan",8,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Perry, Darryl",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Schriner, Joe C",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Smith, Mike",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Sood, Ajay",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Sterling, Shawna",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",100,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Libertarian,"Johnson, Gary",15,200060
+FINNEY,Riverside Precinct H122,President / Vice President,,Republican,"Trump, Donald J.",433,200060
+FINNEY,Friend Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000010
+FINNEY,Friend Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+FINNEY,Friend Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+FINNEY,Friend Township,United States House of Representatives,1,Republican,"Marshall, Roger",46,000010
+FINNEY,Garden City Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",124,000040
+FINNEY,Garden City Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000040
+FINNEY,Garden City Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",65,000040
+FINNEY,Garden City Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",297,000040
+FINNEY,Garden City Ward 5,United States House of Representatives,1,independent,"LaPolice, Alan",72,000060
+FINNEY,Garden City Ward 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000060
+FINNEY,Garden City Ward 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,000060
+FINNEY,Garden City Ward 5,United States House of Representatives,1,Republican,"Marshall, Roger",184,000060
+FINNEY,Garden City Ward 6,United States House of Representatives,1,independent,"LaPolice, Alan",98,000070
+FINNEY,Garden City Ward 6,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+FINNEY,Garden City Ward 6,United States House of Representatives,1,Libertarian,"Burt, Kerry",91,000070
+FINNEY,Garden City Ward 6,United States House of Representatives,1,Republican,"Marshall, Roger",269,000070
+FINNEY,Garden City Ward 7,United States House of Representatives,1,independent,"LaPolice, Alan",65,000080
+FINNEY,Garden City Ward 7,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+FINNEY,Garden City Ward 7,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000080
+FINNEY,Garden City Ward 7,United States House of Representatives,1,Republican,"Marshall, Roger",197,000080
+FINNEY,Garden City Ward 8,United States House of Representatives,1,independent,"LaPolice, Alan",153,00009A
+FINNEY,Garden City Ward 8,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00009A
+FINNEY,Garden City Ward 8,United States House of Representatives,1,Libertarian,"Burt, Kerry",84,00009A
+FINNEY,Garden City Ward 8,United States House of Representatives,1,Republican,"Marshall, Roger",291,00009A
+FINNEY,Garden City Ward 9,United States House of Representatives,1,independent,"LaPolice, Alan",80,000100
+FINNEY,Garden City Ward 9,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+FINNEY,Garden City Ward 9,United States House of Representatives,1,Libertarian,"Burt, Kerry",63,000100
+FINNEY,Garden City Ward 9,United States House of Representatives,1,Republican,"Marshall, Roger",191,000100
+FINNEY,Garden City Ward 10,United States House of Representatives,1,independent,"LaPolice, Alan",83,000110
+FINNEY,Garden City Ward 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+FINNEY,Garden City Ward 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000110
+FINNEY,Garden City Ward 10,United States House of Representatives,1,Republican,"Marshall, Roger",223,000110
+FINNEY,Garden City Ward 11,United States House of Representatives,1,independent,"LaPolice, Alan",111,000120
+FINNEY,Garden City Ward 11,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000120
+FINNEY,Garden City Ward 11,United States House of Representatives,1,Libertarian,"Burt, Kerry",48,000120
+FINNEY,Garden City Ward 11,United States House of Representatives,1,Republican,"Marshall, Roger",340,000120
+FINNEY,Garden City Ward 12,United States House of Representatives,1,independent,"LaPolice, Alan",118,000130
+FINNEY,Garden City Ward 12,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000130
+FINNEY,Garden City Ward 12,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000130
+FINNEY,Garden City Ward 12,United States House of Representatives,1,Republican,"Marshall, Roger",386,000130
+FINNEY,Garden City Ward 13,United States House of Representatives,1,independent,"LaPolice, Alan",93,000140
+FINNEY,Garden City Ward 13,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000140
+FINNEY,Garden City Ward 13,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000140
+FINNEY,Garden City Ward 13,United States House of Representatives,1,Republican,"Marshall, Roger",326,000140
+FINNEY,Garden City Ward 16,United States House of Representatives,1,independent,"LaPolice, Alan",106,000170
+FINNEY,Garden City Ward 16,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000170
+FINNEY,Garden City Ward 16,United States House of Representatives,1,Libertarian,"Burt, Kerry",50,000170
+FINNEY,Garden City Ward 16,United States House of Representatives,1,Republican,"Marshall, Roger",406,000170
+FINNEY,Holcomb Township,United States House of Representatives,1,independent,"LaPolice, Alan",165,000190
+FINNEY,Holcomb Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+FINNEY,Holcomb Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",72,000190
+FINNEY,Holcomb Township,United States House of Representatives,1,Republican,"Marshall, Roger",647,000190
+FINNEY,Huffman Township,United States House of Representatives,1,independent,"LaPolice, Alan",53,000200
+FINNEY,Huffman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+FINNEY,Huffman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",37,000200
+FINNEY,Huffman Township,United States House of Representatives,1,Republican,"Marshall, Roger",166,000200
+FINNEY,Jennie Barker Township,United States House of Representatives,1,independent,"LaPolice, Alan",74,00021A
+FINNEY,Jennie Barker Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00021A
+FINNEY,Jennie Barker Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,00021A
+FINNEY,Jennie Barker Township,United States House of Representatives,1,Republican,"Marshall, Roger",356,00021A
+FINNEY,Kalvesta Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000220
+FINNEY,Kalvesta Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+FINNEY,Kalvesta Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000220
+FINNEY,Kalvesta Township,United States House of Representatives,1,Republican,"Marshall, Roger",42,000220
+FINNEY,Mack Township,United States House of Representatives,1,independent,"LaPolice, Alan",53,000230
+FINNEY,Mack Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+FINNEY,Mack Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",39,000230
+FINNEY,Mack Township,United States House of Representatives,1,Republican,"Marshall, Roger",116,000230
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000250
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000250
+FINNEY,Pleasant Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",53,000250
+FINNEY,Plymell Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000260
+FINNEY,Plymell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000260
+FINNEY,Plymell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000260
+FINNEY,Plymell Township,United States House of Representatives,1,Republican,"Marshall, Roger",116,000260
+FINNEY,Theoni Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000280
+FINNEY,Theoni Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+FINNEY,Theoni Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000280
+FINNEY,Theoni Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000280
+FINNEY,Garden City Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",67,120030
+FINNEY,Garden City Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+FINNEY,Garden City Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",43,120030
+FINNEY,Garden City Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",105,120030
+FINNEY,Garden City Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",120,140010
+FINNEY,Garden City Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140010
+FINNEY,Garden City Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",85,140010
+FINNEY,Garden City Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",224,140010
+FINNEY,Garden City Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",74,140020
+FINNEY,Garden City Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,140020
+FINNEY,Garden City Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,140020
+FINNEY,Garden City Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",205,140020
+FINNEY,Garden City ward 14 H123,United States House of Representatives,1,independent,"LaPolice, Alan",113,140040
+FINNEY,Garden City ward 14 H123,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,140040
+FINNEY,Garden City ward 14 H123,United States House of Representatives,1,Libertarian,"Burt, Kerry",57,140040
+FINNEY,Garden City ward 14 H123,United States House of Representatives,1,Republican,"Marshall, Roger",308,140040
+FINNEY,Garden City ward 15 H123,United States House of Representatives,1,independent,"LaPolice, Alan",99,140060
+FINNEY,Garden City ward 15 H123,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,140060
+FINNEY,Garden City ward 15 H123,United States House of Representatives,1,Libertarian,"Burt, Kerry",70,140060
+FINNEY,Garden City ward 15 H123,United States House of Representatives,1,Republican,"Marshall, Roger",426,140060
+FINNEY,Pierceville Precinct,United States House of Representatives,1,independent,"LaPolice, Alan",32,140070
+FINNEY,Pierceville Precinct,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140070
+FINNEY,Pierceville Precinct,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,140070
+FINNEY,Pierceville Precinct,United States House of Representatives,1,Republican,"Marshall, Roger",123,140070
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,independent,"LaPolice, Alan",73,200060
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,200060
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,200060
+FINNEY,Riverside Precinct H122,United States House of Representatives,1,Republican,"Marshall, Roger",438,200060
+FINNEY,Friend Township,United States Senate,,write - in,"Smith, DJ",0,000010
+FINNEY,Friend Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000010
+FINNEY,Friend Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+FINNEY,Friend Township,United States Senate,,Republican,"Moran, Jerry",53,000010
+FINNEY,Garden City Ward 3,United States Senate,,write - in,"Smith, DJ",0,000040
+FINNEY,Garden City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",133,000040
+FINNEY,Garden City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",34,000040
+FINNEY,Garden City Ward 3,United States Senate,,Republican,"Moran, Jerry",335,000040
+FINNEY,Garden City Ward 5,United States Senate,,write - in,"Smith, DJ",0,000060
+FINNEY,Garden City Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",80,000060
+FINNEY,Garden City Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",17,000060
+FINNEY,Garden City Ward 5,United States Senate,,Republican,"Moran, Jerry",221,000060
+FINNEY,Garden City Ward 6,United States Senate,,write - in,"Smith, DJ",0,000070
+FINNEY,Garden City Ward 6,United States Senate,,Democratic,"Wiesner, Patrick",158,000070
+FINNEY,Garden City Ward 6,United States Senate,,Libertarian,"Garrard, Robert D.",27,000070
+FINNEY,Garden City Ward 6,United States Senate,,Republican,"Moran, Jerry",294,000070
+FINNEY,Garden City Ward 7,United States Senate,,write - in,"Smith, DJ",0,000080
+FINNEY,Garden City Ward 7,United States Senate,,Democratic,"Wiesner, Patrick",97,000080
+FINNEY,Garden City Ward 7,United States Senate,,Libertarian,"Garrard, Robert D.",18,000080
+FINNEY,Garden City Ward 7,United States Senate,,Republican,"Moran, Jerry",186,000080
+FINNEY,Garden City Ward 8,United States Senate,,write - in,"Smith, DJ",0,00009A
+FINNEY,Garden City Ward 8,United States Senate,,Democratic,"Wiesner, Patrick",240,00009A
+FINNEY,Garden City Ward 8,United States Senate,,Libertarian,"Garrard, Robert D.",27,00009A
+FINNEY,Garden City Ward 8,United States Senate,,Republican,"Moran, Jerry",304,00009A
+FINNEY,Garden City Ward 9,United States Senate,,write - in,"Smith, DJ",0,000100
+FINNEY,Garden City Ward 9,United States Senate,,Democratic,"Wiesner, Patrick",118,000100
+FINNEY,Garden City Ward 9,United States Senate,,Libertarian,"Garrard, Robert D.",33,000100
+FINNEY,Garden City Ward 9,United States Senate,,Republican,"Moran, Jerry",199,000100
+FINNEY,Garden City Ward 10,United States Senate,,write - in,"Smith, DJ",0,000110
+FINNEY,Garden City Ward 10,United States Senate,,Democratic,"Wiesner, Patrick",80,000110
+FINNEY,Garden City Ward 10,United States Senate,,Libertarian,"Garrard, Robert D.",14,000110
+FINNEY,Garden City Ward 10,United States Senate,,Republican,"Moran, Jerry",249,000110
+FINNEY,Garden City Ward 11,United States Senate,,write - in,"Smith, DJ",0,000120
+FINNEY,Garden City Ward 11,United States Senate,,Democratic,"Wiesner, Patrick",108,000120
+FINNEY,Garden City Ward 11,United States Senate,,Libertarian,"Garrard, Robert D.",25,000120
+FINNEY,Garden City Ward 11,United States Senate,,Republican,"Moran, Jerry",390,000120
+FINNEY,Garden City Ward 12,United States Senate,,write - in,"Smith, DJ",0,000130
+FINNEY,Garden City Ward 12,United States Senate,,Democratic,"Wiesner, Patrick",80,000130
+FINNEY,Garden City Ward 12,United States Senate,,Libertarian,"Garrard, Robert D.",20,000130
+FINNEY,Garden City Ward 12,United States Senate,,Republican,"Moran, Jerry",445,000130
+FINNEY,Garden City Ward 13,United States Senate,,write - in,"Smith, DJ",0,000140
+FINNEY,Garden City Ward 13,United States Senate,,Democratic,"Wiesner, Patrick",58,000140
+FINNEY,Garden City Ward 13,United States Senate,,Libertarian,"Garrard, Robert D.",15,000140
+FINNEY,Garden City Ward 13,United States Senate,,Republican,"Moran, Jerry",381,000140
+FINNEY,Garden City Ward 16,United States Senate,,write - in,"Smith, DJ",0,000170
+FINNEY,Garden City Ward 16,United States Senate,,Democratic,"Wiesner, Patrick",111,000170
+FINNEY,Garden City Ward 16,United States Senate,,Libertarian,"Garrard, Robert D.",23,000170
+FINNEY,Garden City Ward 16,United States Senate,,Republican,"Moran, Jerry",444,000170
+FINNEY,Holcomb Township,United States Senate,,write - in,"Smith, DJ",0,000190
+FINNEY,Holcomb Township,United States Senate,,Democratic,"Wiesner, Patrick",122,000190
+FINNEY,Holcomb Township,United States Senate,,Libertarian,"Garrard, Robert D.",41,000190
+FINNEY,Holcomb Township,United States Senate,,Republican,"Moran, Jerry",725,000190
+FINNEY,Huffman Township,United States Senate,,write - in,"Smith, DJ",0,000200
+FINNEY,Huffman Township,United States Senate,,Democratic,"Wiesner, Patrick",69,000200
+FINNEY,Huffman Township,United States Senate,,Libertarian,"Garrard, Robert D.",25,000200
+FINNEY,Huffman Township,United States Senate,,Republican,"Moran, Jerry",171,000200
+FINNEY,Jennie Barker Township,United States Senate,,write - in,"Smith, DJ",0,00021A
+FINNEY,Jennie Barker Township,United States Senate,,Democratic,"Wiesner, Patrick",91,00021A
+FINNEY,Jennie Barker Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,00021A
+FINNEY,Jennie Barker Township,United States Senate,,Republican,"Moran, Jerry",371,00021A
+FINNEY,Kalvesta Township,United States Senate,,write - in,"Smith, DJ",0,000220
+FINNEY,Kalvesta Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000220
+FINNEY,Kalvesta Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000220
+FINNEY,Kalvesta Township,United States Senate,,Republican,"Moran, Jerry",47,000220
+FINNEY,Mack Township,United States Senate,,write - in,"Smith, DJ",0,000230
+FINNEY,Mack Township,United States Senate,,Democratic,"Wiesner, Patrick",89,000230
+FINNEY,Mack Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000230
+FINNEY,Mack Township,United States Senate,,Republican,"Moran, Jerry",117,000230
+FINNEY,Pleasant Valley Township,United States Senate,,write - in,"Smith, DJ",0,000250
+FINNEY,Pleasant Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000250
+FINNEY,Pleasant Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000250
+FINNEY,Pleasant Valley Township,United States Senate,,Republican,"Moran, Jerry",64,000250
+FINNEY,Plymell Township,United States Senate,,write - in,"Smith, DJ",0,000260
+FINNEY,Plymell Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000260
+FINNEY,Plymell Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000260
+FINNEY,Plymell Township,United States Senate,,Republican,"Moran, Jerry",133,000260
+FINNEY,Theoni Township,United States Senate,,write - in,"Smith, DJ",0,000280
+FINNEY,Theoni Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000280
+FINNEY,Theoni Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000280
+FINNEY,Theoni Township,United States Senate,,Republican,"Moran, Jerry",53,000280
+FINNEY,Garden City Ward 1,United States Senate,,write - in,"Smith, DJ",0,120030
+FINNEY,Garden City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",106,120030
+FINNEY,Garden City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",29,120030
+FINNEY,Garden City Ward 1,United States Senate,,Republican,"Moran, Jerry",95,120030
+FINNEY,Garden City Ward 2,United States Senate,,write - in,"Smith, DJ",0,140010
+FINNEY,Garden City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",204,140010
+FINNEY,Garden City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",33,140010
+FINNEY,Garden City Ward 2,United States Senate,,Republican,"Moran, Jerry",218,140010
+FINNEY,Garden City Ward 4,United States Senate,,write - in,"Smith, DJ",0,140020
+FINNEY,Garden City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",70,140020
+FINNEY,Garden City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",10,140020
+FINNEY,Garden City Ward 4,United States Senate,,Republican,"Moran, Jerry",238,140020
+FINNEY,Garden City ward 14 H123,United States Senate,,write - in,"Smith, DJ",0,140040
+FINNEY,Garden City ward 14 H123,United States Senate,,Democratic,"Wiesner, Patrick",117,140040
+FINNEY,Garden City ward 14 H123,United States Senate,,Libertarian,"Garrard, Robert D.",31,140040
+FINNEY,Garden City ward 14 H123,United States Senate,,Republican,"Moran, Jerry",346,140040
+FINNEY,Garden City ward 15 H123,United States Senate,,write - in,"Smith, DJ",0,140060
+FINNEY,Garden City ward 15 H123,United States Senate,,Democratic,"Wiesner, Patrick",111,140060
+FINNEY,Garden City ward 15 H123,United States Senate,,Libertarian,"Garrard, Robert D.",32,140060
+FINNEY,Garden City ward 15 H123,United States Senate,,Republican,"Moran, Jerry",471,140060
+FINNEY,Pierceville Precinct,United States Senate,,write - in,"Smith, DJ",0,140070
+FINNEY,Pierceville Precinct,United States Senate,,Democratic,"Wiesner, Patrick",9,140070
+FINNEY,Pierceville Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",9,140070
+FINNEY,Pierceville Precinct,United States Senate,,Republican,"Moran, Jerry",147,140070
+FINNEY,Riverside Precinct H122,United States Senate,,write - in,"Smith, DJ",0,200060
+FINNEY,Riverside Precinct H122,United States Senate,,Democratic,"Wiesner, Patrick",64,200060
+FINNEY,Riverside Precinct H122,United States Senate,,Libertarian,"Garrard, Robert D.",23,200060
+FINNEY,Riverside Precinct H122,United States Senate,,Republican,"Moran, Jerry",468,200060

--- a/2016/20161108__ks__general__ford__precinct.csv
+++ b/2016/20161108__ks__general__ford__precinct.csv
@@ -1,524 +1,1568 @@
-county,precinct,office,district,party,candidate,votes
-Ford,Dodge City 1,President,,L,Gary Johnson,32
-Ford,Dodge City 1,President,,IND,Jill Stein,10
-Ford,Dodge City 1,President,,R,Donald J Trump,250
-Ford,Dodge City 1,President,,D,Hillary Clinton,246
-Ford,Dodge City 1,President,,,Write-ins,6
-Ford,Dodge City 1,U.S. Senate,,R,Jerry Moran,278
-Ford,Dodge City 1,U.S. Senate,,D,Partick Wiesner,201
-Ford,Dodge City 1,U.S. Senate,,L,Robert Garrand,46
-Ford,Dodge City 1,U.S. Senate,,,Write-ins,2
-Ford,Dodge City 1,U.S. House,1,L,Kerry Burt,77
-Ford,Dodge City 1,U.S. House,1,i,Alan LaPolice,161
-Ford,Dodge City 1,U.S. House,1,R,Roger Marshall,252
-Ford,Dodge City 1,U.S. House,1,,Write-ins,3
-Ford,Dodge City 1,State Senate,38,R,Bud Estes,284
-Ford,Dodge City 1,State Senate,38,D,Miguel Angel Rodriguez,234
-Ford,Dodge City 1,State Senate,38,,Write-ins,1
-Ford,Dodge City 1,State House,115,R,Boyd Orr,429
-Ford,Dodge City 1,State House,115,,Write-ins,10
-Ford,Dodge City 2,President,,L,Gary Johnson,19
-Ford,Dodge City 2,President,,IND,Jill Stein,10
-Ford,Dodge City 2,President,,R,Donald J Trump,148
-Ford,Dodge City 2,President,,D,Hillary Clinton,173
-Ford,Dodge City 2,President,,,Write-ins,1
-Ford,Dodge City 2,U.S. Senate,,R,Jerry Moran,172
-Ford,Dodge City 2,U.S. Senate,,D,Partick Wiesner,135
-Ford,Dodge City 2,U.S. Senate,,L,Robert Garrand,32
-Ford,Dodge City 2,U.S. Senate,,,Write-ins,1
-Ford,Dodge City 2,U.S. House,1,L,Kerry Burt,62
-Ford,Dodge City 2,U.S. House,1,i,Alan LaPolice,105
-Ford,Dodge City 2,U.S. House,1,R,Roger Marshall,150
-Ford,Dodge City 2,U.S. House,1,,Write-ins,1
-Ford,Dodge City 2,State Senate,38,R,Bud Estes,164
-Ford,Dodge City 2,State Senate,38,D,Miguel Angel Rodriguez,169
-Ford,Dodge City 2,State Senate,38,,Write-ins,1
-Ford,Dodge City 2,State House,119,D,Daniel L. Love,213
-Ford,Dodge City 2,State House,119,R,Bradley Ralph,122
-Ford,Dodge City 2,State House,119,,Write-ins,1
-Ford,Dodge City 3,President,,L,Gary Johnson,17
-Ford,Dodge City 3,President,,IND,Jill Stein,6
-Ford,Dodge City 3,President,,R,Donald J Trump,163
-Ford,Dodge City 3,President,,D,Hillary Clinton,246
-Ford,Dodge City 3,President,,,Write-ins,2
-Ford,Dodge City 3,U.S. Senate,,R,Jerry Moran,196
-Ford,Dodge City 3,U.S. Senate,,D,Partick Wiesner,180
-Ford,Dodge City 3,U.S. Senate,,L,Robert Garrand,36
-Ford,Dodge City 3,U.S. House,1,L,Kerry Burt,69
-Ford,Dodge City 3,U.S. House,1,i,Alan LaPolice,144
-Ford,Dodge City 3,U.S. House,1,R,Roger Marshall,174
-Ford,Dodge City 3,State Senate,38,R,Bud Estes,188
-Ford,Dodge City 3,State Senate,38,D,Miguel Angel Rodriguez,215
-Ford,Dodge City 3,State Senate,38,,Write-ins,3
-Ford,Dodge City 3,State House,119,D,Daniel L. Love,255
-Ford,Dodge City 3,State House,119,R,Bradley Ralph,156
-Ford,Dodge City 3,State House,119,,Write-ins,1
-Ford,Dodge City 4,President,,L,Gary Johnson,36
-Ford,Dodge City 4,President,,IND,Jill Stein,22
-Ford,Dodge City 4,President,,R,Donald J Trump,428
-Ford,Dodge City 4,President,,D,Hillary Clinton,352
-Ford,Dodge City 4,President,,,Write-ins,11
-Ford,Dodge City 4,U.S. Senate,,R,Jerry Moran,481
-Ford,Dodge City 4,U.S. Senate,,D,Partick Wiesner,282
-Ford,Dodge City 4,U.S. Senate,,L,Robert Garrand,56
-Ford,Dodge City 4,U.S. House,1,L,Kerry Burt,95
-Ford,Dodge City 4,U.S. House,1,i,Alan LaPolice,264
-Ford,Dodge City 4,U.S. House,1,R,Roger Marshall,418
-Ford,Dodge City 4,U.S. House,1,,Write-ins,6
-Ford,Dodge City 4,State Senate,38,R,Bud Estes,487
-Ford,Dodge City 4,State Senate,38,D,Miguel Angel Rodriguez,317
-Ford,Dodge City 4,State Senate,38,,Write-ins,2
-Ford,Dodge City 4,State House,119,D,Daniel L. Love,444
-Ford,Dodge City 4,State House,119,R,Bradley Ralph,363
-Ford,Dodge City 5,President,,L,Gary Johnson,42
-Ford,Dodge City 5,President,,IND,Jill Stein,32
-Ford,Dodge City 5,President,,R,Donald J Trump,873
-Ford,Dodge City 5,President,,D,Hillary Clinton,334
-Ford,Dodge City 5,President,,,Write-ins,15
-Ford,Dodge City 5,U.S. Senate,,R,Jerry Moran,951
-Ford,Dodge City 5,U.S. Senate,,D,Partick Wiesner,258
-Ford,Dodge City 5,U.S. Senate,,L,Robert Garrand,58
-Ford,Dodge City 5,U.S. Senate,,,Write-ins,1
-Ford,Dodge City 5,U.S. House,1,L,Kerry Burt,110
-Ford,Dodge City 5,U.S. House,1,i,Alan LaPolice,311
-Ford,Dodge City 5,U.S. House,1,R,Roger Marshall,800
-Ford,Dodge City 5,U.S. House,1,,Write-ins,11
-Ford,Dodge City 5,State Senate,38,R,Bud Estes,937
-Ford,Dodge City 5,State Senate,38,D,Miguel Angel Rodriguez,316
-Ford,Dodge City 5,State Senate,38,,Write-ins,5
-Ford,Dodge City 5,State House,119,D,Daniel L. Love,557
-Ford,Dodge City 5,State House,119,R,Bradley Ralph,706
-Ford,Dodge City 6,President,,L,Gary Johnson,46
-Ford,Dodge City 6,President,,IND,Jill Stein,26
-Ford,Dodge City 6,President,,R,Donald J Trump,1139
-Ford,Dodge City 6,President,,D,Hillary Clinton,426
-Ford,Dodge City 6,President,,,Write-ins,32
-Ford,Dodge City 6,U.S. Senate,,R,Jerry Moran,1301
-Ford,Dodge City 6,U.S. Senate,,D,Partick Wiesner,296
-Ford,Dodge City 6,U.S. Senate,,L,Robert Garrand,59
-Ford,Dodge City 6,U.S. House,1,L,Kerry Burt,92
-Ford,Dodge City 6,U.S. House,1,i,Alan LaPolice,408
-Ford,Dodge City 6,U.S. House,1,R,Roger Marshall,1100
-Ford,Dodge City 6,U.S. House,1,,Write-ins,11
-Ford,Dodge City 6,State Senate,38,R,Bud Estes,1239
-Ford,Dodge City 6,State Senate,38,D,Miguel Angel Rodriguez,387
-Ford,Dodge City 6,State Senate,38,,Write-ins,8
-Ford,Dodge City 6,State House,119,D,Daniel L. Love,702
-Ford,Dodge City 6,State House,119,R,Bradley Ralph,939
-Ford,Dodge City 6,State House,119,,Write-ins,1
-Ford,Dodge City 7,President,,L,Gary Johnson,2
-Ford,Dodge City 7,President,,IND,Jill Stein,0
-Ford,Dodge City 7,President,,R,Donald J Trump,68
-Ford,Dodge City 7,President,,D,Hillary Clinton,17
-Ford,Dodge City 7,U.S. Senate,,R,Jerry Moran,64
-Ford,Dodge City 7,U.S. Senate,,D,Partick Wiesner,17
-Ford,Dodge City 7,U.S. Senate,,L,Robert Garrand,3
-Ford,Dodge City 7,U.S. House,1,L,Kerry Burt,6
-Ford,Dodge City 7,U.S. House,1,i,Alan LaPolice,16
-Ford,Dodge City 7,U.S. House,1,R,Roger Marshall,58
-Ford,Dodge City 7,State Senate,38,R,Bud Estes,64
-Ford,Dodge City 7,State Senate,38,R,Miguel Angel Rodriguez,18
-Ford,Dodge City 7,State House,119,D,Daniel L. Love,38
-Ford,Dodge City 7,State House,119,R,Bradley Ralph,46
-Ford,Dodge City 9,President,,L,Gary Johnson,2
-Ford,Dodge City 9,President,,IND,Jill Stein,0
-Ford,Dodge City 9,President,,R,Donald J Trump,12
-Ford,Dodge City 9,President,,D,Hillary Clinton,6
-Ford,Dodge City 9,U.S. Senate,,R,Jerry Moran,12
-Ford,Dodge City 9,U.S. Senate,,D,Partick Wiesner,7
-Ford,Dodge City 9,U.S. Senate,,L,Robert Garrand,0
-Ford,Dodge City 9,U.S. House,1,L,Kerry Burt,4
-Ford,Dodge City 9,U.S. House,1,i,Alan LaPolice,4
-Ford,Dodge City 9,U.S. House,1,R,Roger Marshall,10
-Ford,Dodge City 9,U.S. House,1,,Write-ins,1
-Ford,Dodge City 9,State Senate,38,R,Bud Estes,12
-Ford,Dodge City 9,State Senate,38,D,Miguel Angel Rodriguez,7
-Ford,Dodge City 9,State House,115,R,Boyd Orr,18
-Ford,Bloom twp,President,,L,Gary Johnson,2
-Ford,Bloom twp,President,,IND,Jill Stein,0
-Ford,Bloom twp,President,,R,Donald J Trump,34
-Ford,Bloom twp,President,,D,Hillary Clinton,4
-Ford,Bloom twp,U.S. Senate,,R,Jerry Moran,33
-Ford,Bloom twp,U.S. Senate,,D,Partick Wiesner,2
-Ford,Bloom twp,U.S. Senate,,L,Robert Garrand,1
-Ford,Bloom twp,U.S. House,1,L,Kerry Burt,2
-Ford,Bloom twp,U.S. House,1,i,Alan LaPolice,6
-Ford,Bloom twp,U.S. House,1,R,Roger Marshall,26
-Ford,Bloom twp,U.S. House,1,,Write-ins,2
-Ford,Bloom twp,State Senate,38,R,Bud Estes,34
-Ford,Bloom twp,State Senate,38,R,Miguel Angel Rodriguez,1
-Ford,Bloom twp,State House,117,R,Leonard Mastroni,31
-Ford,Bucklin twp,President,,L,Gary Johnson,4
-Ford,Bucklin twp,President,,IND,Jill Stein,0
-Ford,Bucklin twp,President,,R,Donald J Trump,55
-Ford,Bucklin twp,President,,D,Hillary Clinton,3
-Ford,Bucklin twp,President,,,Write-ins,1
-Ford,Bucklin twp,U.S. Senate,,R,Jerry Moran,58
-Ford,Bucklin twp,U.S. Senate,,D,Partick Wiesner,2
-Ford,Bucklin twp,U.S. Senate,,L,Robert Garrand,3
-Ford,Bucklin twp,U.S. House,1,L,Kerry Burt,2
-Ford,Bucklin twp,U.S. House,1,i,Alan LaPolice,12
-Ford,Bucklin twp,U.S. House,1,R,Roger Marshall,45
-Ford,Bucklin twp,State Senate,38,R,Bud Estes,52
-Ford,Bucklin twp,State Senate,38,R,Miguel Angel Rodriguez,6
-Ford,Bucklin twp,State House,117,R,Leonard Mastroni,56
-Ford,Bucklin City,President,,L,Gary Johnson,11
-Ford,Bucklin City,President,,IND,Jill Stein,2
-Ford,Bucklin City,President,,R,Donald J Trump,277
-Ford,Bucklin City,President,,D,Hillary Clinton,26
-Ford,Bucklin City,President,,,Write-ins,2
-Ford,Bucklin City,U.S. Senate,,R,Jerry Moran,274
-Ford,Bucklin City,U.S. Senate,,D,Partick Wiesner,24
-Ford,Bucklin City,U.S. Senate,,L,Robert Garrand,16
-Ford,Bucklin City,U.S. Senate,,,Write-ins,1
-Ford,Bucklin City,U.S. House,1,L,Kerry Burt,10
-Ford,Bucklin City,U.S. House,1,i,Alan LaPolice,44
-Ford,Bucklin City,U.S. House,1,R,Roger Marshall,257
-Ford,Bucklin City,U.S. House,1,,Write-ins,2
-Ford,Bucklin City,State Senate,38,R,Bud Estes,265
-Ford,Bucklin City,State Senate,38,R,Miguel Angel Rodriguez,43
-Ford,Bucklin City,State House,117,R,Leonard Mastroni,280
-Ford,Bucklin City,State House,117,,Write-ins,1
-Ford,Concord twp,President,,L,Gary Johnson,0
-Ford,Concord twp,President,,IND,Jill Stein,1
-Ford,Concord twp,President,,R,Donald J Trump,43
-Ford,Concord twp,President,,D,Hillary Clinton,8
-Ford,Concord twp,U.S. Senate,,R,Jerry Moran,42
-Ford,Concord twp,U.S. Senate,,D,Partick Wiesner,7
-Ford,Concord twp,U.S. Senate,,L,Robert Garrand,1
-Ford,Concord twp,U.S. House,1,L,Kerry Burt,2
-Ford,Concord twp,U.S. House,1,i,Alan LaPolice,7
-Ford,Concord twp,U.S. House,1,R,Roger Marshall,37
-Ford,Concord twp,U.S. House,1,,Write-ins,1
-Ford,Concord twp,State Senate,38,R,Bud Estes,42
-Ford,Concord twp,State Senate,38,R,Miguel Angel Rodriguez,7
-Ford,Concord twp,State House,115,R,Boyd Orr,46
-Ford,Dodge twp H115,President,,L,Gary Johnson,10
-Ford,Dodge twp H115,President,,IND,Jill Stein,3
-Ford,Dodge twp H115,President,,R,Donald J Trump,159
-Ford,Dodge twp H115,President,,D,Hillary Clinton,39
-Ford,Dodge twp H115,President,,,Write-ins,1
-Ford,Dodge twp H115,U.S. Senate,,R,Jerry Moran,165
-Ford,Dodge twp H115,U.S. Senate,,D,Partick Wiesner,34
-Ford,Dodge twp H115,U.S. Senate,,L,Robert Garrand,7
-Ford,Dodge twp H115,U.S. House,1,L,Kerry Burt,9
-Ford,Dodge twp H115,U.S. House,1,i,Alan LaPolice,47
-Ford,Dodge twp H115,U.S. House,1,R,Roger Marshall,148
-Ford,Dodge twp H115,U.S. House,1,,Write-ins,1
-Ford,Dodge twp H115,State Senate,38,R,Bud Estes,175
-Ford,Dodge twp H115,State Senate,38,R,Miguel Angel Rodriguez,34
-Ford,Dodge twp H115,State House,115,R,Boyd Orr,189
-Ford,Dodge twp H115,State House,115,,Write-ins,1
-Ford,Dodge twp H119,President,,L,Gary Johnson,0
-Ford,Dodge twp H119,President,,IND,Jill Stein,1
-Ford,Dodge twp H119,President,,R,Donald J Trump,26
-Ford,Dodge twp H119,President,,D,Hillary Clinton,1
-Ford,Dodge twp H119,U.S. Senate,,R,Jerry Moran,24
-Ford,Dodge twp H119,U.S. Senate,,D,Partick Wiesner,2
-Ford,Dodge twp H119,U.S. Senate,,L,Robert Garrand,0
-Ford,Dodge twp H119,U.S. House,1,L,Kerry Burt,1
-Ford,Dodge twp H119,U.S. House,1,i,Alan LaPolice,3
-Ford,Dodge twp H119,U.S. House,1,R,Roger Marshall,20
-Ford,Dodge twp H119,State Senate,38,R,Bud Estes,25
-Ford,Dodge twp H119,State Senate,38,R,Miguel Angel Rodriguez,3
-Ford,Dodge twp H119,State House,119,D,Daniel L. Love,6
-Ford,Dodge twp H119,State House,119,R,Bradley Ralph,22
-Ford,Dodge twp W H119,President,,L,Gary Johnson,0
-Ford,Dodge twp W H119,President,,IND,Jill Stein,0
-Ford,Dodge twp W H119,President,,R,Donald J Trump,1
-Ford,Dodge twp W H119,President,,D,Hillary Clinton,0
-Ford,Dodge twp W H119,U.S. Senate,,R,Jerry Moran,1
-Ford,Dodge twp W H119,U.S. Senate,,D,Partick Wiesner,0
-Ford,Dodge twp W H119,U.S. Senate,,L,Robert Garrand,0
-Ford,Dodge twp W H119,U.S. House,1,L,Kerry Burt,0
-Ford,Dodge twp W H119,U.S. House,1,i,Alan LaPolice,0
-Ford,Dodge twp W H119,U.S. House,1,R,Roger Marshall,1
-Ford,Dodge twp W H119,State Senate,38,R,Bud Estes,1
-Ford,Dodge twp W H119,State Senate,38,R,Miguel Angel Rodriguez,0
-Ford,Dodge twp W H119,State House,119,D,Daniel L. Love,1
-Ford,Dodge twp W H119,State House,119,R,Bradley Ralph,0
-Ford,Dodge twp 3,President,,L,Gary Johnson,0
-Ford,Dodge twp 3,President,,IND,Jill Stein,1
-Ford,Dodge twp 3,President,,R,Donald J Trump,20
-Ford,Dodge twp 3,President,,D,Hillary Clinton,6
-Ford,Dodge twp 3,U.S. Senate,,R,Jerry Moran,22
-Ford,Dodge twp 3,U.S. Senate,,D,Partick Wiesner,4
-Ford,Dodge twp 3,U.S. Senate,,L,Robert Garrand,2
-Ford,Dodge twp 3,U.S. House,1,L,Kerry Burt,1
-Ford,Dodge twp 3,U.S. House,1,i,Alan LaPolice,7
-Ford,Dodge twp 3,U.S. House,1,R,Roger Marshall,19
-Ford,Dodge twp 3,State Senate,38,R,Bud Estes,20
-Ford,Dodge twp 3,State Senate,38,R,Miguel Angel Rodriguez,7
-Ford,Dodge twp 3,State House,119,D,Daniel L. Love,14
-Ford,Dodge twp 3,State House,119,R,Bradley Ralph,14
-Ford,Enterprise twp H115,President,,L,Gary Johnson,6
-Ford,Enterprise twp H115,President,,IND,Jill Stein,3
-Ford,Enterprise twp H115,President,,R,Donald J Trump,122
-Ford,Enterprise twp H115,President,,D,Hillary Clinton,59
-Ford,Enterprise twp H115,President,,,Write-ins,2
-Ford,Enterprise twp H115,U.S. Senate,,R,Jerry Moran,133
-Ford,Enterprise twp H115,U.S. Senate,,D,Partick Wiesner,45
-Ford,Enterprise twp H115,U.S. Senate,,L,Robert Garrand,11
-Ford,Enterprise twp H115,U.S. House,1,L,Kerry Burt,15
-Ford,Enterprise twp H115,U.S. House,1,i,Alan LaPolice,47
-Ford,Enterprise twp H115,U.S. House,1,R,Roger Marshall,119
-Ford,Enterprise twp H115,U.S. House,1,,Write-ins,1
-Ford,Enterprise twp H115,State Senate,38,R,Bud Estes,132
-Ford,Enterprise twp H115,State Senate,38,R,Miguel Angel Rodriguez,52
-Ford,Enterprise twp H115,State Senate,38,,Write-ins,1
-Ford,Enterprise twp H115,State House,115,R,Boyd Orr,163
-Ford,Enterprise twp H115,State House,115,,Write-ins,1
-Ford,Enterprise twp H119,President,,L,Gary Johnson,0
-Ford,Enterprise twp H119,President,,IND,Jill Stein,0
-Ford,Enterprise twp H119,President,,R,Donald J Trump,2
-Ford,Enterprise twp H119,President,,D,Hillary Clinton,5
-Ford,Enterprise twp H119,U.S. Senate,,R,Jerry Moran,5
-Ford,Enterprise twp H119,U.S. Senate,,D,Partick Wiesner,2
-Ford,Enterprise twp H119,U.S. Senate,,L,Robert Garrand,0
-Ford,Enterprise twp H119,U.S. House,1,L,Kerry Burt,0
-Ford,Enterprise twp H119,U.S. House,1,i,Alan LaPolice,0
-Ford,Enterprise twp H119,U.S. House,1,R,Roger Marshall,6
-Ford,Enterprise twp H119,State Senate,38,R,Bud Estes,1
-Ford,Enterprise twp H119,State Senate,38,R,Miguel Angel Rodriguez,6
-Ford,Enterprise twp H119,State House,119,D,Daniel L. Love,6
-Ford,Enterprise twp H119,State House,119,R,Bradley Ralph,1
-Ford,Fairview twp,President,,L,Gary Johnson,3
-Ford,Fairview twp,President,,IND,Jill Stein,2
-Ford,Fairview twp,President,,R,Donald J Trump,89
-Ford,Fairview twp,President,,D,Hillary Clinton,16
-Ford,Fairview twp,U.S. Senate,,R,Jerry Moran,92
-Ford,Fairview twp,U.S. Senate,,D,Partick Wiesner,12
-Ford,Fairview twp,U.S. Senate,,L,Robert Garrand,6
-Ford,Fairview twp,U.S. House,1,L,Kerry Burt,3
-Ford,Fairview twp,U.S. House,1,i,Alan LaPolice,22
-Ford,Fairview twp,U.S. House,1,R,Roger Marshall,80
-Ford,Fairview twp,U.S. House,1,,Write-ins,1
-Ford,Fairview twp,State Senate,38,R,Bud Estes,93
-Ford,Fairview twp,State Senate,38,R,Miguel Angel Rodriguez,16
-Ford,Fairview twp,State House,115,R,Boyd Orr,97
-Ford,Ford twp,President,,L,Gary Johnson,3
-Ford,Ford twp,President,,IND,Jill Stein,3
-Ford,Ford twp,President,,R,Donald J Trump,62
-Ford,Ford twp,President,,D,Hillary Clinton,5
-Ford,Ford twp,U.S. Senate,,R,Jerry Moran,62
-Ford,Ford twp,U.S. Senate,,D,Partick Wiesner,4
-Ford,Ford twp,U.S. Senate,,L,Robert Garrand,4
-Ford,Ford twp,U.S. House,1,L,Kerry Burt,1
-Ford,Ford twp,U.S. House,1,i,Alan LaPolice,18
-Ford,Ford twp,U.S. House,1,R,Roger Marshall,50
-Ford,Ford twp,State Senate,38,R,Bud Estes,62
-Ford,Ford twp,State Senate,38,R,Miguel Angel Rodriguez,10
-Ford,Ford twp,State House,117,R,Leonard Mastroni,54
-Ford,Ford City,President,,L,Gary Johnson,0
-Ford,Ford City,President,,IND,Jill Stein,0
-Ford,Ford City,President,,R,Donald J Trump,74
-Ford,Ford City,President,,D,Hillary Clinton,8
-Ford,Ford City,U.S. Senate,,R,Jerry Moran,76
-Ford,Ford City,U.S. Senate,,D,Partick Wiesner,3
-Ford,Ford City,U.S. Senate,,L,Robert Garrand,2
-Ford,Ford City,U.S. House,1,L,Kerry Burt,3
-Ford,Ford City,U.S. House,1,i,Alan LaPolice,6
-Ford,Ford City,U.S. House,1,R,Roger Marshall,66
-Ford,Ford City,U.S. House,1,,Write-ins,2
-Ford,Ford City,State Senate,38,R,Bud Estes,75
-Ford,Ford City,State Senate,38,R,Miguel Angel Rodriguez,7
-Ford,Ford City,State House,117,R,Leonard Mastroni,72
-Ford,Grandview twp H115,President,,L,Gary Johnson,6
-Ford,Grandview twp H115,President,,IND,Jill Stein,0
-Ford,Grandview twp H115,President,,R,Donald J Trump,155
-Ford,Grandview twp H115,President,,D,Hillary Clinton,20
-Ford,Grandview twp H115,President,,,Write-ins,4
-Ford,Grandview twp H115,U.S. Senate,,R,Jerry Moran,154
-Ford,Grandview twp H115,U.S. Senate,,D,Partick Wiesner,18
-Ford,Grandview twp H115,U.S. Senate,,L,Robert Garrand,10
-Ford,Grandview twp H115,U.S. House,1,L,Kerry Burt,8
-Ford,Grandview twp H115,U.S. House,1,i,Alan LaPolice,36
-Ford,Grandview twp H115,U.S. House,1,R,Roger Marshall,135
-Ford,Grandview twp H115,U.S. House,1,,Write-ins,1
-Ford,Grandview twp H115,State Senate,38,R,Bud Estes,151
-Ford,Grandview twp H115,State Senate,38,R,Miguel Angel Rodriguez,30
-Ford,Grandview twp H115,State House,115,R,Boyd Orr,157
-Ford,Grandview twp H115,State House,115,,Write-ins,2
-Ford,Grandview twp H119,President,,L,Gary Johnson,0
-Ford,Grandview twp H119,President,,IND,Jill Stein,0
-Ford,Grandview twp H119,President,,R,Donald J Trump,4
-Ford,Grandview twp H119,President,,D,Hillary Clinton,0
-Ford,Grandview twp H119,U.S. Senate,,R,Jerry Moran,3
-Ford,Grandview twp H119,U.S. Senate,,D,Partick Wiesner,0
-Ford,Grandview twp H119,U.S. Senate,,L,Robert Garrand,0
-Ford,Grandview twp H119,U.S. House,1,L,Kerry Burt,0
-Ford,Grandview twp H119,U.S. House,1,i,Alan LaPolice,0
-Ford,Grandview twp H119,U.S. House,1,R,Roger Marshall,4
-Ford,Grandview twp H119,State Senate,38,R,Bud Estes,4
-Ford,Grandview twp H119,State Senate,38,R,Miguel Angel Rodriguez,0
-Ford,Grandview twp H119,State House,119,D,Daniel L. Love,3
-Ford,Grandview twp H119,State House,119,R,Bradley Ralph,0
-Ford,Grandview twp 2 H115,President,,L,Gary Johnson,0
-Ford,Grandview twp 2 H115,President,,IND,Jill Stein,0
-Ford,Grandview twp 2 H115,President,,R,Donald J Trump,27
-Ford,Grandview twp 2 H115,President,,D,Hillary Clinton,11
-Ford,Grandview twp 2 H115,U.S. Senate,,R,Jerry Moran,26
-Ford,Grandview twp 2 H115,U.S. Senate,,D,Partick Wiesner,10
-Ford,Grandview twp 2 H115,U.S. Senate,,L,Robert Garrand,2
-Ford,Grandview twp 2 H115,U.S. House,1,L,Kerry Burt,3
-Ford,Grandview twp 2 H115,U.S. House,1,i,Alan LaPolice,9
-Ford,Grandview twp 2 H115,U.S. House,1,R,Roger Marshall,25
-Ford,Grandview twp 2 H115,State Senate,38,R,Bud Estes,28
-Ford,Grandview twp 2 H115,State Senate,38,R,Miguel Angel Rodriguez,10
-Ford,Grandview twp 2 H115,State House,115,R,Boyd Orr,28
-Ford,Grandview twp 2 H115,State House,115,,Write-ins,1
-Ford,Grandview twp 2 H119,President,,L,Gary Johnson,0
-Ford,Grandview twp 2 H119,President,,IND,Jill Stein,0
-Ford,Grandview twp 2 H119,President,,R,Donald J Trump,3
-Ford,Grandview twp 2 H119,President,,D,Hillary Clinton,0
-Ford,Grandview twp 2 H119,U.S. Senate,,R,Jerry Moran,3
-Ford,Grandview twp 2 H119,U.S. Senate,,D,Partick Wiesner,0
-Ford,Grandview twp 2 H119,U.S. Senate,,L,Robert Garrand,0
-Ford,Grandview twp 2 H119,U.S. House,1,L,Kerry Burt,0
-Ford,Grandview twp 2 H119,U.S. House,1,i,Alan LaPolice,0
-Ford,Grandview twp 2 H119,U.S. House,1,R,Roger Marshall,3
-Ford,Grandview twp 2 H119,State Senate,38,R,Bud Estes,3
-Ford,Grandview twp 2 H119,State Senate,38,R,Miguel Angel Rodriguez,0
-Ford,Grandview twp 2 H119,State House,119,D,Daniel L. Love,1
-Ford,Grandview twp 2 H119,State House,119,R,Bradley Ralph,2
-Ford,Richland twp,President,,L,Gary Johnson,9
-Ford,Richland twp,President,,IND,Jill Stein,3
-Ford,Richland twp,President,,R,Donald J Trump,167
-Ford,Richland twp,President,,D,Hillary Clinton,37
-Ford,Richland twp,President,,,Write-ins,1
-Ford,Richland twp,U.S. Senate,,R,Jerry Moran,170
-Ford,Richland twp,U.S. Senate,,D,Partick Wiesner,32
-Ford,Richland twp,U.S. Senate,,L,Robert Garrand,8
-Ford,Richland twp,U.S. House,1,L,Kerry Burt,14
-Ford,Richland twp,U.S. House,1,i,Alan LaPolice,60
-Ford,Richland twp,U.S. House,1,R,Roger Marshall,135
-Ford,Richland twp,State Senate,38,R,Bud Estes,174
-Ford,Richland twp,State Senate,38,R,Miguel Angel Rodriguez,38
-Ford,Richland twp,State House,115,R,Boyd Orr,192
-Ford,Richland twp,State House,115,,Write-ins,1
-Ford,Royal twp,President,,L,Gary Johnson,4
-Ford,Royal twp,President,,IND,Jill Stein,1
-Ford,Royal twp,President,,R,Donald J Trump,92
-Ford,Royal twp,President,,D,Hillary Clinton,17
-Ford,Royal twp,President,,,Write-ins,5
-Ford,Royal twp,U.S. Senate,,R,Jerry Moran,97
-Ford,Royal twp,U.S. Senate,,D,Partick Wiesner,18
-Ford,Royal twp,U.S. Senate,,L,Robert Garrand,3
-Ford,Royal twp,U.S. House,1,L,Kerry Burt,5
-Ford,Royal twp,U.S. House,1,i,Alan LaPolice,23
-Ford,Royal twp,U.S. House,1,R,Roger Marshall,89
-Ford,Royal twp,State Senate,38,R,Bud Estes,100
-Ford,Royal twp,State Senate,38,R,Miguel Angel Rodriguez,19
-Ford,Royal twp,State House,115,R,Boyd Orr,105
-Ford,Sodville twp,President,,L,Gary Johnson,1
-Ford,Sodville twp,President,,IND,Jill Stein,0
-Ford,Sodville twp,President,,R,Donald J Trump,42
-Ford,Sodville twp,President,,D,Hillary Clinton,5
-Ford,Sodville twp,U.S. Senate,,R,Jerry Moran,43
-Ford,Sodville twp,U.S. Senate,,D,Partick Wiesner,1
-Ford,Sodville twp,U.S. Senate,,L,Robert Garrand,2
-Ford,Sodville twp,U.S. House,1,L,Kerry Burt,1
-Ford,Sodville twp,U.S. House,1,i,Alan LaPolice,9
-Ford,Sodville twp,U.S. House,1,R,Roger Marshall,36
-Ford,Sodville twp,U.S. House,1,,Write-ins,0
-Ford,Sodville twp,State Senate,38,R,Bud Estes,42
-Ford,Sodville twp,State Senate,38,R,Miguel Angel Rodriguez,3
-Ford,Sodville twp,State House,117,R,Leonard Mastroni,38
-Ford,Spearville twp,President,,L,Gary Johnson,3
-Ford,Spearville twp,President,,IND,Jill Stein,0
-Ford,Spearville twp,President,,R,Donald J Trump,178
-Ford,Spearville twp,President,,D,Hillary Clinton,12
-Ford,Spearville twp,U.S. Senate,,R,Jerry Moran,167
-Ford,Spearville twp,U.S. Senate,,D,Partick Wiesner,15
-Ford,Spearville twp,U.S. Senate,,L,Robert Garrand,7
-Ford,Spearville twp,U.S. House,1,L,Kerry Burt,16
-Ford,Spearville twp,U.S. House,1,i,Alan LaPolice,37
-Ford,Spearville twp,U.S. House,1,R,Roger Marshall,134
-Ford,Spearville twp,State Senate,38,R,Bud Estes,166
-Ford,Spearville twp,State Senate,38,R,Miguel Angel Rodriguez,19
-Ford,Spearville twp,State House,117,R,Leonard Mastroni,162
-Ford,Spearville City,President,,L,Gary Johnson,18
-Ford,Spearville City,President,,IND,Jill Stein,7
-Ford,Spearville City,President,,R,Donald J Trump,300
-Ford,Spearville City,President,,D,Hillary Clinton,54
-Ford,Spearville City,President,,,Write-ins,7
-Ford,Spearville City,U.S. Senate,,R,Jerry Moran,317
-Ford,Spearville City,U.S. Senate,,D,Partick Wiesner,35
-Ford,Spearville City,U.S. Senate,,L,Robert Garrand,26
-Ford,Spearville City,U.S. House,1,L,Kerry Burt,15
-Ford,Spearville City,U.S. House,1,i,Alan LaPolice,101
-Ford,Spearville City,U.S. House,1,R,Roger Marshall,262
-Ford,Spearville City,U.S. House,1,,Write-ins,2
-Ford,Spearville City,State Senate,38,R,Bud Estes,310
-Ford,Spearville City,State Senate,38,R,Miguel Angel Rodriguez,65
-Ford,Spearville City,State Senate,38,,Write-ins,1
-Ford,Spearville City,State House,117,R,Leonard Mastroni,331
-Ford,Spearville City,State House,117,,Write-ins,4
-Ford,Wheatland twp,President,,L,Gary Johnson,3
-Ford,Wheatland twp,President,,IND,Jill Stein,2
-Ford,Wheatland twp,President,,R,Donald J Trump,57
-Ford,Wheatland twp,President,,D,Hillary Clinton,7
-Ford,Wheatland twp,President,,,Write-ins,2
-Ford,Wheatland twp,U.S. Senate,,R,Jerry Moran,62
-Ford,Wheatland twp,U.S. Senate,,D,Partick Wiesner,6
-Ford,Wheatland twp,U.S. Senate,,L,Robert Garrand,3
-Ford,Wheatland twp,U.S. House,1,L,Kerry Burt,3
-Ford,Wheatland twp,U.S. House,1,i,Alan LaPolice,11
-Ford,Wheatland twp,U.S. House,1,R,Roger Marshall,57
-Ford,Wheatland twp,State Senate,38,R,Bud Estes,63
-Ford,Wheatland twp,State Senate,38,R,Miguel Angel Rodriguez,5
-Ford,Wheatland twp,State House,117,R,Leonard Mastroni,60
-Ford,Wilburn twp,President,,L,Gary Johnson,1
-Ford,Wilburn twp,President,,IND,Jill Stein,1
-Ford,Wilburn twp,President,,R,Donald J Trump,33
-Ford,Wilburn twp,President,,D,Hillary Clinton,2
-Ford,Wilburn twp,President,,,Write-ins,2
-Ford,Wilburn twp,U.S. Senate,,R,Jerry Moran,38
-Ford,Wilburn twp,U.S. Senate,,D,Partick Wiesner,1
-Ford,Wilburn twp,U.S. Senate,,L,Robert Garrand,0
-Ford,Wilburn twp,U.S. House,1,L,Kerry Burt,0
-Ford,Wilburn twp,U.S. House,1,i,Alan LaPolice,7
-Ford,Wilburn twp,U.S. House,1,R,Roger Marshall,30
-Ford,Wilburn twp,State Senate,38,R,Bud Estes,37
-Ford,Wilburn twp,State Senate,38,R,Miguel Angel Rodriguez,2
-Ford,Wilburn twp,State House,115,R,Boyd Orr,39
-Ford,Hand Count,President,,L,Gary Johnson,1
-Ford,Hand Count,President,,IND,Jill Stein,0
-Ford,Hand Count,President,,R,Donald J Trump,10
-Ford,Hand Count,President,,D,Hillary Clinton,3
-Ford,Hand Count,U.S. Senate,,R,Jerry Moran,8
-Ford,Hand Count,U.S. Senate,,D,Partick Wiesner,2
-Ford,Hand Count,U.S. Senate,,L,Robert Garrand,1
-Ford,Hand Count,U.S. House,1,L,Kerry Burt,0
-Ford,Hand Count,U.S. House,1,i,Alan LaPolice,3
-Ford,Hand Count,U.S. House,1,R,Roger Marshall,6
-Ford,Hand Count,U.S. House,1,,Write-ins,0
-Ford,Hand Count,State Senate,38,R,Bud Estes,9
-Ford,Hand Count,State Senate,38,D,Miguel Angel Rodriguez,2
-Ford,Hand Count,State House,115,R,Boyd Orr,2
-Ford,Hand Count,State House,117,R,Leonard Mastroni,2
-Ford,Hand Count,State House,119,D,Daniel L. Love,3
-Ford,Hand Count,State House,119,R,Bradley Ralph,4
-Ford,Total,President,,L,Gary Johnson,281
-Ford,Total,President,,IND,Jill Stein,136
-Ford,Total,President,,R,Donald J Trump,5113
-Ford,Total,President,,D,Hillary Clinton,2148
-Ford,Total,President,,,Write-ins,94
-Ford,Total,U.S. Senate,,R,Jerry Moran,5530
-Ford,Total,U.S. Senate,,D,Partick Wiesner,1655
-Ford,Total,U.S. Senate,,L,Robert Garrand,405
-Ford,Total,U.S. Senate,,,Write-ins,5
-Ford,Total,U.S. House,1,L,Kerry Burt,629
-Ford,Total,U.S. House,1,i,Alan LaPolice,1928
-Ford,Total,U.S. House,1,R,Roger Marshall,4752
-Ford,Total,U.S. House,1,,Write-ins,46
-Ford,Total,State Senate,38,R,Bud Estes,5439
-Ford,Total,State Senate,38,D,Miguel Angel Rodriguez,2048
-Ford,Total,State Senate,38,,Write-ins,22
-Ford,Total,State House,115,R,Boyd Orr,1465
-Ford,Total,State House,115,,Write-ins,16
-Ford,Total,State House,117,R,Leonard Mastroni,1086
-Ford,Total,State House,117,,Write-ins,5
-Ford,Total,State House,119,D,Daniel L. Love,2243
-Ford,Total,State House,119,R,Bradley Ralph,2375
-Ford,Total,State House,119,,Write-ins,3
+county,precinct,office,district,party,candidate,votes,vtd
+FORD,Bloom Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",31,000010
+FORD,Bucklin City,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",281,000020
+FORD,Bucklin Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",56,000030
+FORD,Concord Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",46,000040
+FORD,Dodge City Precinct 01,Kansas House of Representatives,115,Republican,"Orr, Boyd",429,00005A
+FORD,Dodge City Airport,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,00005B
+FORD,Dodge City Airport,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,00005B
+FORD,Dodge City Industrial Park,Kansas House of Representatives,115,Republican,"Orr, Boyd",0,00005C
+FORD,Dodge City Precinct 03,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",255,000070
+FORD,Dodge City Precinct 03,Kansas House of Representatives,119,Republican,"Ralph, Bradley",156,000070
+FORD,Dodge City Precinct 04,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",444,00008A
+FORD,Dodge City Precinct 04,Kansas House of Representatives,119,Republican,"Ralph, Bradley",364,00008A
+FORD,Dodge City Excel #1,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,00008B
+FORD,Dodge City Excel #1,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,00008B
+FORD,Dodge City Excel #2,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,00008C
+FORD,Dodge City Excel #2,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,00008C
+FORD,Dodge City Millard,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,00008D
+FORD,Dodge City Millard,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,00008D
+FORD,Dodge City Precinct 06,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",703,000100
+FORD,Dodge City Precinct 06,Kansas House of Representatives,119,Republican,"Ralph, Bradley",940,000100
+FORD,Dodge Township Ward 3,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",14,000200
+FORD,Dodge Township Ward 3,Kansas House of Representatives,119,Republican,"Ralph, Bradley",14,000200
+FORD,Fairview Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",97,000220
+FORD,Ford City,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",72,000230
+FORD,Ford Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",54,000240
+FORD,Richland Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",192,000260
+FORD,Royal Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",105,000270
+FORD,Sodville Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",38,000280
+FORD,Spearville City,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",332,000300
+FORD,Spearville Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",162,000310
+FORD,Wheatland Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",60,000320
+FORD,Wilburn Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",39,000330
+FORD,Dodge Township H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",190,120020
+FORD,Dodge Township H119 A,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,12003A
+FORD,Dodge Township H119 A,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,12003A
+FORD,Dodge Township H119,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",6,120030
+FORD,Dodge Township H119,Kansas House of Representatives,119,Republican,"Ralph, Bradley",22,120030
+FORD,Enterprise Township H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",164,120040
+FORD,Enterprise Township H119,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",6,120050
+FORD,Enterprise Township H119,Kansas House of Representatives,119,Republican,"Ralph, Bradley",1,120050
+FORD,Grandview Township H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",157,120060
+FORD,Grandview Township East H119,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",3,12007A
+FORD,Grandview Township East H119,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,12007A
+FORD,Grandview Township H119,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,120070
+FORD,Grandview Township H119,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,120070
+FORD,Grandview Township Ward 2 H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",28,120080
+FORD,Grandview Township Ward 2 H119,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",1,120090
+FORD,Grandview Township Ward 2 H119,Kansas House of Representatives,119,Republican,"Ralph, Bradley",2,120090
+FORD,Dodge City Precinct 03 H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",0,120100
+FORD,Dodge City Township C H115,Kansas House of Representatives,115,Republican,"Orr, Boyd",0,120110
+FORD,Dodge City Township W H119,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",1,120120
+FORD,Dodge City Township W H119,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,120120
+FORD,Dodge City Precinct 09,Kansas House of Representatives,115,Republican,"Orr, Boyd",18,120130
+FORD,Dodge City Precinct 10,Kansas House of Representatives,115,Republican,"Orr, Boyd",0,120140
+FORD,Dodge City Precinct 02,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",213,130010
+FORD,Dodge City Precinct 02,Kansas House of Representatives,119,Republican,"Ralph, Bradley",122,130010
+FORD,Dodge City Precinct 05,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",558,130020
+FORD,Dodge City Precinct 05,Kansas House of Representatives,119,Republican,"Ralph, Bradley",708,130020
+FORD,Dodge City Precinct 07,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",38,600010
+FORD,Dodge City Precinct 07,Kansas House of Representatives,119,Republican,"Ralph, Bradley",46,600010
+FORD,Dodge City Precinct 08,Kansas House of Representatives,119,Democratic,"Love, Daniel L.",0,800010
+FORD,Dodge City Precinct 08,Kansas House of Representatives,119,Republican,"Ralph, Bradley",0,800010
+FORD,Bloom Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",1,000010
+FORD,Bloom Township,Kansas Senate,38,Republican,"Estes, Bud",34,000010
+FORD,Bucklin City,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",43,000020
+FORD,Bucklin City,Kansas Senate,38,Republican,"Estes, Bud",266,000020
+FORD,Bucklin Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",6,000030
+FORD,Bucklin Township,Kansas Senate,38,Republican,"Estes, Bud",52,000030
+FORD,Concord Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000040
+FORD,Concord Township,Kansas Senate,38,Republican,"Estes, Bud",42,000040
+FORD,Dodge City Precinct 01,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",234,00005A
+FORD,Dodge City Precinct 01,Kansas Senate,38,Republican,"Estes, Bud",285,00005A
+FORD,Dodge City Airport,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00005B
+FORD,Dodge City Airport,Kansas Senate,38,Republican,"Estes, Bud",0,00005B
+FORD,Dodge City Industrial Park,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00005C
+FORD,Dodge City Industrial Park,Kansas Senate,38,Republican,"Estes, Bud",0,00005C
+FORD,Dodge City Precinct 03,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",215,000070
+FORD,Dodge City Precinct 03,Kansas Senate,38,Republican,"Estes, Bud",188,000070
+FORD,Dodge City Precinct 04,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",318,00008A
+FORD,Dodge City Precinct 04,Kansas Senate,38,Republican,"Estes, Bud",487,00008A
+FORD,Dodge City Excel #1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00008B
+FORD,Dodge City Excel #1,Kansas Senate,38,Republican,"Estes, Bud",0,00008B
+FORD,Dodge City Excel #2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00008C
+FORD,Dodge City Excel #2,Kansas Senate,38,Republican,"Estes, Bud",0,00008C
+FORD,Dodge City Millard,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00008D
+FORD,Dodge City Millard,Kansas Senate,38,Republican,"Estes, Bud",0,00008D
+FORD,Dodge City Precinct 06,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",387,000100
+FORD,Dodge City Precinct 06,Kansas Senate,38,Republican,"Estes, Bud",1241,000100
+FORD,Dodge Township Ward 3,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000200
+FORD,Dodge Township Ward 3,Kansas Senate,38,Republican,"Estes, Bud",20,000200
+FORD,Fairview Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",16,000220
+FORD,Fairview Township,Kansas Senate,38,Republican,"Estes, Bud",93,000220
+FORD,Ford City,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000230
+FORD,Ford City,Kansas Senate,38,Republican,"Estes, Bud",75,000230
+FORD,Ford Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",10,000240
+FORD,Ford Township,Kansas Senate,38,Republican,"Estes, Bud",62,000240
+FORD,Richland Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",38,000260
+FORD,Richland Township,Kansas Senate,38,Republican,"Estes, Bud",174,000260
+FORD,Royal Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",19,000270
+FORD,Royal Township,Kansas Senate,38,Republican,"Estes, Bud",100,000270
+FORD,Sodville Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",3,000280
+FORD,Sodville Township,Kansas Senate,38,Republican,"Estes, Bud",42,000280
+FORD,Spearville City,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",65,000300
+FORD,Spearville City,Kansas Senate,38,Republican,"Estes, Bud",311,000300
+FORD,Spearville Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",19,000310
+FORD,Spearville Township,Kansas Senate,38,Republican,"Estes, Bud",166,000310
+FORD,Wheatland Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",5,000320
+FORD,Wheatland Township,Kansas Senate,38,Republican,"Estes, Bud",63,000320
+FORD,Wilburn Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",2,000330
+FORD,Wilburn Township,Kansas Senate,38,Republican,"Estes, Bud",37,000330
+FORD,Dodge Township H115,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",34,120020
+FORD,Dodge Township H115,Kansas Senate,38,Republican,"Estes, Bud",176,120020
+FORD,Dodge Township H119 A,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,12003A
+FORD,Dodge Township H119 A,Kansas Senate,38,Republican,"Estes, Bud",0,12003A
+FORD,Dodge Township H119,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",3,120030
+FORD,Dodge Township H119,Kansas Senate,38,Republican,"Estes, Bud",25,120030
+FORD,Enterprise Township H115,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",52,120040
+FORD,Enterprise Township H115,Kansas Senate,38,Republican,"Estes, Bud",133,120040
+FORD,Enterprise Township H119,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",6,120050
+FORD,Enterprise Township H119,Kansas Senate,38,Republican,"Estes, Bud",1,120050
+FORD,Grandview Township H115,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",30,120060
+FORD,Grandview Township H115,Kansas Senate,38,Republican,"Estes, Bud",151,120060
+FORD,Grandview Township East H119,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,12007A
+FORD,Grandview Township East H119,Kansas Senate,38,Republican,"Estes, Bud",4,12007A
+FORD,Grandview Township H119,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,120070
+FORD,Grandview Township H119,Kansas Senate,38,Republican,"Estes, Bud",0,120070
+FORD,Grandview Township Ward 2 H115,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",10,120080
+FORD,Grandview Township Ward 2 H115,Kansas Senate,38,Republican,"Estes, Bud",28,120080
+FORD,Grandview Township Ward 2 H119,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,120090
+FORD,Grandview Township Ward 2 H119,Kansas Senate,38,Republican,"Estes, Bud",3,120090
+FORD,Dodge City Precinct 03 H115,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,120100
+FORD,Dodge City Precinct 03 H115,Kansas Senate,38,Republican,"Estes, Bud",0,120100
+FORD,Dodge City Township C H115,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,120110
+FORD,Dodge City Township C H115,Kansas Senate,38,Republican,"Estes, Bud",0,120110
+FORD,Dodge City Township W H119,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,120120
+FORD,Dodge City Township W H119,Kansas Senate,38,Republican,"Estes, Bud",1,120120
+FORD,Dodge City Precinct 09,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,120130
+FORD,Dodge City Precinct 09,Kansas Senate,38,Republican,"Estes, Bud",12,120130
+FORD,Dodge City Precinct 10,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,120140
+FORD,Dodge City Precinct 10,Kansas Senate,38,Republican,"Estes, Bud",0,120140
+FORD,Dodge City Precinct 02,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",169,130010
+FORD,Dodge City Precinct 02,Kansas Senate,38,Republican,"Estes, Bud",164,130010
+FORD,Dodge City Precinct 05,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",317,130020
+FORD,Dodge City Precinct 05,Kansas Senate,38,Republican,"Estes, Bud",939,130020
+FORD,Dodge City Precinct 07,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",18,600010
+FORD,Dodge City Precinct 07,Kansas Senate,38,Republican,"Estes, Bud",64,600010
+FORD,Dodge City Precinct 08,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,800010
+FORD,Dodge City Precinct 08,Kansas Senate,38,Republican,"Estes, Bud",0,800010
+FORD,Bloom Township,President / Vice President,,independent,"Stein, Jill",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+FORD,Bloom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+FORD,Bloom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000010
+FORD,Bloom Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+FORD,Bloom Township,President / Vice President,,Republican,"Trump, Donald J.",34,000010
+FORD,Bucklin City,President / Vice President,,independent,"Stein, Jill",2,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Hedges, James A",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"McMullin, Evan",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Perry, Darryl",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Smith, Mike",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Sood, Ajay",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+FORD,Bucklin City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+FORD,Bucklin City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000020
+FORD,Bucklin City,President / Vice President,,Libertarian,"Johnson, Gary",11,000020
+FORD,Bucklin City,President / Vice President,,Republican,"Trump, Donald J.",278,000020
+FORD,Bucklin Township,President / Vice President,,independent,"Stein, Jill",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"McMullin, Evan",1,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+FORD,Bucklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+FORD,Bucklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+FORD,Bucklin Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+FORD,Bucklin Township,President / Vice President,,Republican,"Trump, Donald J.",55,000030
+FORD,Concord Township,President / Vice President,,independent,"Stein, Jill",1,000040
+FORD,Concord Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+FORD,Concord Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+FORD,Concord Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000040
+FORD,Concord Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+FORD,Concord Township,President / Vice President,,Republican,"Trump, Donald J.",43,000040
+FORD,Dodge City Precinct 01,President / Vice President,,independent,"Stein, Jill",10,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",247,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",32,00005A
+FORD,Dodge City Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",251,00005A
+FORD,Dodge City Airport,President / Vice President,,independent,"Stein, Jill",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Hedges, James A",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Smith, Mike",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+FORD,Dodge City Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+FORD,Dodge City Airport,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+FORD,Dodge City Industrial Park,President / Vice President,,independent,"Stein, Jill",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Castle, Darrell L",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Giordani, Rocky",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Hedges, James A",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Kahn, Lynn",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"La Riva, Gloria",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Levinson, Michael S.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Maturen, Michael A",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"McMullin, Evan",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Perry, Darryl",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Schriner, Joe C",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Smith, Mike",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Sood, Ajay",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Sterling, Shawna",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+FORD,Dodge City Industrial Park,President / Vice President,,Republican,"Trump, Donald J.",0,00005C
+FORD,Dodge City Precinct 03,President / Vice President,,independent,"Stein, Jill",6,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"McMullin, Evan",2,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",246,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",17,000070
+FORD,Dodge City Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",163,000070
+FORD,Dodge City Precinct 04,President / Vice President,,independent,"Stein, Jill",22,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"McMullin, Evan",4,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",353,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",36,00008A
+FORD,Dodge City Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",428,00008A
+FORD,Dodge City Excel #1,President / Vice President,,independent,"Stein, Jill",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Castle, Darrell L",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Giordani, Rocky",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Hedges, James A",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Kahn, Lynn",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"La Riva, Gloria",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Levinson, Michael S.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Maturen, Michael A",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"McMullin, Evan",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Perry, Darryl",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Schriner, Joe C",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Smith, Mike",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Sood, Ajay",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Sterling, Shawna",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+FORD,Dodge City Excel #1,President / Vice President,,Republican,"Trump, Donald J.",0,00008B
+FORD,Dodge City Excel #2,President / Vice President,,independent,"Stein, Jill",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Castle, Darrell L",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Giordani, Rocky",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Hedges, James A",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Hoefling, Tom",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Kahn, Lynn",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"La Riva, Gloria",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Levinson, Michael S.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Maturen, Michael A",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"McMullin, Evan",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Perry, Darryl",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Schriner, Joe C",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Smith, Mike",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Sood, Ajay",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Sterling, Shawna",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Libertarian,"Johnson, Gary",0,00008C
+FORD,Dodge City Excel #2,President / Vice President,,Republican,"Trump, Donald J.",0,00008C
+FORD,Dodge City Millard,President / Vice President,,independent,"Stein, Jill",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Castle, Darrell L",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Giordani, Rocky",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Hedges, James A",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Hoefling, Tom",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Kahn, Lynn",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"La Riva, Gloria",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Levinson, Michael S.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Maturen, Michael A",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"McMullin, Evan",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Perry, Darryl",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Schriner, Joe C",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Smith, Mike",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Sood, Ajay",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Sterling, Shawna",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008D
+FORD,Dodge City Millard,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Libertarian,"Johnson, Gary",0,00008D
+FORD,Dodge City Millard,President / Vice President,,Republican,"Trump, Donald J.",0,00008D
+FORD,Dodge City Precinct 06,President / Vice President,,independent,"Stein, Jill",26,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",2,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"McMullin, Evan",11,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",426,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",47,000100
+FORD,Dodge City Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",1140,000100
+FORD,Dodge Township Ward 3,President / Vice President,,independent,"Stein, Jill",1,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+FORD,Dodge Township Ward 3,President / Vice President,,Republican,"Trump, Donald J.",20,000200
+FORD,Fairview Township,President / Vice President,,independent,"Stein, Jill",2,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+FORD,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+FORD,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000220
+FORD,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000220
+FORD,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",89,000220
+FORD,Ford City,President / Vice President,,independent,"Stein, Jill",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+FORD,Ford City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Hedges, James A",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+FORD,Ford City,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+FORD,Ford City,President / Vice President,,write - in,"McMullin, Evan",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Perry, Darryl",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Smith, Mike",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Sood, Ajay",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+FORD,Ford City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+FORD,Ford City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000230
+FORD,Ford City,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+FORD,Ford City,President / Vice President,,Republican,"Trump, Donald J.",74,000230
+FORD,Ford Township,President / Vice President,,independent,"Stein, Jill",3,000240
+FORD,Ford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+FORD,Ford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+FORD,Ford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000240
+FORD,Ford Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000240
+FORD,Ford Township,President / Vice President,,Republican,"Trump, Donald J.",62,000240
+FORD,Richland Township,President / Vice President,,independent,"Stein, Jill",3,000260
+FORD,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+FORD,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+FORD,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000260
+FORD,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000260
+FORD,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",167,000260
+FORD,Royal Township,President / Vice President,,independent,"Stein, Jill",1,000270
+FORD,Royal Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Hoefling, Tom",1,000270
+FORD,Royal Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"McMullin, Evan",1,000270
+FORD,Royal Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+FORD,Royal Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+FORD,Royal Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000270
+FORD,Royal Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000270
+FORD,Royal Township,President / Vice President,,Republican,"Trump, Donald J.",92,000270
+FORD,Sodville Township,President / Vice President,,independent,"Stein, Jill",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+FORD,Sodville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+FORD,Sodville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000280
+FORD,Sodville Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000280
+FORD,Sodville Township,President / Vice President,,Republican,"Trump, Donald J.",42,000280
+FORD,Spearville City,President / Vice President,,independent,"Stein, Jill",7,000300
+FORD,Spearville City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Hedges, James A",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"McMullin, Evan",3,000300
+FORD,Spearville City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Perry, Darryl",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Smith, Mike",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Sood, Ajay",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+FORD,Spearville City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+FORD,Spearville City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000300
+FORD,Spearville City,President / Vice President,,Libertarian,"Johnson, Gary",18,000300
+FORD,Spearville City,President / Vice President,,Republican,"Trump, Donald J.",301,000300
+FORD,Spearville Township,President / Vice President,,independent,"Stein, Jill",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"McMullin, Evan",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+FORD,Spearville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+FORD,Spearville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000310
+FORD,Spearville Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000310
+FORD,Spearville Township,President / Vice President,,Republican,"Trump, Donald J.",178,000310
+FORD,Wheatland Township,President / Vice President,,independent,"Stein, Jill",2,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"McMullin, Evan",2,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+FORD,Wheatland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+FORD,Wheatland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000320
+FORD,Wheatland Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000320
+FORD,Wheatland Township,President / Vice President,,Republican,"Trump, Donald J.",57,000320
+FORD,Wilburn Township,President / Vice President,,independent,"Stein, Jill",1,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Castle, Darrell L",2,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Hedges, James A",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"McMullin, Evan",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Perry, Darryl",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Smith, Mike",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Sood, Ajay",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+FORD,Wilburn Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+FORD,Wilburn Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000330
+FORD,Wilburn Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000330
+FORD,Wilburn Township,President / Vice President,,Republican,"Trump, Donald J.",33,000330
+FORD,Dodge Township H115,President / Vice President,,independent,"Stein, Jill",3,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Hedges, James A",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"McMullin, Evan",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Perry, Darryl",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Smith, Mike",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Sood, Ajay",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+FORD,Dodge Township H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+FORD,Dodge Township H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,120020
+FORD,Dodge Township H115,President / Vice President,,Libertarian,"Johnson, Gary",10,120020
+FORD,Dodge Township H115,President / Vice President,,Republican,"Trump, Donald J.",160,120020
+FORD,Dodge Township H119 A,President / Vice President,,independent,"Stein, Jill",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Castle, Darrell L",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Giordani, Rocky",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Hedges, James A",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Hoefling, Tom",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Kahn, Lynn",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"La Riva, Gloria",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Maturen, Michael A",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"McMullin, Evan",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Perry, Darryl",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Schriner, Joe C",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Smith, Mike",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Sood, Ajay",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Sterling, Shawna",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12003A
+FORD,Dodge Township H119 A,President / Vice President,,Republican,"Trump, Donald J.",0,12003A
+FORD,Dodge Township H119,President / Vice President,,independent,"Stein, Jill",1,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Hedges, James A",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"McMullin, Evan",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Perry, Darryl",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Smith, Mike",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Sood, Ajay",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+FORD,Dodge Township H119,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+FORD,Dodge Township H119,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,120030
+FORD,Dodge Township H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+FORD,Dodge Township H119,President / Vice President,,Republican,"Trump, Donald J.",26,120030
+FORD,Enterprise Township H115,President / Vice President,,independent,"Stein, Jill",3,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Hedges, James A",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"McMullin, Evan",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Perry, Darryl",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Smith, Mike",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Sood, Ajay",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+FORD,Enterprise Township H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+FORD,Enterprise Township H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,120040
+FORD,Enterprise Township H115,President / Vice President,,Libertarian,"Johnson, Gary",6,120040
+FORD,Enterprise Township H115,President / Vice President,,Republican,"Trump, Donald J.",123,120040
+FORD,Enterprise Township H119,President / Vice President,,independent,"Stein, Jill",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Hedges, James A",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"McMullin, Evan",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Perry, Darryl",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Smith, Mike",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Sood, Ajay",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+FORD,Enterprise Township H119,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+FORD,Enterprise Township H119,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,120050
+FORD,Enterprise Township H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+FORD,Enterprise Township H119,President / Vice President,,Republican,"Trump, Donald J.",2,120050
+FORD,Grandview Township H115,President / Vice President,,independent,"Stein, Jill",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Hedges, James A",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"McMullin, Evan",2,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Perry, Darryl",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Smith, Mike",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Sood, Ajay",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+FORD,Grandview Township H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+FORD,Grandview Township H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,120060
+FORD,Grandview Township H115,President / Vice President,,Libertarian,"Johnson, Gary",6,120060
+FORD,Grandview Township H115,President / Vice President,,Republican,"Trump, Donald J.",155,120060
+FORD,Grandview Township East H119,President / Vice President,,independent,"Stein, Jill",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Basiago, Andrew D.",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Castle, Darrell L",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Giordani, Rocky",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Hedges, James A",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Hoefling, Tom",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Kahn, Lynn",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"La Riva, Gloria",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Levinson, Michael S.",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Maturen, Michael A",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"McMullin, Evan",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Moorehead, Monica G.",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Perry, Darryl",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Schriner, Joe C",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Smith, Mike",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Sood, Ajay",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Sterling, Shawna",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Valdivia, Anthony J",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,Libertarian,"Johnson, Gary",0,12007A
+FORD,Grandview Township East H119,President / Vice President,,Republican,"Trump, Donald J.",4,12007A
+FORD,Grandview Township H119,President / Vice President,,independent,"Stein, Jill",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Hedges, James A",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"McMullin, Evan",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Perry, Darryl",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Smith, Mike",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Sood, Ajay",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+FORD,Grandview Township H119,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+FORD,Grandview Township H119,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120070
+FORD,Grandview Township H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+FORD,Grandview Township H119,President / Vice President,,Republican,"Trump, Donald J.",0,120070
+FORD,Grandview Township Ward 2 H115,President / Vice President,,independent,"Stein, Jill",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Hedges, James A",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"McMullin, Evan",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Perry, Darryl",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Smith, Mike",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Sood, Ajay",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+FORD,Grandview Township Ward 2 H115,President / Vice President,,Republican,"Trump, Donald J.",27,120080
+FORD,Grandview Township Ward 2 H119,President / Vice President,,independent,"Stein, Jill",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Hedges, James A",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"McMullin, Evan",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Perry, Darryl",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Smith, Mike",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Sood, Ajay",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+FORD,Grandview Township Ward 2 H119,President / Vice President,,Republican,"Trump, Donald J.",3,120090
+FORD,Dodge City Precinct 03 H115,President / Vice President,,independent,"Stein, Jill",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Castle, Darrell L",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Giordani, Rocky",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Hedges, James A",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Kahn, Lynn",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"La Riva, Gloria",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Maturen, Michael A",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"McMullin, Evan",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Perry, Darryl",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Schriner, Joe C",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Smith, Mike",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Sood, Ajay",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Sterling, Shawna",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,Libertarian,"Johnson, Gary",0,120100
+FORD,Dodge City Precinct 03 H115,President / Vice President,,Republican,"Trump, Donald J.",0,120100
+FORD,Dodge City Township C H115,President / Vice President,,independent,"Stein, Jill",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Basiago, Andrew D.",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Castle, Darrell L",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Giordani, Rocky",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Hedges, James A",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Kahn, Lynn",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"La Riva, Gloria",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Levinson, Michael S.",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Maturen, Michael A",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"McMullin, Evan",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Moorehead, Monica G.",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Perry, Darryl",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Schriner, Joe C",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Smith, Mike",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Sood, Ajay",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Sterling, Shawna",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Valdivia, Anthony J",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,Libertarian,"Johnson, Gary",0,120110
+FORD,Dodge City Township C H115,President / Vice President,,Republican,"Trump, Donald J.",0,120110
+FORD,Dodge City Township W H119,President / Vice President,,independent,"Stein, Jill",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Basiago, Andrew D.",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Castle, Darrell L",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Giordani, Rocky",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Hedges, James A",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Kahn, Lynn",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"La Riva, Gloria",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Levinson, Michael S.",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Maturen, Michael A",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"McMullin, Evan",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Moorehead, Monica G.",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Perry, Darryl",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Schriner, Joe C",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Smith, Mike",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Sood, Ajay",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Sterling, Shawna",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Valdivia, Anthony J",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,Libertarian,"Johnson, Gary",0,120120
+FORD,Dodge City Township W H119,President / Vice President,,Republican,"Trump, Donald J.",1,120120
+FORD,Dodge City Precinct 09,President / Vice President,,independent,"Stein, Jill",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"McMullin, Evan",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120130
+FORD,Dodge City Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,120130
+FORD,Dodge City Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",2,120130
+FORD,Dodge City Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",12,120130
+FORD,Dodge City Precinct 10,President / Vice President,,independent,"Stein, Jill",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"McMullin, Evan",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",0,120140
+FORD,Dodge City Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",0,120140
+FORD,Dodge City Precinct 02,President / Vice President,,independent,"Stein, Jill",10,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+FORD,Dodge City Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",174,130010
+FORD,Dodge City Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",19,130010
+FORD,Dodge City Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",151,130010
+FORD,Dodge City Precinct 05,President / Vice President,,independent,"Stein, Jill",32,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",2,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"McMullin, Evan",5,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130020
+FORD,Dodge City Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",335,130020
+FORD,Dodge City Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",42,130020
+FORD,Dodge City Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",875,130020
+FORD,Dodge City Precinct 07,President / Vice President,,independent,"Stein, Jill",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"McMullin, Evan",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",2,600010
+FORD,Dodge City Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",68,600010
+FORD,Dodge City Precinct 08,President / Vice President,,independent,"Stein, Jill",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Castle, Darrell L",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Giordani, Rocky",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Hedges, James A",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Kahn, Lynn",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"La Riva, Gloria",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Levinson, Michael S.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Maturen, Michael A",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"McMullin, Evan",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Perry, Darryl",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Schriner, Joe C",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Smith, Mike",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Sood, Ajay",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Sterling, Shawna",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",0,800010
+FORD,Dodge City Precinct 08,President / Vice President,,Republican,"Trump, Donald J.",0,800010
+FORD,Bloom Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000010
+FORD,Bloom Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+FORD,Bloom Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+FORD,Bloom Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000010
+FORD,Bucklin City,United States House of Representatives,1,independent,"LaPolice, Alan",44,000020
+FORD,Bucklin City,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+FORD,Bucklin City,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000020
+FORD,Bucklin City,United States House of Representatives,1,Republican,"Marshall, Roger",258,000020
+FORD,Bucklin Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000030
+FORD,Bucklin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000030
+FORD,Bucklin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000030
+FORD,Bucklin Township,United States House of Representatives,1,Republican,"Marshall, Roger",45,000030
+FORD,Concord Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000040
+FORD,Concord Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+FORD,Concord Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000040
+FORD,Concord Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000040
+FORD,Dodge City Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",161,00005A
+FORD,Dodge City Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00005A
+FORD,Dodge City Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",77,00005A
+FORD,Dodge City Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",252,00005A
+FORD,Dodge City Airport,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005B
+FORD,Dodge City Airport,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005B
+FORD,Dodge City Airport,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005B
+FORD,Dodge City Airport,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005B
+FORD,Dodge City Industrial Park,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005C
+FORD,Dodge City Industrial Park,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005C
+FORD,Dodge City Industrial Park,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005C
+FORD,Dodge City Industrial Park,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005C
+FORD,Dodge City Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",144,000070
+FORD,Dodge City Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+FORD,Dodge City Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",69,000070
+FORD,Dodge City Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",174,000070
+FORD,Dodge City Precinct 04,United States House of Representatives,1,independent,"LaPolice, Alan",264,00008A
+FORD,Dodge City Precinct 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,00008A
+FORD,Dodge City Precinct 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",95,00008A
+FORD,Dodge City Precinct 04,United States House of Representatives,1,Republican,"Marshall, Roger",418,00008A
+FORD,Dodge City Excel #1,United States House of Representatives,1,independent,"LaPolice, Alan",0,00008B
+FORD,Dodge City Excel #1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00008B
+FORD,Dodge City Excel #1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00008B
+FORD,Dodge City Excel #1,United States House of Representatives,1,Republican,"Marshall, Roger",0,00008B
+FORD,Dodge City Excel #2,United States House of Representatives,1,independent,"LaPolice, Alan",0,00008C
+FORD,Dodge City Excel #2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00008C
+FORD,Dodge City Excel #2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00008C
+FORD,Dodge City Excel #2,United States House of Representatives,1,Republican,"Marshall, Roger",0,00008C
+FORD,Dodge City Millard,United States House of Representatives,1,independent,"LaPolice, Alan",0,00008D
+FORD,Dodge City Millard,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00008D
+FORD,Dodge City Millard,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00008D
+FORD,Dodge City Millard,United States House of Representatives,1,Republican,"Marshall, Roger",0,00008D
+FORD,Dodge City Precinct 06,United States House of Representatives,1,independent,"LaPolice, Alan",409,000100
+FORD,Dodge City Precinct 06,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,000100
+FORD,Dodge City Precinct 06,United States House of Representatives,1,Libertarian,"Burt, Kerry",92,000100
+FORD,Dodge City Precinct 06,United States House of Representatives,1,Republican,"Marshall, Roger",1101,000100
+FORD,Dodge Township Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",7,000200
+FORD,Dodge Township Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+FORD,Dodge Township Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000200
+FORD,Dodge Township Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",19,000200
+FORD,Fairview Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000220
+FORD,Fairview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+FORD,Fairview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000220
+FORD,Fairview Township,United States House of Representatives,1,Republican,"Marshall, Roger",80,000220
+FORD,Ford City,United States House of Representatives,1,independent,"LaPolice, Alan",6,000230
+FORD,Ford City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+FORD,Ford City,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000230
+FORD,Ford City,United States House of Representatives,1,Republican,"Marshall, Roger",66,000230
+FORD,Ford Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000240
+FORD,Ford Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+FORD,Ford Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000240
+FORD,Ford Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000240
+FORD,Richland Township,United States House of Representatives,1,independent,"LaPolice, Alan",60,000260
+FORD,Richland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+FORD,Richland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000260
+FORD,Richland Township,United States House of Representatives,1,Republican,"Marshall, Roger",135,000260
+FORD,Royal Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000270
+FORD,Royal Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+FORD,Royal Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000270
+FORD,Royal Township,United States House of Representatives,1,Republican,"Marshall, Roger",89,000270
+FORD,Sodville Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000280
+FORD,Sodville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+FORD,Sodville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000280
+FORD,Sodville Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000280
+FORD,Spearville City,United States House of Representatives,1,independent,"LaPolice, Alan",101,000300
+FORD,Spearville City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000300
+FORD,Spearville City,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000300
+FORD,Spearville City,United States House of Representatives,1,Republican,"Marshall, Roger",263,000300
+FORD,Spearville Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000310
+FORD,Spearville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+FORD,Spearville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000310
+FORD,Spearville Township,United States House of Representatives,1,Republican,"Marshall, Roger",134,000310
+FORD,Wheatland Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000320
+FORD,Wheatland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000320
+FORD,Wheatland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000320
+FORD,Wheatland Township,United States House of Representatives,1,Republican,"Marshall, Roger",57,000320
+FORD,Wilburn Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000330
+FORD,Wilburn Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000330
+FORD,Wilburn Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000330
+FORD,Wilburn Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000330
+FORD,Dodge Township H115,United States House of Representatives,1,independent,"LaPolice, Alan",47,120020
+FORD,Dodge Township H115,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+FORD,Dodge Township H115,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,120020
+FORD,Dodge Township H115,United States House of Representatives,1,Republican,"Marshall, Roger",149,120020
+FORD,Dodge Township H119 A,United States House of Representatives,1,independent,"LaPolice, Alan",0,12003A
+FORD,Dodge Township H119 A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,12003A
+FORD,Dodge Township H119 A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,12003A
+FORD,Dodge Township H119 A,United States House of Representatives,1,Republican,"Marshall, Roger",0,12003A
+FORD,Dodge Township H119,United States House of Representatives,1,independent,"LaPolice, Alan",3,120030
+FORD,Dodge Township H119,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,120030
+FORD,Dodge Township H119,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120030
+FORD,Dodge Township H119,United States House of Representatives,1,Republican,"Marshall, Roger",20,120030
+FORD,Enterprise Township H115,United States House of Representatives,1,independent,"LaPolice, Alan",48,120040
+FORD,Enterprise Township H115,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+FORD,Enterprise Township H115,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,120040
+FORD,Enterprise Township H115,United States House of Representatives,1,Republican,"Marshall, Roger",119,120040
+FORD,Enterprise Township H119,United States House of Representatives,1,independent,"LaPolice, Alan",0,120050
+FORD,Enterprise Township H119,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120050
+FORD,Enterprise Township H119,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120050
+FORD,Enterprise Township H119,United States House of Representatives,1,Republican,"Marshall, Roger",6,120050
+FORD,Grandview Township H115,United States House of Representatives,1,independent,"LaPolice, Alan",36,120060
+FORD,Grandview Township H115,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120060
+FORD,Grandview Township H115,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,120060
+FORD,Grandview Township H115,United States House of Representatives,1,Republican,"Marshall, Roger",135,120060
+FORD,Grandview Township East H119,United States House of Representatives,1,independent,"LaPolice, Alan",0,12007A
+FORD,Grandview Township East H119,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,12007A
+FORD,Grandview Township East H119,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,12007A
+FORD,Grandview Township East H119,United States House of Representatives,1,Republican,"Marshall, Roger",4,12007A
+FORD,Grandview Township H119,United States House of Representatives,1,independent,"LaPolice, Alan",0,120070
+FORD,Grandview Township H119,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120070
+FORD,Grandview Township H119,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120070
+FORD,Grandview Township H119,United States House of Representatives,1,Republican,"Marshall, Roger",0,120070
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,independent,"LaPolice, Alan",9,120080
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120080
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,120080
+FORD,Grandview Township Ward 2 H115,United States House of Representatives,1,Republican,"Marshall, Roger",25,120080
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,independent,"LaPolice, Alan",0,120090
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120090
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120090
+FORD,Grandview Township Ward 2 H119,United States House of Representatives,1,Republican,"Marshall, Roger",3,120090
+FORD,Dodge City Precinct 03 H115,United States House of Representatives,1,independent,"LaPolice, Alan",0,120100
+FORD,Dodge City Precinct 03 H115,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120100
+FORD,Dodge City Precinct 03 H115,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120100
+FORD,Dodge City Precinct 03 H115,United States House of Representatives,1,Republican,"Marshall, Roger",0,120100
+FORD,Dodge City Township C H115,United States House of Representatives,1,independent,"LaPolice, Alan",0,120110
+FORD,Dodge City Township C H115,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120110
+FORD,Dodge City Township C H115,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120110
+FORD,Dodge City Township C H115,United States House of Representatives,1,Republican,"Marshall, Roger",0,120110
+FORD,Dodge City Township W H119,United States House of Representatives,1,independent,"LaPolice, Alan",0,120120
+FORD,Dodge City Township W H119,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120120
+FORD,Dodge City Township W H119,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120120
+FORD,Dodge City Township W H119,United States House of Representatives,1,Republican,"Marshall, Roger",1,120120
+FORD,Dodge City Precinct 09,United States House of Representatives,1,independent,"LaPolice, Alan",4,120130
+FORD,Dodge City Precinct 09,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120130
+FORD,Dodge City Precinct 09,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,120130
+FORD,Dodge City Precinct 09,United States House of Representatives,1,Republican,"Marshall, Roger",10,120130
+FORD,Dodge City Precinct 10,United States House of Representatives,1,independent,"LaPolice, Alan",0,120140
+FORD,Dodge City Precinct 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120140
+FORD,Dodge City Precinct 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120140
+FORD,Dodge City Precinct 10,United States House of Representatives,1,Republican,"Marshall, Roger",0,120140
+FORD,Dodge City Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",105,130010
+FORD,Dodge City Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,130010
+FORD,Dodge City Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",62,130010
+FORD,Dodge City Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",150,130010
+FORD,Dodge City Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",312,130020
+FORD,Dodge City Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,130020
+FORD,Dodge City Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",110,130020
+FORD,Dodge City Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",802,130020
+FORD,Dodge City Precinct 07,United States House of Representatives,1,independent,"LaPolice, Alan",16,600010
+FORD,Dodge City Precinct 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,600010
+FORD,Dodge City Precinct 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,600010
+FORD,Dodge City Precinct 07,United States House of Representatives,1,Republican,"Marshall, Roger",58,600010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,independent,"LaPolice, Alan",0,800010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,800010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,800010
+FORD,Dodge City Precinct 08,United States House of Representatives,1,Republican,"Marshall, Roger",0,800010
+FORD,Bloom Township,United States Senate,,write - in,"Smith, DJ",0,000010
+FORD,Bloom Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+FORD,Bloom Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+FORD,Bloom Township,United States Senate,,Republican,"Moran, Jerry",33,000010
+FORD,Bucklin City,United States Senate,,write - in,"Smith, DJ",0,000020
+FORD,Bucklin City,United States Senate,,Democratic,"Wiesner, Patrick",24,000020
+FORD,Bucklin City,United States Senate,,Libertarian,"Garrard, Robert D.",16,000020
+FORD,Bucklin City,United States Senate,,Republican,"Moran, Jerry",275,000020
+FORD,Bucklin Township,United States Senate,,write - in,"Smith, DJ",0,000030
+FORD,Bucklin Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+FORD,Bucklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000030
+FORD,Bucklin Township,United States Senate,,Republican,"Moran, Jerry",58,000030
+FORD,Concord Township,United States Senate,,write - in,"Smith, DJ",0,000040
+FORD,Concord Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000040
+FORD,Concord Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+FORD,Concord Township,United States Senate,,Republican,"Moran, Jerry",42,000040
+FORD,Dodge City Precinct 01,United States Senate,,write - in,"Smith, DJ",0,00005A
+FORD,Dodge City Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",201,00005A
+FORD,Dodge City Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",47,00005A
+FORD,Dodge City Precinct 01,United States Senate,,Republican,"Moran, Jerry",278,00005A
+FORD,Dodge City Airport,United States Senate,,write - in,"Smith, DJ",0,00005B
+FORD,Dodge City Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+FORD,Dodge City Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+FORD,Dodge City Airport,United States Senate,,Republican,"Moran, Jerry",0,00005B
+FORD,Dodge City Industrial Park,United States Senate,,write - in,"Smith, DJ",0,00005C
+FORD,Dodge City Industrial Park,United States Senate,,Democratic,"Wiesner, Patrick",0,00005C
+FORD,Dodge City Industrial Park,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005C
+FORD,Dodge City Industrial Park,United States Senate,,Republican,"Moran, Jerry",0,00005C
+FORD,Dodge City Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000070
+FORD,Dodge City Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",180,000070
+FORD,Dodge City Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",36,000070
+FORD,Dodge City Precinct 03,United States Senate,,Republican,"Moran, Jerry",196,000070
+FORD,Dodge City Precinct 04,United States Senate,,write - in,"Smith, DJ",0,00008A
+FORD,Dodge City Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",283,00008A
+FORD,Dodge City Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",56,00008A
+FORD,Dodge City Precinct 04,United States Senate,,Republican,"Moran, Jerry",481,00008A
+FORD,Dodge City Excel #1,United States Senate,,write - in,"Smith, DJ",0,00008B
+FORD,Dodge City Excel #1,United States Senate,,Democratic,"Wiesner, Patrick",0,00008B
+FORD,Dodge City Excel #1,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008B
+FORD,Dodge City Excel #1,United States Senate,,Republican,"Moran, Jerry",0,00008B
+FORD,Dodge City Excel #2,United States Senate,,write - in,"Smith, DJ",0,00008C
+FORD,Dodge City Excel #2,United States Senate,,Democratic,"Wiesner, Patrick",0,00008C
+FORD,Dodge City Excel #2,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008C
+FORD,Dodge City Excel #2,United States Senate,,Republican,"Moran, Jerry",0,00008C
+FORD,Dodge City Millard,United States Senate,,write - in,"Smith, DJ",0,00008D
+FORD,Dodge City Millard,United States Senate,,Democratic,"Wiesner, Patrick",0,00008D
+FORD,Dodge City Millard,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008D
+FORD,Dodge City Millard,United States Senate,,Republican,"Moran, Jerry",0,00008D
+FORD,Dodge City Precinct 06,United States Senate,,write - in,"Smith, DJ",0,000100
+FORD,Dodge City Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",296,000100
+FORD,Dodge City Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",59,000100
+FORD,Dodge City Precinct 06,United States Senate,,Republican,"Moran, Jerry",1303,000100
+FORD,Dodge Township Ward 3,United States Senate,,write - in,"Smith, DJ",0,000200
+FORD,Dodge Township Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",4,000200
+FORD,Dodge Township Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",2,000200
+FORD,Dodge Township Ward 3,United States Senate,,Republican,"Moran, Jerry",22,000200
+FORD,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000220
+FORD,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000220
+FORD,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000220
+FORD,Fairview Township,United States Senate,,Republican,"Moran, Jerry",92,000220
+FORD,Ford City,United States Senate,,write - in,"Smith, DJ",0,000230
+FORD,Ford City,United States Senate,,Democratic,"Wiesner, Patrick",3,000230
+FORD,Ford City,United States Senate,,Libertarian,"Garrard, Robert D.",2,000230
+FORD,Ford City,United States Senate,,Republican,"Moran, Jerry",76,000230
+FORD,Ford Township,United States Senate,,write - in,"Smith, DJ",0,000240
+FORD,Ford Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000240
+FORD,Ford Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000240
+FORD,Ford Township,United States Senate,,Republican,"Moran, Jerry",62,000240
+FORD,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000260
+FORD,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",32,000260
+FORD,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000260
+FORD,Richland Township,United States Senate,,Republican,"Moran, Jerry",170,000260
+FORD,Royal Township,United States Senate,,write - in,"Smith, DJ",0,000270
+FORD,Royal Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000270
+FORD,Royal Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000270
+FORD,Royal Township,United States Senate,,Republican,"Moran, Jerry",97,000270
+FORD,Sodville Township,United States Senate,,write - in,"Smith, DJ",0,000280
+FORD,Sodville Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000280
+FORD,Sodville Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000280
+FORD,Sodville Township,United States Senate,,Republican,"Moran, Jerry",43,000280
+FORD,Spearville City,United States Senate,,write - in,"Smith, DJ",0,000300
+FORD,Spearville City,United States Senate,,Democratic,"Wiesner, Patrick",35,000300
+FORD,Spearville City,United States Senate,,Libertarian,"Garrard, Robert D.",26,000300
+FORD,Spearville City,United States Senate,,Republican,"Moran, Jerry",318,000300
+FORD,Spearville Township,United States Senate,,write - in,"Smith, DJ",0,000310
+FORD,Spearville Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000310
+FORD,Spearville Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000310
+FORD,Spearville Township,United States Senate,,Republican,"Moran, Jerry",167,000310
+FORD,Wheatland Township,United States Senate,,write - in,"Smith, DJ",0,000320
+FORD,Wheatland Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000320
+FORD,Wheatland Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000320
+FORD,Wheatland Township,United States Senate,,Republican,"Moran, Jerry",62,000320
+FORD,Wilburn Township,United States Senate,,write - in,"Smith, DJ",0,000330
+FORD,Wilburn Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000330
+FORD,Wilburn Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000330
+FORD,Wilburn Township,United States Senate,,Republican,"Moran, Jerry",38,000330
+FORD,Dodge Township H115,United States Senate,,write - in,"Smith, DJ",0,120020
+FORD,Dodge Township H115,United States Senate,,Democratic,"Wiesner, Patrick",34,120020
+FORD,Dodge Township H115,United States Senate,,Libertarian,"Garrard, Robert D.",7,120020
+FORD,Dodge Township H115,United States Senate,,Republican,"Moran, Jerry",166,120020
+FORD,Dodge Township H119 A,United States Senate,,write - in,"Smith, DJ",0,12003A
+FORD,Dodge Township H119 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12003A
+FORD,Dodge Township H119 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12003A
+FORD,Dodge Township H119 A,United States Senate,,Republican,"Moran, Jerry",0,12003A
+FORD,Dodge Township H119,United States Senate,,write - in,"Smith, DJ",0,120030
+FORD,Dodge Township H119,United States Senate,,Democratic,"Wiesner, Patrick",2,120030
+FORD,Dodge Township H119,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+FORD,Dodge Township H119,United States Senate,,Republican,"Moran, Jerry",24,120030
+FORD,Enterprise Township H115,United States Senate,,write - in,"Smith, DJ",0,120040
+FORD,Enterprise Township H115,United States Senate,,Democratic,"Wiesner, Patrick",45,120040
+FORD,Enterprise Township H115,United States Senate,,Libertarian,"Garrard, Robert D.",11,120040
+FORD,Enterprise Township H115,United States Senate,,Republican,"Moran, Jerry",134,120040
+FORD,Enterprise Township H119,United States Senate,,write - in,"Smith, DJ",0,120050
+FORD,Enterprise Township H119,United States Senate,,Democratic,"Wiesner, Patrick",2,120050
+FORD,Enterprise Township H119,United States Senate,,Libertarian,"Garrard, Robert D.",0,120050
+FORD,Enterprise Township H119,United States Senate,,Republican,"Moran, Jerry",5,120050
+FORD,Grandview Township H115,United States Senate,,write - in,"Smith, DJ",0,120060
+FORD,Grandview Township H115,United States Senate,,Democratic,"Wiesner, Patrick",18,120060
+FORD,Grandview Township H115,United States Senate,,Libertarian,"Garrard, Robert D.",10,120060
+FORD,Grandview Township H115,United States Senate,,Republican,"Moran, Jerry",154,120060
+FORD,Grandview Township East H119,United States Senate,,write - in,"Smith, DJ",0,12007A
+FORD,Grandview Township East H119,United States Senate,,Democratic,"Wiesner, Patrick",0,12007A
+FORD,Grandview Township East H119,United States Senate,,Libertarian,"Garrard, Robert D.",0,12007A
+FORD,Grandview Township East H119,United States Senate,,Republican,"Moran, Jerry",3,12007A
+FORD,Grandview Township H119,United States Senate,,write - in,"Smith, DJ",0,120070
+FORD,Grandview Township H119,United States Senate,,Democratic,"Wiesner, Patrick",0,120070
+FORD,Grandview Township H119,United States Senate,,Libertarian,"Garrard, Robert D.",0,120070
+FORD,Grandview Township H119,United States Senate,,Republican,"Moran, Jerry",0,120070
+FORD,Grandview Township Ward 2 H115,United States Senate,,write - in,"Smith, DJ",0,120080
+FORD,Grandview Township Ward 2 H115,United States Senate,,Democratic,"Wiesner, Patrick",10,120080
+FORD,Grandview Township Ward 2 H115,United States Senate,,Libertarian,"Garrard, Robert D.",2,120080
+FORD,Grandview Township Ward 2 H115,United States Senate,,Republican,"Moran, Jerry",26,120080
+FORD,Grandview Township Ward 2 H119,United States Senate,,write - in,"Smith, DJ",0,120090
+FORD,Grandview Township Ward 2 H119,United States Senate,,Democratic,"Wiesner, Patrick",0,120090
+FORD,Grandview Township Ward 2 H119,United States Senate,,Libertarian,"Garrard, Robert D.",0,120090
+FORD,Grandview Township Ward 2 H119,United States Senate,,Republican,"Moran, Jerry",3,120090
+FORD,Dodge City Precinct 03 H115,United States Senate,,write - in,"Smith, DJ",0,120100
+FORD,Dodge City Precinct 03 H115,United States Senate,,Democratic,"Wiesner, Patrick",0,120100
+FORD,Dodge City Precinct 03 H115,United States Senate,,Libertarian,"Garrard, Robert D.",0,120100
+FORD,Dodge City Precinct 03 H115,United States Senate,,Republican,"Moran, Jerry",0,120100
+FORD,Dodge City Township C H115,United States Senate,,write - in,"Smith, DJ",0,120110
+FORD,Dodge City Township C H115,United States Senate,,Democratic,"Wiesner, Patrick",0,120110
+FORD,Dodge City Township C H115,United States Senate,,Libertarian,"Garrard, Robert D.",0,120110
+FORD,Dodge City Township C H115,United States Senate,,Republican,"Moran, Jerry",0,120110
+FORD,Dodge City Township W H119,United States Senate,,write - in,"Smith, DJ",0,120120
+FORD,Dodge City Township W H119,United States Senate,,Democratic,"Wiesner, Patrick",0,120120
+FORD,Dodge City Township W H119,United States Senate,,Libertarian,"Garrard, Robert D.",0,120120
+FORD,Dodge City Township W H119,United States Senate,,Republican,"Moran, Jerry",1,120120
+FORD,Dodge City Precinct 09,United States Senate,,write - in,"Smith, DJ",0,120130
+FORD,Dodge City Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",7,120130
+FORD,Dodge City Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",0,120130
+FORD,Dodge City Precinct 09,United States Senate,,Republican,"Moran, Jerry",12,120130
+FORD,Dodge City Precinct 10,United States Senate,,write - in,"Smith, DJ",0,120140
+FORD,Dodge City Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",0,120140
+FORD,Dodge City Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",0,120140
+FORD,Dodge City Precinct 10,United States Senate,,Republican,"Moran, Jerry",0,120140
+FORD,Dodge City Precinct 02,United States Senate,,write - in,"Smith, DJ",0,130010
+FORD,Dodge City Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",135,130010
+FORD,Dodge City Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",32,130010
+FORD,Dodge City Precinct 02,United States Senate,,Republican,"Moran, Jerry",172,130010
+FORD,Dodge City Precinct 05,United States Senate,,write - in,"Smith, DJ",0,130020
+FORD,Dodge City Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",259,130020
+FORD,Dodge City Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",58,130020
+FORD,Dodge City Precinct 05,United States Senate,,Republican,"Moran, Jerry",953,130020
+FORD,Dodge City Precinct 07,United States Senate,,write - in,"Smith, DJ",0,600010
+FORD,Dodge City Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",17,600010
+FORD,Dodge City Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",3,600010
+FORD,Dodge City Precinct 07,United States Senate,,Republican,"Moran, Jerry",64,600010
+FORD,Dodge City Precinct 08,United States Senate,,write - in,"Smith, DJ",0,800010
+FORD,Dodge City Precinct 08,United States Senate,,Democratic,"Wiesner, Patrick",0,800010
+FORD,Dodge City Precinct 08,United States Senate,,Libertarian,"Garrard, Robert D.",0,800010
+FORD,Dodge City Precinct 08,United States Senate,,Republican,"Moran, Jerry",0,800010

--- a/2016/20161108__ks__general__franklin__precinct.csv
+++ b/2016/20161108__ks__general__franklin__precinct.csv
@@ -1,439 +1,952 @@
-county,precinct,office,district,candidate,party,votes
-Franklin,0001 1ST PREC,President,,Gary Johnson,LBT,19
-Franklin,0001 1ST PREC,President,,Jill Stein,IND,7
-Franklin,0001 1ST PREC,President,,Donald Trump,REP,268
-Franklin,0001 1ST PREC,President,,Hillary Clinton,DEM,117
-Franklin,0001 1ST PREC,President,,Write-ins,,7
-Franklin,0001 1ST PREC,U.S. Senate,,Jerry Moran,REP,268
-Franklin,0001 1ST PREC,U.S. Senate,,Patrick Wiesner,DEM,108
-Franklin,0001 1ST PREC,U.S. Senate,,Robert Garrard,LBT,27
-Franklin,0001 1ST PREC,U.S. Senate,,Write-ins,,3
-Franklin,0001 1ST PREC,U.S. House,2,James Bales,LBT,19
-Franklin,0001 1ST PREC,U.S. House,2,Lynn Jenkins,REP,255
-Franklin,0001 1ST PREC,U.S. House,2,Britani Potter,DEM,139
-Franklin,0001 1ST PREC,U.S. House,2,Write-ins,,1
-Franklin,0001 1ST PREC,State Senate,16,Caryn Tyson,REP,224
-Franklin,0001 1ST PREC,State Senate,16,Christopher Johnston,DEM,134
-Franklin,0001 1ST PREC,State Senate,16,Write-ins,,40
-Franklin,0001 1ST PREC,State House,59,Blaine Finch,REP,362
-Franklin,0001 1ST PREC,State House,59,Write-ins,,13
-Franklin,0002 2ND PREC,President,,Gary Johnson,LBT,19
-Franklin,0002 2ND PREC,President,,Jill Stein,IND,16
-Franklin,0002 2ND PREC,President,,Donald Trump,REP,312
-Franklin,0002 2ND PREC,President,,Hillary Clinton,DEM,132
-Franklin,0002 2ND PREC,President,,Write-ins,,10
-Franklin,0002 2ND PREC,U.S. Senate,,Jerry Moran,REP,295
-Franklin,0002 2ND PREC,U.S. Senate,,Patrick Wiesner,DEM,140
-Franklin,0002 2ND PREC,U.S. Senate,,Robert Garrard,LBT,42
-Franklin,0002 2ND PREC,U.S. Senate,,Write-ins,,1
-Franklin,0002 2ND PREC,U.S. House,2,James Bales,LBT,32
-Franklin,0002 2ND PREC,U.S. House,2,Lynn Jenkins,REP,283
-Franklin,0002 2ND PREC,U.S. House,2,Britani Potter,DEM,155
-Franklin,0002 2ND PREC,U.S. House,2,Write-ins,,7
-Franklin,0002 2ND PREC,State Senate,16,Caryn Tyson,REP,262
-Franklin,0002 2ND PREC,State Senate,16,Christopher Johnston,DEM,148
-Franklin,0002 2ND PREC,State Senate,16,Write-ins,,63
-Franklin,0002 2ND PREC,State House,59,Blaine Finch,REP,430
-Franklin,0002 2ND PREC,State House,59,Write-ins,,12
-Franklin,0003 3RD PREC,President,,Gary Johnson,LBT,15
-Franklin,0003 3RD PREC,President,,Jill Stein,IND,6
-Franklin,0003 3RD PREC,President,,Donald Trump,REP,160
-Franklin,0003 3RD PREC,President,,Hillary Clinton,DEM,85
-Franklin,0003 3RD PREC,President,,Write-ins,,3
-Franklin,0003 3RD PREC,U.S. Senate,,Jerry Moran,REP,159
-Franklin,0003 3RD PREC,U.S. Senate,,Patrick Wiesner,DEM,80
-Franklin,0003 3RD PREC,U.S. Senate,,Robert Garrard,LBT,18
-Franklin,0003 3RD PREC,U.S. Senate,,Write-ins,,2
-Franklin,0003 3RD PREC,U.S. House,2,James Bales,LBT,11
-Franklin,0003 3RD PREC,U.S. House,2,Lynn Jenkins,REP,156
-Franklin,0003 3RD PREC,U.S. House,2,Britani Potter,DEM,96
-Franklin,0003 3RD PREC,U.S. House,2,Write-ins,,2
-Franklin,0003 3RD PREC,State Senate,16,Caryn Tyson,REP,141
-Franklin,0003 3RD PREC,State Senate,16,Christopher Johnston,DEM,99
-Franklin,0003 3RD PREC,State Senate,16,Write-ins,,22
-Franklin,0003 3RD PREC,State House,59,Blaine Finch,REP,234
-Franklin,0003 3RD PREC,State House,59,Write-ins,,6
-Franklin,0004 4TH PREC,President,,Gary Johnson,LBT,68
-Franklin,0004 4TH PREC,President,,Jill Stein,IND,40
-Franklin,0004 4TH PREC,President,,Donald Trump,REP,591
-Franklin,0004 4TH PREC,President,,Hillary Clinton,DEM,321
-Franklin,0004 4TH PREC,President,,Write-ins,,15
-Franklin,0004 4TH PREC,U.S. Senate,,Jerry Moran,REP,644
-Franklin,0004 4TH PREC,U.S. Senate,,Patrick Wiesner,DEM,300
-Franklin,0004 4TH PREC,U.S. Senate,,Robert Garrard,LBT,75
-Franklin,0004 4TH PREC,U.S. Senate,,Write-ins,,2
-Franklin,0004 4TH PREC,U.S. House,2,James Bales,LBT,63
-Franklin,0004 4TH PREC,U.S. House,2,Lynn Jenkins,REP,607
-Franklin,0004 4TH PREC,U.S. House,2,Britani Potter,DEM,337
-Franklin,0004 4TH PREC,U.S. House,2,Write-ins,,11
-Franklin,0004 4TH PREC,State Senate,16,Caryn Tyson,REP,549
-Franklin,0004 4TH PREC,State Senate,16,Christopher Johnston,DEM,308
-Franklin,0004 4TH PREC,State Senate,16,Write-ins,,132
-Franklin,0004 4TH PREC,State House,59,Blaine Finch,REP,916
-Franklin,0004 4TH PREC,State House,59,Write-ins,,25
-Franklin,0006 6TH PREC,President,,Gary Johnson,LBT,23
-Franklin,0006 6TH PREC,President,,Jill Stein,IND,11
-Franklin,0006 6TH PREC,President,,Donald Trump,REP,210
-Franklin,0006 6TH PREC,President,,Hillary Clinton,DEM,119
-Franklin,0006 6TH PREC,President,,Write-ins,,5
-Franklin,0006 6TH PREC,U.S. Senate,,Jerry Moran,REP,225
-Franklin,0006 6TH PREC,U.S. Senate,,Patrick Wiesner,DEM,116
-Franklin,0006 6TH PREC,U.S. Senate,,Robert Garrard,LBT,21
-Franklin,0006 6TH PREC,U.S. Senate,,Write-ins,,3
-Franklin,0006 6TH PREC,U.S. House,2,James Bales,LBT,24
-Franklin,0006 6TH PREC,U.S. House,2,Lynn Jenkins,REP,219
-Franklin,0006 6TH PREC,U.S. House,2,Britani Potter,DEM,120
-Franklin,0006 6TH PREC,U.S. House,2,Write-ins,,1
-Franklin,0006 6TH PREC,State Senate,16,Caryn Tyson,REP,175
-Franklin,0006 6TH PREC,State Senate,16,Christopher Johnston,DEM,103
-Franklin,0006 6TH PREC,State Senate,16,Write-ins,,72
-Franklin,0006 6TH PREC,State House,59,Blaine Finch,REP,330
-Franklin,0006 6TH PREC,State House,59,Write-ins,,7
-Franklin,0007 7TH PREC,President,,Gary Johnson,LBT,44
-Franklin,0007 7TH PREC,President,,Jill Stein,IND,25
-Franklin,0007 7TH PREC,President,,Donald Trump,REP,493
-Franklin,0007 7TH PREC,President,,Hillary Clinton,DEM,302
-Franklin,0007 7TH PREC,President,,Write-ins,,24
-Franklin,0007 7TH PREC,U.S. Senate,,Jerry Moran,REP,517
-Franklin,0007 7TH PREC,U.S. Senate,,Patrick Wiesner,DEM,268
-Franklin,0007 7TH PREC,U.S. Senate,,Robert Garrard,LBT,71
-Franklin,0007 7TH PREC,U.S. Senate,,Write-ins,,3
-Franklin,0007 7TH PREC,U.S. House,2,James Bales,LBT,55
-Franklin,0007 7TH PREC,U.S. House,2,Lynn Jenkins,REP,460
-Franklin,0007 7TH PREC,U.S. House,2,Britani Potter,DEM,337
-Franklin,0007 7TH PREC,U.S. House,2,Write-ins,,8
-Franklin,0007 7TH PREC,State Senate,16,Caryn Tyson,REP,419
-Franklin,0007 7TH PREC,State Senate,16,Christopher Johnston,DEM,312
-Franklin,0007 7TH PREC,State Senate,16,Write-ins,,115
-Franklin,0007 7TH PREC,State House,59,Blaine Finch,REP,757
-Franklin,0007 7TH PREC,State House,59,Write-ins,,24
-Franklin,0008 8TH PREC,President,,Gary Johnson,LBT,47
-Franklin,0008 8TH PREC,President,,Jill Stein,IND,21
-Franklin,0008 8TH PREC,President,,Donald Trump,REP,674
-Franklin,0008 8TH PREC,President,,Hillary Clinton,DEM,363
-Franklin,0008 8TH PREC,President,,Write-ins,,23
-Franklin,0008 8TH PREC,U.S. Senate,,Jerry Moran,REP,712
-Franklin,0008 8TH PREC,U.S. Senate,,Patrick Wiesner,DEM,330
-Franklin,0008 8TH PREC,U.S. Senate,,Robert Garrard,LBT,62
-Franklin,0008 8TH PREC,U.S. Senate,,Write-ins,,8
-Franklin,0008 8TH PREC,U.S. House,2,James Bales,LBT,48
-Franklin,0008 8TH PREC,U.S. House,2,Lynn Jenkins,REP,668
-Franklin,0008 8TH PREC,U.S. House,2,Britani Potter,DEM,391
-Franklin,0008 8TH PREC,U.S. House,2,Write-ins,,7
-Franklin,0008 8TH PREC,State Senate,16,Caryn Tyson,REP,574
-Franklin,0008 8TH PREC,State Senate,16,Christopher Johnston,DEM,304
-Franklin,0008 8TH PREC,State Senate,16,Write-ins,,200
-Franklin,0008 8TH PREC,State House,59,Blaine Finch,REP,988
-Franklin,0008 8TH PREC,State House,59,Write-ins,,32
-Franklin,0009 Appanoose twp,President,,Gary Johnson,LBT,9
-Franklin,0009 Appanoose twp,President,,Jill Stein,IND,3
-Franklin,0009 Appanoose twp,President,,Donald Trump,REP,93
-Franklin,0009 Appanoose twp,President,,Hillary Clinton,DEM,32
-Franklin,0009 Appanoose twp,President,,Write-ins,,3
-Franklin,0009 Appanoose twp,U.S. Senate,,Jerry Moran,REP,101
-Franklin,0009 Appanoose twp,U.S. Senate,,Patrick Wiesner,DEM,29
-Franklin,0009 Appanoose twp,U.S. Senate,,Robert Garrard,LBT,11
-Franklin,0009 Appanoose twp,U.S. Senate,,Write-ins,,0
-Franklin,0009 Appanoose twp,U.S. House,2,James Bales,LBT,14
-Franklin,0009 Appanoose twp,U.S. House,2,Lynn Jenkins,REP,94
-Franklin,0009 Appanoose twp,U.S. House,2,Britani Potter,DEM,31
-Franklin,0009 Appanoose twp,U.S. House,2,Write-ins,,1
-Franklin,0009 Appanoose twp,State Senate,16,Caryn Tyson,REP,84
-Franklin,0009 Appanoose twp,State Senate,16,Christopher Johnston,DEM,37
-Franklin,0009 Appanoose twp,State Senate,16,Write-ins,,14
-Franklin,0009 Appanoose twp,State House,59,Blaine Finch,REP,120
-Franklin,0009 Appanoose twp,State House,59,Write-ins,,2
-Franklin,0010 N Centropolis twp,President,,Gary Johnson,LBT,14
-Franklin,0010 N Centropolis twp,President,,Jill Stein,IND,5
-Franklin,0010 N Centropolis twp,President,,Donald Trump,REP,164
-Franklin,0010 N Centropolis twp,President,,Hillary Clinton,DEM,34
-Franklin,0010 N Centropolis twp,President,,Write-ins,,6
-Franklin,0010 N Centropolis twp,U.S. Senate,,Jerry Moran,REP,164
-Franklin,0010 N Centropolis twp,U.S. Senate,,Patrick Wiesner,DEM,39
-Franklin,0010 N Centropolis twp,U.S. Senate,,Robert Garrard,LBT,15
-Franklin,0010 N Centropolis twp,U.S. Senate,,Write-ins,,0
-Franklin,0010 N Centropolis twp,U.S. House,2,James Bales,LBT,14
-Franklin,0010 N Centropolis twp,U.S. House,2,Lynn Jenkins,REP,153
-Franklin,0010 N Centropolis twp,U.S. House,2,Britani Potter,DEM,51
-Franklin,0010 N Centropolis twp,U.S. House,2,Write-ins,,0
-Franklin,0010 N Centropolis twp,State Senate,16,Caryn Tyson,REP,158
-Franklin,0010 N Centropolis twp,State Senate,16,Christopher Johnston,DEM,44
-Franklin,0010 N Centropolis twp,State Senate,16,Write-ins,,12
-Franklin,0010 N Centropolis twp,State House,59,Blaine Finch,REP,186
-Franklin,0010 N Centropolis twp,State House,59,Write-ins,,4
-Franklin,0011 S Centropolis twp,President,,Gary Johnson,LBT,9
-Franklin,0011 S Centropolis twp,President,,Jill Stein,IND,5
-Franklin,0011 S Centropolis twp,President,,Donald Trump,REP,181
-Franklin,0011 S Centropolis twp,President,,Hillary Clinton,DEM,52
-Franklin,0011 S Centropolis twp,President,,Write-ins,,4
-Franklin,0011 S Centropolis twp,U.S. Senate,,Jerry Moran,REP,184
-Franklin,0011 S Centropolis twp,U.S. Senate,,Patrick Wiesner,DEM,46
-Franklin,0011 S Centropolis twp,U.S. Senate,,Robert Garrard,LBT,18
-Franklin,0011 S Centropolis twp,U.S. Senate,,Write-ins,,1
-Franklin,0011 S Centropolis twp,U.S. House,2,James Bales,LBT,19
-Franklin,0011 S Centropolis twp,U.S. House,2,Lynn Jenkins,REP,187
-Franklin,0011 S Centropolis twp,U.S. House,2,Britani Potter,DEM,43
-Franklin,0011 S Centropolis twp,U.S. House,2,Write-ins,,0
-Franklin,0011 S Centropolis twp,State Senate,16,Caryn Tyson,REP,178
-Franklin,0011 S Centropolis twp,State Senate,16,Christopher Johnston,DEM,54
-Franklin,0011 S Centropolis twp,State Senate,16,Write-ins,,14
-Franklin,0011 S Centropolis twp,State House,59,Blaine Finch,REP,219
-Franklin,0011 S Centropolis twp,State House,59,Write-ins,,8
-Franklin,0012 Cutler twp/Rantoul C,President,,Gary Johnson,LBT,20
-Franklin,0012 Cutler twp/Rantoul C,President,,Jill Stein,IND,7
-Franklin,0012 Cutler twp/Rantoul C,President,,Donald Trump,REP,286
-Franklin,0012 Cutler twp/Rantoul C,President,,Hillary Clinton,DEM,82
-Franklin,0012 Cutler twp/Rantoul C,President,,Write-ins,,6
-Franklin,0012 Cutler twp/Rantoul C,U.S. Senate,,Jerry Moran,REP,290
-Franklin,0012 Cutler twp/Rantoul C,U.S. Senate,,Patrick Wiesner,DEM,79
-Franklin,0012 Cutler twp/Rantoul C,U.S. Senate,,Robert Garrard,LBT,20
-Franklin,0012 Cutler twp/Rantoul C,U.S. Senate,,Write-ins,,2
-Franklin,0012 Cutler twp/Rantoul C,U.S. House,2,James Bales,LBT,24
-Franklin,0012 Cutler twp/Rantoul C,U.S. House,2,Lynn Jenkins,REP,297
-Franklin,0012 Cutler twp/Rantoul C,U.S. House,2,Britani Potter,DEM,69
-Franklin,0012 Cutler twp/Rantoul C,U.S. House,2,Write-ins,,2
-Franklin,0012 Cutler twp/Rantoul C,State Senate,16,Caryn Tyson,REP,264
-Franklin,0012 Cutler twp/Rantoul C,State Senate,16,Christopher Johnston,DEM,88
-Franklin,0012 Cutler twp/Rantoul C,State Senate,16,Write-ins,,29
-Franklin,0012 Cutler twp/Rantoul C,State House,5,Doug Walker,DEM,125
-Franklin,0012 Cutler twp/Rantoul C,State House,5,Kevin Jones,REP,259
-Franklin,0012 Cutler twp/Rantoul C,State House,5,Write-ins,,5
-Franklin,0013 Franklin twp,President,,Gary Johnson,LBT,69
-Franklin,0013 Franklin twp,President,,Jill Stein,IND,30
-Franklin,0013 Franklin twp,President,,Donald Trump,REP,881
-Franklin,0013 Franklin twp,President,,Hillary Clinton,DEM,351
-Franklin,0013 Franklin twp,President,,Write-ins,,18
-Franklin,0013 Franklin twp,U.S. Senate,,Jerry Moran,REP,864
-Franklin,0013 Franklin twp,U.S. Senate,,Patrick Wiesner,DEM,345
-Franklin,0013 Franklin twp,U.S. Senate,,Robert Garrard,LBT,126
-Franklin,0013 Franklin twp,U.S. Senate,,Write-ins,,1
-Franklin,0013 Franklin twp,U.S. House,2,James Bales,LBT,91
-Franklin,0013 Franklin twp,U.S. House,2,Lynn Jenkins,REP,892
-Franklin,0013 Franklin twp,U.S. House,2,Britani Potter,DEM,346
-Franklin,0013 Franklin twp,U.S. House,2,Write-ins,,0
-Franklin,0013 Franklin twp,State Senate,16,Caryn Tyson,REP,827
-Franklin,0013 Franklin twp,State Senate,16,Christopher Johnston,DEM,429
-Franklin,0013 Franklin twp,State Senate,16,Write-ins,,54
-Franklin,0013 Franklin twp,State House,5,Doug Walker,DEM,535
-Franklin,0013 Franklin twp,State House,5,Kevin Jones,REP,809
-Franklin,0013 Franklin twp,State House,5,Write-ins,,3
-Franklin,0014 Greenwood twp,President,,Gary Johnson,LBT,7
-Franklin,0014 Greenwood twp,President,,Jill Stein,IND,1
-Franklin,0014 Greenwood twp,President,,Donald Trump,REP,176
-Franklin,0014 Greenwood twp,President,,Hillary Clinton,DEM,38
-Franklin,0014 Greenwood twp,President,,Write-ins,,2
-Franklin,0014 Greenwood twp,U.S. Senate,,Jerry Moran,REP,171
-Franklin,0014 Greenwood twp,U.S. Senate,,Patrick Wiesner,DEM,44
-Franklin,0014 Greenwood twp,U.S. Senate,,Robert Garrard,LBT,9
-Franklin,0014 Greenwood twp,U.S. Senate,,Write-ins,,0
-Franklin,0014 Greenwood twp,U.S. House,2,James Bales,LBT,8
-Franklin,0014 Greenwood twp,U.S. House,2,Lynn Jenkins,REP,172
-Franklin,0014 Greenwood twp,U.S. House,2,Britani Potter,DEM,43
-Franklin,0014 Greenwood twp,U.S. House,2,Write-ins,,0
-Franklin,0014 Greenwood twp,State Senate,16,Caryn Tyson,REP,151
-Franklin,0014 Greenwood twp,State Senate,16,Christopher Johnston,DEM,45
-Franklin,0014 Greenwood twp,State Senate,16,Write-ins,,25
-Franklin,0014 Greenwood twp,State House,59,Blaine Finch,REP,203
-Franklin,0014 Greenwood twp,State House,59,Write-ins,,6
-Franklin,0015 Harrison twp,President,,Gary Johnson,LBT,11
-Franklin,0015 Harrison twp,President,,Jill Stein,IND,6
-Franklin,0015 Harrison twp,President,,Donald Trump,REP,214
-Franklin,0015 Harrison twp,President,,Hillary Clinton,DEM,46
-Franklin,0015 Harrison twp,President,,Write-ins,,6
-Franklin,0015 Harrison twp,U.S. Senate,,Jerry Moran,REP,225
-Franklin,0015 Harrison twp,U.S. Senate,,Patrick Wiesner,DEM,48
-Franklin,0015 Harrison twp,U.S. Senate,,Robert Garrard,LBT,7
-Franklin,0015 Harrison twp,U.S. Senate,,Write-ins,,0
-Franklin,0015 Harrison twp,U.S. House,2,James Bales,LBT,9
-Franklin,0015 Harrison twp,U.S. House,2,Lynn Jenkins,REP,220
-Franklin,0015 Harrison twp,U.S. House,2,Britani Potter,DEM,50
-Franklin,0015 Harrison twp,U.S. House,2,Write-ins,,1
-Franklin,0015 Harrison twp,State Senate,16,Caryn Tyson,REP,200
-Franklin,0015 Harrison twp,State Senate,16,Christopher Johnston,DEM,52
-Franklin,0015 Harrison twp,State Senate,16,Write-ins,,23
-Franklin,0015 Harrison twp,State House,59,Blaine Finch,REP,256
-Franklin,0015 Harrison twp,State House,59,Write-ins,,2
-Franklin,0016 Hayes twp,President,,Gary Johnson,LBT,16
-Franklin,0016 Hayes twp,President,,Jill Stein,IND,2
-Franklin,0016 Hayes twp,President,,Donald Trump,REP,144
-Franklin,0016 Hayes twp,President,,Hillary Clinton,DEM,62
-Franklin,0016 Hayes twp,President,,Write-ins,,4
-Franklin,0016 Hayes twp,U.S. Senate,,Jerry Moran,REP,165
-Franklin,0016 Hayes twp,U.S. Senate,,Patrick Wiesner,DEM,46
-Franklin,0016 Hayes twp,U.S. Senate,,Robert Garrard,LBT,12
-Franklin,0016 Hayes twp,U.S. Senate,,Write-ins,,1
-Franklin,0016 Hayes twp,U.S. House,2,James Bales,LBT,14
-Franklin,0016 Hayes twp,U.S. House,2,Lynn Jenkins,REP,168
-Franklin,0016 Hayes twp,U.S. House,2,Britani Potter,DEM,43
-Franklin,0016 Hayes twp,U.S. House,2,Write-ins,,0
-Franklin,0016 Hayes twp,State Senate,16,Caryn Tyson,REP,144
-Franklin,0016 Hayes twp,State Senate,16,Christopher Johnston,DEM,50
-Franklin,0016 Hayes twp,State Senate,16,Write-ins,,25
-Franklin,0016 Hayes twp,State House,59,Blaine Finch,REP,203
-Franklin,0016 Hayes twp,State House,59,Write-ins,,2
-Franklin,0017 Homewood twp,President,,Gary Johnson,LBT,18
-Franklin,0017 Homewood twp,President,,Jill Stein,IND,6
-Franklin,0017 Homewood twp,President,,Donald Trump,REP,180
-Franklin,0017 Homewood twp,President,,Hillary Clinton,DEM,83
-Franklin,0017 Homewood twp,President,,Write-ins,,4
-Franklin,0017 Homewood twp,U.S. Senate,,Jerry Moran,REP,195
-Franklin,0017 Homewood twp,U.S. Senate,,Patrick Wiesner,DEM,80
-Franklin,0017 Homewood twp,U.S. Senate,,Robert Garrard,LBT,10
-Franklin,0017 Homewood twp,U.S. Senate,,Write-ins,,0
-Franklin,0017 Homewood twp,U.S. House,2,James Bales,LBT,15
-Franklin,0017 Homewood twp,U.S. House,2,Lynn Jenkins,REP,177
-Franklin,0017 Homewood twp,U.S. House,2,Britani Potter,DEM,95
-Franklin,0017 Homewood twp,U.S. House,2,Write-ins,,0
-Franklin,0017 Homewood twp,State Senate,16,Caryn Tyson,REP,170
-Franklin,0017 Homewood twp,State Senate,16,Christopher Johnston,DEM,91
-Franklin,0017 Homewood twp,State Senate,16,Write-ins,,21
-Franklin,0017 Homewood twp,State House,59,Blaine Finch,REP,268
-Franklin,0017 Homewood twp,State House,59,Write-ins,,2
-Franklin,0018 Lincoln twp,President,,Gary Johnson,LBT,20
-Franklin,0018 Lincoln twp,President,,Jill Stein,IND,11
-Franklin,0018 Lincoln twp,President,,Donald Trump,REP,359
-Franklin,0018 Lincoln twp,President,,Hillary Clinton,DEM,123
-Franklin,0018 Lincoln twp,President,,Write-ins,,7
-Franklin,0018 Lincoln twp,U.S. Senate,,Jerry Moran,REP,375
-Franklin,0018 Lincoln twp,U.S. Senate,,Patrick Wiesner,DEM,108
-Franklin,0018 Lincoln twp,U.S. Senate,,Robert Garrard,LBT,27
-Franklin,0018 Lincoln twp,U.S. Senate,,Write-ins,,1
-Franklin,0018 Lincoln twp,U.S. House,2,James Bales,LBT,28
-Franklin,0018 Lincoln twp,U.S. House,2,Lynn Jenkins,REP,363
-Franklin,0018 Lincoln twp,U.S. House,2,Britani Potter,DEM,120
-Franklin,0018 Lincoln twp,U.S. House,2,Write-ins,,3
-Franklin,0018 Lincoln twp,State Senate,16,Caryn Tyson,REP,307
-Franklin,0018 Lincoln twp,State Senate,16,Christopher Johnston,DEM,126
-Franklin,0018 Lincoln twp,State Senate,16,Write-ins,,64
-Franklin,0018 Lincoln twp,State House,59,Blaine Finch,REP,457
-Franklin,0018 Lincoln twp,State House,59,Write-ins,,8
-Franklin,0019 Ohio twp/Princeton,President,,Gary Johnson,LBT,16
-Franklin,0019 Ohio twp/Princeton,President,,Jill Stein,IND,15
-Franklin,0019 Ohio twp/Princeton,President,,Donald Trump,REP,280
-Franklin,0019 Ohio twp/Princeton,President,,Hillary Clinton,DEM,90
-Franklin,0019 Ohio twp/Princeton,President,,Write-ins,,2
-Franklin,0019 Ohio twp/Princeton,U.S. Senate,,Jerry Moran,REP,296
-Franklin,0019 Ohio twp/Princeton,U.S. Senate,,Patrick Wiesner,DEM,80
-Franklin,0019 Ohio twp/Princeton,U.S. Senate,,Robert Garrard,LBT,22
-Franklin,0019 Ohio twp/Princeton,U.S. Senate,,Write-ins,,1
-Franklin,0019 Ohio twp/Princeton,U.S. House,2,James Bales,LBT,22
-Franklin,0019 Ohio twp/Princeton,U.S. House,2,Lynn Jenkins,REP,290
-Franklin,0019 Ohio twp/Princeton,U.S. House,2,Britani Potter,DEM,93
-Franklin,0019 Ohio twp/Princeton,U.S. House,2,Write-ins,,0
-Franklin,0019 Ohio twp/Princeton,State Senate,16,Caryn Tyson,REP,254
-Franklin,0019 Ohio twp/Princeton,State Senate,16,Christopher Johnston,DEM,84
-Franklin,0019 Ohio twp/Princeton,State Senate,16,Write-ins,,54
-Franklin,0019 Ohio twp/Princeton,State House,5,Doug Walker,DEM,137
-Franklin,0019 Ohio twp/Princeton,State House,5,Kevin Jones,REP,260
-Franklin,0019 Ohio twp/Princeton,State House,5,Write-ins,,2
-Franklin,0020 Ottawa twp,President,,Gary Johnson,LBT,23
-Franklin,0020 Ottawa twp,President,,Jill Stein,IND,9
-Franklin,0020 Ottawa twp,President,,Donald Trump,REP,316
-Franklin,0020 Ottawa twp,President,,Hillary Clinton,DEM,93
-Franklin,0020 Ottawa twp,President,,Write-ins,,3
-Franklin,0020 Ottawa twp,U.S. Senate,,Jerry Moran,REP,335
-Franklin,0020 Ottawa twp,U.S. Senate,,Patrick Wiesner,DEM,75
-Franklin,0020 Ottawa twp,U.S. Senate,,Robert Garrard,LBT,23
-Franklin,0020 Ottawa twp,U.S. Senate,,Write-ins,,0
-Franklin,0020 Ottawa twp,U.S. House,2,James Bales,LBT,10
-Franklin,0020 Ottawa twp,U.S. House,2,Lynn Jenkins,REP,319
-Franklin,0020 Ottawa twp,U.S. House,2,Britani Potter,DEM,106
-Franklin,0020 Ottawa twp,U.S. House,2,Write-ins,,0
-Franklin,0020 Ottawa twp,State Senate,16,Caryn Tyson,REP,290
-Franklin,0020 Ottawa twp,State Senate,16,Christopher Johnston,DEM,98
-Franklin,0020 Ottawa twp,State Senate,16,Write-ins,,41
-Franklin,0020 Ottawa twp,State House,59,Blaine Finch,REP,396
-Franklin,0020 Ottawa twp,State House,59,Write-ins,,5
-Franklin,0021 Peoria twp,President,,Gary Johnson,LBT,32
-Franklin,0021 Peoria twp,President,,Jill Stein,IND,5
-Franklin,0021 Peoria twp,President,,Donald Trump,REP,250
-Franklin,0021 Peoria twp,President,,Hillary Clinton,DEM,67
-Franklin,0021 Peoria twp,President,,Write-ins,,6
-Franklin,0021 Peoria twp,U.S. Senate,,Jerry Moran,REP,256
-Franklin,0021 Peoria twp,U.S. Senate,,Patrick Wiesner,DEM,70
-Franklin,0021 Peoria twp,U.S. Senate,,Robert Garrard,LBT,28
-Franklin,0021 Peoria twp,U.S. Senate,,Write-ins,,0
-Franklin,0021 Peoria twp,U.S. House,2,James Bales,LBT,17
-Franklin,0021 Peoria twp,U.S. House,2,Lynn Jenkins,REP,254
-Franklin,0021 Peoria twp,U.S. House,2,Britani Potter,DEM,82
-Franklin,0021 Peoria twp,U.S. House,2,Write-ins,,0
-Franklin,0021 Peoria twp,State Senate,16,Caryn Tyson,REP,245
-Franklin,0021 Peoria twp,State Senate,16,Christopher Johnston,DEM,76
-Franklin,0021 Peoria twp,State Senate,16,Write-ins,,23
-Franklin,0021 Peoria twp,State House,5,Doug Walker,DEM,106
-Franklin,0021 Peoria twp,State House,5,Kevin Jones,REP,244
-Franklin,0021 Peoria twp,State House,5,Write-ins,,1
-Franklin,0022 Pomona twp/Pomona City,President,,Gary Johnson,LBT,22
-Franklin,0022 Pomona twp/Pomona City,President,,Jill Stein,IND,11
-Franklin,0022 Pomona twp/Pomona City,President,,Donald Trump,REP,312
-Franklin,0022 Pomona twp/Pomona City,President,,Hillary Clinton,DEM,91
-Franklin,0022 Pomona twp/Pomona City,President,,Write-ins,,3
-Franklin,0022 Pomona twp/Pomona City,U.S. Senate,,Jerry Moran,REP,311
-Franklin,0022 Pomona twp/Pomona City,U.S. Senate,,Patrick Wiesner,DEM,97
-Franklin,0022 Pomona twp/Pomona City,U.S. Senate,,Robert Garrard,LBT,21
-Franklin,0022 Pomona twp/Pomona City,U.S. Senate,,Write-ins,,0
-Franklin,0022 Pomona twp/Pomona City,U.S. House,2,James Bales,LBT,23
-Franklin,0022 Pomona twp/Pomona City,U.S. House,2,Lynn Jenkins,REP,306
-Franklin,0022 Pomona twp/Pomona City,U.S. House,2,Britani Potter,DEM,104
-Franklin,0022 Pomona twp/Pomona City,U.S. House,2,Write-ins,,1
-Franklin,0022 Pomona twp/Pomona City,State Senate,16,Caryn Tyson,REP,274
-Franklin,0022 Pomona twp/Pomona City,State Senate,16,Christopher Johnston,DEM,99
-Franklin,0022 Pomona twp/Pomona City,State Senate,16,Write-ins,,53
-Franklin,0022 Pomona twp/Pomona City,State House,59,Blaine Finch,REP,405
-Franklin,0022 Pomona twp/Pomona City,State House,59,Write-ins,,5
-Franklin,0023 Pottawatomie twp/Lane,President,,Gary Johnson,LBT,11
-Franklin,0023 Pottawatomie twp/Lane,President,,Jill Stein,IND,5
-Franklin,0023 Pottawatomie twp/Lane,President,,Donald Trump,REP,212
-Franklin,0023 Pottawatomie twp/Lane,President,,Hillary Clinton,DEM,65
-Franklin,0023 Pottawatomie twp/Lane,President,,Write-ins,,1
-Franklin,0023 Pottawatomie twp/Lane,U.S. Senate,,Jerry Moran,REP,211
-Franklin,0023 Pottawatomie twp/Lane,U.S. Senate,,Patrick Wiesner,DEM,62
-Franklin,0023 Pottawatomie twp/Lane,U.S. Senate,,Robert Garrard,LBT,17
-Franklin,0023 Pottawatomie twp/Lane,U.S. Senate,,Write-ins,,1
-Franklin,0023 Pottawatomie twp/Lane,U.S. House,2,James Bales,LBT,6
-Franklin,0023 Pottawatomie twp/Lane,U.S. House,2,Lynn Jenkins,REP,210
-Franklin,0023 Pottawatomie twp/Lane,U.S. House,2,Britani Potter,DEM,73
-Franklin,0023 Pottawatomie twp/Lane,U.S. House,2,Write-ins,,0
-Franklin,0023 Pottawatomie twp/Lane,State Senate,16,Caryn Tyson,REP,211
-Franklin,0023 Pottawatomie twp/Lane,State Senate,16,Christopher Johnston,DEM,68
-Franklin,0023 Pottawatomie twp/Lane,State Senate,16,Write-ins,,9
-Franklin,0023 Pottawatomie twp/Lane,State House,5,Doug Walker,DEM,107
-Franklin,0023 Pottawatomie twp/Lane,State House,5,Kevin Jones,REP,183
-Franklin,0023 Pottawatomie twp/Lane,State House,5,Write-ins,,0
-Franklin,0024 Richmond twp/Richmond,President,,Gary Johnson,LBT,22
-Franklin,0024 Richmond twp/Richmond,President,,Jill Stein,IND,8
-Franklin,0024 Richmond twp/Richmond,President,,Donald Trump,REP,242
-Franklin,0024 Richmond twp/Richmond,President,,Hillary Clinton,DEM,81
-Franklin,0024 Richmond twp/Richmond,President,,Write-ins,,5
-Franklin,0024 Richmond twp/Richmond,U.S. Senate,,Jerry Moran,REP,240
-Franklin,0024 Richmond twp/Richmond,U.S. Senate,,Patrick Wiesner,DEM,80
-Franklin,0024 Richmond twp/Richmond,U.S. Senate,,Robert Garrard,LBT,32
-Franklin,0024 Richmond twp/Richmond,U.S. Senate,,Write-ins,,0
-Franklin,0024 Richmond twp/Richmond,U.S. House,2,James Bales,LBT,21
-Franklin,0024 Richmond twp/Richmond,U.S. House,2,Lynn Jenkins,REP,245
-Franklin,0024 Richmond twp/Richmond,U.S. House,2,Britani Potter,DEM,89
-Franklin,0024 Richmond twp/Richmond,U.S. House,2,Write-ins,,0
-Franklin,0024 Richmond twp/Richmond,State Senate,16,Caryn Tyson,REP,223
-Franklin,0024 Richmond twp/Richmond,State Senate,16,Christopher Johnston,DEM,87
-Franklin,0024 Richmond twp/Richmond,State Senate,16,Write-ins,,38
-Franklin,0024 Richmond twp/Richmond,State House,5,Doug Walker,DEM,135
-Franklin,0024 Richmond twp/Richmond,State House,5,Kevin Jones,REP,218
-Franklin,0024 Richmond twp/Richmond,State House,5,Write-ins,,1
-Franklin,0025 Williamsburg twp/Williamsburg,President,,Gary Johnson,LBT,14
-Franklin,0025 Williamsburg twp/Williamsburg,President,,Jill Stein,IND,10
-Franklin,0025 Williamsburg twp/Williamsburg,President,,Donald Trump,REP,187
-Franklin,0025 Williamsburg twp/Williamsburg,President,,Hillary Clinton,DEM,63
-Franklin,0025 Williamsburg twp/Williamsburg,President,,Write-ins,,5
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. Senate,,Jerry Moran,REP,191
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. Senate,,Patrick Wiesner,DEM,65
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. Senate,,Robert Garrard,LBT,19
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. Senate,,Write-ins,,1
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. House,2,James Bales,LBT,18
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. House,2,Lynn Jenkins,REP,175
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. House,2,Britani Potter,DEM,80
-Franklin,0025 Williamsburg twp/Williamsburg,U.S. House,2,Write-ins,,1
-Franklin,0025 Williamsburg twp/Williamsburg,State Senate,16,Caryn Tyson,REP,169
-Franklin,0025 Williamsburg twp/Williamsburg,State Senate,16,Christopher Johnston,DEM,76
-Franklin,0025 Williamsburg twp/Williamsburg,State Senate,16,Write-ins,,26
-Franklin,0025 Williamsburg twp/Williamsburg,State House,59,Blaine Finch,REP,243
-Franklin,0025 Williamsburg twp/Williamsburg,State House,59,Write-ins,,5
+county,precinct,office,district,party,candidate,votes,vtd
+FRANKLIN,Appanoose Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",120,000010
+FRANKLIN,Centropolis North Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",186,000020
+FRANKLIN,Centropolis South Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",219,000030
+FRANKLIN,Cutler Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",125,000040
+FRANKLIN,Cutler Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",259,000040
+FRANKLIN,Franklin Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",535,000050
+FRANKLIN,Franklin Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",809,000050
+FRANKLIN,Greenwood Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",203,000060
+FRANKLIN,Harrison Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",256,000070
+FRANKLIN,Hayes Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",203,000080
+FRANKLIN,Homewood Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",268,000090
+FRANKLIN,Lincoln Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",457,000100
+FRANKLIN,Ohio Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",137,000110
+FRANKLIN,Ohio Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",260,000110
+FRANKLIN,Ottawa Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",396,00012A
+FRANKLIN,Ottawa Precinct 1,Kansas House of Representatives,59,Republican,"Finch, Blaine",362,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas House of Representatives,59,Republican,"Finch, Blaine",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas House of Representatives,59,Republican,"Finch, Blaine",0,00013C
+FRANKLIN,Ottawa Precinct 2,Kansas House of Representatives,59,Republican,"Finch, Blaine",430,000140
+FRANKLIN,Ottawa Precinct 3,Kansas House of Representatives,59,Republican,"Finch, Blaine",234,000150
+FRANKLIN,Ottawa Precinct 6,Kansas House of Representatives,59,Republican,"Finch, Blaine",330,000180
+FRANKLIN,Ottawa Precinct 7,Kansas House of Representatives,59,Republican,"Finch, Blaine",757,000190
+FRANKLIN,Ottawa Precinct 8,Kansas House of Representatives,59,Republican,"Finch, Blaine",988,00020A
+FRANKLIN,Peoria Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",106,000210
+FRANKLIN,Peoria Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",244,000210
+FRANKLIN,Pomona Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",405,000220
+FRANKLIN,Pottawatomie Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",107,000230
+FRANKLIN,Pottawatomie Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",183,000230
+FRANKLIN,Richmond Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",135,000240
+FRANKLIN,Richmond Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",218,000240
+FRANKLIN,Williamsburg Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",243,000250
+FRANKLIN,Ottawa Precinct 4,Kansas House of Representatives,59,Republican,"Finch, Blaine",916,140010
+FRANKLIN,Ottawa Exclave Airport,Kansas House of Representatives,59,Republican,"Finch, Blaine",0,900010
+FRANKLIN,Appanoose Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",37,000010
+FRANKLIN,Appanoose Township,Kansas Senate,12,Republican,"Tyson, Caryn",84,000010
+FRANKLIN,Centropolis North Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",44,000020
+FRANKLIN,Centropolis North Township,Kansas Senate,12,Republican,"Tyson, Caryn",158,000020
+FRANKLIN,Centropolis South Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",54,000030
+FRANKLIN,Centropolis South Township,Kansas Senate,12,Republican,"Tyson, Caryn",178,000030
+FRANKLIN,Cutler Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",88,000040
+FRANKLIN,Cutler Township,Kansas Senate,12,Republican,"Tyson, Caryn",264,000040
+FRANKLIN,Franklin Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",429,000050
+FRANKLIN,Franklin Township,Kansas Senate,12,Republican,"Tyson, Caryn",827,000050
+FRANKLIN,Greenwood Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",45,000060
+FRANKLIN,Greenwood Township,Kansas Senate,12,Republican,"Tyson, Caryn",151,000060
+FRANKLIN,Harrison Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",52,000070
+FRANKLIN,Harrison Township,Kansas Senate,12,Republican,"Tyson, Caryn",200,000070
+FRANKLIN,Hayes Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",50,000080
+FRANKLIN,Hayes Township,Kansas Senate,12,Republican,"Tyson, Caryn",144,000080
+FRANKLIN,Homewood Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",91,000090
+FRANKLIN,Homewood Township,Kansas Senate,12,Republican,"Tyson, Caryn",170,000090
+FRANKLIN,Lincoln Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",126,000100
+FRANKLIN,Lincoln Township,Kansas Senate,12,Republican,"Tyson, Caryn",307,000100
+FRANKLIN,Ohio Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",84,000110
+FRANKLIN,Ohio Township,Kansas Senate,12,Republican,"Tyson, Caryn",254,000110
+FRANKLIN,Ottawa Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",98,00012A
+FRANKLIN,Ottawa Township,Kansas Senate,12,Republican,"Tyson, Caryn",290,00012A
+FRANKLIN,Ottawa Precinct 1,Kansas Senate,12,Democratic,"Johnston, Christopher B.",134,00013A
+FRANKLIN,Ottawa Precinct 1,Kansas Senate,12,Republican,"Tyson, Caryn",224,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),Kansas Senate,12,Republican,"Tyson, Caryn",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),Kansas Senate,12,Republican,"Tyson, Caryn",0,00013C
+FRANKLIN,Ottawa Precinct 2,Kansas Senate,12,Democratic,"Johnston, Christopher B.",148,000140
+FRANKLIN,Ottawa Precinct 2,Kansas Senate,12,Republican,"Tyson, Caryn",262,000140
+FRANKLIN,Ottawa Precinct 3,Kansas Senate,12,Democratic,"Johnston, Christopher B.",99,000150
+FRANKLIN,Ottawa Precinct 3,Kansas Senate,12,Republican,"Tyson, Caryn",141,000150
+FRANKLIN,Ottawa Precinct 6,Kansas Senate,12,Democratic,"Johnston, Christopher B.",103,000180
+FRANKLIN,Ottawa Precinct 6,Kansas Senate,12,Republican,"Tyson, Caryn",175,000180
+FRANKLIN,Ottawa Precinct 7,Kansas Senate,12,Democratic,"Johnston, Christopher B.",312,000190
+FRANKLIN,Ottawa Precinct 7,Kansas Senate,12,Republican,"Tyson, Caryn",419,000190
+FRANKLIN,Ottawa Precinct 8,Kansas Senate,12,Democratic,"Johnston, Christopher B.",304,00020A
+FRANKLIN,Ottawa Precinct 8,Kansas Senate,12,Republican,"Tyson, Caryn",574,00020A
+FRANKLIN,Peoria Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",76,000210
+FRANKLIN,Peoria Township,Kansas Senate,12,Republican,"Tyson, Caryn",245,000210
+FRANKLIN,Pomona Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",99,000220
+FRANKLIN,Pomona Township,Kansas Senate,12,Republican,"Tyson, Caryn",274,000220
+FRANKLIN,Pottawatomie Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",68,000230
+FRANKLIN,Pottawatomie Township,Kansas Senate,12,Republican,"Tyson, Caryn",211,000230
+FRANKLIN,Richmond Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",87,000240
+FRANKLIN,Richmond Township,Kansas Senate,12,Republican,"Tyson, Caryn",223,000240
+FRANKLIN,Williamsburg Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",76,000250
+FRANKLIN,Williamsburg Township,Kansas Senate,12,Republican,"Tyson, Caryn",169,000250
+FRANKLIN,Ottawa Precinct 4,Kansas Senate,12,Democratic,"Johnston, Christopher B.",308,140010
+FRANKLIN,Ottawa Precinct 4,Kansas Senate,12,Republican,"Tyson, Caryn",549,140010
+FRANKLIN,Ottawa Exclave Airport,Kansas Senate,12,Democratic,"Johnston, Christopher B.",0,900010
+FRANKLIN,Ottawa Exclave Airport,Kansas Senate,12,Republican,"Tyson, Caryn",0,900010
+FRANKLIN,Appanoose Township,President / Vice President,,independent,"Stein, Jill",3,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"McMullin, Evan",2,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000010
+FRANKLIN,Appanoose Township,President / Vice President,,Republican,"Trump, Donald J.",93,000010
+FRANKLIN,Centropolis North Township,President / Vice President,,independent,"Stein, Jill",5,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Castle, Darrell L",1,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"McMullin, Evan",3,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000020
+FRANKLIN,Centropolis North Township,President / Vice President,,Republican,"Trump, Donald J.",164,000020
+FRANKLIN,Centropolis South Township,President / Vice President,,independent,"Stein, Jill",5,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"McMullin, Evan",2,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+FRANKLIN,Centropolis South Township,President / Vice President,,Republican,"Trump, Donald J.",181,000030
+FRANKLIN,Cutler Township,President / Vice President,,independent,"Stein, Jill",7,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"McMullin, Evan",4,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+FRANKLIN,Cutler Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,000040
+FRANKLIN,Cutler Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000040
+FRANKLIN,Cutler Township,President / Vice President,,Republican,"Trump, Donald J.",286,000040
+FRANKLIN,Franklin Township,President / Vice President,,independent,"Stein, Jill",30,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",5,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+FRANKLIN,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",351,000050
+FRANKLIN,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",69,000050
+FRANKLIN,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",881,000050
+FRANKLIN,Greenwood Township,President / Vice President,,independent,"Stein, Jill",1,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"McMullin, Evan",1,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+FRANKLIN,Greenwood Township,President / Vice President,,Republican,"Trump, Donald J.",176,000060
+FRANKLIN,Harrison Township,President / Vice President,,independent,"Stein, Jill",6,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Castle, Darrell L",2,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+FRANKLIN,Harrison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",46,000070
+FRANKLIN,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000070
+FRANKLIN,Harrison Township,President / Vice President,,Republican,"Trump, Donald J.",214,000070
+FRANKLIN,Hayes Township,President / Vice President,,independent,"Stein, Jill",2,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+FRANKLIN,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000080
+FRANKLIN,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000080
+FRANKLIN,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",144,000080
+FRANKLIN,Homewood Township,President / Vice President,,independent,"Stein, Jill",6,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"McMullin, Evan",2,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+FRANKLIN,Homewood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000090
+FRANKLIN,Homewood Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000090
+FRANKLIN,Homewood Township,President / Vice President,,Republican,"Trump, Donald J.",180,000090
+FRANKLIN,Lincoln Township,President / Vice President,,independent,"Stein, Jill",11,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",1,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000100
+FRANKLIN,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",359,000100
+FRANKLIN,Ohio Township,President / Vice President,,independent,"Stein, Jill",15,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+FRANKLIN,Ohio Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",90,000110
+FRANKLIN,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000110
+FRANKLIN,Ohio Township,President / Vice President,,Republican,"Trump, Donald J.",280,000110
+FRANKLIN,Ottawa Township,President / Vice President,,independent,"Stein, Jill",9,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Hedges, James A",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"McMullin, Evan",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Smith, Mike",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",93,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Libertarian,"Johnson, Gary",23,00012A
+FRANKLIN,Ottawa Township,President / Vice President,,Republican,"Trump, Donald J.",316,00012A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,independent,"Stein, Jill",7,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",117,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",19,00013A
+FRANKLIN,Ottawa Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",268,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,independent,"Stein, Jill",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Basiago, Andrew D.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Castle, Darrell L",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Giordani, Rocky",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Hedges, James A",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Kahn, Lynn",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"La Riva, Gloria",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Levinson, Michael S.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Maturen, Michael A",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"McMullin, Evan",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Moorehead, Monica G.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Perry, Darryl",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Schriner, Joe C",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Smith, Mike",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Sood, Ajay",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Sterling, Shawna",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Valdivia, Anthony J",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),President / Vice President,,Republican,"Trump, Donald J.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,independent,"Stein, Jill",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Basiago, Andrew D.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Castle, Darrell L",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Giordani, Rocky",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Hedges, James A",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Hoefling, Tom",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Kahn, Lynn",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"La Riva, Gloria",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Levinson, Michael S.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Maturen, Michael A",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"McMullin, Evan",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Moorehead, Monica G.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Perry, Darryl",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Schriner, Joe C",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Smith, Mike",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Sood, Ajay",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Sterling, Shawna",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Valdivia, Anthony J",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Libertarian,"Johnson, Gary",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),President / Vice President,,Republican,"Trump, Donald J.",0,00013C
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,independent,"Stein, Jill",16,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"McMullin, Evan",6,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",132,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",19,000140
+FRANKLIN,Ottawa Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",312,000140
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,independent,"Stein, Jill",6,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",85,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",15,000150
+FRANKLIN,Ottawa Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",160,000150
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,independent,"Stein, Jill",11,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Hedges, James A",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"McMullin, Evan",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Perry, Darryl",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Smith, Mike",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Sood, Ajay",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",119,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",23,000180
+FRANKLIN,Ottawa Precinct 6,President / Vice President,,Republican,"Trump, Donald J.",210,000180
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,independent,"Stein, Jill",25,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Hedges, James A",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"McMullin, Evan",9,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Perry, Darryl",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Smith, Mike",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Sood, Ajay",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",302,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Libertarian,"Johnson, Gary",44,000190
+FRANKLIN,Ottawa Precinct 7,President / Vice President,,Republican,"Trump, Donald J.",493,000190
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,independent,"Stein, Jill",21,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Castle, Darrell L",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Giordani, Rocky",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Hedges, James A",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Kahn, Lynn",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"La Riva, Gloria",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Levinson, Michael S.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Maturen, Michael A",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"McMullin, Evan",6,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Perry, Darryl",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Schriner, Joe C",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Smith, Mike",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Sood, Ajay",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Sterling, Shawna",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Democratic,"Clinton, Hillary Rodham",363,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Libertarian,"Johnson, Gary",47,00020A
+FRANKLIN,Ottawa Precinct 8,President / Vice President,,Republican,"Trump, Donald J.",674,00020A
+FRANKLIN,Peoria Township,President / Vice President,,independent,"Stein, Jill",5,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Castle, Darrell L",2,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"McMullin, Evan",2,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+FRANKLIN,Peoria Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000210
+FRANKLIN,Peoria Township,President / Vice President,,Libertarian,"Johnson, Gary",32,000210
+FRANKLIN,Peoria Township,President / Vice President,,Republican,"Trump, Donald J.",250,000210
+FRANKLIN,Pomona Township,President / Vice President,,independent,"Stein, Jill",11,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+FRANKLIN,Pomona Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",91,000220
+FRANKLIN,Pomona Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000220
+FRANKLIN,Pomona Township,President / Vice President,,Republican,"Trump, Donald J.",312,000220
+FRANKLIN,Pottawatomie Township,President / Vice President,,independent,"Stein, Jill",5,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000230
+FRANKLIN,Pottawatomie Township,President / Vice President,,Republican,"Trump, Donald J.",212,000230
+FRANKLIN,Richmond Township,President / Vice President,,independent,"Stein, Jill",8,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+FRANKLIN,Richmond Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,000240
+FRANKLIN,Richmond Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000240
+FRANKLIN,Richmond Township,President / Vice President,,Republican,"Trump, Donald J.",242,000240
+FRANKLIN,Williamsburg Township,President / Vice President,,independent,"Stein, Jill",10,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"McMullin, Evan",1,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000250
+FRANKLIN,Williamsburg Township,President / Vice President,,Republican,"Trump, Donald J.",187,000250
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,independent,"Stein, Jill",40,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"McMullin, Evan",6,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",321,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",68,140010
+FRANKLIN,Ottawa Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",591,140010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,independent,"Stein, Jill",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Hedges, James A",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"McMullin, Evan",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Perry, Darryl",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Smith, Mike",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Sood, Ajay",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+FRANKLIN,Ottawa Exclave Airport,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Democratic,"Potter, Britani",31,000010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000010
+FRANKLIN,Appanoose Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",94,000010
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Democratic,"Potter, Britani",51,000020
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000020
+FRANKLIN,Centropolis North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,000020
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Democratic,"Potter, Britani",43,000030
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000030
+FRANKLIN,Centropolis South Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",187,000030
+FRANKLIN,Cutler Township,United States House of Representatives,2,Democratic,"Potter, Britani",69,000040
+FRANKLIN,Cutler Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000040
+FRANKLIN,Cutler Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",297,000040
+FRANKLIN,Franklin Township,United States House of Representatives,2,Democratic,"Potter, Britani",346,000050
+FRANKLIN,Franklin Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",91,000050
+FRANKLIN,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",892,000050
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Democratic,"Potter, Britani",43,000060
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000060
+FRANKLIN,Greenwood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",172,000060
+FRANKLIN,Harrison Township,United States House of Representatives,2,Democratic,"Potter, Britani",50,000070
+FRANKLIN,Harrison Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000070
+FRANKLIN,Harrison Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",220,000070
+FRANKLIN,Hayes Township,United States House of Representatives,2,Democratic,"Potter, Britani",43,000080
+FRANKLIN,Hayes Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000080
+FRANKLIN,Hayes Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,000080
+FRANKLIN,Homewood Township,United States House of Representatives,2,Democratic,"Potter, Britani",95,000090
+FRANKLIN,Homewood Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000090
+FRANKLIN,Homewood Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",177,000090
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",120,000100
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,000100
+FRANKLIN,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",363,000100
+FRANKLIN,Ohio Township,United States House of Representatives,2,Democratic,"Potter, Britani",93,000110
+FRANKLIN,Ohio Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000110
+FRANKLIN,Ohio Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",290,000110
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Democratic,"Potter, Britani",106,00012A
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,00012A
+FRANKLIN,Ottawa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",319,00012A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",139,00013A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,00013A
+FRANKLIN,Ottawa Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",255,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Democratic,"Potter, Britani",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Democratic,"Potter, Britani",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00013C
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",155,000140
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",32,000140
+FRANKLIN,Ottawa Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",283,000140
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",96,000150
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000150
+FRANKLIN,Ottawa Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000150
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Democratic,"Potter, Britani",120,000180
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000180
+FRANKLIN,Ottawa Precinct 6,United States House of Representatives,2,Republican,"Jenkins, Lynn",219,000180
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Democratic,"Potter, Britani",337,000190
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Libertarian,"Bales, James Houston",55,000190
+FRANKLIN,Ottawa Precinct 7,United States House of Representatives,2,Republican,"Jenkins, Lynn",460,000190
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Democratic,"Potter, Britani",391,00020A
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Libertarian,"Bales, James Houston",48,00020A
+FRANKLIN,Ottawa Precinct 8,United States House of Representatives,2,Republican,"Jenkins, Lynn",668,00020A
+FRANKLIN,Peoria Township,United States House of Representatives,2,Democratic,"Potter, Britani",82,000210
+FRANKLIN,Peoria Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000210
+FRANKLIN,Peoria Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",254,000210
+FRANKLIN,Pomona Township,United States House of Representatives,2,Democratic,"Potter, Britani",104,000220
+FRANKLIN,Pomona Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000220
+FRANKLIN,Pomona Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",306,000220
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Democratic,"Potter, Britani",73,000230
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000230
+FRANKLIN,Pottawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",210,000230
+FRANKLIN,Richmond Township,United States House of Representatives,2,Democratic,"Potter, Britani",89,000240
+FRANKLIN,Richmond Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000240
+FRANKLIN,Richmond Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",245,000240
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Democratic,"Potter, Britani",80,000250
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000250
+FRANKLIN,Williamsburg Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",175,000250
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",337,140010
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",63,140010
+FRANKLIN,Ottawa Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",607,140010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+FRANKLIN,Appanoose Township,United States Senate,,write - in,"Smith, DJ",0,000010
+FRANKLIN,Appanoose Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000010
+FRANKLIN,Appanoose Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000010
+FRANKLIN,Appanoose Township,United States Senate,,Republican,"Moran, Jerry",101,000010
+FRANKLIN,Centropolis North Township,United States Senate,,write - in,"Smith, DJ",0,000020
+FRANKLIN,Centropolis North Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000020
+FRANKLIN,Centropolis North Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000020
+FRANKLIN,Centropolis North Township,United States Senate,,Republican,"Moran, Jerry",164,000020
+FRANKLIN,Centropolis South Township,United States Senate,,write - in,"Smith, DJ",0,000030
+FRANKLIN,Centropolis South Township,United States Senate,,Democratic,"Wiesner, Patrick",46,000030
+FRANKLIN,Centropolis South Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000030
+FRANKLIN,Centropolis South Township,United States Senate,,Republican,"Moran, Jerry",184,000030
+FRANKLIN,Cutler Township,United States Senate,,write - in,"Smith, DJ",0,000040
+FRANKLIN,Cutler Township,United States Senate,,Democratic,"Wiesner, Patrick",79,000040
+FRANKLIN,Cutler Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000040
+FRANKLIN,Cutler Township,United States Senate,,Republican,"Moran, Jerry",290,000040
+FRANKLIN,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000050
+FRANKLIN,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",345,000050
+FRANKLIN,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",126,000050
+FRANKLIN,Franklin Township,United States Senate,,Republican,"Moran, Jerry",864,000050
+FRANKLIN,Greenwood Township,United States Senate,,write - in,"Smith, DJ",0,000060
+FRANKLIN,Greenwood Township,United States Senate,,Democratic,"Wiesner, Patrick",44,000060
+FRANKLIN,Greenwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000060
+FRANKLIN,Greenwood Township,United States Senate,,Republican,"Moran, Jerry",171,000060
+FRANKLIN,Harrison Township,United States Senate,,write - in,"Smith, DJ",0,000070
+FRANKLIN,Harrison Township,United States Senate,,Democratic,"Wiesner, Patrick",48,000070
+FRANKLIN,Harrison Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000070
+FRANKLIN,Harrison Township,United States Senate,,Republican,"Moran, Jerry",225,000070
+FRANKLIN,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000080
+FRANKLIN,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",46,000080
+FRANKLIN,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000080
+FRANKLIN,Hayes Township,United States Senate,,Republican,"Moran, Jerry",165,000080
+FRANKLIN,Homewood Township,United States Senate,,write - in,"Smith, DJ",0,000090
+FRANKLIN,Homewood Township,United States Senate,,Democratic,"Wiesner, Patrick",80,000090
+FRANKLIN,Homewood Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000090
+FRANKLIN,Homewood Township,United States Senate,,Republican,"Moran, Jerry",195,000090
+FRANKLIN,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000100
+FRANKLIN,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",108,000100
+FRANKLIN,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",27,000100
+FRANKLIN,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",375,000100
+FRANKLIN,Ohio Township,United States Senate,,write - in,"Smith, DJ",0,000110
+FRANKLIN,Ohio Township,United States Senate,,Democratic,"Wiesner, Patrick",80,000110
+FRANKLIN,Ohio Township,United States Senate,,Libertarian,"Garrard, Robert D.",22,000110
+FRANKLIN,Ohio Township,United States Senate,,Republican,"Moran, Jerry",296,000110
+FRANKLIN,Ottawa Township,United States Senate,,write - in,"Smith, DJ",0,00012A
+FRANKLIN,Ottawa Township,United States Senate,,Democratic,"Wiesner, Patrick",75,00012A
+FRANKLIN,Ottawa Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,00012A
+FRANKLIN,Ottawa Township,United States Senate,,Republican,"Moran, Jerry",335,00012A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00013A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",108,00013A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",27,00013A
+FRANKLIN,Ottawa Precinct 1,United States Senate,,Republican,"Moran, Jerry",268,00013A
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,write - in,"Smith, DJ",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,Democratic,"Wiesner, Patrick",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,Libertarian,"Garrard, Robert D.",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (A),United States Senate,,Republican,"Moran, Jerry",0,00013B
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,write - in,"Smith, DJ",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,Democratic,"Wiesner, Patrick",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,Libertarian,"Garrard, Robert D.",0,00013C
+FRANKLIN,Ottawa Precinct 1 Exclave (B),United States Senate,,Republican,"Moran, Jerry",0,00013C
+FRANKLIN,Ottawa Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000140
+FRANKLIN,Ottawa Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",140,000140
+FRANKLIN,Ottawa Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",42,000140
+FRANKLIN,Ottawa Precinct 2,United States Senate,,Republican,"Moran, Jerry",295,000140
+FRANKLIN,Ottawa Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000150
+FRANKLIN,Ottawa Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",80,000150
+FRANKLIN,Ottawa Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",18,000150
+FRANKLIN,Ottawa Precinct 3,United States Senate,,Republican,"Moran, Jerry",159,000150
+FRANKLIN,Ottawa Precinct 6,United States Senate,,write - in,"Smith, DJ",0,000180
+FRANKLIN,Ottawa Precinct 6,United States Senate,,Democratic,"Wiesner, Patrick",116,000180
+FRANKLIN,Ottawa Precinct 6,United States Senate,,Libertarian,"Garrard, Robert D.",21,000180
+FRANKLIN,Ottawa Precinct 6,United States Senate,,Republican,"Moran, Jerry",225,000180
+FRANKLIN,Ottawa Precinct 7,United States Senate,,write - in,"Smith, DJ",0,000190
+FRANKLIN,Ottawa Precinct 7,United States Senate,,Democratic,"Wiesner, Patrick",268,000190
+FRANKLIN,Ottawa Precinct 7,United States Senate,,Libertarian,"Garrard, Robert D.",71,000190
+FRANKLIN,Ottawa Precinct 7,United States Senate,,Republican,"Moran, Jerry",517,000190
+FRANKLIN,Ottawa Precinct 8,United States Senate,,write - in,"Smith, DJ",0,00020A
+FRANKLIN,Ottawa Precinct 8,United States Senate,,Democratic,"Wiesner, Patrick",330,00020A
+FRANKLIN,Ottawa Precinct 8,United States Senate,,Libertarian,"Garrard, Robert D.",62,00020A
+FRANKLIN,Ottawa Precinct 8,United States Senate,,Republican,"Moran, Jerry",712,00020A
+FRANKLIN,Peoria Township,United States Senate,,write - in,"Smith, DJ",0,000210
+FRANKLIN,Peoria Township,United States Senate,,Democratic,"Wiesner, Patrick",70,000210
+FRANKLIN,Peoria Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,000210
+FRANKLIN,Peoria Township,United States Senate,,Republican,"Moran, Jerry",256,000210
+FRANKLIN,Pomona Township,United States Senate,,write - in,"Smith, DJ",0,000220
+FRANKLIN,Pomona Township,United States Senate,,Democratic,"Wiesner, Patrick",97,000220
+FRANKLIN,Pomona Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000220
+FRANKLIN,Pomona Township,United States Senate,,Republican,"Moran, Jerry",311,000220
+FRANKLIN,Pottawatomie Township,United States Senate,,write - in,"Smith, DJ",1,000230
+FRANKLIN,Pottawatomie Township,United States Senate,,Democratic,"Wiesner, Patrick",62,000230
+FRANKLIN,Pottawatomie Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000230
+FRANKLIN,Pottawatomie Township,United States Senate,,Republican,"Moran, Jerry",211,000230
+FRANKLIN,Richmond Township,United States Senate,,write - in,"Smith, DJ",0,000240
+FRANKLIN,Richmond Township,United States Senate,,Democratic,"Wiesner, Patrick",80,000240
+FRANKLIN,Richmond Township,United States Senate,,Libertarian,"Garrard, Robert D.",32,000240
+FRANKLIN,Richmond Township,United States Senate,,Republican,"Moran, Jerry",240,000240
+FRANKLIN,Williamsburg Township,United States Senate,,write - in,"Smith, DJ",0,000250
+FRANKLIN,Williamsburg Township,United States Senate,,Democratic,"Wiesner, Patrick",65,000250
+FRANKLIN,Williamsburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000250
+FRANKLIN,Williamsburg Township,United States Senate,,Republican,"Moran, Jerry",191,000250
+FRANKLIN,Ottawa Precinct 4,United States Senate,,write - in,"Smith, DJ",0,140010
+FRANKLIN,Ottawa Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",300,140010
+FRANKLIN,Ottawa Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",75,140010
+FRANKLIN,Ottawa Precinct 4,United States Senate,,Republican,"Moran, Jerry",644,140010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,write - in,"Smith, DJ",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+FRANKLIN,Ottawa Exclave Airport,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__geary__precinct.csv
+++ b/2016/20161108__ks__general__geary__precinct.csv
@@ -1,534 +1,1808 @@
-county,precinct,office,district,candidate,party,votes
-Geary,W1P1,President,,Gary Johnson,LBT,4
-Geary,W1P2,President,,Gary Johnson,LBT,7
-Geary,W1P3,President,,Gary Johnson,LBT,10
-Geary,W1P4,President,,Gary Johnson,LBT,16
-Geary,W1P5,President,,Gary Johnson,LBT,6
-Geary,W1P6,President,,Gary Johnson,LBT,15
-Geary,W1P7,President,,Gary Johnson,LBT,24
-Geary,W2P1,President,,Gary Johnson,LBT,6
-Geary,W2P2,President,,Gary Johnson,LBT,9
-Geary,W2P3,President,,Gary Johnson,LBT,0
-Geary,W2P4,President,,Gary Johnson,LBT,4
-Geary,W2P5,President,,Gary Johnson,LBT,9
-Geary,W2P6,President,,Gary Johnson,LBT,5
-Geary,W2P7,President,,Gary Johnson,LBT,12
-Geary,W2P8,President,,Gary Johnson,LBT,3
-Geary,W3P1,President,,Gary Johnson,LBT,6
-Geary,W3P2,President,,Gary Johnson,LBT,25
-Geary,W3P3,President,,Gary Johnson,LBT,12
-Geary,W3P4,President,,Gary Johnson,LBT,1
-Geary,W4P1,President,,Gary Johnson,LBT,10
-Geary,W4P2,President,,Gary Johnson,LBT,5
-Geary,W4P3,President,,Gary Johnson,LBT,9
-Geary,W4P4,President,,Gary Johnson,LBT,13
-Geary,Blakely Twp,President,,Gary Johnson,LBT,1
-Geary,Grandview Plaza Pct,President,,Gary Johnson,LBT,23
-Geary,Jefferson Precinct,President,,Gary Johnson,LBT,6
-Geary,Jackson Twp,President,,Gary Johnson,LBT,2
-Geary,Liberty Twp,President,,Gary Johnson,LBT,0
-Geary,Lyon Twp,President,,Gary Johnson,LBT,5
-Geary,Milford City,President,,Gary Johnson,LBT,7
-Geary,Milford Twp,President,,Gary Johnson,LBT,18
-Geary,Ft. Riley B,President,,Gary Johnson,LBT,16
-Geary,Ft. Riley A,President,,Gary Johnson,LBT,0
-Geary,Smoky Hill Twp Pct 2,President,,Gary Johnson,LBT,0
-Geary,Smoky Hill Twp Pct 3,President,,Gary Johnson,LBT,5
-Geary,Smoky Hill Twp Pct 4,President,,Gary Johnson,LBT,2
-Geary,Smoky Hill Twp Pct 5,President,,Gary Johnson,LBT,10
-Geary,Smoky Hill Twp Pct 6,President,,Gary Johnson,LBT,1
-Geary,Wingfield Twp,President,,Gary Johnson,LBT,5
-Geary,Total,President,,Gary Johnson,LBT,312
-Geary,W1P1,President,,Jill Stein,GRN,4
-Geary,W1P2,President,,Jill Stein,GRN,2
-Geary,W1P3,President,,Jill Stein,GRN,9
-Geary,W1P4,President,,Jill Stein,GRN,13
-Geary,W1P5,President,,Jill Stein,GRN,10
-Geary,W1P6,President,,Jill Stein,GRN,7
-Geary,W1P7,President,,Jill Stein,GRN,9
-Geary,W2P1,President,,Jill Stein,GRN,1
-Geary,W2P2,President,,Jill Stein,GRN,8
-Geary,W2P3,President,,Jill Stein,GRN,2
-Geary,W2P4,President,,Jill Stein,GRN,3
-Geary,W2P5,President,,Jill Stein,GRN,2
-Geary,W2P6,President,,Jill Stein,GRN,3
-Geary,W2P7,President,,Jill Stein,GRN,5
-Geary,W2P8,President,,Jill Stein,GRN,3
-Geary,W3P1,President,,Jill Stein,GRN,8
-Geary,W3P2,President,,Jill Stein,GRN,8
-Geary,W3P3,President,,Jill Stein,GRN,3
-Geary,W3P4,President,,Jill Stein,GRN,1
-Geary,W4P1,President,,Jill Stein,GRN,4
-Geary,W4P2,President,,Jill Stein,GRN,2
-Geary,W4P3,President,,Jill Stein,GRN,5
-Geary,W4P4,President,,Jill Stein,GRN,6
-Geary,Blakely Twp,President,,Jill Stein,GRN,0
-Geary,Grandview Plaza Pct,President,,Jill Stein,GRN,4
-Geary,Jefferson Precinct,President,,Jill Stein,GRN,1
-Geary,Jackson Twp,President,,Jill Stein,GRN,1
-Geary,Liberty Twp,President,,Jill Stein,GRN,2
-Geary,Lyon Twp,President,,Jill Stein,GRN,1
-Geary,Milford City,President,,Jill Stein,GRN,1
-Geary,Milford Twp,President,,Jill Stein,GRN,14
-Geary,Ft. Riley B,President,,Jill Stein,GRN,5
-Geary,Ft. Riley A,President,,Jill Stein,GRN,2
-Geary,Smoky Hill Twp Pct 2,President,,Jill Stein,GRN,0
-Geary,Smoky Hill Twp Pct 3,President,,Jill Stein,GRN,0
-Geary,Smoky Hill Twp Pct 4,President,,Jill Stein,GRN,2
-Geary,Smoky Hill Twp Pct 5,President,,Jill Stein,GRN,2
-Geary,Smoky Hill Twp Pct 6,President,,Jill Stein,GRN,1
-Geary,Wingfield Twp,President,,Jill Stein,GRN,2
-Geary,Total,President,,Jill Stein,GRN,156
-Geary,W1P1,President,,Donald J Trump,R,99
-Geary,W1P2,President,,Donald J Trump,R,100
-Geary,W1P3,President,,Donald J Trump,R,185
-Geary,W1P4,President,,Donald J Trump,R,255
-Geary,W1P5,President,,Donald J Trump,R,148
-Geary,W1P6,President,,Donald J Trump,R,180
-Geary,W1P7,President,,Donald J Trump,R,242
-Geary,W2P1,President,,Donald J Trump,R,43
-Geary,W2P2,President,,Donald J Trump,R,126
-Geary,W2P3,President,,Donald J Trump,R,30
-Geary,W2P4,President,,Donald J Trump,R,32
-Geary,W2P5,President,,Donald J Trump,R,146
-Geary,W2P6,President,,Donald J Trump,R,90
-Geary,W2P7,President,,Donald J Trump,R,147
-Geary,W2P8,President,,Donald J Trump,R,53
-Geary,W3P1,President,,Donald J Trump,R,65
-Geary,W3P2,President,,Donald J Trump,R,159
-Geary,W3P3,President,,Donald J Trump,R,98
-Geary,W3P4,President,,Donald J Trump,R,51
-Geary,W4P1,President,,Donald J Trump,R,88
-Geary,W4P2,President,,Donald J Trump,R,41
-Geary,W4P3,President,,Donald J Trump,R,94
-Geary,W4P4,President,,Donald J Trump,R,164
-Geary,Blakely Twp,President,,Donald J Trump,R,54
-Geary,Grandview Plaza Pct,President,,Donald J Trump,R,199
-Geary,Jefferson Precinct,President,,Donald J Trump,R,146
-Geary,Jackson Twp,President,,Donald J Trump,R,36
-Geary,Liberty Twp,President,,Donald J Trump,R,77
-Geary,Lyon Twp,President,,Donald J Trump,R,130
-Geary,Milford City,President,,Donald J Trump,R,118
-Geary,Milford Twp,President,,Donald J Trump,R,380
-Geary,Ft. Riley B,President,,Donald J Trump,R,118
-Geary,Ft. Riley A,President,,Donald J Trump,R,25
-Geary,Smoky Hill Twp Pct 2,President,,Donald J Trump,R,6
-Geary,Smoky Hill Twp Pct 3,President,,Donald J Trump,R,57
-Geary,Smoky Hill Twp Pct 4,President,,Donald J Trump,R,60
-Geary,Smoky Hill Twp Pct 5,President,,Donald J Trump,R,138
-Geary,Smoky Hill Twp Pct 6,President,,Donald J Trump,R,21
-Geary,Wingfield Twp,President,,Donald J Trump,R,73
-Geary,Total,President,,Donald J Trump,R,4274
-Geary,W1P1,President,,Hillary Clinton,D,84
-Geary,W1P2,President,,Hillary Clinton,D,65
-Geary,W1P3,President,,Hillary Clinton,D,74
-Geary,W1P4,President,,Hillary Clinton,D,200
-Geary,W1P5,President,,Hillary Clinton,D,116
-Geary,W1P6,President,,Hillary Clinton,D,171
-Geary,W1P7,President,,Hillary Clinton,D,188
-Geary,W2P1,President,,Hillary Clinton,D,37
-Geary,W2P2,President,,Hillary Clinton,D,124
-Geary,W2P3,President,,Hillary Clinton,D,33
-Geary,W2P4,President,,Hillary Clinton,D,18
-Geary,W2P5,President,,Hillary Clinton,D,112
-Geary,W2P6,President,,Hillary Clinton,D,74
-Geary,W2P7,President,,Hillary Clinton,D,116
-Geary,W2P8,President,,Hillary Clinton,D,32
-Geary,W3P1,President,,Hillary Clinton,D,52
-Geary,W3P2,President,,Hillary Clinton,D,103
-Geary,W3P3,President,,Hillary Clinton,D,96
-Geary,W3P4,President,,Hillary Clinton,D,29
-Geary,W4P1,President,,Hillary Clinton,D,90
-Geary,W4P2,President,,Hillary Clinton,D,43
-Geary,W4P3,President,,Hillary Clinton,D,123
-Geary,W4P4,President,,Hillary Clinton,D,201
-Geary,Blakely Twp,President,,Hillary Clinton,D,8
-Geary,Grandview Plaza Pct,President,,Hillary Clinton,D,69
-Geary,Jefferson Precinct,President,,Hillary Clinton,D,38
-Geary,Jackson Twp,President,,Hillary Clinton,D,11
-Geary,Liberty Twp,President,,Hillary Clinton,D,24
-Geary,Lyon Twp,President,,Hillary Clinton,D,15
-Geary,Milford City,President,,Hillary Clinton,D,48
-Geary,Milford Twp,President,,Hillary Clinton,D,120
-Geary,Ft. Riley B,President,,Hillary Clinton,D,79
-Geary,Ft. Riley A,President,,Hillary Clinton,D,21
-Geary,Smoky Hill Twp Pct 2,President,,Hillary Clinton,D,1
-Geary,Smoky Hill Twp Pct 3,President,,Hillary Clinton,D,26
-Geary,Smoky Hill Twp Pct 4,President,,Hillary Clinton,D,22
-Geary,Smoky Hill Twp Pct 5,President,,Hillary Clinton,D,35
-Geary,Smoky Hill Twp Pct 6,President,,Hillary Clinton,D,2
-Geary,Wingfield Twp,President,,Hillary Clinton,D,22
-Geary,Total,President,,Hillary Clinton,D,2722
-Geary,W1P1,U.S. Senate,,Jerry Moran,R,117
-Geary,W1P2,U.S. Senate,,Jerry Moran,R,111
-Geary,W1P3,U.S. Senate,,Jerry Moran,R,214
-Geary,W1P4,U.S. Senate,,Jerry Moran,R,322
-Geary,W1P5,U.S. Senate,,Jerry Moran,R,179
-Geary,W1P6,U.S. Senate,,Jerry Moran,R,229
-Geary,W1P7,U.S. Senate,,Jerry Moran,R,284
-Geary,W2P1,U.S. Senate,,Jerry Moran,R,51
-Geary,W2P2,U.S. Senate,,Jerry Moran,R,156
-Geary,W2P3,U.S. Senate,,Jerry Moran,R,44
-Geary,W2P4,U.S. Senate,,Jerry Moran,R,34
-Geary,W2P5,U.S. Senate,,Jerry Moran,R,169
-Geary,W2P6,U.S. Senate,,Jerry Moran,R,114
-Geary,W2P7,U.S. Senate,,Jerry Moran,R,180
-Geary,W2P8,U.S. Senate,,Jerry Moran,R,61
-Geary,W3P1,U.S. Senate,,Jerry Moran,R,69
-Geary,W3P2,U.S. Senate,,Jerry Moran,R,177
-Geary,W3P3,U.S. Senate,,Jerry Moran,R,130
-Geary,W3P4,U.S. Senate,,Jerry Moran,R,56
-Geary,W4P1,U.S. Senate,,Jerry Moran,R,99
-Geary,W4P2,U.S. Senate,,Jerry Moran,R,42
-Geary,W4P3,U.S. Senate,,Jerry Moran,R,113
-Geary,W4P4,U.S. Senate,,Jerry Moran,R,197
-Geary,Blakely Twp,U.S. Senate,,Jerry Moran,R,55
-Geary,Grandview Plaza Pct,U.S. Senate,,Jerry Moran,R,208
-Geary,Jefferson Precinct,U.S. Senate,,Jerry Moran,R,159
-Geary,Jackson Twp,U.S. Senate,,Jerry Moran,R,41
-Geary,Liberty Twp,U.S. Senate,,Jerry Moran,R,84
-Geary,Lyon Twp,U.S. Senate,,Jerry Moran,R,133
-Geary,Milford City,U.S. Senate,,Jerry Moran,R,124
-Geary,Milford Twp,U.S. Senate,,Jerry Moran,R,409
-Geary,Ft. Riley B,U.S. Senate,,Jerry Moran,R,130
-Geary,Ft. Riley A,U.S. Senate,,Jerry Moran,R,26
-Geary,Smoky Hill Twp Pct 2,U.S. Senate,,Jerry Moran,R,7
-Geary,Smoky Hill Twp Pct 3,U.S. Senate,,Jerry Moran,R,65
-Geary,Smoky Hill Twp Pct 4,U.S. Senate,,Jerry Moran,R,66
-Geary,Smoky Hill Twp Pct 5,U.S. Senate,,Jerry Moran,R,169
-Geary,Smoky Hill Twp Pct 6,U.S. Senate,,Jerry Moran,R,20
-Geary,Wingfield Twp,U.S. Senate,,Jerry Moran,R,74
-Geary,Total,U.S. Senate,,Jerry Moran,R,4918
-Geary,W1P1,U.S. Senate,,Patrick Wiesner,D,67
-Geary,W1P2,U.S. Senate,,Patrick Wiesner,D,56
-Geary,W1P3,U.S. Senate,,Patrick Wiesner,D,49
-Geary,W1P4,U.S. Senate,,Patrick Wiesner,D,151
-Geary,W1P5,U.S. Senate,,Patrick Wiesner,D,91
-Geary,W1P6,U.S. Senate,,Patrick Wiesner,D,129
-Geary,W1P7,U.S. Senate,,Patrick Wiesner,D,147
-Geary,W2P1,U.S. Senate,,Patrick Wiesner,D,29
-Geary,W2P2,U.S. Senate,,Patrick Wiesner,D,94
-Geary,W2P3,U.S. Senate,,Patrick Wiesner,D,20
-Geary,W2P4,U.S. Senate,,Patrick Wiesner,D,18
-Geary,W2P5,U.S. Senate,,Patrick Wiesner,D,96
-Geary,W2P6,U.S. Senate,,Patrick Wiesner,D,55
-Geary,W2P7,U.S. Senate,,Patrick Wiesner,D,93
-Geary,W2P8,U.S. Senate,,Patrick Wiesner,D,27
-Geary,W3P1,U.S. Senate,,Patrick Wiesner,D,52
-Geary,W3P2,U.S. Senate,,Patrick Wiesner,D,90
-Geary,W3P3,U.S. Senate,,Patrick Wiesner,D,73
-Geary,W3P4,U.S. Senate,,Patrick Wiesner,D,27
-Geary,W4P1,U.S. Senate,,Patrick Wiesner,D,74
-Geary,W4P2,U.S. Senate,,Patrick Wiesner,D,45
-Geary,W4P3,U.S. Senate,,Patrick Wiesner,D,105
-Geary,W4P4,U.S. Senate,,Patrick Wiesner,D,164
-Geary,Blakely Twp,U.S. Senate,,Patrick Wiesner,D,6
-Geary,Grandview Plaza Pct,U.S. Senate,,Patrick Wiesner,D,58
-Geary,Jefferson Precinct,U.S. Senate,,Patrick Wiesner,D,25
-Geary,Jackson Twp,U.S. Senate,,Patrick Wiesner,D,5
-Geary,Liberty Twp,U.S. Senate,,Patrick Wiesner,D,19
-Geary,Lyon Twp,U.S. Senate,,Patrick Wiesner,D,12
-Geary,Milford City,U.S. Senate,,Patrick Wiesner,D,32
-Geary,Milford Twp,U.S. Senate,,Patrick Wiesner,D,104
-Geary,Ft. Riley B,U.S. Senate,,Patrick Wiesner,D,70
-Geary,Ft. Riley A,U.S. Senate,,Patrick Wiesner,D,19
-Geary,Smoky Hill Twp Pct 2,U.S. Senate,,Patrick Wiesner,D,1
-Geary,Smoky Hill Twp Pct 3,U.S. Senate,,Patrick Wiesner,D,19
-Geary,Smoky Hill Twp Pct 4,U.S. Senate,,Patrick Wiesner,D,20
-Geary,Smoky Hill Twp Pct 5,U.S. Senate,,Patrick Wiesner,D,16
-Geary,Smoky Hill Twp Pct 6,U.S. Senate,,Patrick Wiesner,D,3
-Geary,Wingfield Twp,U.S. Senate,,Patrick Wiesner,D,26
-Geary,Total,U.S. Senate,,Patrick Wiesner,D,2187
-Geary,W1P1,U.S. Senate,,Robert Garrard,LBT,8
-Geary,W1P2,U.S. Senate,,Robert Garrard,LBT,8
-Geary,W1P3,U.S. Senate,,Robert Garrard,LBT,15
-Geary,W1P4,U.S. Senate,,Robert Garrard,LBT,14
-Geary,W1P5,U.S. Senate,,Robert Garrard,LBT,11
-Geary,W1P6,U.S. Senate,,Robert Garrard,LBT,17
-Geary,W1P7,U.S. Senate,,Robert Garrard,LBT,27
-Geary,W2P1,U.S. Senate,,Robert Garrard,LBT,5
-Geary,W2P2,U.S. Senate,,Robert Garrard,LBT,16
-Geary,W2P3,U.S. Senate,,Robert Garrard,LBT,0
-Geary,W2P4,U.S. Senate,,Robert Garrard,LBT,3
-Geary,W2P5,U.S. Senate,,Robert Garrard,LBT,11
-Geary,W2P6,U.S. Senate,,Robert Garrard,LBT,7
-Geary,W2P7,U.S. Senate,,Robert Garrard,LBT,11
-Geary,W2P8,U.S. Senate,,Robert Garrard,LBT,2
-Geary,W3P1,U.S. Senate,,Robert Garrard,LBT,7
-Geary,W3P2,U.S. Senate,,Robert Garrard,LBT,18
-Geary,W3P3,U.S. Senate,,Robert Garrard,LBT,10
-Geary,W3P4,U.S. Senate,,Robert Garrard,LBT,2
-Geary,W4P1,U.S. Senate,,Robert Garrard,LBT,14
-Geary,W4P2,U.S. Senate,,Robert Garrard,LBT,6
-Geary,W4P3,U.S. Senate,,Robert Garrard,LBT,9
-Geary,W4P4,U.S. Senate,,Robert Garrard,LBT,12
-Geary,Blakely Twp,U.S. Senate,,Robert Garrard,LBT,2
-Geary,Grandview Plaza Pct,U.S. Senate,,Robert Garrard,LBT,15
-Geary,Jefferson Precinct,U.S. Senate,,Robert Garrard,LBT,8
-Geary,Jackson Twp,U.S. Senate,,Robert Garrard,LBT,2
-Geary,Liberty Twp,U.S. Senate,,Robert Garrard,LBT,3
-Geary,Lyon Twp,U.S. Senate,,Robert Garrard,LBT,3
-Geary,Milford City,U.S. Senate,,Robert Garrard,LBT,15
-Geary,Milford Twp,U.S. Senate,,Robert Garrard,LBT,26
-Geary,Ft. Riley B,U.S. Senate,,Robert Garrard,LBT,14
-Geary,Ft. Riley A,U.S. Senate,,Robert Garrard,LBT,4
-Geary,Smoky Hill Twp Pct 2,U.S. Senate,,Robert Garrard,LBT,0
-Geary,Smoky Hill Twp Pct 3,U.S. Senate,,Robert Garrard,LBT,4
-Geary,Smoky Hill Twp Pct 4,U.S. Senate,,Robert Garrard,LBT,1
-Geary,Smoky Hill Twp Pct 5,U.S. Senate,,Robert Garrard,LBT,2
-Geary,Smoky Hill Twp Pct 6,U.S. Senate,,Robert Garrard,LBT,3
-Geary,Wingfield Twp,U.S. Senate,,Robert Garrard,LBT,3
-Geary,Total,U.S. Senate,,Robert Garrard,LBT,338
-Geary,W1P1,U.S. House,1,Kerry Burt,LBT,18
-Geary,W1P2,U.S. House,1,Kerry Burt,LBT,20
-Geary,W1P3,U.S. House,1,Kerry Burt,LBT,19
-Geary,W1P4,U.S. House,1,Kerry Burt,LBT,40
-Geary,W1P5,U.S. House,1,Kerry Burt,LBT,25
-Geary,W1P6,U.S. House,1,Kerry Burt,LBT,42
-Geary,W1P7,U.S. House,1,Kerry Burt,LBT,48
-Geary,W2P1,U.S. House,1,Kerry Burt,LBT,18
-Geary,W2P2,U.S. House,1,Kerry Burt,LBT,29
-Geary,W2P3,U.S. House,1,Kerry Burt,LBT,2
-Geary,W2P4,U.S. House,1,Kerry Burt,LBT,7
-Geary,W2P5,U.S. House,1,Kerry Burt,LBT,34
-Geary,W2P6,U.S. House,1,Kerry Burt,LBT,21
-Geary,W2P7,U.S. House,1,Kerry Burt,LBT,38
-Geary,W2P8,U.S. House,1,Kerry Burt,LBT,13
-Geary,W3P1,U.S. House,1,Kerry Burt,LBT,15
-Geary,W3P2,U.S. House,1,Kerry Burt,LBT,46
-Geary,W3P3,U.S. House,1,Kerry Burt,LBT,23
-Geary,W3P4,U.S. House,1,Kerry Burt,LBT,9
-Geary,W4P1,U.S. House,1,Kerry Burt,LBT,39
-Geary,W4P2,U.S. House,1,Kerry Burt,LBT,12
-Geary,W4P3,U.S. House,1,Kerry Burt,LBT,45
-Geary,W4P4,U.S. House,1,Kerry Burt,LBT,44
-Geary,Blakely Twp,U.S. House,1,Kerry Burt,LBT,6
-Geary,Grandview Plaza Pct,U.S. House,1,Kerry Burt,LBT,42
-Geary,Jefferson Precinct,U.S. House,1,Kerry Burt,LBT,13
-Geary,Jackson Twp,U.S. House,1,Kerry Burt,LBT,3
-Geary,Liberty Twp,U.S. House,1,Kerry Burt,LBT,7
-Geary,Lyon Twp,U.S. House,1,Kerry Burt,LBT,5
-Geary,Milford City,U.S. House,1,Kerry Burt,LBT,20
-Geary,Milford Twp,U.S. House,1,Kerry Burt,LBT,42
-Geary,Ft. Riley B,U.S. House,1,Kerry Burt,LBT,30
-Geary,Ft. Riley A,U.S. House,1,Kerry Burt,LBT,7
-Geary,Smoky Hill Twp Pct 2,U.S. House,1,Kerry Burt,LBT,0
-Geary,Smoky Hill Twp Pct 3,U.S. House,1,Kerry Burt,LBT,11
-Geary,Smoky Hill Twp Pct 4,U.S. House,1,Kerry Burt,LBT,10
-Geary,Smoky Hill Twp Pct 5,U.S. House,1,Kerry Burt,LBT,8
-Geary,Smoky Hill Twp Pct 6,U.S. House,1,Kerry Burt,LBT,4
-Geary,Wingfield Twp,U.S. House,1,Kerry Burt,LBT,3
-Geary,Total,U.S. House,1,Kerry Burt,LBT,818
-Geary,W1P1,U.S. House,1,Alan LaPolice,IND,43
-Geary,W1P2,U.S. House,1,Alan LaPolice,IND,53
-Geary,W1P3,U.S. House,1,Alan LaPolice,IND,62
-Geary,W1P4,U.S. House,1,Alan LaPolice,IND,129
-Geary,W1P5,U.S. House,1,Alan LaPolice,IND,88
-Geary,W1P6,U.S. House,1,Alan LaPolice,IND,96
-Geary,W1P7,U.S. House,1,Alan LaPolice,IND,117
-Geary,W2P1,U.S. House,1,Alan LaPolice,IND,19
-Geary,W2P2,U.S. House,1,Alan LaPolice,IND,77
-Geary,W2P3,U.S. House,1,Alan LaPolice,IND,11
-Geary,W2P4,U.S. House,1,Alan LaPolice,IND,11
-Geary,W2P5,U.S. House,1,Alan LaPolice,IND,64
-Geary,W2P6,U.S. House,1,Alan LaPolice,IND,43
-Geary,W2P7,U.S. House,1,Alan LaPolice,IND,67
-Geary,W2P8,U.S. House,1,Alan LaPolice,IND,24
-Geary,W3P1,U.S. House,1,Alan LaPolice,IND,36
-Geary,W3P2,U.S. House,1,Alan LaPolice,IND,80
-Geary,W3P3,U.S. House,1,Alan LaPolice,IND,65
-Geary,W3P4,U.S. House,1,Alan LaPolice,IND,23
-Geary,W4P1,U.S. House,1,Alan LaPolice,IND,55
-Geary,W4P2,U.S. House,1,Alan LaPolice,IND,32
-Geary,W4P3,U.S. House,1,Alan LaPolice,IND,59
-Geary,W4P4,U.S. House,1,Alan LaPolice,IND,127
-Geary,Blakely Twp,U.S. House,1,Alan LaPolice,IND,7
-Geary,Grandview Plaza Pct,U.S. House,1,Alan LaPolice,IND,66
-Geary,Jefferson Precinct,U.S. House,1,Alan LaPolice,IND,32
-Geary,Jackson Twp,U.S. House,1,Alan LaPolice,IND,12
-Geary,Liberty Twp,U.S. House,1,Alan LaPolice,IND,26
-Geary,Lyon Twp,U.S. House,1,Alan LaPolice,IND,23
-Geary,Milford City,U.S. House,1,Alan LaPolice,IND,37
-Geary,Milford Twp,U.S. House,1,Alan LaPolice,IND,120
-Geary,Ft. Riley B,U.S. House,1,Alan LaPolice,IND,52
-Geary,Ft. Riley A,U.S. House,1,Alan LaPolice,IND,14
-Geary,Smoky Hill Twp Pct 2,U.S. House,1,Alan LaPolice,IND,2
-Geary,Smoky Hill Twp Pct 3,U.S. House,1,Alan LaPolice,IND,26
-Geary,Smoky Hill Twp Pct 4,U.S. House,1,Alan LaPolice,IND,15
-Geary,Smoky Hill Twp Pct 5,U.S. House,1,Alan LaPolice,IND,25
-Geary,Smoky Hill Twp Pct 6,U.S. House,1,Alan LaPolice,IND,6
-Geary,Wingfield Twp,U.S. House,1,Alan LaPolice,IND,31
-Geary,Total,U.S. House,1,Alan LaPolice,IND,1875
-Geary,W1P1,U.S. House,1,Roger Marshall,R,114
-Geary,W1P2,U.S. House,1,Roger Marshall,R,92
-Geary,W1P3,U.S. House,1,Roger Marshall,R,182
-Geary,W1P4,U.S. House,1,Roger Marshall,R,280
-Geary,W1P5,U.S. House,1,Roger Marshall,R,141
-Geary,W1P6,U.S. House,1,Roger Marshall,R,206
-Geary,W1P7,U.S. House,1,Roger Marshall,R,262
-Geary,W2P1,U.S. House,1,Roger Marshall,R,41
-Geary,W2P2,U.S. House,1,Roger Marshall,R,150
-Geary,W2P3,U.S. House,1,Roger Marshall,R,43
-Geary,W2P4,U.S. House,1,Roger Marshall,R,36
-Geary,W2P5,U.S. House,1,Roger Marshall,R,156
-Geary,W2P6,U.S. House,1,Roger Marshall,R,101
-Geary,W2P7,U.S. House,1,Roger Marshall,R,161
-Geary,W2P8,U.S. House,1,Roger Marshall,R,50
-Geary,W3P1,U.S. House,1,Roger Marshall,R,71
-Geary,W3P2,U.S. House,1,Roger Marshall,R,143
-Geary,W3P3,U.S. House,1,Roger Marshall,R,115
-Geary,W3P4,U.S. House,1,Roger Marshall,R,48
-Geary,W4P1,U.S. House,1,Roger Marshall,R,81
-Geary,W4P2,U.S. House,1,Roger Marshall,R,35
-Geary,W4P3,U.S. House,1,Roger Marshall,R,97
-Geary,W4P4,U.S. House,1,Roger Marshall,R,156
-Geary,Blakely Twp,U.S. House,1,Roger Marshall,R,48
-Geary,Grandview Plaza Pct,U.S. House,1,Roger Marshall,R,158
-Geary,Jefferson Precinct,U.S. House,1,Roger Marshall,R,135
-Geary,Jackson Twp,U.S. House,1,Roger Marshall,R,33
-Geary,Liberty Twp,U.S. House,1,Roger Marshall,R,70
-Geary,Lyon Twp,U.S. House,1,Roger Marshall,R,118
-Geary,Milford City,U.S. House,1,Roger Marshall,R,106
-Geary,Milford Twp,U.S. House,1,Roger Marshall,R,357
-Geary,Ft. Riley B,U.S. House,1,Roger Marshall,R,125
-Geary,Ft. Riley A,U.S. House,1,Roger Marshall,R,20
-Geary,Smoky Hill Twp Pct 2,U.S. House,1,Roger Marshall,R,6
-Geary,Smoky Hill Twp Pct 3,U.S. House,1,Roger Marshall,R,50
-Geary,Smoky Hill Twp Pct 4,U.S. House,1,Roger Marshall,R,59
-Geary,Smoky Hill Twp Pct 5,U.S. House,1,Roger Marshall,R,149
-Geary,Smoky Hill Twp Pct 6,U.S. House,1,Roger Marshall,R,16
-Geary,Wingfield Twp,U.S. House,1,Roger Marshall,R,63
-Geary,Total,U.S. House,1,Roger Marshall,R,4274
-Geary,W1P1,State Senate,17,Susan Fowler,D,83
-Geary,W1P2,State Senate,17,Susan Fowler,D,68
-Geary,W1P3,State Senate,17,Susan Fowler,D,89
-Geary,W1P4,State Senate,17,Susan Fowler,D,216
-Geary,W1P5,State Senate,17,Susan Fowler,D,133
-Geary,W1P6,State Senate,17,Susan Fowler,D,170
-Geary,W1P7,State Senate,17,Susan Fowler,D,190
-Geary,W2P1,State Senate,17,Susan Fowler,D,44
-Geary,W2P2,State Senate,17,Susan Fowler,D,134
-Geary,W2P3,State Senate,17,Susan Fowler,D,25
-Geary,W2P4,State Senate,17,Susan Fowler,D,24
-Geary,W2P5,State Senate,17,Susan Fowler,D,113
-Geary,W2P6,State Senate,17,Susan Fowler,D,66
-Geary,W2P7,State Senate,17,Susan Fowler,D,114
-Geary,W2P8,State Senate,22,Tom Hawk,D,74
-Geary,W3P1,State Senate,17,Susan Fowler,D,64
-Geary,W3P2,State Senate,17,Susan Fowler,D,132
-Geary,W3P3,State Senate,17,Susan Fowler,D,98
-Geary,W3P4,State Senate,22,Tom Hawk,D,60
-Geary,W4P1,State Senate,17,Susan Fowler,D,98
-Geary,W4P2,State Senate,17,Susan Fowler,D,54
-Geary,W4P3,State Senate,17,Susan Fowler,D,137
-Geary,W4P4,State Senate,17,Susan Fowler,D,201
-Geary,Blakely Twp,State Senate,17,Susan Fowler,D,11
-Geary,Grandview Plaza Pct,State Senate,17,Susan Fowler,D,96
-Geary,Jefferson Precinct,State Senate,17,Susan Fowler,D,50
-Geary,Jackson Twp,State Senate,17,Susan Fowler,D,18
-Geary,Liberty Twp,State Senate,17,Susan Fowler,D,35
-Geary,Lyon Twp,State Senate,17,Susan Fowler,D,20
-Geary,Milford City,State Senate,22,Tom Hawk,D,112
-Geary,Milford Twp,State Senate,22,Tom Hawk,D,348
-Geary,Ft. Riley B,State Senate,17,Susan Fowler,D,88
-Geary,Ft. Riley A,State Senate,22,Tom Hawk,D,32
-Geary,Smoky Hill Twp Pct 2,State Senate,17,Susan Fowler,D,2
-Geary,Smoky Hill Twp Pct 3,State Senate,22,Tom Hawk,D,66
-Geary,Smoky Hill Twp Pct 4,State Senate,17,Susan Fowler,D,21
-Geary,Smoky Hill Twp Pct 5,State Senate,22,Tom Hawk,D,124
-Geary,Smoky Hill Twp Pct 6,State Senate,17,Susan Fowler,D,7
-Geary,Wingfield Twp,State Senate,17,Susan Fowler,D,35
-Geary,Total,State Senate,17,Susan Fowler,D,2636
-Geary,Total,State Senate,22,Tom Hawk,D,816
-Geary,W1P1,State Senate,17,Jeff Longbine,R,101
-Geary,W1P2,State Senate,17,Jeff Longbine,R,100
-Geary,W1P3,State Senate,17,Jeff Longbine,R,186
-Geary,W1P4,State Senate,17,Jeff Longbine,R,268
-Geary,W1P5,State Senate,17,Jeff Longbine,R,142
-Geary,W1P6,State Senate,17,Jeff Longbine,R,191
-Geary,W1P7,State Senate,17,Jeff Longbine,R,258
-Geary,W2P1,State Senate,17,Jeff Longbine,R,36
-Geary,W2P2,State Senate,17,Jeff Longbine,R,130
-Geary,W2P3,State Senate,17,Jeff Longbine,R,36
-Geary,W2P4,State Senate,17,Jeff Longbine,R,31
-Geary,W2P5,State Senate,17,Jeff Longbine,R,155
-Geary,W2P6,State Senate,17,Jeff Longbine,R,107
-Geary,W2P7,State Senate,17,Jeff Longbine,R,166
-Geary,W3P1,State Senate,17,Jeff Longbine,R,60
-Geary,W3P2,State Senate,17,Jeff Longbine,R,151
-Geary,W3P3,State Senate,17,Jeff Longbine,R,112
-Geary,W4P1,State Senate,17,Jeff Longbine,R,84
-Geary,W4P2,State Senate,17,Jeff Longbine,R,37
-Geary,W4P3,State Senate,17,Jeff Longbine,R,82
-Geary,W4P4,State Senate,17,Jeff Longbine,R,166
-Geary,Blakely Twp,State Senate,17,Jeff Longbine,R,49
-Geary,Grandview Plaza Pct,State Senate,17,Jeff Longbine,R,182
-Geary,Jefferson Precinct,State Senate,17,Jeff Longbine,R,138
-Geary,Jackson Twp,State Senate,17,Jeff Longbine,R,29
-Geary,Liberty Twp,State Senate,17,Jeff Longbine,R,71
-Geary,Lyon Twp,State Senate,17,Jeff Longbine,R,126
-Geary,Ft. Riley B,State Senate,17,Jeff Longbine,R,126
-Geary,Smoky Hill Twp Pct 2,State Senate,17,Jeff Longbine,R,6
-Geary,Smoky Hill Twp Pct 4,State Senate,17,Jeff Longbine,R,66
-Geary,Smoky Hill Twp Pct 6,State Senate,17,Jeff Longbine,R,18
-Geary,Wingfield Twp,State Senate,17,Jeff Longbine,R,68
-Geary,Total,State Senate,17,Jeff Longbine,R,3478
-Geary,W1P1,State House,65,Lonnie Clark,R,153
-Geary,W1P2,State House,65,Lonnie Clark,R,146
-Geary,W1P3,State House,65,Lonnie Clark,R,247
-Geary,W1P4,State House,68,Dave Baker,R,277
-Geary,W1P5,State House,68,Dave Baker,R,156
-Geary,W1P6,State House,68,Dave Baker,R,208
-Geary,W1P7,State House,68,Dave Baker,R,261
-Geary,W2P1,State House,65,Lonnie Clark,R,61
-Geary,W2P2,State House,65,Lonnie Clark,R,223
-Geary,W2P3,State House,68,Dave Baker,R,36
-Geary,W2P4,State House,68,Dave Baker,R,33
-Geary,W2P5,State House,68,Dave Baker,R,152
-Geary,W2P6,State House,68,Dave Baker,R,105
-Geary,W2P7,State House,68,Dave Baker,R,171
-Geary,W2P8,State House,68,Dave Baker,R,45
-Geary,W3P1,State House,65,Lonnie Clark,R,113
-Geary,W3P2,State House,65,Lonnie Clark,R,240
-Geary,W3P3,State House,68,Dave Baker,R,111
-Geary,W3P4,State House,68,Dave Baker,R,50
-Geary,W4P1,State House,65,Lonnie Clark,R,136
-Geary,W4P2,State House,65,Lonnie Clark,R,58
-Geary,W4P3,State House,65,Lonnie Clark,R,166
-Geary,W4P4,State House,65,Lonnie Clark,R,283
-Geary,Blakely Twp,State House,65,Lonnie Clark,R,52
-Geary,Grandview Plaza Pct,State House,65,Lonnie Clark,R,245
-Geary,Jefferson Precinct,State House,65,Lonnie Clark,R,183
-Geary,Jackson Twp,State House,65,Lonnie Clark,R,45
-Geary,Liberty Twp,State House,65,Lonnie Clark,R,92
-Geary,Lyon Twp,State House,68,Dave Baker,R,123
-Geary,Milford City,State House,65,Lonnie Clark,R,143
-Geary,Milford Twp,State House,65,Lonnie Clark,R,476
-Geary,Ft. Riley B,State House,65,Lonnie Clark,R,187
-Geary,Ft. Riley A,State House,65,Lonnie Clark,R,35
-Geary,Smoky Hill Twp Pct 2,State House,68,Dave Baker,R,4
-Geary,Smoky Hill Twp Pct 3,State House,65,Lonnie Clark,R,75
-Geary,Smoky Hill Twp Pct 4,State House,68,Dave Baker,R,66
-Geary,Smoky Hill Twp Pct 5,State House,68,Dave Baker,R,153
-Geary,Smoky Hill Twp Pct 6,State House,68,Dave Baker,R,17
-Geary,Wingfield Twp,State House,65,Lonnie Clark,R,88
-Geary,Total,State House,65,Lonnie Clark,R,3447
-Geary,Total,State House,68,Dave Baker,R,1968
-Geary,W1P4,State House,68,Laura Blevins,D,192
-Geary,W1P5,State House,68,Laura Blevins,D,119
-Geary,W1P6,State House,68,Laura Blevins,D,148
-Geary,W1P7,State House,68,Laura Blevins,D,184
-Geary,W2P3,State House,68,Laura Blevins,D,23
-Geary,W2P4,State House,68,Laura Blevins,D,22
-Geary,W2P5,State House,68,Laura Blevins,D,113
-Geary,W2P6,State House,68,Laura Blevins,D,66
-Geary,W2P7,State House,68,Laura Blevins,D,107
-Geary,W2P8,State House,68,Laura Blevins,D,41
-Geary,W3P3,State House,68,Laura Blevins,D,94
-Geary,W3P4,State House,68,Laura Blevins,D,32
-Geary,Lyon Twp,State House,68,Laura Blevins,D,21
-Geary,Smoky Hill Twp Pct 2,State House,68,Laura Blevins,D,4
-Geary,Smoky Hill Twp Pct 4,State House,68,Laura Blevins,D,21
-Geary,Smoky Hill Twp Pct 5,State House,68,Laura Blevins,D,24
-Geary,Smoky Hill Twp Pct 6,State House,68,Laura Blevins,D,7
-Geary,Total,State House,68,Laura Blevins,D,1218
+county,precinct,office,district,party,candidate,votes,vtd
+GEARY,Blakely Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",52,000010
+GEARY,Fort Riley Milford Township Block 401,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00002R
+GEARY,Wingfield Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",88,000040
+GEARY,Jackson Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",45,000050
+GEARY,Jefferson Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",183,000060
+GEARY,Junction City Ward 1 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",153,00007A
+GEARY,Junction City Ward 1 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",146,000080
+GEARY,Junction City Ward 1 Precinct 3,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",247,000090
+GEARY,Junction City Ward 1 Precinct 4,Kansas House of Representatives,68,Democratic,"Blevins, Laura",192,000100
+GEARY,Junction City Ward 1 Precinct 4,Kansas House of Representatives,68,Republican,"Baker, Dave",277,000100
+GEARY,Junction City Ward 1 Precinct 7,Kansas House of Representatives,68,Democratic,"Blevins, Laura",184,00013A
+GEARY,Junction City Ward 1 Precinct 7,Kansas House of Representatives,68,Republican,"Baker, Dave",261,00013A
+GEARY,Junction City Ward 2 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",61,000140
+GEARY,Junction City Ward 2 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",223,000150
+GEARY,Junction City Ward 2 Precinct 3,Kansas House of Representatives,68,Democratic,"Blevins, Laura",23,00016A
+GEARY,Junction City Ward 2 Precinct 3,Kansas House of Representatives,68,Republican,"Baker, Dave",36,00016A
+GEARY,Junction City Ward 3 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",113,000180
+GEARY,Junction City Ward 3 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",240,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",283,000230
+GEARY,Liberty Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",92,000240
+GEARY,Lyon Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",21,000250
+GEARY,Lyon Township,Kansas House of Representatives,68,Republican,"Baker, Dave",123,000250
+GEARY,Milford Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",476,000270
+GEARY,Fort Riley Precinct A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",35,140010
+GEARY,Fort Riley Precinct B,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",187,140020
+GEARY,Junction City Ward 1 Precinct 5,Kansas House of Representatives,68,Democratic,"Blevins, Laura",119,140040
+GEARY,Junction City Ward 1 Precinct 5,Kansas House of Representatives,68,Republican,"Baker, Dave",156,140040
+GEARY,Junction City Ward 1 Precinct 6,Kansas House of Representatives,68,Democratic,"Blevins, Laura",148,140050
+GEARY,Junction City Ward 1 Precinct 6,Kansas House of Representatives,68,Republican,"Baker, Dave",208,140050
+GEARY,Junction City Ward 2 Precinct 4,Kansas House of Representatives,68,Democratic,"Blevins, Laura",22,140060
+GEARY,Junction City Ward 2 Precinct 4,Kansas House of Representatives,68,Republican,"Baker, Dave",33,140060
+GEARY,Junction City Ward 2 Precinct 5,Kansas House of Representatives,68,Democratic,"Blevins, Laura",113,140070
+GEARY,Junction City Ward 2 Precinct 5,Kansas House of Representatives,68,Republican,"Baker, Dave",152,140070
+GEARY,Junction City Ward 2 Precinct 6,Kansas House of Representatives,68,Democratic,"Blevins, Laura",66,140080
+GEARY,Junction City Ward 2 Precinct 6,Kansas House of Representatives,68,Republican,"Baker, Dave",105,140080
+GEARY,Junction City Ward 2 Precinct 7,Kansas House of Representatives,68,Democratic,"Blevins, Laura",107,140090
+GEARY,Junction City Ward 2 Precinct 7,Kansas House of Representatives,68,Republican,"Baker, Dave",171,140090
+GEARY,Junction City Ward 2 Precinct 8,Kansas House of Representatives,68,Democratic,"Blevins, Laura",41,140100
+GEARY,Junction City Ward 2 Precinct 8,Kansas House of Representatives,68,Republican,"Baker, Dave",45,140100
+GEARY,Junction City Ward 3 Precinct 3,Kansas House of Representatives,68,Democratic,"Blevins, Laura",94,140110
+GEARY,Junction City Ward 3 Precinct 3,Kansas House of Representatives,68,Republican,"Baker, Dave",111,140110
+GEARY,Junction City Ward 3 Precinct 4,Kansas House of Representatives,68,Democratic,"Blevins, Laura",32,140120
+GEARY,Junction City Ward 3 Precinct 4,Kansas House of Representatives,68,Republican,"Baker, Dave",50,140120
+GEARY,Milford City Precinct,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",143,140130
+GEARY,Smoky Hill Township Precinct 01,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,140140
+GEARY,Smoky Hill Township Precinct 2,Kansas House of Representatives,68,Democratic,"Blevins, Laura",4,140150
+GEARY,Smoky Hill Township Precinct 2,Kansas House of Representatives,68,Republican,"Baker, Dave",4,140150
+GEARY,Smoky Hill Township Precinct 3,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",75,140160
+GEARY,Smoky Hill Township Precinct 4,Kansas House of Representatives,68,Democratic,"Blevins, Laura",21,140170
+GEARY,Smoky Hill Township Precinct 4,Kansas House of Representatives,68,Republican,"Baker, Dave",66,140170
+GEARY,Smoky Hill Township Precinct 05,Kansas House of Representatives,68,Democratic,"Blevins, Laura",24,140180
+GEARY,Smoky Hill Township Precinct 05,Kansas House of Representatives,68,Republican,"Baker, Dave",153,140180
+GEARY,Smoky Hill Township Precinct 6,Kansas House of Representatives,68,Democratic,"Blevins, Laura",7,140190
+GEARY,Smoky Hill Township Precinct 6,Kansas House of Representatives,68,Republican,"Baker, Dave",17,140190
+GEARY,Smoky Hill Township Enclave A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,900020
+GEARY,Smoky Hill Township Enclave B,Kansas House of Representatives,68,Democratic,"Blevins, Laura",0,900030
+GEARY,Smoky Hill Township Enclave B,Kansas House of Representatives,68,Republican,"Baker, Dave",0,900030
+GEARY,Smoky Hill Township Enclave C,Kansas House of Representatives,68,Democratic,"Blevins, Laura",0,900040
+GEARY,Smoky Hill Township Enclave C,Kansas House of Representatives,68,Republican,"Baker, Dave",0,900040
+GEARY,Grandview Township Enclave A,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",136,900190
+GEARY,Junction City Ward 4 Precinct 2,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",58,900210
+GEARY,Junction City Ward 4 Precinct 3,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",166,990120
+GEARY,Grandview Township,Kansas House of Representatives,65,Republican,"Clark, Lonnie G.",245,999090
+GEARY,Blakely Township,Kansas Senate,17,Democratic,"Fowler, Susan G",11,000010
+GEARY,Blakely Township,Kansas Senate,17,Republican,"Longbine, Jeff",49,000010
+GEARY,Fort Riley Milford Township Block 401,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002O
+GEARY,Fort Riley Milford Township Block 501,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002P
+GEARY,Fort Riley Milford Township Block 601,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,Kansas Senate,22,Democratic,"Hawk, Tom",0,00002R
+GEARY,Wingfield Township,Kansas Senate,17,Democratic,"Fowler, Susan G",35,000040
+GEARY,Wingfield Township,Kansas Senate,17,Republican,"Longbine, Jeff",68,000040
+GEARY,Jackson Township,Kansas Senate,17,Democratic,"Fowler, Susan G",18,000050
+GEARY,Jackson Township,Kansas Senate,17,Republican,"Longbine, Jeff",29,000050
+GEARY,Jefferson Township,Kansas Senate,17,Democratic,"Fowler, Susan G",50,000060
+GEARY,Jefferson Township,Kansas Senate,17,Republican,"Longbine, Jeff",138,000060
+GEARY,Junction City Ward 1 Precinct 1,Kansas Senate,17,Democratic,"Fowler, Susan G",83,00007A
+GEARY,Junction City Ward 1 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",101,00007A
+GEARY,Junction City Ward 1 Precinct 2,Kansas Senate,17,Democratic,"Fowler, Susan G",68,000080
+GEARY,Junction City Ward 1 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",100,000080
+GEARY,Junction City Ward 1 Precinct 3,Kansas Senate,17,Democratic,"Fowler, Susan G",89,000090
+GEARY,Junction City Ward 1 Precinct 3,Kansas Senate,17,Republican,"Longbine, Jeff",186,000090
+GEARY,Junction City Ward 1 Precinct 4,Kansas Senate,17,Democratic,"Fowler, Susan G",216,000100
+GEARY,Junction City Ward 1 Precinct 4,Kansas Senate,17,Republican,"Longbine, Jeff",268,000100
+GEARY,Junction City Ward 1 Precinct 7,Kansas Senate,17,Democratic,"Fowler, Susan G",190,00013A
+GEARY,Junction City Ward 1 Precinct 7,Kansas Senate,17,Republican,"Longbine, Jeff",258,00013A
+GEARY,Junction City Ward 2 Precinct 1,Kansas Senate,17,Democratic,"Fowler, Susan G",44,000140
+GEARY,Junction City Ward 2 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",36,000140
+GEARY,Junction City Ward 2 Precinct 2,Kansas Senate,17,Democratic,"Fowler, Susan G",134,000150
+GEARY,Junction City Ward 2 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",130,000150
+GEARY,Junction City Ward 2 Precinct 3,Kansas Senate,17,Democratic,"Fowler, Susan G",25,00016A
+GEARY,Junction City Ward 2 Precinct 3,Kansas Senate,17,Republican,"Longbine, Jeff",36,00016A
+GEARY,Junction City Ward 3 Precinct 1,Kansas Senate,17,Democratic,"Fowler, Susan G",64,000180
+GEARY,Junction City Ward 3 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",60,000180
+GEARY,Junction City Ward 3 Precinct 2,Kansas Senate,17,Democratic,"Fowler, Susan G",132,000190
+GEARY,Junction City Ward 3 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",151,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,Kansas Senate,22,Democratic,"Hawk, Tom",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,Kansas Senate,17,Democratic,"Fowler, Susan G",201,000230
+GEARY,Junction City Ward 4 Precinct 4,Kansas Senate,17,Republican,"Longbine, Jeff",166,000230
+GEARY,Liberty Township,Kansas Senate,17,Democratic,"Fowler, Susan G",35,000240
+GEARY,Liberty Township,Kansas Senate,17,Republican,"Longbine, Jeff",71,000240
+GEARY,Lyon Township,Kansas Senate,17,Democratic,"Fowler, Susan G",20,000250
+GEARY,Lyon Township,Kansas Senate,17,Republican,"Longbine, Jeff",126,000250
+GEARY,Milford Township,Kansas Senate,22,Democratic,"Hawk, Tom",348,000270
+GEARY,Fort Riley Precinct A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,140010
+GEARY,Fort Riley Precinct A,Kansas Senate,17,Republican,"Longbine, Jeff",0,140010
+GEARY,Fort Riley Precinct B,Kansas Senate,17,Democratic,"Fowler, Susan G",88,140020
+GEARY,Fort Riley Precinct B,Kansas Senate,17,Republican,"Longbine, Jeff",126,140020
+GEARY,Grandview Plaza,Kansas Senate,17,Democratic,"Fowler, Susan G",96,140030
+GEARY,Grandview Plaza,Kansas Senate,17,Republican,"Longbine, Jeff",182,140030
+GEARY,Junction City Ward 1 Precinct 5,Kansas Senate,17,Democratic,"Fowler, Susan G",133,140040
+GEARY,Junction City Ward 1 Precinct 5,Kansas Senate,17,Republican,"Longbine, Jeff",142,140040
+GEARY,Junction City Ward 1 Precinct 6,Kansas Senate,17,Democratic,"Fowler, Susan G",170,140050
+GEARY,Junction City Ward 1 Precinct 6,Kansas Senate,17,Republican,"Longbine, Jeff",191,140050
+GEARY,Junction City Ward 2 Precinct 4,Kansas Senate,17,Democratic,"Fowler, Susan G",24,140060
+GEARY,Junction City Ward 2 Precinct 4,Kansas Senate,17,Republican,"Longbine, Jeff",31,140060
+GEARY,Junction City Ward 2 Precinct 5,Kansas Senate,17,Democratic,"Fowler, Susan G",113,140070
+GEARY,Junction City Ward 2 Precinct 5,Kansas Senate,17,Republican,"Longbine, Jeff",155,140070
+GEARY,Junction City Ward 2 Precinct 6,Kansas Senate,17,Democratic,"Fowler, Susan G",66,140080
+GEARY,Junction City Ward 2 Precinct 6,Kansas Senate,17,Republican,"Longbine, Jeff",107,140080
+GEARY,Junction City Ward 2 Precinct 7,Kansas Senate,17,Democratic,"Fowler, Susan G",114,140090
+GEARY,Junction City Ward 2 Precinct 7,Kansas Senate,17,Republican,"Longbine, Jeff",166,140090
+GEARY,Junction City Ward 2 Precinct 8,Kansas Senate,22,Democratic,"Hawk, Tom",74,140100
+GEARY,Junction City Ward 3 Precinct 3,Kansas Senate,17,Democratic,"Fowler, Susan G",98,140110
+GEARY,Junction City Ward 3 Precinct 3,Kansas Senate,17,Republican,"Longbine, Jeff",112,140110
+GEARY,Junction City Ward 3 Precinct 4,Kansas Senate,22,Democratic,"Hawk, Tom",60,140120
+GEARY,Milford City Precinct,Kansas Senate,22,Democratic,"Hawk, Tom",112,140130
+GEARY,Smoky Hill Township Precinct 01,Kansas Senate,17,Democratic,"Fowler, Susan G",0,140140
+GEARY,Smoky Hill Township Precinct 01,Kansas Senate,17,Republican,"Longbine, Jeff",0,140140
+GEARY,Smoky Hill Township Precinct 2,Kansas Senate,17,Democratic,"Fowler, Susan G",2,140150
+GEARY,Smoky Hill Township Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",6,140150
+GEARY,Smoky Hill Township Precinct 3,Kansas Senate,22,Democratic,"Hawk, Tom",66,140160
+GEARY,Smoky Hill Township Precinct 4,Kansas Senate,17,Democratic,"Fowler, Susan G",21,140170
+GEARY,Smoky Hill Township Precinct 4,Kansas Senate,17,Republican,"Longbine, Jeff",66,140170
+GEARY,Smoky Hill Township Precinct 05,Kansas Senate,22,Democratic,"Hawk, Tom",124,140180
+GEARY,Smoky Hill Township Precinct 6,Kansas Senate,17,Democratic,"Fowler, Susan G",7,140190
+GEARY,Smoky Hill Township Precinct 6,Kansas Senate,17,Republican,"Longbine, Jeff",18,140190
+GEARY,Smoky Hill Township Enclave A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900020
+GEARY,Smoky Hill Township Enclave A,Kansas Senate,17,Republican,"Longbine, Jeff",0,900020
+GEARY,Smoky Hill Township Enclave B,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900030
+GEARY,Smoky Hill Township Enclave B,Kansas Senate,17,Republican,"Longbine, Jeff",0,900030
+GEARY,Smoky Hill Township Enclave C,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900040
+GEARY,Smoky Hill Township Enclave C,Kansas Senate,17,Republican,"Longbine, Jeff",0,900040
+GEARY,Grandview Township Enclave A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900100
+GEARY,Grandview Township Enclave A,Kansas Senate,17,Republican,"Longbine, Jeff",0,900100
+GEARY,Junction City Ward 4 Precinct 1,Kansas Senate,17,Democratic,"Fowler, Susan G",98,900190
+GEARY,Junction City Ward 4 Precinct 1,Kansas Senate,17,Republican,"Longbine, Jeff",84,900190
+GEARY,Junction City Ward 4 Precinct 2,Kansas Senate,17,Democratic,"Fowler, Susan G",54,900210
+GEARY,Junction City Ward 4 Precinct 2,Kansas Senate,17,Republican,"Longbine, Jeff",37,900210
+GEARY,Junction City Ward 4 Precinct 3,Kansas Senate,17,Democratic,"Fowler, Susan G",137,990120
+GEARY,Junction City Ward 4 Precinct 3,Kansas Senate,17,Republican,"Longbine, Jeff",82,990120
+GEARY,Grandview Township,Kansas Senate,17,Democratic,"Fowler, Susan G",0,999090
+GEARY,Grandview Township,Kansas Senate,17,Republican,"Longbine, Jeff",0,999090
+GEARY,Blakely Township,President / Vice President,,independent,"Stein, Jill",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+GEARY,Blakely Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+GEARY,Blakely Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000010
+GEARY,Blakely Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+GEARY,Blakely Township,President / Vice President,,Republican,"Trump, Donald J.",54,000010
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,independent,"Stein, Jill",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Castle, Darrell L",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Giordani, Rocky",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Hedges, James A",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Hoefling, Tom",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Kahn, Lynn",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"La Riva, Gloria",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Levinson, Michael S.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Maturen, Michael A",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"McMullin, Evan",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Perry, Darryl",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Schriner, Joe C",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Smith, Mike",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Sood, Ajay",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Sterling, Shawna",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Libertarian,"Johnson, Gary",0,00002O
+GEARY,Fort Riley Milford Township Block 401,President / Vice President,,Republican,"Trump, Donald J.",0,00002O
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,independent,"Stein, Jill",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Castle, Darrell L",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Giordani, Rocky",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Hedges, James A",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Hoefling, Tom",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Kahn, Lynn",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"La Riva, Gloria",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Levinson, Michael S.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Maturen, Michael A",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"McMullin, Evan",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Perry, Darryl",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Schriner, Joe C",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Smith, Mike",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Sood, Ajay",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Sterling, Shawna",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Libertarian,"Johnson, Gary",0,00002P
+GEARY,Fort Riley Milford Township Block 501,President / Vice President,,Republican,"Trump, Donald J.",0,00002P
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,independent,"Stein, Jill",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Castle, Darrell L",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Giordani, Rocky",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Hedges, James A",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Hoefling, Tom",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Kahn, Lynn",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"La Riva, Gloria",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Levinson, Michael S.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Maturen, Michael A",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"McMullin, Evan",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Perry, Darryl",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Schriner, Joe C",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Smith, Mike",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Sood, Ajay",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Sterling, Shawna",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Libertarian,"Johnson, Gary",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,President / Vice President,,Republican,"Trump, Donald J.",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,independent,"Stein, Jill",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Castle, Darrell L",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Giordani, Rocky",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Hedges, James A",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Hoefling, Tom",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Kahn, Lynn",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"La Riva, Gloria",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Levinson, Michael S.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Maturen, Michael A",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"McMullin, Evan",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Perry, Darryl",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Schriner, Joe C",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Smith, Mike",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Sood, Ajay",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Sterling, Shawna",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Libertarian,"Johnson, Gary",0,00002R
+GEARY,Fort Riley Milford Township Block 701,President / Vice President,,Republican,"Trump, Donald J.",0,00002R
+GEARY,Wingfield Township,President / Vice President,,independent,"Stein, Jill",2,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+GEARY,Wingfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+GEARY,Wingfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000040
+GEARY,Wingfield Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+GEARY,Wingfield Township,President / Vice President,,Republican,"Trump, Donald J.",73,000040
+GEARY,Jackson Township,President / Vice President,,independent,"Stein, Jill",1,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+GEARY,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+GEARY,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000050
+GEARY,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+GEARY,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",36,000050
+GEARY,Jefferson Township,President / Vice President,,independent,"Stein, Jill",1,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+GEARY,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+GEARY,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000060
+GEARY,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000060
+GEARY,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",146,000060
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",4,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,00007A
+GEARY,Junction City Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",99,00007A
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",2,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000080
+GEARY,Junction City Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",100,000080
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,independent,"Stein, Jill",9,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",2,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",1,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000090
+GEARY,Junction City Ward 1 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",185,000090
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,independent,"Stein, Jill",13,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",2,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",200,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",16,000100
+GEARY,Junction City Ward 1 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",255,000100
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,independent,"Stein, Jill",9,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Hedges, James A",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"McMullin, Evan",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Smith, Mike",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",188,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Libertarian,"Johnson, Gary",24,00013A
+GEARY,Junction City Ward 1 Precinct 7,President / Vice President,,Republican,"Trump, Donald J.",242,00013A
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",1,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+GEARY,Junction City Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",43,000140
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000150
+GEARY,Junction City Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",126,000150
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",2,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",30,00016A
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",8,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+GEARY,Junction City Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",65,000180
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",25,000190
+GEARY,Junction City Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",159,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,independent,"Stein, Jill",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Castle, Darrell L",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Giordani, Rocky",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Hedges, James A",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Kahn, Lynn",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"La Riva, Gloria",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Levinson, Michael S.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Maturen, Michael A",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"McMullin, Evan",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Perry, Darryl",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Schriner, Joe C",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Smith, Mike",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Sood, Ajay",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Sterling, Shawna",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,President / Vice President,,Republican,"Trump, Donald J.",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,independent,"Stein, Jill",6,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",1,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",201,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",13,000230
+GEARY,Junction City Ward 4 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",164,000230
+GEARY,Liberty Township,President / Vice President,,independent,"Stein, Jill",2,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+GEARY,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+GEARY,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000240
+GEARY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+GEARY,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",77,000240
+GEARY,Lyon Township,President / Vice President,,independent,"Stein, Jill",1,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+GEARY,Lyon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+GEARY,Lyon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000250
+GEARY,Lyon Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000250
+GEARY,Lyon Township,President / Vice President,,Republican,"Trump, Donald J.",130,000250
+GEARY,Milford Township,President / Vice President,,independent,"Stein, Jill",14,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Castle, Darrell L",3,000270
+GEARY,Milford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"McMullin, Evan",1,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+GEARY,Milford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+GEARY,Milford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000270
+GEARY,Milford Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000270
+GEARY,Milford Township,President / Vice President,,Republican,"Trump, Donald J.",380,000270
+GEARY,Fort Riley Precinct A,President / Vice President,,independent,"Stein, Jill",2,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Hedges, James A",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"McMullin, Evan",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Perry, Darryl",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Smith, Mike",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Sood, Ajay",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,Libertarian,"Johnson, Gary",0,140010
+GEARY,Fort Riley Precinct A,President / Vice President,,Republican,"Trump, Donald J.",25,140010
+GEARY,Fort Riley Precinct B,President / Vice President,,independent,"Stein, Jill",5,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Basiago, Andrew D.",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Castle, Darrell L",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Giordani, Rocky",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Hedges, James A",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Hoefling, Tom",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Kahn, Lynn",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"La Riva, Gloria",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Levinson, Michael S.",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Maturen, Michael A",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"McMullin, Evan",1,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Moorehead, Monica G.",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Perry, Darryl",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Schriner, Joe C",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Smith, Mike",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Sood, Ajay",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Sterling, Shawna",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Valdivia, Anthony J",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,Libertarian,"Johnson, Gary",16,140020
+GEARY,Fort Riley Precinct B,President / Vice President,,Republican,"Trump, Donald J.",118,140020
+GEARY,Grandview Plaza,President / Vice President,,independent,"Stein, Jill",4,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Basiago, Andrew D.",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Castle, Darrell L",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Giordani, Rocky",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Hedges, James A",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Hoefling, Tom",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Kahn, Lynn",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"La Riva, Gloria",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Levinson, Michael S.",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Maturen, Michael A",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"McMullin, Evan",1,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Moorehead, Monica G.",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Perry, Darryl",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Schriner, Joe C",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Smith, Mike",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Sood, Ajay",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Sterling, Shawna",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Valdivia, Anthony J",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140030
+GEARY,Grandview Plaza,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140030
+GEARY,Grandview Plaza,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,140030
+GEARY,Grandview Plaza,President / Vice President,,Libertarian,"Johnson, Gary",23,140030
+GEARY,Grandview Plaza,President / Vice President,,Republican,"Trump, Donald J.",199,140030
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,independent,"Stein, Jill",10,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",116,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",6,140040
+GEARY,Junction City Ward 1 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",148,140040
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,independent,"Stein, Jill",7,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Castle, Darrell L",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Giordani, Rocky",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Hedges, James A",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Kahn, Lynn",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"La Riva, Gloria",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Levinson, Michael S.",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Maturen, Michael A",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"McMullin, Evan",3,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Perry, Darryl",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Schriner, Joe C",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Smith, Mike",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Sood, Ajay",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Sterling, Shawna",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",171,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",15,140050
+GEARY,Junction City Ward 1 Precinct 6,President / Vice President,,Republican,"Trump, Donald J.",180,140050
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,independent,"Stein, Jill",3,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",4,140060
+GEARY,Junction City Ward 2 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",32,140060
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,independent,"Stein, Jill",2,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",112,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",9,140070
+GEARY,Junction City Ward 2 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",146,140070
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,independent,"Stein, Jill",3,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Castle, Darrell L",2,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Giordani, Rocky",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Hedges, James A",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Kahn, Lynn",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"La Riva, Gloria",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Levinson, Michael S.",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Maturen, Michael A",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"McMullin, Evan",2,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Perry, Darryl",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Schriner, Joe C",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Smith, Mike",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Sood, Ajay",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Sterling, Shawna",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",5,140080
+GEARY,Junction City Ward 2 Precinct 6,President / Vice President,,Republican,"Trump, Donald J.",90,140080
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,independent,"Stein, Jill",5,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Castle, Darrell L",5,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Giordani, Rocky",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Hedges, James A",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Hoefling, Tom",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Kahn, Lynn",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"La Riva, Gloria",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Levinson, Michael S.",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Maturen, Michael A",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"McMullin, Evan",1,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Perry, Darryl",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Schriner, Joe C",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Smith, Mike",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Sood, Ajay",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Sterling, Shawna",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",116,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,Libertarian,"Johnson, Gary",12,140090
+GEARY,Junction City Ward 2 Precinct 7,President / Vice President,,Republican,"Trump, Donald J.",147,140090
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,independent,"Stein, Jill",3,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Basiago, Andrew D.",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Castle, Darrell L",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Giordani, Rocky",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Hedges, James A",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Hoefling, Tom",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Kahn, Lynn",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"La Riva, Gloria",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Levinson, Michael S.",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Maturen, Michael A",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"McMullin, Evan",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Moorehead, Monica G.",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Perry, Darryl",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Schriner, Joe C",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Smith, Mike",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Sood, Ajay",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Sterling, Shawna",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Valdivia, Anthony J",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,Libertarian,"Johnson, Gary",3,140100
+GEARY,Junction City Ward 2 Precinct 8,President / Vice President,,Republican,"Trump, Donald J.",53,140100
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,independent,"Stein, Jill",3,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",7,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",96,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",12,140110
+GEARY,Junction City Ward 3 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",98,140110
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,independent,"Stein, Jill",1,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",1,140120
+GEARY,Junction City Ward 3 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",51,140120
+GEARY,Milford City Precinct,President / Vice President,,independent,"Stein, Jill",1,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Hedges, James A",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"McMullin, Evan",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Perry, Darryl",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Smith, Mike",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Sood, Ajay",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140130
+GEARY,Milford City Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140130
+GEARY,Milford City Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,140130
+GEARY,Milford City Precinct,President / Vice President,,Libertarian,"Johnson, Gary",7,140130
+GEARY,Milford City Precinct,President / Vice President,,Republican,"Trump, Donald J.",118,140130
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,independent,"Stein, Jill",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,140140
+GEARY,Smoky Hill Township Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",0,140140
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,independent,"Stein, Jill",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,140150
+GEARY,Smoky Hill Township Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",6,140150
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,independent,"Stein, Jill",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",5,140160
+GEARY,Smoky Hill Township Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",57,140160
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,independent,"Stein, Jill",2,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"McMullin, Evan",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",2,140170
+GEARY,Smoky Hill Township Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",60,140170
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,independent,"Stein, Jill",2,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"McMullin, Evan",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",10,140180
+GEARY,Smoky Hill Township Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",138,140180
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,independent,"Stein, Jill",1,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Castle, Darrell L",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Giordani, Rocky",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Hedges, James A",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Hoefling, Tom",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Kahn, Lynn",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"La Riva, Gloria",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Levinson, Michael S.",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Maturen, Michael A",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"McMullin, Evan",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Perry, Darryl",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Schriner, Joe C",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Smith, Mike",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Sood, Ajay",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Sterling, Shawna",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,Libertarian,"Johnson, Gary",1,140190
+GEARY,Smoky Hill Township Precinct 6,President / Vice President,,Republican,"Trump, Donald J.",21,140190
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,independent,"Stein, Jill",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Hedges, James A",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Smith, Mike",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+GEARY,Smoky Hill Township Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,independent,"Stein, Jill",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Hedges, James A",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Smith, Mike",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+GEARY,Smoky Hill Township Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,independent,"Stein, Jill",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Hedges, James A",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"McMullin, Evan",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Perry, Darryl",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Smith, Mike",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Sood, Ajay",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+GEARY,Smoky Hill Township Enclave C,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+GEARY,Grandview Township Enclave A,President / Vice President,,independent,"Stein, Jill",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Hedges, James A",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Smith, Mike",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+GEARY,Grandview Township Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900100
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",4,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",90,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,900190
+GEARY,Junction City Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",88,900190
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",5,900210
+GEARY,Junction City Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",41,900210
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",5,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",9,990120
+GEARY,Junction City Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",94,990120
+GEARY,Grandview Township,President / Vice President,,independent,"Stein, Jill",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Castle, Darrell L",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Giordani, Rocky",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Hedges, James A",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Hoefling, Tom",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Kahn, Lynn",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"La Riva, Gloria",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Maturen, Michael A",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"McMullin, Evan",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Perry, Darryl",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Schriner, Joe C",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Smith, Mike",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Sood, Ajay",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Sterling, Shawna",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,999090
+GEARY,Grandview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,999090
+GEARY,Grandview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,999090
+GEARY,Grandview Township,President / Vice President,,Libertarian,"Johnson, Gary",0,999090
+GEARY,Grandview Township,President / Vice President,,Republican,"Trump, Donald J.",0,999090
+GEARY,Blakely Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000010
+GEARY,Blakely Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+GEARY,Blakely Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000010
+GEARY,Blakely Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000010
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,independent,"LaPolice, Alan",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States House of Representatives,1,Republican,"Marshall, Roger",0,00002O
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,independent,"LaPolice, Alan",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States House of Representatives,1,Republican,"Marshall, Roger",0,00002P
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,independent,"LaPolice, Alan",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States House of Representatives,1,Republican,"Marshall, Roger",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,independent,"LaPolice, Alan",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States House of Representatives,1,Republican,"Marshall, Roger",0,00002R
+GEARY,Wingfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000040
+GEARY,Wingfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000040
+GEARY,Wingfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000040
+GEARY,Wingfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",63,000040
+GEARY,Jackson Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000050
+GEARY,Jackson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+GEARY,Jackson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000050
+GEARY,Jackson Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000050
+GEARY,Jefferson Township,United States House of Representatives,1,independent,"LaPolice, Alan",32,000060
+GEARY,Jefferson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+GEARY,Jefferson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000060
+GEARY,Jefferson Township,United States House of Representatives,1,Republican,"Marshall, Roger",135,000060
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",43,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",114,00007A
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",53,000080
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000080
+GEARY,Junction City Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",92,000080
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",62,000090
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000090
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000090
+GEARY,Junction City Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",182,000090
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",129,000100
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",40,000100
+GEARY,Junction City Ward 1 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",280,000100
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,independent,"LaPolice, Alan",117,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,Libertarian,"Burt, Kerry",48,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States House of Representatives,1,Republican,"Marshall, Roger",262,00013A
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",19,000140
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000140
+GEARY,Junction City Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",41,000140
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",77,000150
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000150
+GEARY,Junction City Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",150,000150
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",11,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",43,00016A
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",36,000180
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000180
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000180
+GEARY,Junction City Ward 3 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",71,000180
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",80,000190
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000190
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",46,000190
+GEARY,Junction City Ward 3 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",143,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",127,000230
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000230
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",44,000230
+GEARY,Junction City Ward 4 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",156,000230
+GEARY,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000240
+GEARY,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000240
+GEARY,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000240
+GEARY,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",70,000240
+GEARY,Lyon Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000250
+GEARY,Lyon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+GEARY,Lyon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000250
+GEARY,Lyon Township,United States House of Representatives,1,Republican,"Marshall, Roger",118,000250
+GEARY,Milford Township,United States House of Representatives,1,independent,"LaPolice, Alan",120,000270
+GEARY,Milford Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000270
+GEARY,Milford Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",42,000270
+GEARY,Milford Township,United States House of Representatives,1,Republican,"Marshall, Roger",357,000270
+GEARY,Fort Riley Precinct A,United States House of Representatives,1,independent,"LaPolice, Alan",14,140010
+GEARY,Fort Riley Precinct A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140010
+GEARY,Fort Riley Precinct A,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,140010
+GEARY,Fort Riley Precinct A,United States House of Representatives,1,Republican,"Marshall, Roger",20,140010
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,independent,"LaPolice, Alan",52,140020
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140020
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,140020
+GEARY,Fort Riley Precinct B,United States House of Representatives,1,Republican,"Marshall, Roger",125,140020
+GEARY,Grandview Plaza,United States House of Representatives,1,independent,"LaPolice, Alan",66,140030
+GEARY,Grandview Plaza,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,140030
+GEARY,Grandview Plaza,United States House of Representatives,1,Libertarian,"Burt, Kerry",42,140030
+GEARY,Grandview Plaza,United States House of Representatives,1,Republican,"Marshall, Roger",158,140030
+GEARY,Junction City Ward 1 Precinct 5,United States House of Representatives,1,independent,"LaPolice, Alan",88,140040
+GEARY,Junction City Ward 1 Precinct 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140040
+GEARY,Junction City Ward 1 Precinct 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,140040
+GEARY,Junction City Ward 1 Precinct 5,United States House of Representatives,1,Republican,"Marshall, Roger",141,140040
+GEARY,Junction City Ward 1 Precinct 6,United States House of Representatives,1,independent,"LaPolice, Alan",96,140050
+GEARY,Junction City Ward 1 Precinct 6,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140050
+GEARY,Junction City Ward 1 Precinct 6,United States House of Representatives,1,Libertarian,"Burt, Kerry",42,140050
+GEARY,Junction City Ward 1 Precinct 6,United States House of Representatives,1,Republican,"Marshall, Roger",206,140050
+GEARY,Junction City Ward 2 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",11,140060
+GEARY,Junction City Ward 2 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140060
+GEARY,Junction City Ward 2 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,140060
+GEARY,Junction City Ward 2 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",36,140060
+GEARY,Junction City Ward 2 Precinct 5,United States House of Representatives,1,independent,"LaPolice, Alan",64,140070
+GEARY,Junction City Ward 2 Precinct 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140070
+GEARY,Junction City Ward 2 Precinct 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,140070
+GEARY,Junction City Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Marshall, Roger",156,140070
+GEARY,Junction City Ward 2 Precinct 6,United States House of Representatives,1,independent,"LaPolice, Alan",43,140080
+GEARY,Junction City Ward 2 Precinct 6,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140080
+GEARY,Junction City Ward 2 Precinct 6,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,140080
+GEARY,Junction City Ward 2 Precinct 6,United States House of Representatives,1,Republican,"Marshall, Roger",101,140080
+GEARY,Junction City Ward 2 Precinct 7,United States House of Representatives,1,independent,"LaPolice, Alan",67,140090
+GEARY,Junction City Ward 2 Precinct 7,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140090
+GEARY,Junction City Ward 2 Precinct 7,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,140090
+GEARY,Junction City Ward 2 Precinct 7,United States House of Representatives,1,Republican,"Marshall, Roger",161,140090
+GEARY,Junction City Ward 2 Precinct 8,United States House of Representatives,1,independent,"LaPolice, Alan",24,140100
+GEARY,Junction City Ward 2 Precinct 8,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140100
+GEARY,Junction City Ward 2 Precinct 8,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,140100
+GEARY,Junction City Ward 2 Precinct 8,United States House of Representatives,1,Republican,"Marshall, Roger",50,140100
+GEARY,Junction City Ward 3 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",65,140110
+GEARY,Junction City Ward 3 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140110
+GEARY,Junction City Ward 3 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,140110
+GEARY,Junction City Ward 3 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",115,140110
+GEARY,Junction City Ward 3 Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",23,140120
+GEARY,Junction City Ward 3 Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140120
+GEARY,Junction City Ward 3 Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,140120
+GEARY,Junction City Ward 3 Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",48,140120
+GEARY,Milford City Precinct,United States House of Representatives,1,independent,"LaPolice, Alan",37,140130
+GEARY,Milford City Precinct,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140130
+GEARY,Milford City Precinct,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,140130
+GEARY,Milford City Precinct,United States House of Representatives,1,Republican,"Marshall, Roger",106,140130
+GEARY,Smoky Hill Township Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",0,140140
+GEARY,Smoky Hill Township Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140140
+GEARY,Smoky Hill Township Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,140140
+GEARY,Smoky Hill Township Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",0,140140
+GEARY,Smoky Hill Township Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",2,140150
+GEARY,Smoky Hill Township Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140150
+GEARY,Smoky Hill Township Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,140150
+GEARY,Smoky Hill Township Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",6,140150
+GEARY,Smoky Hill Township Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",26,140160
+GEARY,Smoky Hill Township Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140160
+GEARY,Smoky Hill Township Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,140160
+GEARY,Smoky Hill Township Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",50,140160
+GEARY,Smoky Hill Township Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",15,140170
+GEARY,Smoky Hill Township Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140170
+GEARY,Smoky Hill Township Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,140170
+GEARY,Smoky Hill Township Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",59,140170
+GEARY,Smoky Hill Township Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",25,140180
+GEARY,Smoky Hill Township Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140180
+GEARY,Smoky Hill Township Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,140180
+GEARY,Smoky Hill Township Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",149,140180
+GEARY,Smoky Hill Township Precinct 6,United States House of Representatives,1,independent,"LaPolice, Alan",6,140190
+GEARY,Smoky Hill Township Precinct 6,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140190
+GEARY,Smoky Hill Township Precinct 6,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,140190
+GEARY,Smoky Hill Township Precinct 6,United States House of Representatives,1,Republican,"Marshall, Roger",16,140190
+GEARY,Smoky Hill Township Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+GEARY,Smoky Hill Township Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+GEARY,Smoky Hill Township Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+GEARY,Smoky Hill Township Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+GEARY,Smoky Hill Township Enclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,900030
+GEARY,Smoky Hill Township Enclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+GEARY,Smoky Hill Township Enclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900030
+GEARY,Smoky Hill Township Enclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,900030
+GEARY,Smoky Hill Township Enclave C,United States House of Representatives,1,independent,"LaPolice, Alan",0,900040
+GEARY,Smoky Hill Township Enclave C,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900040
+GEARY,Smoky Hill Township Enclave C,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900040
+GEARY,Smoky Hill Township Enclave C,United States House of Representatives,1,Republican,"Marshall, Roger",0,900040
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,900100
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900100
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900100
+GEARY,Grandview Township Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,900100
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",55,900190
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,900190
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",39,900190
+GEARY,Junction City Ward 4 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",81,900190
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",32,900210
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900210
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,900210
+GEARY,Junction City Ward 4 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",35,900210
+GEARY,Junction City Ward 4 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",59,990120
+GEARY,Junction City Ward 4 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,990120
+GEARY,Junction City Ward 4 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,990120
+GEARY,Junction City Ward 4 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",97,990120
+GEARY,Grandview Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,999090
+GEARY,Grandview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,999090
+GEARY,Grandview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,999090
+GEARY,Grandview Township,United States House of Representatives,1,Republican,"Marshall, Roger",0,999090
+GEARY,Blakely Township,United States Senate,,write - in,"Smith, DJ",0,000010
+GEARY,Blakely Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000010
+GEARY,Blakely Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+GEARY,Blakely Township,United States Senate,,Republican,"Moran, Jerry",55,000010
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,write - in,"Smith, DJ",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,Democratic,"Wiesner, Patrick",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002O
+GEARY,Fort Riley Milford Township Block 401,United States Senate,,Republican,"Moran, Jerry",0,00002O
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,write - in,"Smith, DJ",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,Democratic,"Wiesner, Patrick",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002P
+GEARY,Fort Riley Milford Township Block 501,United States Senate,,Republican,"Moran, Jerry",0,00002P
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,write - in,"Smith, DJ",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,Democratic,"Wiesner, Patrick",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002Q
+GEARY,Fort Riley Milford Township Block 601,United States Senate,,Republican,"Moran, Jerry",0,00002Q
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,write - in,"Smith, DJ",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,Democratic,"Wiesner, Patrick",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002R
+GEARY,Fort Riley Milford Township Block 701,United States Senate,,Republican,"Moran, Jerry",0,00002R
+GEARY,Wingfield Township,United States Senate,,write - in,"Smith, DJ",0,000040
+GEARY,Wingfield Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000040
+GEARY,Wingfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000040
+GEARY,Wingfield Township,United States Senate,,Republican,"Moran, Jerry",74,000040
+GEARY,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000050
+GEARY,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000050
+GEARY,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+GEARY,Jackson Township,United States Senate,,Republican,"Moran, Jerry",41,000050
+GEARY,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000060
+GEARY,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000060
+GEARY,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000060
+GEARY,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",159,000060
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",67,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",8,00007A
+GEARY,Junction City Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",117,00007A
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000080
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",56,000080
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+GEARY,Junction City Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",111,000080
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000090
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",49,000090
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",15,000090
+GEARY,Junction City Ward 1 Precinct 3,United States Senate,,Republican,"Moran, Jerry",214,000090
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000100
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",151,000100
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",14,000100
+GEARY,Junction City Ward 1 Precinct 4,United States Senate,,Republican,"Moran, Jerry",322,000100
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,write - in,"Smith, DJ",0,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,Democratic,"Wiesner, Patrick",147,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,Libertarian,"Garrard, Robert D.",27,00013A
+GEARY,Junction City Ward 1 Precinct 7,United States Senate,,Republican,"Moran, Jerry",284,00013A
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000140
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",29,000140
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",5,000140
+GEARY,Junction City Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",51,000140
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000150
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",94,000150
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000150
+GEARY,Junction City Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",156,000150
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",20,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016A
+GEARY,Junction City Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",44,00016A
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000180
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",52,000180
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",7,000180
+GEARY,Junction City Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",69,000180
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000190
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",90,000190
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,000190
+GEARY,Junction City Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",177,000190
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,write - in,"Smith, DJ",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,Democratic,"Wiesner, Patrick",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022B
+GEARY,Junction City Ward 4 Precinct 3 Exclave Golf,United States Senate,,Republican,"Moran, Jerry",0,00022B
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000230
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",164,000230
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",12,000230
+GEARY,Junction City Ward 4 Precinct 4,United States Senate,,Republican,"Moran, Jerry",197,000230
+GEARY,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000240
+GEARY,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000240
+GEARY,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000240
+GEARY,Liberty Township,United States Senate,,Republican,"Moran, Jerry",84,000240
+GEARY,Lyon Township,United States Senate,,write - in,"Smith, DJ",0,000250
+GEARY,Lyon Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000250
+GEARY,Lyon Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000250
+GEARY,Lyon Township,United States Senate,,Republican,"Moran, Jerry",133,000250
+GEARY,Milford Township,United States Senate,,write - in,"Smith, DJ",0,000270
+GEARY,Milford Township,United States Senate,,Democratic,"Wiesner, Patrick",104,000270
+GEARY,Milford Township,United States Senate,,Libertarian,"Garrard, Robert D.",26,000270
+GEARY,Milford Township,United States Senate,,Republican,"Moran, Jerry",409,000270
+GEARY,Fort Riley Precinct A,United States Senate,,write - in,"Smith, DJ",0,140010
+GEARY,Fort Riley Precinct A,United States Senate,,Democratic,"Wiesner, Patrick",19,140010
+GEARY,Fort Riley Precinct A,United States Senate,,Libertarian,"Garrard, Robert D.",4,140010
+GEARY,Fort Riley Precinct A,United States Senate,,Republican,"Moran, Jerry",26,140010
+GEARY,Fort Riley Precinct B,United States Senate,,write - in,"Smith, DJ",0,140020
+GEARY,Fort Riley Precinct B,United States Senate,,Democratic,"Wiesner, Patrick",70,140020
+GEARY,Fort Riley Precinct B,United States Senate,,Libertarian,"Garrard, Robert D.",14,140020
+GEARY,Fort Riley Precinct B,United States Senate,,Republican,"Moran, Jerry",130,140020
+GEARY,Grandview Plaza,United States Senate,,write - in,"Smith, DJ",0,140030
+GEARY,Grandview Plaza,United States Senate,,Democratic,"Wiesner, Patrick",58,140030
+GEARY,Grandview Plaza,United States Senate,,Libertarian,"Garrard, Robert D.",15,140030
+GEARY,Grandview Plaza,United States Senate,,Republican,"Moran, Jerry",208,140030
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,140040
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",91,140040
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",11,140040
+GEARY,Junction City Ward 1 Precinct 5,United States Senate,,Republican,"Moran, Jerry",179,140040
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,write - in,"Smith, DJ",0,140050
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,Democratic,"Wiesner, Patrick",129,140050
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,Libertarian,"Garrard, Robert D.",17,140050
+GEARY,Junction City Ward 1 Precinct 6,United States Senate,,Republican,"Moran, Jerry",229,140050
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,140060
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",18,140060
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",3,140060
+GEARY,Junction City Ward 2 Precinct 4,United States Senate,,Republican,"Moran, Jerry",34,140060
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,140070
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",96,140070
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",11,140070
+GEARY,Junction City Ward 2 Precinct 5,United States Senate,,Republican,"Moran, Jerry",169,140070
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,write - in,"Smith, DJ",0,140080
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,Democratic,"Wiesner, Patrick",55,140080
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,Libertarian,"Garrard, Robert D.",7,140080
+GEARY,Junction City Ward 2 Precinct 6,United States Senate,,Republican,"Moran, Jerry",114,140080
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,write - in,"Smith, DJ",0,140090
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,Democratic,"Wiesner, Patrick",93,140090
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,Libertarian,"Garrard, Robert D.",11,140090
+GEARY,Junction City Ward 2 Precinct 7,United States Senate,,Republican,"Moran, Jerry",180,140090
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,write - in,"Smith, DJ",0,140100
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,Democratic,"Wiesner, Patrick",27,140100
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,Libertarian,"Garrard, Robert D.",2,140100
+GEARY,Junction City Ward 2 Precinct 8,United States Senate,,Republican,"Moran, Jerry",61,140100
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,140110
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",73,140110
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",10,140110
+GEARY,Junction City Ward 3 Precinct 3,United States Senate,,Republican,"Moran, Jerry",130,140110
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,140120
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",27,140120
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",2,140120
+GEARY,Junction City Ward 3 Precinct 4,United States Senate,,Republican,"Moran, Jerry",56,140120
+GEARY,Milford City Precinct,United States Senate,,write - in,"Smith, DJ",0,140130
+GEARY,Milford City Precinct,United States Senate,,Democratic,"Wiesner, Patrick",32,140130
+GEARY,Milford City Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",15,140130
+GEARY,Milford City Precinct,United States Senate,,Republican,"Moran, Jerry",124,140130
+GEARY,Smoky Hill Township Precinct 01,United States Senate,,write - in,"Smith, DJ",0,140140
+GEARY,Smoky Hill Township Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",0,140140
+GEARY,Smoky Hill Township Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",0,140140
+GEARY,Smoky Hill Township Precinct 01,United States Senate,,Republican,"Moran, Jerry",0,140140
+GEARY,Smoky Hill Township Precinct 2,United States Senate,,write - in,"Smith, DJ",0,140150
+GEARY,Smoky Hill Township Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",1,140150
+GEARY,Smoky Hill Township Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,140150
+GEARY,Smoky Hill Township Precinct 2,United States Senate,,Republican,"Moran, Jerry",7,140150
+GEARY,Smoky Hill Township Precinct 3,United States Senate,,write - in,"Smith, DJ",0,140160
+GEARY,Smoky Hill Township Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",19,140160
+GEARY,Smoky Hill Township Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",4,140160
+GEARY,Smoky Hill Township Precinct 3,United States Senate,,Republican,"Moran, Jerry",65,140160
+GEARY,Smoky Hill Township Precinct 4,United States Senate,,write - in,"Smith, DJ",0,140170
+GEARY,Smoky Hill Township Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",20,140170
+GEARY,Smoky Hill Township Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",1,140170
+GEARY,Smoky Hill Township Precinct 4,United States Senate,,Republican,"Moran, Jerry",66,140170
+GEARY,Smoky Hill Township Precinct 05,United States Senate,,write - in,"Smith, DJ",0,140180
+GEARY,Smoky Hill Township Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",16,140180
+GEARY,Smoky Hill Township Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",2,140180
+GEARY,Smoky Hill Township Precinct 05,United States Senate,,Republican,"Moran, Jerry",169,140180
+GEARY,Smoky Hill Township Precinct 6,United States Senate,,write - in,"Smith, DJ",0,140190
+GEARY,Smoky Hill Township Precinct 6,United States Senate,,Democratic,"Wiesner, Patrick",3,140190
+GEARY,Smoky Hill Township Precinct 6,United States Senate,,Libertarian,"Garrard, Robert D.",3,140190
+GEARY,Smoky Hill Township Precinct 6,United States Senate,,Republican,"Moran, Jerry",20,140190
+GEARY,Smoky Hill Township Enclave A,United States Senate,,write - in,"Smith, DJ",0,900020
+GEARY,Smoky Hill Township Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+GEARY,Smoky Hill Township Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+GEARY,Smoky Hill Township Enclave A,United States Senate,,Republican,"Moran, Jerry",0,900020
+GEARY,Smoky Hill Township Enclave B,United States Senate,,write - in,"Smith, DJ",0,900030
+GEARY,Smoky Hill Township Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+GEARY,Smoky Hill Township Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+GEARY,Smoky Hill Township Enclave B,United States Senate,,Republican,"Moran, Jerry",0,900030
+GEARY,Smoky Hill Township Enclave C,United States Senate,,write - in,"Smith, DJ",0,900040
+GEARY,Smoky Hill Township Enclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+GEARY,Smoky Hill Township Enclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+GEARY,Smoky Hill Township Enclave C,United States Senate,,Republican,"Moran, Jerry",0,900040
+GEARY,Grandview Township Enclave A,United States Senate,,write - in,"Smith, DJ",0,900100
+GEARY,Grandview Township Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900100
+GEARY,Grandview Township Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900100
+GEARY,Grandview Township Enclave A,United States Senate,,Republican,"Moran, Jerry",0,900100
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,900190
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",74,900190
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,900190
+GEARY,Junction City Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",99,900190
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,900210
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",45,900210
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",6,900210
+GEARY,Junction City Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",42,900210
+GEARY,Junction City Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,990120
+GEARY,Junction City Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",105,990120
+GEARY,Junction City Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",9,990120
+GEARY,Junction City Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",113,990120
+GEARY,Grandview Township,United States Senate,,write - in,"Smith, DJ",0,999090
+GEARY,Grandview Township,United States Senate,,Democratic,"Wiesner, Patrick",0,999090
+GEARY,Grandview Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,999090
+GEARY,Grandview Township,United States Senate,,Republican,"Moran, Jerry",0,999090

--- a/2016/20161108__ks__general__gove__precinct.csv
+++ b/2016/20161108__ks__general__gove__precinct.csv
@@ -1,325 +1,325 @@
-county,precinct,office,district,candidate,party,votes
-Gove,Baker Township,State House,118,"Hineman, Don  ",Republican,542
-Gove,Gaeland Township,State House,118,"Hineman, Don  ",Republican,18
-Gove,Gove Township,State House,118,"Hineman, Don  ",Republican,90
-Gove,Grainfield Township,State House,118,"Hineman, Don  ",Republican,185
-Gove,Grinnell Township,State House,118,"Hineman, Don  ",Republican,197
-Gove,Jerome Township,State House,118,"Hineman, Don  ",Republican,64
-Gove,Larrabee Township,State House,118,"Hineman, Don  ",Republican,29
-Gove,Lewis Township,State House,118,"Hineman, Don  ",Republican,5
-Gove,Payne Township,State House,118,"Hineman, Don  ",Republican,92
-Gove,Baker Township,State Senate,40,"Herman, Alex  ",Democratic,91
-Gove,Baker Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,506
-Gove,Gaeland Township,State Senate,40,"Herman, Alex  ",Democratic,0
-Gove,Gaeland Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,21
-Gove,Gove Township,State Senate,40,"Herman, Alex  ",Democratic,11
-Gove,Gove Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,85
-Gove,Grainfield Township,State Senate,40,"Herman, Alex  ",Democratic,18
-Gove,Grainfield Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,188
-Gove,Grinnell Township,State Senate,40,"Herman, Alex  ",Democratic,21
-Gove,Grinnell Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,193
-Gove,Jerome Township,State Senate,40,"Herman, Alex  ",Democratic,6
-Gove,Jerome Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,58
-Gove,Larrabee Township,State Senate,40,"Herman, Alex  ",Democratic,0
-Gove,Larrabee Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,28
-Gove,Lewis Township,State Senate,40,"Herman, Alex  ",Democratic,0
-Gove,Lewis Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,5
-Gove,Payne Township,State Senate,40,"Herman, Alex  ",Democratic,11
-Gove,Payne Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,93
-Gove,Baker Township,U.S. House,1,"LaPolice, Alan  ",independent,97
-Gove,Baker Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Baker Township,U.S. House,1,"Burt, Kerry  ",Libertarian,22
-Gove,Baker Township,U.S. House,1,"Marshall, Roger  ",Republican,473
-Gove,Gaeland Township,U.S. House,1,"LaPolice, Alan  ",independent,2
-Gove,Gaeland Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Gaeland Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Gove,Gaeland Township,U.S. House,1,"Marshall, Roger  ",Republican,19
-Gove,Gove Township,U.S. House,1,"LaPolice, Alan  ",independent,18
-Gove,Gove Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Gove Township,U.S. House,1,"Burt, Kerry  ",Libertarian,5
-Gove,Gove Township,U.S. House,1,"Marshall, Roger  ",Republican,69
-Gove,Grainfield Township,U.S. House,1,"LaPolice, Alan  ",independent,29
-Gove,Grainfield Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Grainfield Township,U.S. House,1,"Burt, Kerry  ",Libertarian,8
-Gove,Grainfield Township,U.S. House,1,"Marshall, Roger  ",Republican,160
-Gove,Grinnell Township,U.S. House,1,"LaPolice, Alan  ",independent,33
-Gove,Grinnell Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Grinnell Township,U.S. House,1,"Burt, Kerry  ",Libertarian,11
-Gove,Grinnell Township,U.S. House,1,"Marshall, Roger  ",Republican,171
-Gove,Jerome Township,U.S. House,1,"LaPolice, Alan  ",independent,12
-Gove,Jerome Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Jerome Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Gove,Jerome Township,U.S. House,1,"Marshall, Roger  ",Republican,50
-Gove,Larrabee Township,U.S. House,1,"LaPolice, Alan  ",independent,0
-Gove,Larrabee Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Larrabee Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Gove,Larrabee Township,U.S. House,1,"Marshall, Roger  ",Republican,26
-Gove,Lewis Township,U.S. House,1,"LaPolice, Alan  ",independent,0
-Gove,Lewis Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Lewis Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Gove,Lewis Township,U.S. House,1,"Marshall, Roger  ",Republican,5
-Gove,Payne Township,U.S. House,1,"LaPolice, Alan  ",independent,8
-Gove,Payne Township,U.S. House,1,"Huelskamp, Tim  ",,0
-Gove,Payne Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Gove,Payne Township,U.S. House,1,"Marshall, Roger  ",Republican,89
-Gove,Baker Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Baker Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,59
-Gove,Baker Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Gove,Baker Township,U.S. Senate,,"Moran, Jerry  ",Republican,537
-Gove,Gaeland Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Gaeland Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Gove,Gaeland Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Gove,Gaeland Township,U.S. Senate,,"Moran, Jerry  ",Republican,24
-Gove,Gove Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Gove Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Gove,Gove Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Gove,Gove Township,U.S. Senate,,"Moran, Jerry  ",Republican,84
-Gove,Grainfield Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Grainfield Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,19
-Gove,Grainfield Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-Gove,Grainfield Township,U.S. Senate,,"Moran, Jerry  ",Republican,178
-Gove,Grinnell Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Grinnell Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,19
-Gove,Grinnell Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,10
-Gove,Grinnell Township,U.S. Senate,,"Moran, Jerry  ",Republican,190
-Gove,Jerome Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Jerome Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Gove,Jerome Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Gove,Jerome Township,U.S. Senate,,"Moran, Jerry  ",Republican,62
-Gove,Larrabee Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Larrabee Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Gove,Larrabee Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Gove,Larrabee Township,U.S. Senate,,"Moran, Jerry  ",Republican,29
-Gove,Lewis Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Lewis Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Gove,Lewis Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Gove,Lewis Township,U.S. Senate,,"Moran, Jerry  ",Republican,5
-Gove,Payne Township,U.S. Senate,,"Smith, DJ  ",,0
-Gove,Payne Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,10
-Gove,Payne Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Gove,Payne Township,U.S. Senate,,"Moran, Jerry  ",Republican,91
-Gove,Baker Township,President,,"Stein, Jill  ",independent,8
-Gove,Baker Township,President,,"Basiago, Andrew D. ",,0
-Gove,Baker Township,President,,"Castle, Darrell L ",,0
-Gove,Baker Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Baker Township,President,,"Giordani, Rocky  ",,0
-Gove,Baker Township,President,,"Hedges, James A ",,0
-Gove,Baker Township,President,,"Hoefling, Tom  ",,0
-Gove,Baker Township,President,,"Kahn, Lynn  ",,0
-Gove,Baker Township,President,,"La Riva, Gloria  ",,0
-Gove,Baker Township,President,,"Levinson, Michael S. ",,0
-Gove,Baker Township,President,,"Maturen, Michael A ",,0
-Gove,Baker Township,President,,"McMullin, Evan  ",,0
-Gove,Baker Township,President,,"Moorehead, Monica G. ",,0
-Gove,Baker Township,President,,"Perry, Darryl  ",,0
-Gove,Baker Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Baker Township,President,,"Schriner, Joe C ",,0
-Gove,Baker Township,President,,"Smith, Mike  ",,0
-Gove,Baker Township,President,,"Sood, Ajay  ",,0
-Gove,Baker Township,President,,"Sterling, Shawna  ",,0
-Gove,Baker Township,President,,"Valdivia, Anthony J ",,0
-Gove,Baker Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Baker Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Baker Township,President,,"Clinton, Hillary Rodham ",Democratic,87
-Gove,Baker Township,President,,"Johnson, Gary  ",Libertarian,18
-Gove,Baker Township,President,,"Trump, Donald J. ",Republican,481
-Gove,Gaeland Township,President,,"Stein, Jill  ",independent,0
-Gove,Gaeland Township,President,,"Basiago, Andrew D. ",,0
-Gove,Gaeland Township,President,,"Castle, Darrell L ",,0
-Gove,Gaeland Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Gaeland Township,President,,"Giordani, Rocky  ",,0
-Gove,Gaeland Township,President,,"Hedges, James A ",,0
-Gove,Gaeland Township,President,,"Hoefling, Tom  ",,0
-Gove,Gaeland Township,President,,"Kahn, Lynn  ",,0
-Gove,Gaeland Township,President,,"La Riva, Gloria  ",,0
-Gove,Gaeland Township,President,,"Levinson, Michael S. ",,0
-Gove,Gaeland Township,President,,"Maturen, Michael A ",,0
-Gove,Gaeland Township,President,,"McMullin, Evan  ",,0
-Gove,Gaeland Township,President,,"Moorehead, Monica G. ",,0
-Gove,Gaeland Township,President,,"Perry, Darryl  ",,0
-Gove,Gaeland Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Gaeland Township,President,,"Schriner, Joe C ",,0
-Gove,Gaeland Township,President,,"Smith, Mike  ",,0
-Gove,Gaeland Township,President,,"Sood, Ajay  ",,0
-Gove,Gaeland Township,President,,"Sterling, Shawna  ",,0
-Gove,Gaeland Township,President,,"Valdivia, Anthony J ",,0
-Gove,Gaeland Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Gaeland Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Gaeland Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Gove,Gaeland Township,President,,"Johnson, Gary  ",Libertarian,0
-Gove,Gaeland Township,President,,"Trump, Donald J. ",Republican,25
-Gove,Gove Township,President,,"Stein, Jill  ",independent,1
-Gove,Gove Township,President,,"Basiago, Andrew D. ",,0
-Gove,Gove Township,President,,"Castle, Darrell L ",,0
-Gove,Gove Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Gove Township,President,,"Giordani, Rocky  ",,0
-Gove,Gove Township,President,,"Hedges, James A ",,0
-Gove,Gove Township,President,,"Hoefling, Tom  ",,0
-Gove,Gove Township,President,,"Kahn, Lynn  ",,0
-Gove,Gove Township,President,,"La Riva, Gloria  ",,0
-Gove,Gove Township,President,,"Levinson, Michael S. ",,0
-Gove,Gove Township,President,,"Maturen, Michael A ",,0
-Gove,Gove Township,President,,"McMullin, Evan  ",,0
-Gove,Gove Township,President,,"Moorehead, Monica G. ",,0
-Gove,Gove Township,President,,"Perry, Darryl  ",,0
-Gove,Gove Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Gove Township,President,,"Schriner, Joe C ",,0
-Gove,Gove Township,President,,"Smith, Mike  ",,0
-Gove,Gove Township,President,,"Sood, Ajay  ",,0
-Gove,Gove Township,President,,"Sterling, Shawna  ",,0
-Gove,Gove Township,President,,"Valdivia, Anthony J ",,0
-Gove,Gove Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Gove Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Gove Township,President,,"Clinton, Hillary Rodham ",Democratic,9
-Gove,Gove Township,President,,"Johnson, Gary  ",Libertarian,3
-Gove,Gove Township,President,,"Trump, Donald J. ",Republican,86
-Gove,Grainfield Township,President,,"Stein, Jill  ",independent,0
-Gove,Grainfield Township,President,,"Basiago, Andrew D. ",,0
-Gove,Grainfield Township,President,,"Castle, Darrell L ",,0
-Gove,Grainfield Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Grainfield Township,President,,"Giordani, Rocky  ",,0
-Gove,Grainfield Township,President,,"Hedges, James A ",,0
-Gove,Grainfield Township,President,,"Hoefling, Tom  ",,0
-Gove,Grainfield Township,President,,"Kahn, Lynn  ",,0
-Gove,Grainfield Township,President,,"La Riva, Gloria  ",,0
-Gove,Grainfield Township,President,,"Levinson, Michael S. ",,0
-Gove,Grainfield Township,President,,"Maturen, Michael A ",,0
-Gove,Grainfield Township,President,,"McMullin, Evan  ",,0
-Gove,Grainfield Township,President,,"Moorehead, Monica G. ",,0
-Gove,Grainfield Township,President,,"Perry, Darryl  ",,0
-Gove,Grainfield Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Grainfield Township,President,,"Schriner, Joe C ",,0
-Gove,Grainfield Township,President,,"Smith, Mike  ",,0
-Gove,Grainfield Township,President,,"Sood, Ajay  ",,0
-Gove,Grainfield Township,President,,"Sterling, Shawna  ",,0
-Gove,Grainfield Township,President,,"Valdivia, Anthony J ",,0
-Gove,Grainfield Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Grainfield Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Grainfield Township,President,,"Clinton, Hillary Rodham ",Democratic,20
-Gove,Grainfield Township,President,,"Johnson, Gary  ",Libertarian,6
-Gove,Grainfield Township,President,,"Trump, Donald J. ",Republican,182
-Gove,Grinnell Township,President,,"Stein, Jill  ",independent,2
-Gove,Grinnell Township,President,,"Basiago, Andrew D. ",,0
-Gove,Grinnell Township,President,,"Castle, Darrell L ",,0
-Gove,Grinnell Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Grinnell Township,President,,"Giordani, Rocky  ",,0
-Gove,Grinnell Township,President,,"Hedges, James A ",,0
-Gove,Grinnell Township,President,,"Hoefling, Tom  ",,0
-Gove,Grinnell Township,President,,"Kahn, Lynn  ",,0
-Gove,Grinnell Township,President,,"La Riva, Gloria  ",,0
-Gove,Grinnell Township,President,,"Levinson, Michael S. ",,0
-Gove,Grinnell Township,President,,"Maturen, Michael A ",,0
-Gove,Grinnell Township,President,,"McMullin, Evan  ",,0
-Gove,Grinnell Township,President,,"Moorehead, Monica G. ",,0
-Gove,Grinnell Township,President,,"Perry, Darryl  ",,0
-Gove,Grinnell Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Grinnell Township,President,,"Schriner, Joe C ",,0
-Gove,Grinnell Township,President,,"Smith, Mike  ",,0
-Gove,Grinnell Township,President,,"Sood, Ajay  ",,0
-Gove,Grinnell Township,President,,"Sterling, Shawna  ",,0
-Gove,Grinnell Township,President,,"Valdivia, Anthony J ",,0
-Gove,Grinnell Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Grinnell Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Grinnell Township,President,,"Clinton, Hillary Rodham ",Democratic,20
-Gove,Grinnell Township,President,,"Johnson, Gary  ",Libertarian,12
-Gove,Grinnell Township,President,,"Trump, Donald J. ",Republican,182
-Gove,Jerome Township,President,,"Stein, Jill  ",independent,0
-Gove,Jerome Township,President,,"Basiago, Andrew D. ",,0
-Gove,Jerome Township,President,,"Castle, Darrell L ",,0
-Gove,Jerome Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Jerome Township,President,,"Giordani, Rocky  ",,0
-Gove,Jerome Township,President,,"Hedges, James A ",,0
-Gove,Jerome Township,President,,"Hoefling, Tom  ",,0
-Gove,Jerome Township,President,,"Kahn, Lynn  ",,0
-Gove,Jerome Township,President,,"La Riva, Gloria  ",,0
-Gove,Jerome Township,President,,"Levinson, Michael S. ",,0
-Gove,Jerome Township,President,,"Maturen, Michael A ",,0
-Gove,Jerome Township,President,,"McMullin, Evan  ",,0
-Gove,Jerome Township,President,,"Moorehead, Monica G. ",,0
-Gove,Jerome Township,President,,"Perry, Darryl  ",,0
-Gove,Jerome Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Jerome Township,President,,"Schriner, Joe C ",,0
-Gove,Jerome Township,President,,"Smith, Mike  ",,0
-Gove,Jerome Township,President,,"Sood, Ajay  ",,0
-Gove,Jerome Township,President,,"Sterling, Shawna  ",,0
-Gove,Jerome Township,President,,"Valdivia, Anthony J ",,0
-Gove,Jerome Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Jerome Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Jerome Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Gove,Jerome Township,President,,"Johnson, Gary  ",Libertarian,1
-Gove,Jerome Township,President,,"Trump, Donald J. ",Republican,57
-Gove,Larrabee Township,President,,"Stein, Jill  ",independent,0
-Gove,Larrabee Township,President,,"Basiago, Andrew D. ",,0
-Gove,Larrabee Township,President,,"Castle, Darrell L ",,0
-Gove,Larrabee Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Larrabee Township,President,,"Giordani, Rocky  ",,0
-Gove,Larrabee Township,President,,"Hedges, James A ",,0
-Gove,Larrabee Township,President,,"Hoefling, Tom  ",,0
-Gove,Larrabee Township,President,,"Kahn, Lynn  ",,0
-Gove,Larrabee Township,President,,"La Riva, Gloria  ",,0
-Gove,Larrabee Township,President,,"Levinson, Michael S. ",,0
-Gove,Larrabee Township,President,,"Maturen, Michael A ",,0
-Gove,Larrabee Township,President,,"McMullin, Evan  ",,0
-Gove,Larrabee Township,President,,"Moorehead, Monica G. ",,0
-Gove,Larrabee Township,President,,"Perry, Darryl  ",,0
-Gove,Larrabee Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Larrabee Township,President,,"Schriner, Joe C ",,0
-Gove,Larrabee Township,President,,"Smith, Mike  ",,0
-Gove,Larrabee Township,President,,"Sood, Ajay  ",,0
-Gove,Larrabee Township,President,,"Sterling, Shawna  ",,0
-Gove,Larrabee Township,President,,"Valdivia, Anthony J ",,0
-Gove,Larrabee Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Larrabee Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Larrabee Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Gove,Larrabee Township,President,,"Johnson, Gary  ",Libertarian,1
-Gove,Larrabee Township,President,,"Trump, Donald J. ",Republican,29
-Gove,Lewis Township,President,,"Stein, Jill  ",independent,0
-Gove,Lewis Township,President,,"Basiago, Andrew D. ",,0
-Gove,Lewis Township,President,,"Castle, Darrell L ",,0
-Gove,Lewis Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Lewis Township,President,,"Giordani, Rocky  ",,0
-Gove,Lewis Township,President,,"Hedges, James A ",,0
-Gove,Lewis Township,President,,"Hoefling, Tom  ",,0
-Gove,Lewis Township,President,,"Kahn, Lynn  ",,0
-Gove,Lewis Township,President,,"La Riva, Gloria  ",,0
-Gove,Lewis Township,President,,"Levinson, Michael S. ",,0
-Gove,Lewis Township,President,,"Maturen, Michael A ",,0
-Gove,Lewis Township,President,,"McMullin, Evan  ",,0
-Gove,Lewis Township,President,,"Moorehead, Monica G. ",,0
-Gove,Lewis Township,President,,"Perry, Darryl  ",,0
-Gove,Lewis Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Lewis Township,President,,"Schriner, Joe C ",,0
-Gove,Lewis Township,President,,"Smith, Mike  ",,0
-Gove,Lewis Township,President,,"Sood, Ajay  ",,0
-Gove,Lewis Township,President,,"Sterling, Shawna  ",,0
-Gove,Lewis Township,President,,"Valdivia, Anthony J ",,0
-Gove,Lewis Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Lewis Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Lewis Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Gove,Lewis Township,President,,"Johnson, Gary  ",Libertarian,0
-Gove,Lewis Township,President,,"Trump, Donald J. ",Republican,5
-Gove,Payne Township,President,,"Stein, Jill  ",independent,2
-Gove,Payne Township,President,,"Basiago, Andrew D. ",,0
-Gove,Payne Township,President,,"Castle, Darrell L ",,0
-Gove,Payne Township,President,,"De La Fuente, ""Rocky"" Roque  ",,0
-Gove,Payne Township,President,,"Giordani, Rocky  ",,0
-Gove,Payne Township,President,,"Hedges, James A ",,0
-Gove,Payne Township,President,,"Hoefling, Tom  ",,0
-Gove,Payne Township,President,,"Kahn, Lynn  ",,0
-Gove,Payne Township,President,,"La Riva, Gloria  ",,0
-Gove,Payne Township,President,,"Levinson, Michael S. ",,0
-Gove,Payne Township,President,,"Maturen, Michael A ",,0
-Gove,Payne Township,President,,"McMullin, Evan  ",,0
-Gove,Payne Township,President,,"Moorehead, Monica G. ",,0
-Gove,Payne Township,President,,"Perry, Darryl  ",,0
-Gove,Payne Township,President,,"Schoenke, Marshall R. ",,0
-Gove,Payne Township,President,,"Schriner, Joe C ",,0
-Gove,Payne Township,President,,"Smith, Mike  ",,0
-Gove,Payne Township,President,,"Sood, Ajay  ",,0
-Gove,Payne Township,President,,"Sterling, Shawna  ",,0
-Gove,Payne Township,President,,"Valdivia, Anthony J ",,0
-Gove,Payne Township,President,,"Vogel-Walcutt, J.J.  ",,0
-Gove,Payne Township,President,,"Wysinger, Demetra Jefferson ",,0
-Gove,Payne Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Gove,Payne Township,President,,"Johnson, Gary  ",Libertarian,0
-Gove,Payne Township,President,,"Trump, Donald J. ",Republican,93
+county,precinct,office,district,party,candidate,votes,vtd
+GOVE,Baker Township,Kansas House of Representatives,118,Republican,"Hineman, Don",542,000010
+GOVE,Gaeland Township,Kansas House of Representatives,118,Republican,"Hineman, Don",18,000020
+GOVE,Gove Township,Kansas House of Representatives,118,Republican,"Hineman, Don",90,000030
+GOVE,Grainfield Township,Kansas House of Representatives,118,Republican,"Hineman, Don",185,000040
+GOVE,Grinnell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",197,000050
+GOVE,Jerome Township,Kansas House of Representatives,118,Republican,"Hineman, Don",64,000060
+GOVE,Larrabee Township,Kansas House of Representatives,118,Republican,"Hineman, Don",29,000070
+GOVE,Lewis Township,Kansas House of Representatives,118,Republican,"Hineman, Don",5,000080
+GOVE,Payne Township,Kansas House of Representatives,118,Republican,"Hineman, Don",92,000090
+GOVE,Baker Township,Kansas Senate,40,Democratic,"Herman, Alex",91,000010
+GOVE,Baker Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",506,000010
+GOVE,Gaeland Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000020
+GOVE,Gaeland Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",21,000020
+GOVE,Gove Township,Kansas Senate,40,Democratic,"Herman, Alex",11,000030
+GOVE,Gove Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",85,000030
+GOVE,Grainfield Township,Kansas Senate,40,Democratic,"Herman, Alex",18,000040
+GOVE,Grainfield Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",188,000040
+GOVE,Grinnell Township,Kansas Senate,40,Democratic,"Herman, Alex",21,000050
+GOVE,Grinnell Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",193,000050
+GOVE,Jerome Township,Kansas Senate,40,Democratic,"Herman, Alex",6,000060
+GOVE,Jerome Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",58,000060
+GOVE,Larrabee Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000070
+GOVE,Larrabee Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",28,000070
+GOVE,Lewis Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000080
+GOVE,Lewis Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",5,000080
+GOVE,Payne Township,Kansas Senate,40,Democratic,"Herman, Alex",11,000090
+GOVE,Payne Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",93,000090
+GOVE,Baker Township,President / Vice President,,independent,"Stein, Jill",8,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+GOVE,Baker Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+GOVE,Baker Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",87,000010
+GOVE,Baker Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000010
+GOVE,Baker Township,President / Vice President,,Republican,"Trump, Donald J.",481,000010
+GOVE,Gaeland Township,President / Vice President,,independent,"Stein, Jill",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+GOVE,Gaeland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+GOVE,Gaeland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+GOVE,Gaeland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+GOVE,Gaeland Township,President / Vice President,,Republican,"Trump, Donald J.",25,000020
+GOVE,Gove Township,President / Vice President,,independent,"Stein, Jill",1,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+GOVE,Gove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+GOVE,Gove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000030
+GOVE,Gove Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+GOVE,Gove Township,President / Vice President,,Republican,"Trump, Donald J.",86,000030
+GOVE,Grainfield Township,President / Vice President,,independent,"Stein, Jill",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+GOVE,Grainfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+GOVE,Grainfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000040
+GOVE,Grainfield Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+GOVE,Grainfield Township,President / Vice President,,Republican,"Trump, Donald J.",182,000040
+GOVE,Grinnell Township,President / Vice President,,independent,"Stein, Jill",2,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+GOVE,Grinnell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+GOVE,Grinnell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000050
+GOVE,Grinnell Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000050
+GOVE,Grinnell Township,President / Vice President,,Republican,"Trump, Donald J.",182,000050
+GOVE,Jerome Township,President / Vice President,,independent,"Stein, Jill",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+GOVE,Jerome Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+GOVE,Jerome Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000060
+GOVE,Jerome Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+GOVE,Jerome Township,President / Vice President,,Republican,"Trump, Donald J.",57,000060
+GOVE,Larrabee Township,President / Vice President,,independent,"Stein, Jill",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+GOVE,Larrabee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+GOVE,Larrabee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000070
+GOVE,Larrabee Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+GOVE,Larrabee Township,President / Vice President,,Republican,"Trump, Donald J.",29,000070
+GOVE,Lewis Township,President / Vice President,,independent,"Stein, Jill",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+GOVE,Lewis Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+GOVE,Lewis Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+GOVE,Lewis Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+GOVE,Lewis Township,President / Vice President,,Republican,"Trump, Donald J.",5,000080
+GOVE,Payne Township,President / Vice President,,independent,"Stein, Jill",2,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+GOVE,Payne Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+GOVE,Payne Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000090
+GOVE,Payne Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+GOVE,Payne Township,President / Vice President,,Republican,"Trump, Donald J.",93,000090
+GOVE,Baker Township,United States House of Representatives,1,independent,"LaPolice, Alan",97,000010
+GOVE,Baker Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+GOVE,Baker Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000010
+GOVE,Baker Township,United States House of Representatives,1,Republican,"Marshall, Roger",473,000010
+GOVE,Gaeland Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000020
+GOVE,Gaeland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+GOVE,Gaeland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000020
+GOVE,Gaeland Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000020
+GOVE,Gove Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000030
+GOVE,Gove Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+GOVE,Gove Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000030
+GOVE,Gove Township,United States House of Representatives,1,Republican,"Marshall, Roger",69,000030
+GOVE,Grainfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000040
+GOVE,Grainfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+GOVE,Grainfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000040
+GOVE,Grainfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",160,000040
+GOVE,Grinnell Township,United States House of Representatives,1,independent,"LaPolice, Alan",33,000050
+GOVE,Grinnell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+GOVE,Grinnell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000050
+GOVE,Grinnell Township,United States House of Representatives,1,Republican,"Marshall, Roger",171,000050
+GOVE,Jerome Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000060
+GOVE,Jerome Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+GOVE,Jerome Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+GOVE,Jerome Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000060
+GOVE,Larrabee Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000070
+GOVE,Larrabee Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+GOVE,Larrabee Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000070
+GOVE,Larrabee Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000070
+GOVE,Lewis Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000080
+GOVE,Lewis Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+GOVE,Lewis Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+GOVE,Lewis Township,United States House of Representatives,1,Republican,"Marshall, Roger",5,000080
+GOVE,Payne Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000090
+GOVE,Payne Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+GOVE,Payne Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000090
+GOVE,Payne Township,United States House of Representatives,1,Republican,"Marshall, Roger",89,000090
+GOVE,Baker Township,United States Senate,,write - in,"Smith, DJ",0,000010
+GOVE,Baker Township,United States Senate,,Democratic,"Wiesner, Patrick",59,000010
+GOVE,Baker Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000010
+GOVE,Baker Township,United States Senate,,Republican,"Moran, Jerry",537,000010
+GOVE,Gaeland Township,United States Senate,,write - in,"Smith, DJ",0,000020
+GOVE,Gaeland Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+GOVE,Gaeland Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+GOVE,Gaeland Township,United States Senate,,Republican,"Moran, Jerry",24,000020
+GOVE,Gove Township,United States Senate,,write - in,"Smith, DJ",0,000030
+GOVE,Gove Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000030
+GOVE,Gove Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000030
+GOVE,Gove Township,United States Senate,,Republican,"Moran, Jerry",84,000030
+GOVE,Grainfield Township,United States Senate,,write - in,"Smith, DJ",0,000040
+GOVE,Grainfield Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000040
+GOVE,Grainfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000040
+GOVE,Grainfield Township,United States Senate,,Republican,"Moran, Jerry",178,000040
+GOVE,Grinnell Township,United States Senate,,write - in,"Smith, DJ",0,000050
+GOVE,Grinnell Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000050
+GOVE,Grinnell Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000050
+GOVE,Grinnell Township,United States Senate,,Republican,"Moran, Jerry",190,000050
+GOVE,Jerome Township,United States Senate,,write - in,"Smith, DJ",0,000060
+GOVE,Jerome Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+GOVE,Jerome Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+GOVE,Jerome Township,United States Senate,,Republican,"Moran, Jerry",62,000060
+GOVE,Larrabee Township,United States Senate,,write - in,"Smith, DJ",0,000070
+GOVE,Larrabee Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000070
+GOVE,Larrabee Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+GOVE,Larrabee Township,United States Senate,,Republican,"Moran, Jerry",29,000070
+GOVE,Lewis Township,United States Senate,,write - in,"Smith, DJ",0,000080
+GOVE,Lewis Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000080
+GOVE,Lewis Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+GOVE,Lewis Township,United States Senate,,Republican,"Moran, Jerry",5,000080
+GOVE,Payne Township,United States Senate,,write - in,"Smith, DJ",0,000090
+GOVE,Payne Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000090
+GOVE,Payne Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+GOVE,Payne Township,United States Senate,,Republican,"Moran, Jerry",91,000090

--- a/2016/20161108__ks__general__graham__precinct.csv
+++ b/2016/20161108__ks__general__graham__precinct.csv
@@ -1,288 +1,732 @@
-county,precinct,office,district,party,candidate,votes
-Graham,Allodium,President,,LBT,Johnson and Weld,0
-Graham,Allodium,President,,IND,Stein and Baraka,0
-Graham,Allodium,President,,R,Trump and Pence,14
-Graham,Allodium,President,,D,Clinton and Kaine,0
-Graham,Bryant,President,,LBT,Johnson and Weld,1
-Graham,Bryant,President,,IND,Stein and Baraka,0
-Graham,Bryant,President,,R,Trump and Pence,22
-Graham,Bryant,President,,D,Clinton and Kaine,2
-Graham,Gettysburg,President,,LBT,Johnson and Weld,0
-Graham,Gettysburg,President,,IND,Stein and Baraka,0
-Graham,Gettysburg,President,,R,Trump and Pence,35
-Graham,Gettysburg,President,,D,Clinton and Kaine,3
-Graham,Graham,President,,LBT,Johnson and Weld,2
-Graham,Graham,President,,IND,Stein and Baraka,0
-Graham,Graham,President,,R,Trump and Pence,27
-Graham,Graham,President,,D,Clinton and Kaine,4
-Graham,Happy,President,,LBT,Johnson and Weld,0
-Graham,Happy,President,,IND,Stein and Baraka,0
-Graham,Happy,President,,R,Trump and Pence,20
-Graham,Happy,President,,D,Clinton and Kaine,2
-Graham,Hill City H110,President,,LBT,Johnson and Weld,4
-Graham,Hill City H110,President,,IND,Stein and Baraka,4
-Graham,Hill City H110,President,,R,Trump and Pence,52
-Graham,Hill City H110,President,,D,Clinton and Kaine,10
-Graham,Hill City 2 H110,President,,LBT,Johnson and Weld,9
-Graham,Hill City 2 H110,President,,IND,Stein and Baraka,12
-Graham,Hill City 2 H110,President,,R,Trump and Pence,230
-Graham,Hill City 2 H110,President,,D,Clinton and Kaine,46
-Graham,Hill City 3 H110,President,,LBT,Johnson and Weld,3
-Graham,Hill City 3 H110,President,,IND,Stein and Baraka,3
-Graham,Hill City 3 H110,President,,R,Trump and Pence,97
-Graham,Hill City 3 H110,President,,D,Clinton and Kaine,19
-Graham,Hill City 3 H118,President,,LBT,Johnson and Weld,0
-Graham,Hill City 3 H118,President,,IND,Stein and Baraka,0
-Graham,Hill City 3 H118,President,,R,Trump and Pence,3
-Graham,Hill City 3 H118,President,,D,Clinton and Kaine,2
-Graham,Hill City twp 71 H118,President,,LBT,Johnson and Weld,0
-Graham,Hill City twp 71 H118,President,,IND,Stein and Baraka,0
-Graham,Hill City twp 71 H118,President,,R,Trump and Pence,3
-Graham,Hill City twp 71 H118,President,,D,Clinton and Kaine,0
-Graham,Hill City twp 72 H110,President,,LBT,Johnson and Weld,1
-Graham,Hill City twp 72 H110,President,,IND,Stein and Baraka,0
-Graham,Hill City twp 72 H110,President,,R,Trump and Pence,19
-Graham,Hill City twp 72 H110,President,,D,Clinton and Kaine,7
-Graham,Hill City twp 72 H118,President,,LBT,Johnson and Weld,0
-Graham,Hill City twp 72 H118,President,,IND,Stein and Baraka,0
-Graham,Hill City twp 72 H118,President,,R,Trump and Pence,2
-Graham,Hill City twp 72 H118,President,,D,Clinton and Kaine,0
-Graham,Hill City twp 73 H118,President,,LBT,Johnson and Weld,0
-Graham,Hill City twp 73 H118,President,,IND,Stein and Baraka,0
-Graham,Hill City twp 73 H118,President,,R,Trump and Pence,17
-Graham,Hill City twp 73 H118,President,,D,Clinton and Kaine,2
-Graham,Indiana,President,,LBT,Johnson and Weld,0
-Graham,Indiana,President,,IND,Stein and Baraka,0
-Graham,Indiana,President,,R,Trump and Pence,11
-Graham,Indiana,President,,D,Clinton and Kaine,0
-Graham,Millbrook,President,,LBT,Johnson and Weld,1
-Graham,Millbrook,President,,IND,Stein and Baraka,0
-Graham,Millbrook,President,,R,Trump and Pence,34
-Graham,Millbrook,President,,D,Clinton and Kaine,3
-Graham,Morlan,President,,LBT,Johnson and Weld,1
-Graham,Morlan,President,,IND,Stein and Baraka,0
-Graham,Morlan,President,,R,Trump and Pence,25
-Graham,Morlan,President,,D,Clinton and Kaine,0
-Graham,Nicodemus 110,President,,LBT,Johnson and Weld,0
-Graham,Nicodemus 110,President,,IND,Stein and Baraka,0
-Graham,Nicodemus 110,President,,R,Trump and Pence,4
-Graham,Nicodemus 110,President,,D,Clinton and Kaine,2
-Graham,Nicodemus 118,President,,LBT,Johnson and Weld,2
-Graham,Nicodemus 118,President,,IND,Stein and Baraka,1
-Graham,Nicodemus 118,President,,R,Trump and Pence,3
-Graham,Nicodemus 118,President,,D,Clinton and Kaine,5
-Graham,Pioneer,President,,LBT,Johnson and Weld,0
-Graham,Pioneer,President,,IND,Stein and Baraka,0
-Graham,Pioneer,President,,R,Trump and Pence,18
-Graham,Pioneer,President,,D,Clinton and Kaine,1
-Graham,Solomon,President,,LBT,Johnson and Weld,0
-Graham,Solomon,President,,IND,Stein and Baraka,0
-Graham,Solomon,President,,R,Trump and Pence,68
-Graham,Solomon,President,,D,Clinton and Kaine,9
-Graham,Wildhorse,President,,LBT,Johnson and Weld,6
-Graham,Wildhorse,President,,IND,Stein and Baraka,3
-Graham,Wildhorse,President,,R,Trump and Pence,73
-Graham,Wildhorse,President,,D,Clinton and Kaine,17
-Graham,Advance,President,,LBT,Johnson and Weld,8
-Graham,Advance,President,,IND,Stein and Baraka,6
-Graham,Advance,President,,R,Trump and Pence,236
-Graham,Advance,President,,D,Clinton and Kaine,51
-Graham,Allodium,U.S. Senate,,R,Jerry Moran ,14
-Graham,Allodium,U.S. Senate,,D,Patrick Wisner,0
-Graham,Allodium,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Allodium,U.S. House,1,LBT,Kerry Burt,0
-Graham,Allodium,U.S. House,1,IND,Alan LaPolice,1
-Graham,Allodium,U.S. House,1,R,Roger Marshall,13
-Graham,Allodium,State Senate,40,D,Alex Herman,0
-Graham,Allodium,State Senate,40,R,Rick Billinger,14
-Graham,Allodium,State House,118,R,Don Hineman,14
-Graham,Bryant,U.S. Senate,,R,Jerry Moran ,24
-Graham,Bryant,U.S. Senate,,D,Patrick Wisner,1
-Graham,Bryant,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Bryant,U.S. House,1,LBT,Kerry Burt,0
-Graham,Bryant,U.S. House,1,IND,Alan LaPolice,2
-Graham,Bryant,U.S. House,1,R,Roger Marshall,22
-Graham,Bryant,State Senate,40,D,Alex Herman,6
-Graham,Bryant,State Senate,40,R,Rick Billinger,18
-Graham,Bryant,State House,118,R,Don Hineman,25
-Graham,Gettysburg,U.S. Senate,,R,Jerry Moran ,30
-Graham,Gettysburg,U.S. Senate,,D,Patrick Wisner,2
-Graham,Gettysburg,U.S. Senate,,LBT,Robert Garrard,1
-Graham,Gettysburg,U.S. House,1,LBT,Kerry Burt,2
-Graham,Gettysburg,U.S. House,1,IND,Alan LaPolice,7
-Graham,Gettysburg,U.S. House,1,R,Roger Marshall,29
-Graham,Gettysburg,State Senate,40,D,Alex Herman,3
-Graham,Gettysburg,State Senate,40,R,Rick Billinger,35
-Graham,Gettysburg,State House,118,R,Don Hineman,33
-Graham,Graham,U.S. Senate,,R,Jerry Moran ,27
-Graham,Graham,U.S. Senate,,D,Patrick Wisner,3
-Graham,Graham,U.S. Senate,,LBT,Robert Garrard,3
-Graham,Graham,U.S. House,1,LBT,Kerry Burt,0
-Graham,Graham,U.S. House,1,IND,Alan LaPolice,6
-Graham,Graham,U.S. House,1,R,Roger Marshall,24
-Graham,Graham,State Senate,40,D,Alex Herman,5
-Graham,Graham,State Senate,40,R,Rick Billinger,27
-Graham,Graham,State House,118,R,Don Hineman,30
-Graham,Happy,U.S. Senate,,R,Jerry Moran ,21
-Graham,Happy,U.S. Senate,,D,Patrick Wisner,1
-Graham,Happy,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Happy,U.S. House,1,LBT,Kerry Burt,0
-Graham,Happy,U.S. House,1,IND,Alan LaPolice,0
-Graham,Happy,U.S. House,1,R,Roger Marshall,22
-Graham,Happy,State Senate,40,D,Alex Herman,3
-Graham,Happy,State Senate,40,R,Rick Billinger,19
-Graham,Happy,State House,118,R,Don Hineman,20
-Graham,Hill City H110,U.S. Senate,,R,Jerry Moran ,55
-Graham,Hill City H110,U.S. Senate,,D,Patrick Wisner,11
-Graham,Hill City H110,U.S. Senate,,LBT,Robert Garrard,4
-Graham,Hill City H110,U.S. House,1,LBT,Kerry Burt,6
-Graham,Hill City H110,U.S. House,1,IND,Alan LaPolice,16
-Graham,Hill City H110,U.S. House,1,R,Roger Marshall,48
-Graham,Hill City H110,State Senate,40,D,Alex Herman,15
-Graham,Hill City H110,State Senate,40,R,Rick Billinger,55
-Graham,Hill City H110,State House,110,R,Ken Rajhes,57
-Graham,Hill City 2 H110,U.S. Senate,,R,Jerry Moran ,240
-Graham,Hill City 2 H110,U.S. Senate,,D,Patrick Wisner,37
-Graham,Hill City 2 H110,U.S. Senate,,LBT,Robert Garrard,19
-Graham,Hill City 2 H110,U.S. House,1,LBT,Kerry Burt,13
-Graham,Hill City 2 H110,U.S. House,1,IND,Alan LaPolice,59
-Graham,Hill City 2 H110,U.S. House,1,R,Roger Marshall,218
-Graham,Hill City 2 H110,State Senate,40,D,Alex Herman,70
-Graham,Hill City 2 H110,State Senate,40,R,Rick Billinger,218
-Graham,Hill City 2 H110,State House,110,R,Ken Rajhes,241
-Graham,Hill City 3 H110,U.S. Senate,,R,Jerry Moran ,98
-Graham,Hill City 3 H110,U.S. Senate,,D,Patrick Wisner,12
-Graham,Hill City 3 H110,U.S. Senate,,LBT,Robert Garrard,8
-Graham,Hill City 3 H110,U.S. House,1,LBT,Kerry Burt,4
-Graham,Hill City 3 H110,U.S. House,1,IND,Alan LaPolice,25
-Graham,Hill City 3 H110,U.S. House,1,R,Roger Marshall,84
-Graham,Hill City 3 H110,State Senate,40,D,Alex Herman,29
-Graham,Hill City 3 H110,State Senate,40,R,Rick Billinger,86
-Graham,Hill City 3 H110,State House,110,R,Ken Rajhes,102
-Graham,Hill City 3 H118,U.S. Senate,,R,Jerry Moran ,4
-Graham,Hill City 3 H118,U.S. Senate,,D,Patrick Wisner,1
-Graham,Hill City 3 H118,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Hill City 3 H118,U.S. House,1,LBT,Kerry Burt,0
-Graham,Hill City 3 H118,U.S. House,1,IND,Alan LaPolice,1
-Graham,Hill City 3 H118,U.S. House,1,R,Roger Marshall,4
-Graham,Hill City 3 H118,State Senate,40,D,Alex Herman,1
-Graham,Hill City 3 H118,State Senate,40,R,Rick Billinger,4
-Graham,Hill City 3 H118,State House,118,R,Don Hineman,4
-Graham,Hill City twp 71 H118,U.S. Senate,,R,Jerry Moran ,3
-Graham,Hill City twp 71 H118,U.S. Senate,,D,Patrick Wisner,0
-Graham,Hill City twp 71 H118,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Hill City twp 71 H118,U.S. House,1,LBT,Kerry Burt,0
-Graham,Hill City twp 71 H118,U.S. House,1,IND,Alan LaPolice,0
-Graham,Hill City twp 71 H118,U.S. House,1,R,Roger Marshall,3
-Graham,Hill City twp 71 H118,State Senate,40,D,Alex Herman,0
-Graham,Hill City twp 71 H118,State Senate,40,R,Rick Billinger,3
-Graham,Hill City twp 71 H118,State House,118,R,Don Hineman,2
-Graham,Hill City twp 72 H110,U.S. Senate,,R,Jerry Moran ,25
-Graham,Hill City twp 72 H110,U.S. Senate,,D,Patrick Wisner,2
-Graham,Hill City twp 72 H110,U.S. Senate,,LBT,Robert Garrard,2
-Graham,Hill City twp 72 H110,U.S. House,1,LBT,Kerry Burt,0
-Graham,Hill City twp 72 H110,U.S. House,1,IND,Alan LaPolice,3
-Graham,Hill City twp 72 H110,U.S. House,1,R,Roger Marshall,21
-Graham,Hill City twp 72 H110,State Senate,40,D,Alex Herman,5
-Graham,Hill City twp 72 H110,State Senate,40,R,Rick Billinger,19
-Graham,Hill City twp 72 H110,State House,118,R,Don Hineman,24
-Graham,Hill City twp 72 H118,U.S. Senate,,R,Jerry Moran ,2
-Graham,Hill City twp 72 H118,U.S. Senate,,D,Patrick Wisner,0
-Graham,Hill City twp 72 H118,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Hill City twp 72 H118,U.S. House,1,LBT,Kerry Burt,0
-Graham,Hill City twp 72 H118,U.S. House,1,IND,Alan LaPolice,0
-Graham,Hill City twp 72 H118,U.S. House,1,R,Roger Marshall,2
-Graham,Hill City twp 72 H118,State Senate,40,D,Alex Herman,0
-Graham,Hill City twp 72 H118,State Senate,40,R,Rick Billinger,2
-Graham,Hill City twp 72 H118,State House,118,R,Don Hineman,2
-Graham,Hill City twp 73 H118,U.S. Senate,,R,Jerry Moran ,19
-Graham,Hill City twp 73 H118,U.S. Senate,,D,Patrick Wisner,0
-Graham,Hill City twp 73 H118,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Hill City twp 73 H118,U.S. House,1,LBT,Kerry Burt,1
-Graham,Hill City twp 73 H118,U.S. House,1,IND,Alan LaPolice,4
-Graham,Hill City twp 73 H118,U.S. House,1,R,Roger Marshall,13
-Graham,Hill City twp 73 H118,State Senate,40,D,Alex Herman,4
-Graham,Hill City twp 73 H118,State Senate,40,R,Rick Billinger,14
-Graham,Hill City twp 73 H118,State House,118,R,Don Hineman,15
-Graham,Indiana,U.S. Senate,,R,Jerry Moran ,9
-Graham,Indiana,U.S. Senate,,D,Patrick Wisner,1
-Graham,Indiana,U.S. Senate,,LBT,Robert Garrard,1
-Graham,Indiana,U.S. House,1,LBT,Kerry Burt,3
-Graham,Indiana,U.S. House,1,IND,Alan LaPolice,1
-Graham,Indiana,U.S. House,1,R,Roger Marshall,6
-Graham,Indiana,State Senate,40,D,Alex Herman,1
-Graham,Indiana,State Senate,40,R,Rick Billinger,9
-Graham,Indiana,State House,118,R,Don Hineman,7
-Graham,Millbrook,U.S. Senate,,R,Jerry Moran ,37
-Graham,Millbrook,U.S. Senate,,D,Patrick Wisner,2
-Graham,Millbrook,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Millbrook,U.S. House,1,LBT,Kerry Burt,0
-Graham,Millbrook,U.S. House,1,IND,Alan LaPolice,16
-Graham,Millbrook,U.S. House,1,R,Roger Marshall,24
-Graham,Millbrook,State Senate,40,D,Alex Herman,3
-Graham,Millbrook,State Senate,40,R,Rick Billinger,37
-Graham,Millbrook,State House,118,R,Don Hineman,40
-Graham,Morlan,U.S. Senate,,R,Jerry Moran ,24
-Graham,Morlan,U.S. Senate,,D,Patrick Wisner,2
-Graham,Morlan,U.S. Senate,,LBT,Robert Garrard,1
-Graham,Morlan,U.S. House,1,LBT,Kerry Burt,0
-Graham,Morlan,U.S. House,1,IND,Alan LaPolice,1
-Graham,Morlan,U.S. House,1,R,Roger Marshall,26
-Graham,Morlan,State Senate,40,D,Alex Herman,4
-Graham,Morlan,State Senate,40,R,Rick Billinger,22
-Graham,Morlan,State House,118,R,Don Hineman,27
-Graham,Nicodemus 110,U.S. Senate,,R,Jerry Moran ,4
-Graham,Nicodemus 110,U.S. Senate,,D,Patrick Wisner,1
-Graham,Nicodemus 110,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Nicodemus 110,U.S. House,1,LBT,Kerry Burt,0
-Graham,Nicodemus 110,U.S. House,1,IND,Alan LaPolice,2
-Graham,Nicodemus 110,U.S. House,1,R,Roger Marshall,3
-Graham,Nicodemus 110,State Senate,40,D,Alex Herman,4
-Graham,Nicodemus 110,State Senate,40,R,Rick Billinger,1
-Graham,Nicodemus 110,State House,110,R,Ken Rajhes,5
-Graham,Nicodemus 118,U.S. Senate,,R,Jerry Moran ,5
-Graham,Nicodemus 118,U.S. Senate,,D,Patrick Wisner,3
-Graham,Nicodemus 118,U.S. Senate,,LBT,Robert Garrard,1
-Graham,Nicodemus 118,U.S. House,1,LBT,Kerry Burt,2
-Graham,Nicodemus 118,U.S. House,1,IND,Alan LaPolice,3
-Graham,Nicodemus 118,U.S. House,1,R,Roger Marshall,3
-Graham,Nicodemus 118,State Senate,40,D,Alex Herman,7
-Graham,Nicodemus 118,State Senate,40,R,Rick Billinger,3
-Graham,Nicodemus 118,State House,118,R,Don Hineman,6
-Graham,Pioneer,U.S. Senate,,R,Jerry Moran ,18
-Graham,Pioneer,U.S. Senate,,D,Patrick Wisner,0
-Graham,Pioneer,U.S. Senate,,LBT,Robert Garrard,0
-Graham,Pioneer,U.S. House,1,LBT,Kerry Burt,1
-Graham,Pioneer,U.S. House,1,IND,Alan LaPolice,2
-Graham,Pioneer,U.S. House,1,R,Roger Marshall,16
-Graham,Pioneer,State Senate,40,D,Alex Herman,1
-Graham,Pioneer,State Senate,40,R,Rick Billinger,18
-Graham,Pioneer,State House,118,R,Don Hineman,16
-Graham,Solomon,U.S. Senate,,R,Jerry Moran ,74
-Graham,Solomon,U.S. Senate,,D,Patrick Wisner,5
-Graham,Solomon,U.S. Senate,,LBT,Robert Garrard,2
-Graham,Solomon,U.S. House,1,LBT,Kerry Burt,3
-Graham,Solomon,U.S. House,1,IND,Alan LaPolice,13
-Graham,Solomon,U.S. House,1,R,Roger Marshall,62
-Graham,Solomon,State Senate,40,D,Alex Herman,11
-Graham,Solomon,State Senate,40,R,Rick Billinger,69
-Graham,Solomon,State House,118,R,Don Hineman,74
-Graham,Wildhorse,U.S. Senate,,R,Jerry Moran ,89
-Graham,Wildhorse,U.S. Senate,,D,Patrick Wisner,10
-Graham,Wildhorse,U.S. Senate,,LBT,Robert Garrard,2
-Graham,Wildhorse,U.S. House,1,LBT,Kerry Burt,0
-Graham,Wildhorse,U.S. House,1,IND,Alan LaPolice,22
-Graham,Wildhorse,U.S. House,1,R,Roger Marshall,74
-Graham,Wildhorse,State Senate,40,D,Alex Herman,21
-Graham,Wildhorse,State Senate,40,R,Rick Billinger,78
-Graham,Wildhorse,State House,118,R,Don Hineman,86
-Graham,Advance,U.S. Senate,,R,Jerry Moran ,256
-Graham,Advance,U.S. Senate,,D,Patrick Wisner,38
-Graham,Advance,U.S. Senate,,LBT,Robert Garrard,10
-Graham,Advance,U.S. House,1,LBT,Kerry Burt,11
-Graham,Advance,U.S. House,1,IND,Alan LaPolice,64
-Graham,Advance,U.S. House,1,R,Roger Marshall,221
-Graham,Advance,State Senate,40,D,Alex Herman,67
-Graham,Advance,State Senate,40,R,Rick Billinger,229
-Graham,Advance,State House,110,R,Ken Rajhes,133
-Graham,Advance,State House,118,R,Don Hineman,125
+county,precinct,office,district,party,candidate,votes,vtd
+GRAHAM,Allodium Township,Kansas House of Representatives,118,Republican,"Hineman, Don",17,000010
+GRAHAM,Bogue City,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000020
+GRAHAM,Bryant Township,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000030
+GRAHAM,Gettysburg Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000040
+GRAHAM,Graham Township,Kansas House of Representatives,118,Republican,"Hineman, Don",33,000050
+GRAHAM,Happy Township,Kansas House of Representatives,118,Republican,"Hineman, Don",28,000060
+GRAHAM,Indiana Township,Kansas House of Representatives,118,Republican,"Hineman, Don",11,000100
+GRAHAM,Millbrook Township,Kansas House of Representatives,118,Republican,"Hineman, Don",73,000110
+GRAHAM,Morlan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",36,000120
+GRAHAM,Morland City,Kansas House of Representatives,118,Republican,"Hineman, Don",0,000130
+GRAHAM,Pioneer Township,Kansas House of Representatives,118,Republican,"Hineman, Don",17,000150
+GRAHAM,Solomon Township,Kansas House of Representatives,118,Republican,"Hineman, Don",94,000160
+GRAHAM,Wildhorse Township,Kansas House of Representatives,118,Republican,"Hineman, Don",103,000170
+GRAHAM,Hill City Precinct 1 H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",73,120020
+GRAHAM,Hill City Precinct 1 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",7,120030
+GRAHAM,Hill City Precinct 2 H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",362,120040
+GRAHAM,Hill City Precinct 2 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",3,120050
+GRAHAM,Hill City Precinct 3 H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",127,120060
+GRAHAM,Hill City Precinct 3 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",24,120070
+GRAHAM,Nicodemus Township  H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",8,120080
+GRAHAM,Nicodemus Township H118,Kansas House of Representatives,118,Republican,"Hineman, Don",7,120090
+GRAHAM,Allodium Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000010
+GRAHAM,Allodium Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",17,000010
+GRAHAM,Bogue City,Kansas Senate,40,Democratic,"Herman, Alex",0,000020
+GRAHAM,Bogue City,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,000020
+GRAHAM,Bryant Township,Kansas Senate,40,Democratic,"Herman, Alex",10,000030
+GRAHAM,Bryant Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",26,000030
+GRAHAM,Gettysburg Township,Kansas Senate,40,Democratic,"Herman, Alex",4,000040
+GRAHAM,Gettysburg Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",44,000040
+GRAHAM,Graham Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000050
+GRAHAM,Graham Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",28,000050
+GRAHAM,Happy Township,Kansas Senate,40,Democratic,"Herman, Alex",5,000060
+GRAHAM,Happy Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",26,000060
+GRAHAM,Indiana Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000100
+GRAHAM,Indiana Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",13,000100
+GRAHAM,Millbrook Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000110
+GRAHAM,Millbrook Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",66,000110
+GRAHAM,Morlan Township,Kansas Senate,40,Democratic,"Herman, Alex",5,000120
+GRAHAM,Morlan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",30,000120
+GRAHAM,Morland City,Kansas Senate,40,Democratic,"Herman, Alex",0,000130
+GRAHAM,Morland City,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,000130
+GRAHAM,Pioneer Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000150
+GRAHAM,Pioneer Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",19,000150
+GRAHAM,Solomon Township,Kansas Senate,40,Democratic,"Herman, Alex",13,000160
+GRAHAM,Solomon Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",88,000160
+GRAHAM,Wildhorse Township,Kansas Senate,40,Democratic,"Herman, Alex",29,000170
+GRAHAM,Wildhorse Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",91,000170
+GRAHAM,Hill City Precinct 1 H110,Kansas Senate,40,Democratic,"Herman, Alex",18,120020
+GRAHAM,Hill City Precinct 1 H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",70,120020
+GRAHAM,Hill City Precinct 1 H118,Kansas Senate,40,Democratic,"Herman, Alex",1,120030
+GRAHAM,Hill City Precinct 1 H118,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",7,120030
+GRAHAM,Hill City Precinct 2 H110,Kansas Senate,40,Democratic,"Herman, Alex",103,120040
+GRAHAM,Hill City Precinct 2 H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",325,120040
+GRAHAM,Hill City Precinct 2 H118,Kansas Senate,40,Democratic,"Herman, Alex",1,120050
+GRAHAM,Hill City Precinct 2 H118,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",2,120050
+GRAHAM,Hill City Precinct 3 H110,Kansas Senate,40,Democratic,"Herman, Alex",38,120060
+GRAHAM,Hill City Precinct 3 H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",110,120060
+GRAHAM,Hill City Precinct 3 H118,Kansas Senate,40,Democratic,"Herman, Alex",7,120070
+GRAHAM,Hill City Precinct 3 H118,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",23,120070
+GRAHAM,Nicodemus Township  H110,Kansas Senate,40,Democratic,"Herman, Alex",5,120080
+GRAHAM,Nicodemus Township  H110,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",3,120080
+GRAHAM,Nicodemus Township H118,Kansas Senate,40,Democratic,"Herman, Alex",8,120090
+GRAHAM,Nicodemus Township H118,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",3,120090
+GRAHAM,Allodium Township,President / Vice President,,independent,"Stein, Jill",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+GRAHAM,Allodium Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+GRAHAM,Allodium Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+GRAHAM,Allodium Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+GRAHAM,Allodium Township,President / Vice President,,Republican,"Trump, Donald J.",17,000010
+GRAHAM,Bogue City,President / Vice President,,independent,"Stein, Jill",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Hedges, James A",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"McMullin, Evan",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Perry, Darryl",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Smith, Mike",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Sood, Ajay",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+GRAHAM,Bogue City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+GRAHAM,Bogue City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+GRAHAM,Bogue City,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+GRAHAM,Bogue City,President / Vice President,,Republican,"Trump, Donald J.",0,000020
+GRAHAM,Bryant Township,President / Vice President,,independent,"Stein, Jill",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+GRAHAM,Bryant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+GRAHAM,Bryant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+GRAHAM,Bryant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+GRAHAM,Bryant Township,President / Vice President,,Republican,"Trump, Donald J.",34,000030
+GRAHAM,Gettysburg Township,President / Vice President,,independent,"Stein, Jill",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+GRAHAM,Gettysburg Township,President / Vice President,,Republican,"Trump, Donald J.",44,000040
+GRAHAM,Graham Township,President / Vice President,,independent,"Stein, Jill",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+GRAHAM,Graham Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+GRAHAM,Graham Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000050
+GRAHAM,Graham Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+GRAHAM,Graham Township,President / Vice President,,Republican,"Trump, Donald J.",29,000050
+GRAHAM,Happy Township,President / Vice President,,independent,"Stein, Jill",2,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+GRAHAM,Happy Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+GRAHAM,Happy Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000060
+GRAHAM,Happy Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+GRAHAM,Happy Township,President / Vice President,,Republican,"Trump, Donald J.",25,000060
+GRAHAM,Indiana Township,President / Vice President,,independent,"Stein, Jill",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+GRAHAM,Indiana Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+GRAHAM,Indiana Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000100
+GRAHAM,Indiana Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+GRAHAM,Indiana Township,President / Vice President,,Republican,"Trump, Donald J.",16,000100
+GRAHAM,Millbrook Township,President / Vice President,,independent,"Stein, Jill",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+GRAHAM,Millbrook Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000110
+GRAHAM,Millbrook Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+GRAHAM,Millbrook Township,President / Vice President,,Republican,"Trump, Donald J.",63,000110
+GRAHAM,Morlan Township,President / Vice President,,independent,"Stein, Jill",1,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+GRAHAM,Morlan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+GRAHAM,Morlan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+GRAHAM,Morlan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+GRAHAM,Morlan Township,President / Vice President,,Republican,"Trump, Donald J.",33,000120
+GRAHAM,Pioneer Township,President / Vice President,,independent,"Stein, Jill",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000150
+GRAHAM,Pioneer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+GRAHAM,Pioneer Township,President / Vice President,,Republican,"Trump, Donald J.",19,000150
+GRAHAM,Solomon Township,President / Vice President,,independent,"Stein, Jill",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+GRAHAM,Solomon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+GRAHAM,Solomon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000160
+GRAHAM,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+GRAHAM,Solomon Township,President / Vice President,,Republican,"Trump, Donald J.",87,000160
+GRAHAM,Wildhorse Township,President / Vice President,,independent,"Stein, Jill",4,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000170
+GRAHAM,Wildhorse Township,President / Vice President,,Republican,"Trump, Donald J.",88,000170
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,independent,"Stein, Jill",4,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Hedges, James A",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"McMullin, Evan",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Perry, Darryl",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Smith, Mike",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Sood, Ajay",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Libertarian,"Johnson, Gary",5,120020
+GRAHAM,Hill City Precinct 1 H110,President / Vice President,,Republican,"Trump, Donald J.",67,120020
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,independent,"Stein, Jill",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Hedges, James A",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"McMullin, Evan",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Perry, Darryl",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Smith, Mike",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Sood, Ajay",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+GRAHAM,Hill City Precinct 1 H118,President / Vice President,,Republican,"Trump, Donald J.",8,120030
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,independent,"Stein, Jill",15,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Hedges, James A",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"McMullin, Evan",3,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Perry, Darryl",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Smith, Mike",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Sood, Ajay",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",80,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Libertarian,"Johnson, Gary",14,120040
+GRAHAM,Hill City Precinct 2 H110,President / Vice President,,Republican,"Trump, Donald J.",335,120040
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,independent,"Stein, Jill",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Hedges, James A",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"McMullin, Evan",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Perry, Darryl",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Smith, Mike",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Sood, Ajay",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120050
+GRAHAM,Hill City Precinct 2 H118,President / Vice President,,Republican,"Trump, Donald J.",3,120050
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,independent,"Stein, Jill",3,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Hedges, James A",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"McMullin, Evan",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Perry, Darryl",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Smith, Mike",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Sood, Ajay",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Libertarian,"Johnson, Gary",4,120060
+GRAHAM,Hill City Precinct 3 H110,President / Vice President,,Republican,"Trump, Donald J.",122,120060
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,independent,"Stein, Jill",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Hedges, James A",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"McMullin, Evan",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Perry, Darryl",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Smith, Mike",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Sood, Ajay",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Libertarian,"Johnson, Gary",1,120070
+GRAHAM,Hill City Precinct 3 H118,President / Vice President,,Republican,"Trump, Donald J.",26,120070
+GRAHAM,Nicodemus Township  H110,President / Vice President,,independent,"Stein, Jill",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Hedges, James A",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"McMullin, Evan",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Perry, Darryl",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Smith, Mike",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Sood, Ajay",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+GRAHAM,Nicodemus Township  H110,President / Vice President,,Republican,"Trump, Donald J.",5,120080
+GRAHAM,Nicodemus Township H118,President / Vice President,,independent,"Stein, Jill",1,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Hedges, James A",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"McMullin, Evan",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Perry, Darryl",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Smith, Mike",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Sood, Ajay",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Libertarian,"Johnson, Gary",2,120090
+GRAHAM,Nicodemus Township H118,President / Vice President,,Republican,"Trump, Donald J.",4,120090
+GRAHAM,Allodium Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000010
+GRAHAM,Allodium Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+GRAHAM,Allodium Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+GRAHAM,Allodium Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000010
+GRAHAM,Bogue City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000020
+GRAHAM,Bogue City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+GRAHAM,Bogue City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+GRAHAM,Bogue City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000020
+GRAHAM,Bryant Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000030
+GRAHAM,Bryant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+GRAHAM,Bryant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000030
+GRAHAM,Bryant Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000030
+GRAHAM,Gettysburg Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000040
+GRAHAM,Gettysburg Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+GRAHAM,Gettysburg Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000040
+GRAHAM,Gettysburg Township,United States House of Representatives,1,Republican,"Marshall, Roger",39,000040
+GRAHAM,Graham Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000050
+GRAHAM,Graham Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+GRAHAM,Graham Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+GRAHAM,Graham Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000050
+GRAHAM,Happy Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000060
+GRAHAM,Happy Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+GRAHAM,Happy Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+GRAHAM,Happy Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000060
+GRAHAM,Indiana Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000100
+GRAHAM,Indiana Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+GRAHAM,Indiana Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000100
+GRAHAM,Indiana Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000100
+GRAHAM,Millbrook Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000110
+GRAHAM,Millbrook Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+GRAHAM,Millbrook Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000110
+GRAHAM,Millbrook Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000110
+GRAHAM,Morlan Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000120
+GRAHAM,Morlan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+GRAHAM,Morlan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+GRAHAM,Morlan Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000120
+GRAHAM,Morland City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000130
+GRAHAM,Morland City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+GRAHAM,Morland City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+GRAHAM,Morland City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000130
+GRAHAM,Pioneer Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000150
+GRAHAM,Pioneer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+GRAHAM,Pioneer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000150
+GRAHAM,Pioneer Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000150
+GRAHAM,Solomon Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000160
+GRAHAM,Solomon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+GRAHAM,Solomon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000160
+GRAHAM,Solomon Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000160
+GRAHAM,Wildhorse Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000170
+GRAHAM,Wildhorse Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+GRAHAM,Wildhorse Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+GRAHAM,Wildhorse Township,United States House of Representatives,1,Republican,"Marshall, Roger",88,000170
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,independent,"LaPolice, Alan",20,120020
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,120020
+GRAHAM,Hill City Precinct 1 H110,United States House of Representatives,1,Republican,"Marshall, Roger",61,120020
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,independent,"LaPolice, Alan",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States House of Representatives,1,Republican,"Marshall, Roger",8,120030
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,independent,"LaPolice, Alan",88,120040
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,120040
+GRAHAM,Hill City Precinct 2 H110,United States House of Representatives,1,Republican,"Marshall, Roger",328,120040
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,independent,"LaPolice, Alan",0,120050
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120050
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120050
+GRAHAM,Hill City Precinct 2 H118,United States House of Representatives,1,Republican,"Marshall, Roger",2,120050
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,independent,"LaPolice, Alan",31,120060
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120060
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,120060
+GRAHAM,Hill City Precinct 3 H110,United States House of Representatives,1,Republican,"Marshall, Roger",109,120060
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,independent,"LaPolice, Alan",6,120070
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120070
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120070
+GRAHAM,Hill City Precinct 3 H118,United States House of Representatives,1,Republican,"Marshall, Roger",23,120070
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,independent,"LaPolice, Alan",3,120080
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120080
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120080
+GRAHAM,Nicodemus Township  H110,United States House of Representatives,1,Republican,"Marshall, Roger",5,120080
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,independent,"LaPolice, Alan",4,120090
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120090
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120090
+GRAHAM,Nicodemus Township H118,United States House of Representatives,1,Republican,"Marshall, Roger",3,120090
+GRAHAM,Allodium Township,United States Senate,,write - in,"Smith, DJ",0,000010
+GRAHAM,Allodium Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+GRAHAM,Allodium Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+GRAHAM,Allodium Township,United States Senate,,Republican,"Moran, Jerry",17,000010
+GRAHAM,Bogue City,United States Senate,,write - in,"Smith, DJ",0,000020
+GRAHAM,Bogue City,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+GRAHAM,Bogue City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+GRAHAM,Bogue City,United States Senate,,Republican,"Moran, Jerry",0,000020
+GRAHAM,Bryant Township,United States Senate,,write - in,"Smith, DJ",0,000030
+GRAHAM,Bryant Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+GRAHAM,Bryant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+GRAHAM,Bryant Township,United States Senate,,Republican,"Moran, Jerry",33,000030
+GRAHAM,Gettysburg Township,United States Senate,,write - in,"Smith, DJ",0,000040
+GRAHAM,Gettysburg Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000040
+GRAHAM,Gettysburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+GRAHAM,Gettysburg Township,United States Senate,,Republican,"Moran, Jerry",44,000040
+GRAHAM,Graham Township,United States Senate,,write - in,"Smith, DJ",0,000050
+GRAHAM,Graham Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000050
+GRAHAM,Graham Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000050
+GRAHAM,Graham Township,United States Senate,,Republican,"Moran, Jerry",29,000050
+GRAHAM,Happy Township,United States Senate,,write - in,"Smith, DJ",0,000060
+GRAHAM,Happy Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+GRAHAM,Happy Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+GRAHAM,Happy Township,United States Senate,,Republican,"Moran, Jerry",27,000060
+GRAHAM,Indiana Township,United States Senate,,write - in,"Smith, DJ",0,000100
+GRAHAM,Indiana Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000100
+GRAHAM,Indiana Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+GRAHAM,Indiana Township,United States Senate,,Republican,"Moran, Jerry",14,000100
+GRAHAM,Millbrook Township,United States Senate,,write - in,"Smith, DJ",0,000110
+GRAHAM,Millbrook Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000110
+GRAHAM,Millbrook Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+GRAHAM,Millbrook Township,United States Senate,,Republican,"Moran, Jerry",67,000110
+GRAHAM,Morlan Township,United States Senate,,write - in,"Smith, DJ",0,000120
+GRAHAM,Morlan Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000120
+GRAHAM,Morlan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000120
+GRAHAM,Morlan Township,United States Senate,,Republican,"Moran, Jerry",33,000120
+GRAHAM,Morland City,United States Senate,,write - in,"Smith, DJ",0,000130
+GRAHAM,Morland City,United States Senate,,Democratic,"Wiesner, Patrick",0,000130
+GRAHAM,Morland City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000130
+GRAHAM,Morland City,United States Senate,,Republican,"Moran, Jerry",0,000130
+GRAHAM,Pioneer Township,United States Senate,,write - in,"Smith, DJ",0,000150
+GRAHAM,Pioneer Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000150
+GRAHAM,Pioneer Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+GRAHAM,Pioneer Township,United States Senate,,Republican,"Moran, Jerry",19,000150
+GRAHAM,Solomon Township,United States Senate,,write - in,"Smith, DJ",0,000160
+GRAHAM,Solomon Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000160
+GRAHAM,Solomon Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000160
+GRAHAM,Solomon Township,United States Senate,,Republican,"Moran, Jerry",93,000160
+GRAHAM,Wildhorse Township,United States Senate,,write - in,"Smith, DJ",0,000170
+GRAHAM,Wildhorse Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000170
+GRAHAM,Wildhorse Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+GRAHAM,Wildhorse Township,United States Senate,,Republican,"Moran, Jerry",108,000170
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,write - in,"Smith, DJ",0,120020
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,Democratic,"Wiesner, Patrick",14,120020
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,Libertarian,"Garrard, Robert D.",5,120020
+GRAHAM,Hill City Precinct 1 H110,United States Senate,,Republican,"Moran, Jerry",70,120020
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,write - in,"Smith, DJ",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,Libertarian,"Garrard, Robert D.",1,120030
+GRAHAM,Hill City Precinct 1 H118,United States Senate,,Republican,"Moran, Jerry",7,120030
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,write - in,"Smith, DJ",0,120040
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,Democratic,"Wiesner, Patrick",53,120040
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,Libertarian,"Garrard, Robert D.",24,120040
+GRAHAM,Hill City Precinct 2 H110,United States Senate,,Republican,"Moran, Jerry",370,120040
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,write - in,"Smith, DJ",0,120050
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,Democratic,"Wiesner, Patrick",0,120050
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,Libertarian,"Garrard, Robert D.",0,120050
+GRAHAM,Hill City Precinct 2 H118,United States Senate,,Republican,"Moran, Jerry",3,120050
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,write - in,"Smith, DJ",0,120060
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,Democratic,"Wiesner, Patrick",21,120060
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,Libertarian,"Garrard, Robert D.",9,120060
+GRAHAM,Hill City Precinct 3 H110,United States Senate,,Republican,"Moran, Jerry",121,120060
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,write - in,"Smith, DJ",0,120070
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,Democratic,"Wiesner, Patrick",2,120070
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,Libertarian,"Garrard, Robert D.",0,120070
+GRAHAM,Hill City Precinct 3 H118,United States Senate,,Republican,"Moran, Jerry",29,120070
+GRAHAM,Nicodemus Township  H110,United States Senate,,write - in,"Smith, DJ",0,120080
+GRAHAM,Nicodemus Township  H110,United States Senate,,Democratic,"Wiesner, Patrick",2,120080
+GRAHAM,Nicodemus Township  H110,United States Senate,,Libertarian,"Garrard, Robert D.",0,120080
+GRAHAM,Nicodemus Township  H110,United States Senate,,Republican,"Moran, Jerry",6,120080
+GRAHAM,Nicodemus Township H118,United States Senate,,write - in,"Smith, DJ",0,120090
+GRAHAM,Nicodemus Township H118,United States Senate,,Democratic,"Wiesner, Patrick",4,120090
+GRAHAM,Nicodemus Township H118,United States Senate,,Libertarian,"Garrard, Robert D.",1,120090
+GRAHAM,Nicodemus Township H118,United States Senate,,Republican,"Moran, Jerry",5,120090

--- a/2016/20161108__ks__general__grant__precinct.csv
+++ b/2016/20161108__ks__general__grant__precinct.csv
@@ -1,85 +1,217 @@
-county,precinct,office,district,party,candidate,votes
-Grant,Ward 1,President,,LBT,Gary Johnson,12
-Grant,Ward 1,President,,IND,Jill Stein,7
-Grant,Ward 1,President,,REP,Donald J Trump,162
-Grant,Ward 1,President,,DEM,Hillary Clinton,57
-Grant,Ward 2,President,,LBT,Gary Johnson,19
-Grant,Ward 2,President,,IND,Jill Stein,3
-Grant,Ward 2,President,,REP,Donald J Trump,374
-Grant,Ward 2,President,,DEM,Hillary Clinton,69
-Grant,Ward 3,President,,LBT,Gary Johnson,27
-Grant,Ward 3,President,,IND,Jill Stein,9
-Grant,Ward 3,President,,REP,Donald J Trump,350
-Grant,Ward 3,President,,DEM,Hillary Clinton,115
-Grant,Prec 4,President,,LBT,Gary Johnson,12
-Grant,Prec 4,President,,IND,Jill Stein,1
-Grant,Prec 4,President,,REP,Donald J Trump,302
-Grant,Prec 4,President,,DEM,Hillary Clinton,44
-Grant,Advance,President,,LBT,Gary Johnson,28
-Grant,Advance,President,,IND,Jill Stein,11
-Grant,Advance,President,,REP,Donald J Trump,567
-Grant,Advance,President,,DEM,Hillary Clinton,142
-Grant,Provisional,President,,LBT,Gary Johnson,3
-Grant,Provisional,President,,IND,Jill Stein,2
-Grant,Provisional,President,,REP,Donald J Trump,49
-Grant,Provisional,President,,DEM,Hillary Clinton,14
-Grant,Ward 1,U.S. Senate,,REP,Jerry Moran,174
-Grant,Ward 1,U.S. Senate,,DEM,Patrick Wiesner,43
-Grant,Ward 1,U.S. Senate,,LBT,Robert D. Garrard,14
-Grant,Ward 2,U.S. Senate,,REP,Jerry Moran,382
-Grant,Ward 2,U.S. Senate,,DEM,Patrick Wiesner,50
-Grant,Ward 2,U.S. Senate,,LBT,Robert D. Garrard,26
-Grant,Ward 3,U.S. Senate,,REP,Jerry Moran,375
-Grant,Ward 3,U.S. Senate,,DEM,Patrick Wiesner,82
-Grant,Ward 3,U.S. Senate,,LBT,Robert D. Garrard,27
-Grant,Prec 4,U.S. Senate,,REP,Jerry Moran,300
-Grant,Prec 4,U.S. Senate,,DEM,Patrick Wiesner,27
-Grant,Prec 4,U.S. Senate,,LBT,Robert D. Garrard,26
-Grant,Advance,U.S. Senate,,REP,Jerry Moran,613
-Grant,Advance,U.S. Senate,,DEM,Patrick Wiesner,104
-Grant,Advance,U.S. Senate,,LBT,Robert D. Garrard,32
-Grant,Provisional,U.S. Senate,,REP,Jerry Moran,53
-Grant,Provisional,U.S. Senate,,DEM,Patrick Wiesner,10
-Grant,Provisional,U.S. Senate,,LBT,Robert D. Garrard,6
-Grant,Ward 1,U.S. House,1,LBT,Kerry Burt,13
-Grant,Ward 1,U.S. House,1,IND,Alan LaPolice,41
-Grant,Ward 1,U.S. House,1,REP,Roger Marshall,172
-Grant,Ward 2,U.S. House,1,LBT,Kerry Burt,25
-Grant,Ward 2,U.S. House,1,IND,Alan LaPolice,55
-Grant,Ward 2,U.S. House,1,REP,Roger Marshall,373
-Grant,Ward 3,U.S. House,1,LBT,Kerry Burt,45
-Grant,Ward 3,U.S. House,1,IND,Alan LaPolice,59
-Grant,Ward 3,U.S. House,1,REP,Roger Marshall,364
-Grant,Prec 4,U.S. House,1,LBT,Kerry Burt,27
-Grant,Prec 4,U.S. House,1,IND,Alan LaPolice,34
-Grant,Prec 4,U.S. House,1,REP,Roger Marshall,286
-Grant,Advance,U.S. House,1,LBT,Kerry Burt,46
-Grant,Advance,U.S. House,1,IND,Alan LaPolice,75
-Grant,Advance,U.S. House,1,REP,Roger Marshall,597
-Grant,Provisional,U.S. House,1,LBT,Kerry Burt,5
-Grant,Provisional,U.S. House,1,IND,Alan LaPolice,8
-Grant,Provisional,U.S. House,1,REP,Roger Marshall,54
-Grant,Ward 1,State Senate,39,DEM,A. Zacheriah Wolf,38
-Grant,Ward 1,State Senate,39,REP,John Doll,191
-Grant,Ward 2,State Senate,39,DEM,A. Zacheriah Wolf,48
-Grant,Ward 2,State Senate,39,REP,John Doll,409
-Grant,Ward 3,State Senate,39,DEM,A. Zacheriah Wolf,86
-Grant,Ward 3,State Senate,39,REP,John Doll,398
-Grant,Prec 4,State Senate,39,DEM,A. Zacheriah Wolf,38
-Grant,Prec 4,State Senate,39,REP,John Doll,304
-Grant,Advance,State Senate,39,DEM,A. Zacheriah Wolf,97
-Grant,Advance,State Senate,39,REP,John Doll,634
-Grant,Provisional,State Senate,39,DEM,A. Zacheriah Wolf,8
-Grant,Provisional,State Senate,39,REP,John Doll,58
-Grant,Ward 1,State House,122,REP,J. Russell Jennings,0
-Grant,Ward 2,State House,122,REP,J. Russell Jennings,0
-Grant,Ward 3,State House,122,REP,J. Russell Jennings,0
-Grant,Prec 4,State House,122,REP,J. Russell Jennings,0
-Grant,Advance,State House,122,REP,J. Russell Jennings,0
-Grant,Provisional,State House,122,REP,J. Russell Jennings,0
-Grant,Ward 1,State House,124,REP,J. Stephen Alford,203
-Grant,Ward 2,State House,124,REP,J. Stephen Alford,415
-Grant,Ward 3,State House,124,REP,J. Stephen Alford,441
-Grant,Prec 4,State House,124,REP,J. Stephen Alford,317
-Grant,Advance,State House,124,REP,J. Stephen Alford,662
-Grant,Provisional,State House,124,REP,J. Stephen Alford,64
+county,precinct,office,district,party,candidate,votes,vtd
+GRANT,Ulysses Ward 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",304,000020
+GRANT,Ulysses Ward 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",654,00003A
+GRANT,Ulysses Ward 2 Exclave,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",0,00003B
+GRANT,Ulysses Ward 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",681,000040
+GRANT,Precinct 4 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",0,120020
+GRANT,Precinct 4 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",463,120030
+GRANT,Ulysses Ward 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",59,000020
+GRANT,Ulysses Ward 1,Kansas Senate,39,Republican,"Doll, John",282,000020
+GRANT,Ulysses Ward 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",82,00003A
+GRANT,Ulysses Ward 2,Kansas Senate,39,Republican,"Doll, John",639,00003A
+GRANT,Ulysses Ward 2 Exclave,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,00003B
+GRANT,Ulysses Ward 2 Exclave,Kansas Senate,39,Republican,"Doll, John",0,00003B
+GRANT,Ulysses Ward 3,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",120,000040
+GRANT,Ulysses Ward 3,Kansas Senate,39,Republican,"Doll, John",622,000040
+GRANT,Precinct 4 H122,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,120020
+GRANT,Precinct 4 H122,Kansas Senate,39,Republican,"Doll, John",0,120020
+GRANT,Precinct 4 H124,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",54,120030
+GRANT,Precinct 4 H124,Kansas Senate,39,Republican,"Doll, John",451,120030
+GRANT,Ulysses Ward 1,President / Vice President,,independent,"Stein, Jill",9,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",89,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",16,000020
+GRANT,Ulysses Ward 1,President / Vice President,,Republican,"Trump, Donald J.",241,000020
+GRANT,Ulysses Ward 2,President / Vice President,,independent,"Stein, Jill",6,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"McMullin, Evan",5,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",132,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",27,00003A
+GRANT,Ulysses Ward 2,President / Vice President,,Republican,"Trump, Donald J.",569,00003A
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00003B
+GRANT,Ulysses Ward 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00003B
+GRANT,Ulysses Ward 3,President / Vice President,,independent,"Stein, Jill",13,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"McMullin, Evan",4,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",159,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",42,000040
+GRANT,Ulysses Ward 3,President / Vice President,,Republican,"Trump, Donald J.",556,000040
+GRANT,Precinct 4 H122,President / Vice President,,independent,"Stein, Jill",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Hedges, James A",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"McMullin, Evan",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Perry, Darryl",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Smith, Mike",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Sood, Ajay",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+GRANT,Precinct 4 H122,President / Vice President,,Republican,"Trump, Donald J.",0,120020
+GRANT,Precinct 4 H124,President / Vice President,,independent,"Stein, Jill",5,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Hedges, James A",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"McMullin, Evan",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Perry, Darryl",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Smith, Mike",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Sood, Ajay",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+GRANT,Precinct 4 H124,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,120030
+GRANT,Precinct 4 H124,President / Vice President,,Libertarian,"Johnson, Gary",16,120030
+GRANT,Precinct 4 H124,President / Vice President,,Republican,"Trump, Donald J.",438,120030
+GRANT,Ulysses Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",55,000020
+GRANT,Ulysses Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+GRANT,Ulysses Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",26,000020
+GRANT,Ulysses Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",259,000020
+GRANT,Ulysses Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",72,00003A
+GRANT,Ulysses Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00003A
+GRANT,Ulysses Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",40,00003A
+GRANT,Ulysses Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",594,00003A
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00003B
+GRANT,Ulysses Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",88,000040
+GRANT,Ulysses Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+GRANT,Ulysses Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",60,000040
+GRANT,Ulysses Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",575,000040
+GRANT,Precinct 4 H122,United States House of Representatives,1,independent,"LaPolice, Alan",0,120020
+GRANT,Precinct 4 H122,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+GRANT,Precinct 4 H122,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120020
+GRANT,Precinct 4 H122,United States House of Representatives,1,Republican,"Marshall, Roger",0,120020
+GRANT,Precinct 4 H124,United States House of Representatives,1,independent,"LaPolice, Alan",57,120030
+GRANT,Precinct 4 H124,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+GRANT,Precinct 4 H124,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,120030
+GRANT,Precinct 4 H124,United States House of Representatives,1,Republican,"Marshall, Roger",418,120030
+GRANT,Ulysses Ward 1,United States Senate,,write - in,"Smith, DJ",0,000020
+GRANT,Ulysses Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",68,000020
+GRANT,Ulysses Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",21,000020
+GRANT,Ulysses Ward 1,United States Senate,,Republican,"Moran, Jerry",259,000020
+GRANT,Ulysses Ward 2,United States Senate,,write - in,"Smith, DJ",0,00003A
+GRANT,Ulysses Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",87,00003A
+GRANT,Ulysses Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",36,00003A
+GRANT,Ulysses Ward 2,United States Senate,,Republican,"Moran, Jerry",603,00003A
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00003B
+GRANT,Ulysses Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00003B
+GRANT,Ulysses Ward 3,United States Senate,,write - in,"Smith, DJ",0,000040
+GRANT,Ulysses Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",119,000040
+GRANT,Ulysses Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",36,000040
+GRANT,Ulysses Ward 3,United States Senate,,Republican,"Moran, Jerry",598,000040
+GRANT,Precinct 4 H122,United States Senate,,write - in,"Smith, DJ",0,120020
+GRANT,Precinct 4 H122,United States Senate,,Democratic,"Wiesner, Patrick",0,120020
+GRANT,Precinct 4 H122,United States Senate,,Libertarian,"Garrard, Robert D.",0,120020
+GRANT,Precinct 4 H122,United States Senate,,Republican,"Moran, Jerry",0,120020
+GRANT,Precinct 4 H124,United States Senate,,write - in,"Smith, DJ",0,120030
+GRANT,Precinct 4 H124,United States Senate,,Democratic,"Wiesner, Patrick",42,120030
+GRANT,Precinct 4 H124,United States Senate,,Libertarian,"Garrard, Robert D.",38,120030
+GRANT,Precinct 4 H124,United States Senate,,Republican,"Moran, Jerry",437,120030

--- a/2016/20161108__ks__general__gray__precinct.csv
+++ b/2016/20161108__ks__general__gray__precinct.csv
@@ -1,105 +1,289 @@
-county,precinct,office,district,party,candidate,votes
-Gray,Cimarron #1 ,President,,LBT,Gary Johnson,7
-Gray,Cimarron #2 ,President,,LBT,Gary Johnson,27
-Gray,Copeland ,President,,LBT,Gary Johnson,8
-Gray,East Hess ,President,,LBT,Gary Johnson,8
-Gray,Foote ,President,,LBT,Gary Johnson,0
-Gray,Ingalls ,President,,LBT,Gary Johnson,5
-Gray,Logan ,President,,LBT,Gary Johnson,3
-Gray,Montezuma ,President,,LBT,Gary Johnson,15
-Gray,Cimarron #1 ,President,,IND,Jill Stein,2
-Gray,Cimarron #2 ,President,,IND,Jill Stein,9
-Gray,Copeland ,President,,IND,Jill Stein,4
-Gray,East Hess ,President,,IND,Jill Stein,7
-Gray,Foote ,President,,IND,Jill Stein,1
-Gray,Ingalls ,President,,IND,Jill Stein,3
-Gray,Logan ,President,,IND,Jill Stein,0
-Gray,Montezuma ,President,,IND,Jill Stein,4
-Gray,Cimarron #1 ,President,,REP,Donald J Trump,220
-Gray,Cimarron #2 ,President,,REP,Donald J Trump,623
-Gray,Copeland ,President,,REP,Donald J Trump,108
-Gray,East Hess ,President,,REP,Donald J Trump,104
-Gray,Foote ,President,,REP,Donald J Trump,40
-Gray,Ingalls ,President,,REP,Donald J Trump,170
-Gray,Logan ,President,,REP,Donald J Trump,100
-Gray,Montezuma ,President,,REP,Donald J Trump,286
-Gray,Cimarron #1 ,President,,DEM,Hillary Clinton,37
-Gray,Cimarron #2 ,President,,DEM,Hillary Clinton,112
-Gray,Copeland ,President,,DEM,Hillary Clinton,11
-Gray,East Hess ,President,,DEM,Hillary Clinton,19
-Gray,Foote ,President,,DEM,Hillary Clinton,5
-Gray,Ingalls ,President,,DEM,Hillary Clinton,26
-Gray,Logan ,President,,DEM,Hillary Clinton,3
-Gray,Montezuma ,President,,DEM,Hillary Clinton,44
-Gray,Cimarron #1 ,U.S. Senate,,REP,Jerry Moran,230
-Gray,Cimarron #2 ,U.S. Senate,,REP,Jerry Moran,653
-Gray,Copeland ,U.S. Senate,,REP,Jerry Moran,119
-Gray,East Hess ,U.S. Senate,,REP,Jerry Moran,105
-Gray,Foote ,U.S. Senate,,REP,Jerry Moran,41
-Gray,Ingalls ,U.S. Senate,,REP,Jerry Moran,170
-Gray,Logan ,U.S. Senate,,REP,Jerry Moran,92
-Gray,Montezuma ,U.S. Senate,,REP,Jerry Moran,297
-Gray,Cimarron #1 ,U.S. Senate,,DEM,Patrick Wiesner,29
-Gray,Cimarron #2 ,U.S. Senate,,DEM,Patrick Wiesner,86
-Gray,Copeland ,U.S. Senate,,DEM,Patrick Wiesner,6
-Gray,East Hess ,U.S. Senate,,DEM,Patrick Wiesner,22
-Gray,Foote ,U.S. Senate,,DEM,Patrick Wiesner,5
-Gray,Ingalls ,U.S. Senate,,DEM,Patrick Wiesner,22
-Gray,Logan ,U.S. Senate,,DEM,Patrick Wiesner,8
-Gray,Montezuma ,U.S. Senate,,DEM,Patrick Wiesner,40
-Gray,Cimarron #1 ,U.S. Senate,,LBT,Robert D. Garrard,6
-Gray,Cimarron #2 ,U.S. Senate,,LBT,Robert D. Garrard,33
-Gray,Copeland ,U.S. Senate,,LBT,Robert D. Garrard,9
-Gray,East Hess ,U.S. Senate,,LBT,Robert D. Garrard,6
-Gray,Foote ,U.S. Senate,,LBT,Robert D. Garrard,1
-Gray,Ingalls ,U.S. Senate,,LBT,Robert D. Garrard,10
-Gray,Logan ,U.S. Senate,,LBT,Robert D. Garrard,5
-Gray,Montezuma ,U.S. Senate,,LBT,Robert D. Garrard,9
-Gray,Cimarron #1 ,U.S. House,1,LBT,Kerry Burt,12
-Gray,Cimarron #2 ,U.S. House,1,LBT,Kerry Burt,38
-Gray,Copeland ,U.S. House,1,LBT,Kerry Burt,2
-Gray,East Hess ,U.S. House,1,LBT,Kerry Burt,8
-Gray,Foote ,U.S. House,1,LBT,Kerry Burt,1
-Gray,Ingalls ,U.S. House,1,LBT,Kerry Burt,14
-Gray,Logan ,U.S. House,1,LBT,Kerry Burt,4
-Gray,Montezuma ,U.S. House,1,LBT,Kerry Burt,11
-Gray,Cimarron #1 ,U.S. House,1,IND,Alan LaPolice,42
-Gray,Cimarron #2 ,U.S. House,1,IND,Alan LaPolice,144
-Gray,Copeland ,U.S. House,1,IND,Alan LaPolice,21
-Gray,East Hess ,U.S. House,1,IND,Alan LaPolice,26
-Gray,Foote ,U.S. House,1,IND,Alan LaPolice,6
-Gray,Ingalls ,U.S. House,1,IND,Alan LaPolice,38
-Gray,Logan ,U.S. House,1,IND,Alan LaPolice,15
-Gray,Montezuma ,U.S. House,1,IND,Alan LaPolice,68
-Gray,Cimarron #1 ,U.S. House,1,REP,Roger Marshall,199
-Gray,Cimarron #2 ,U.S. House,1,REP,Roger Marshall,582
-Gray,Copeland ,U.S. House,1,REP,Roger Marshall,109
-Gray,East Hess ,U.S. House,1,REP,Roger Marshall,97
-Gray,Foote ,U.S. House,1,REP,Roger Marshall,39
-Gray,Ingalls ,U.S. House,1,REP,Roger Marshall,145
-Gray,Logan ,U.S. House,1,REP,Roger Marshall,84
-Gray,Montezuma ,U.S. House,1,REP,Roger Marshall,248
-Gray,Cimarron #1 ,State Senate,38,,Miguel Angel Rodriguez,31
-Gray,Cimarron #2 ,State Senate,38,,Miguel Angel Rodriguez,107
-Gray,Copeland ,State Senate,38,,Miguel Angel Rodriguez,14
-Gray,East Hess ,State Senate,38,,Miguel Angel Rodriguez,19
-Gray,Foote ,State Senate,38,,Miguel Angel Rodriguez,7
-Gray,Ingalls ,State Senate,38,,Miguel Angel Rodriguez,25
-Gray,Logan ,State Senate,38,,Miguel Angel Rodriguez,7
-Gray,Montezuma ,State Senate,38,,Miguel Angel Rodriguez,51
-Gray,Cimarron #1 ,State Senate,38,,Bud Estes,234
-Gray,Cimarron #2 ,State Senate,38,,Bud Estes,651
-Gray,Copeland ,State Senate,38,,Bud Estes,118
-Gray,East Hess ,State Senate,38,,Bud Estes,114
-Gray,Foote ,State Senate,38,,Bud Estes,40
-Gray,Ingalls ,State Senate,38,,Bud Estes,177
-Gray,Logan ,State Senate,38,,Bud Estes,98
-Gray,Montezuma ,State Senate,38,,Bud Estes,285
-Gray,Cimarron #1 ,State House,115,,Boyd Orr,248
-Gray,Cimarron #2 ,State House,115,,Boyd Orr,704
-Gray,Copeland ,State House,115,,Boyd Orr,119
-Gray,East Hess ,State House,115,,Boyd Orr,130
-Gray,Foote ,State House,115,,Boyd Orr,41
-Gray,Ingalls ,State House,115,,Boyd Orr,183
-Gray,Logan ,State House,115,,Boyd Orr,98
-Gray,Montezuma ,State House,115,,Boyd Orr,307
+county,precinct,office,district,party,candidate,votes,vtd
+GRAY,Copeland Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",121,000020
+GRAY,East Hess Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",134,000030
+GRAY,Foote Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",42,000040
+GRAY,Ingalls Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",187,000050
+GRAY,Logan Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",98,000060
+GRAY,Montezuma Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",316,000070
+GRAY,Cimarron Township Precinct 1,Kansas House of Representatives,115,Republican,"Orr, Boyd",252,500010
+GRAY,Cimarron Township Precinct 2,Kansas House of Representatives,115,Republican,"Orr, Boyd",734,500020
+GRAY,Copeland Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",14,000020
+GRAY,Copeland Township,Kansas Senate,38,Republican,"Estes, Bud",121,000020
+GRAY,East Hess Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",20,000030
+GRAY,East Hess Township,Kansas Senate,38,Republican,"Estes, Bud",117,000030
+GRAY,Foote Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000040
+GRAY,Foote Township,Kansas Senate,38,Republican,"Estes, Bud",41,000040
+GRAY,Ingalls Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",25,000050
+GRAY,Ingalls Township,Kansas Senate,38,Republican,"Estes, Bud",181,000050
+GRAY,Logan Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000060
+GRAY,Logan Township,Kansas Senate,38,Republican,"Estes, Bud",98,000060
+GRAY,Montezuma Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",51,000070
+GRAY,Montezuma Township,Kansas Senate,38,Republican,"Estes, Bud",294,000070
+GRAY,Cimarron Township Precinct 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",31,500010
+GRAY,Cimarron Township Precinct 1,Kansas Senate,38,Republican,"Estes, Bud",238,500010
+GRAY,Cimarron Township Precinct 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",109,500020
+GRAY,Cimarron Township Precinct 2,Kansas Senate,38,Republican,"Estes, Bud",678,500020
+GRAY,Copeland Township,President / Vice President,,independent,"Stein, Jill",4,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+GRAY,Copeland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+GRAY,Copeland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000020
+GRAY,Copeland Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000020
+GRAY,Copeland Township,President / Vice President,,Republican,"Trump, Donald J.",111,000020
+GRAY,East Hess Township,President / Vice President,,independent,"Stein, Jill",7,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+GRAY,East Hess Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+GRAY,East Hess Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000030
+GRAY,East Hess Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+GRAY,East Hess Township,President / Vice President,,Republican,"Trump, Donald J.",105,000030
+GRAY,Foote Township,President / Vice President,,independent,"Stein, Jill",1,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+GRAY,Foote Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+GRAY,Foote Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000040
+GRAY,Foote Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+GRAY,Foote Township,President / Vice President,,Republican,"Trump, Donald J.",41,000040
+GRAY,Ingalls Township,President / Vice President,,independent,"Stein, Jill",3,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+GRAY,Ingalls Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+GRAY,Ingalls Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000050
+GRAY,Ingalls Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+GRAY,Ingalls Township,President / Vice President,,Republican,"Trump, Donald J.",174,000050
+GRAY,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+GRAY,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+GRAY,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000060
+GRAY,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+GRAY,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",100,000060
+GRAY,Montezuma Township,President / Vice President,,independent,"Stein, Jill",4,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+GRAY,Montezuma Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+GRAY,Montezuma Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000070
+GRAY,Montezuma Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000070
+GRAY,Montezuma Township,President / Vice President,,Republican,"Trump, Donald J.",294,000070
+GRAY,Cimarron Township Precinct 1,President / Vice President,,independent,"Stein, Jill",2,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,500010
+GRAY,Cimarron Township Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",223,500010
+GRAY,Cimarron Township Precinct 2,President / Vice President,,independent,"Stein, Jill",9,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",116,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",27,500020
+GRAY,Cimarron Township Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",650,500020
+GRAY,Copeland Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000020
+GRAY,Copeland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+GRAY,Copeland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000020
+GRAY,Copeland Township,United States House of Representatives,1,Republican,"Marshall, Roger",111,000020
+GRAY,East Hess Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000030
+GRAY,East Hess Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+GRAY,East Hess Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000030
+GRAY,East Hess Township,United States House of Representatives,1,Republican,"Marshall, Roger",99,000030
+GRAY,Foote Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000040
+GRAY,Foote Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+GRAY,Foote Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+GRAY,Foote Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000040
+GRAY,Ingalls Township,United States House of Representatives,1,independent,"LaPolice, Alan",38,000050
+GRAY,Ingalls Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+GRAY,Ingalls Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000050
+GRAY,Ingalls Township,United States House of Representatives,1,Republican,"Marshall, Roger",149,000050
+GRAY,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000060
+GRAY,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+GRAY,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000060
+GRAY,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",84,000060
+GRAY,Montezuma Township,United States House of Representatives,1,independent,"LaPolice, Alan",70,000070
+GRAY,Montezuma Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+GRAY,Montezuma Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000070
+GRAY,Montezuma Township,United States House of Representatives,1,Republican,"Marshall, Roger",255,000070
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",43,500010
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,500010
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,500010
+GRAY,Cimarron Township Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",202,500010
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",151,500020
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,500020
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,500020
+GRAY,Cimarron Township Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",605,500020
+GRAY,Copeland Township,United States Senate,,write - in,"Smith, DJ",0,000020
+GRAY,Copeland Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000020
+GRAY,Copeland Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000020
+GRAY,Copeland Township,United States Senate,,Republican,"Moran, Jerry",122,000020
+GRAY,East Hess Township,United States Senate,,write - in,"Smith, DJ",0,000030
+GRAY,East Hess Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000030
+GRAY,East Hess Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000030
+GRAY,East Hess Township,United States Senate,,Republican,"Moran, Jerry",107,000030
+GRAY,Foote Township,United States Senate,,write - in,"Smith, DJ",0,000040
+GRAY,Foote Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000040
+GRAY,Foote Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000040
+GRAY,Foote Township,United States Senate,,Republican,"Moran, Jerry",41,000040
+GRAY,Ingalls Township,United States Senate,,write - in,"Smith, DJ",0,000050
+GRAY,Ingalls Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000050
+GRAY,Ingalls Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000050
+GRAY,Ingalls Township,United States Senate,,Republican,"Moran, Jerry",174,000050
+GRAY,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000060
+GRAY,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000060
+GRAY,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000060
+GRAY,Logan Township,United States Senate,,Republican,"Moran, Jerry",92,000060
+GRAY,Montezuma Township,United States Senate,,write - in,"Smith, DJ",0,000070
+GRAY,Montezuma Township,United States Senate,,Democratic,"Wiesner, Patrick",40,000070
+GRAY,Montezuma Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000070
+GRAY,Montezuma Township,United States Senate,,Republican,"Moran, Jerry",306,000070
+GRAY,Cimarron Township Precinct 1,United States Senate,,write - in,"Smith, DJ",0,500010
+GRAY,Cimarron Township Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",29,500010
+GRAY,Cimarron Township Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",7,500010
+GRAY,Cimarron Township Precinct 1,United States Senate,,Republican,"Moran, Jerry",233,500010
+GRAY,Cimarron Township Precinct 2,United States Senate,,write - in,"Smith, DJ",0,500020
+GRAY,Cimarron Township Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",88,500020
+GRAY,Cimarron Township Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",34,500020
+GRAY,Cimarron Township Precinct 2,United States Senate,,Republican,"Moran, Jerry",681,500020

--- a/2016/20161108__ks__general__greeley__precinct.csv
+++ b/2016/20161108__ks__general__greeley__precinct.csv
@@ -1,69 +1,109 @@
-county,precinct,office,district,party,candidate,votes
-Greeley,MSD - 408,President,,LBT,Gary Johnson,15
-Greeley,MSD - 408,President,,IND,Jill Stein,6
-Greeley,MSD - 408,President,,REP,Donald J Trump,317
-Greeley,MSD - 408,President,,DEM,Hillary Clinton,63
-Greeley,MSD - 408,President,,,Write-ins,0
-Greeley,GSD - 202,President,,LBT,Gary Johnson,7
-Greeley,GSD - 202,President,,IND,Jill Stein,1
-Greeley,GSD - 202,President,,REP,Donald J Trump,182
-Greeley,GSD - 202,President,,DEM,Hillary Clinton,16
-Greeley,GSD - 202,President,,,Write-ins,0
-Greeley,HC - 46,President,,LBT,Gary Johnson,3
-Greeley,HC - 46,President,,IND,Jill Stein,1
-Greeley,HC - 46,President,,REP,Donald J Trump,35
-Greeley,HC - 46,President,,DEM,Hillary Clinton,4
-Greeley,HC - 46,President,,,Write-ins,0
-Greeley,Prov.-11,President,,LBT,Gary Johnson,0
-Greeley,Prov.-11,President,,IND,Jill Stein,0
-Greeley,Prov.-11,President,,REP,Donald J Trump,0
-Greeley,Prov.-11,President,,DEM,Hillary Clinton,0
-Greeley,Prov.-11,President,,,Write-ins,0
-Greeley,MSD - 408,U.S. Senate,,REP,Jerry Moran,355
-Greeley,MSD - 408,U.S. Senate,,DEM,Patrick Wiesner,34
-Greeley,MSD - 408,U.S. Senate,,LBT,Robert Garrard,11
-Greeley,MSD - 408,U.S. Senate,,,Write-ins,0
-Greeley,GSD - 202,U.S. Senate,,REP,Jerry Moran,176
-Greeley,GSD - 202,U.S. Senate,,DEM,Patrick Wiesner,12
-Greeley,GSD - 202,U.S. Senate,,LBT,Robert Garrard,11
-Greeley,GSD - 202,U.S. Senate,,,Write-ins,0
-Greeley,HC - 46,U.S. Senate,,REP,Jerry Moran,39
-Greeley,HC - 46,U.S. Senate,,DEM,Patrick Wiesner,2
-Greeley,HC - 46,U.S. Senate,,LBT,Robert Garrard,1
-Greeley,HC - 46,U.S. Senate,,,Write-ins,0
-Greeley,Prov.-11,U.S. Senate,,REP,Jerry Moran,0
-Greeley,Prov.-11,U.S. Senate,,DEM,Patrick Wiesner,0
-Greeley,Prov.-11,U.S. Senate,,LBT,Robert Garrard,0
-Greeley,Prov.-11,U.S. Senate,,,Write-ins,0
-Greeley,MSD - 408,U.S. House,1,LBT,Kerry Burt,23
-Greeley,MSD - 408,U.S. House,1,IND,Alan LaPolice,32
-Greeley,MSD - 408,U.S. House,1,REP,Roger Marshall,333
-Greeley,MSD - 408,U.S. House,1,,Write-ins,0
-Greeley,GSD - 202,U.S. House,1,LBT,Kerry Burt,9
-Greeley,GSD - 202,U.S. House,1,IND,Alan LaPolice,24
-Greeley,GSD - 202,U.S. House,1,REP,Roger Marshall,156
-Greeley,GSD - 202,U.S. House,1,,Write-ins,0
-Greeley,HC - 46,U.S. House,1,LBT,Kerry Burt,2
-Greeley,HC - 46,U.S. House,1,IND,Alan LaPolice,6
-Greeley,HC - 46,U.S. House,1,REP,Roger Marshall,36
-Greeley,HC - 46,U.S. House,1,,Write-ins,0
-Greeley,Prov.-11,U.S. House,1,LBT,Kerry Burt,0
-Greeley,Prov.-11,U.S. House,1,IND,Alan LaPolice,0
-Greeley,Prov.-11,U.S. House,1,REP,Roger Marshall,0
-Greeley,Prov.-11,U.S. House,1,,Write-ins,0
-Greeley,MSD - 408,State Senate,,DEM,A. Zacheriah Worf,38
-Greeley,MSD - 408,State Senate,,REP,John Doll,349
-Greeley,MSD - 408,State Senate,,,Write-ins,0
-Greeley,GSD - 202,State Senate,,DEM,A. Zacheriah Worf,21
-Greeley,GSD - 202,State Senate,,REP,John Doll,160
-Greeley,GSD - 202,State Senate,,,Write-ins,0
-Greeley,HC - 46,State Senate,,DEM,A. Zacheriah Worf,5
-Greeley,HC - 46,State Senate,,REP,John Doll,36
-Greeley,HC - 46,State Senate,,,Write-ins,0
-Greeley,Prov.-11,State Senate,,DEM,A. Zacheriah Worf,0
-Greeley,Prov.-11,State Senate,,REP,John Doll,0
-Greeley,Prov.-11,State Senate,,,Write-ins,0
-Greeley,MSD - 408,State House,122,REP,J. Russell 'Russ' Jennings,385
-Greeley,GSD - 202,State House,122,REP,J. Russell 'Russ' Jennings,181
-Greeley,HC - 46,State House,122,REP,J. Russell 'Russ' Jennings,41
-Greeley,Prov.-11,State House,122,REP,J. Russell 'Russ' Jennings,0
+county,precinct,office,district,party,candidate,votes,vtd
+GREELEY,Tribune Precinct 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",385,000010
+GREELEY,Tribune Precinct 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",181,000020
+GREELEY,Tribune Precinct 3,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",41,000030
+GREELEY,Tribune Precinct 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",38,000010
+GREELEY,Tribune Precinct 1,Kansas Senate,39,Republican,"Doll, John",349,000010
+GREELEY,Tribune Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",21,000020
+GREELEY,Tribune Precinct 2,Kansas Senate,39,Republican,"Doll, John",160,000020
+GREELEY,Tribune Precinct 3,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",5,000030
+GREELEY,Tribune Precinct 3,Kansas Senate,39,Republican,"Doll, John",36,000030
+GREELEY,Tribune Precinct 1,President / Vice President,,independent,"Stein, Jill",6,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000010
+GREELEY,Tribune Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",317,000010
+GREELEY,Tribune Precinct 2,President / Vice President,,independent,"Stein, Jill",1,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000020
+GREELEY,Tribune Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",182,000020
+GREELEY,Tribune Precinct 3,President / Vice President,,independent,"Stein, Jill",1,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+GREELEY,Tribune Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",35,000030
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",32,000010
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,000010
+GREELEY,Tribune Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",333,000010
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",24,000020
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000020
+GREELEY,Tribune Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",156,000020
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",6,000030
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000030
+GREELEY,Tribune Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",36,000030
+GREELEY,Tribune Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000010
+GREELEY,Tribune Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",34,000010
+GREELEY,Tribune Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000010
+GREELEY,Tribune Precinct 1,United States Senate,,Republican,"Moran, Jerry",355,000010
+GREELEY,Tribune Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000020
+GREELEY,Tribune Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",12,000020
+GREELEY,Tribune Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,000020
+GREELEY,Tribune Precinct 2,United States Senate,,Republican,"Moran, Jerry",176,000020
+GREELEY,Tribune Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000030
+GREELEY,Tribune Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+GREELEY,Tribune Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+GREELEY,Tribune Precinct 3,United States Senate,,Republican,"Moran, Jerry",39,000030

--- a/2016/20161108__ks__general__greenwood__precinct.csv
+++ b/2016/20161108__ks__general__greenwood__precinct.csv
@@ -1,757 +1,757 @@
-county,precinct,office,district,candidate,party,votes
-Greenwood,Bachelor Township,President,,"Stein, Jill  ",independent,1
-Greenwood,Bachelor Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Bachelor Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Bachelor Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Bachelor Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Bachelor Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Bachelor Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Bachelor Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Bachelor Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Bachelor Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Bachelor Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Bachelor Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Bachelor Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Bachelor Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Bachelor Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Bachelor Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Bachelor Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Bachelor Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Bachelor Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Bachelor Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Bachelor Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Bachelor Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Bachelor Township,President,,"Clinton, Hillary Rodham ",Democratic,19
-Greenwood,Bachelor Township,President,,"Johnson, Gary  ",Libertarian,1
-Greenwood,Bachelor Township,President,,"Trump, Donald J. ",Republican,95
-Greenwood,Eureka Township,President,,"Stein, Jill  ",independent,1
-Greenwood,Eureka Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Eureka Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Eureka Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Eureka Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Eureka Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Eureka Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Eureka Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Eureka Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Eureka Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Eureka Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Eureka Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Eureka Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Eureka Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Eureka Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Eureka Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Eureka Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Eureka Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Eureka Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Eureka Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Eureka Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Eureka Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Eureka Township,President,,"Clinton, Hillary Rodham ",Democratic,55
-Greenwood,Eureka Township,President,,"Johnson, Gary  ",Libertarian,7
-Greenwood,Eureka Township,President,,"Trump, Donald J. ",Republican,162
-Greenwood,Eureka Ward 1,President,,"Stein, Jill  ",independent,8
-Greenwood,Eureka Ward 1,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Eureka Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Hedges, James A ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Eureka Ward 1,President,,"McMullin, Evan  ",write - in,1
-Greenwood,Eureka Ward 1,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Smith, Mike  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Eureka Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,63
-Greenwood,Eureka Ward 1,President,,"Johnson, Gary  ",Libertarian,24
-Greenwood,Eureka Ward 1,President,,"Trump, Donald J. ",Republican,268
-Greenwood,Eureka Ward 2,President,,"Stein, Jill  ",independent,7
-Greenwood,Eureka Ward 2,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Castle, Darrell L ",write - in,2
-Greenwood,Eureka Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Hedges, James A ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Eureka Ward 2,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Smith, Mike  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Eureka Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,53
-Greenwood,Eureka Ward 2,President,,"Johnson, Gary  ",Libertarian,9
-Greenwood,Eureka Ward 2,President,,"Trump, Donald J. ",Republican,180
-Greenwood,Eureka Ward 3,President,,"Stein, Jill  ",independent,10
-Greenwood,Eureka Ward 3,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Castle, Darrell L ",write - in,2
-Greenwood,Eureka Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Hedges, James A ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Eureka Ward 3,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Smith, Mike  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Eureka Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,58
-Greenwood,Eureka Ward 3,President,,"Johnson, Gary  ",Libertarian,16
-Greenwood,Eureka Ward 3,President,,"Trump, Donald J. ",Republican,213
-Greenwood,Fall River Township,President,,"Stein, Jill  ",independent,1
-Greenwood,Fall River Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Fall River Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Fall River Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Fall River Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Fall River Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Fall River Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Fall River Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Fall River Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Fall River Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Fall River Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Fall River Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Fall River Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Fall River Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Fall River Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Fall River Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Fall River Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Fall River Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Fall River Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Fall River Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Fall River Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Fall River Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Fall River Township,President,,"Clinton, Hillary Rodham ",Democratic,20
-Greenwood,Fall River Township,President,,"Johnson, Gary  ",Libertarian,3
-Greenwood,Fall River Township,President,,"Trump, Donald J. ",Republican,81
-Greenwood,Janesville Township,President,,"Stein, Jill  ",independent,2
-Greenwood,Janesville Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Janesville Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Janesville Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Janesville Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Janesville Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Janesville Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Janesville Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Janesville Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Janesville Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Janesville Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Janesville Township,President,,"McMullin, Evan  ",write - in,1
-Greenwood,Janesville Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Janesville Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Janesville Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Janesville Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Janesville Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Janesville Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Janesville Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Janesville Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Janesville Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Janesville Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Janesville Township,President,,"Clinton, Hillary Rodham ",Democratic,27
-Greenwood,Janesville Township,President,,"Johnson, Gary  ",Libertarian,11
-Greenwood,Janesville Township,President,,"Trump, Donald J. ",Republican,180
-Greenwood,Lane Township,President,,"Stein, Jill  ",independent,1
-Greenwood,Lane Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Lane Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Lane Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Lane Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Lane Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Lane Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Lane Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Lane Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Lane Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Lane Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Lane Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Lane Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Lane Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Lane Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Lane Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Lane Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Lane Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Lane Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Lane Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Lane Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Lane Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Lane Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Greenwood,Lane Township,President,,"Johnson, Gary  ",Libertarian,1
-Greenwood,Lane Township,President,,"Trump, Donald J. ",Republican,33
-Greenwood,Madison Township,President,,"Stein, Jill  ",independent,16
-Greenwood,Madison Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Madison Township,President,,"Castle, Darrell L ",write - in,2
-Greenwood,Madison Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Madison Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Madison Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Madison Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Madison Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Madison Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Madison Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Madison Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Madison Township,President,,"McMullin, Evan  ",write - in,6
-Greenwood,Madison Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Madison Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Madison Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Madison Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Madison Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Madison Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Madison Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Madison Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Madison Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Madison Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Madison Township,President,,"Clinton, Hillary Rodham ",Democratic,77
-Greenwood,Madison Township,President,,"Johnson, Gary  ",Libertarian,23
-Greenwood,Madison Township,President,,"Trump, Donald J. ",Republican,320
-Greenwood,Otter Creek Township,President,,"Stein, Jill  ",independent,0
-Greenwood,Otter Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Otter Creek Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Otter Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Otter Creek Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Otter Creek Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Otter Creek Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Otter Creek Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Otter Creek Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Otter Creek Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Otter Creek Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Otter Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Otter Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Otter Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,26
-Greenwood,Otter Creek Township,President,,"Johnson, Gary  ",Libertarian,5
-Greenwood,Otter Creek Township,President,,"Trump, Donald J. ",Republican,67
-Greenwood,Pleasant Grove Township,President,,"Stein, Jill  ",independent,2
-Greenwood,Pleasant Grove Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Pleasant Grove Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Greenwood,Pleasant Grove Township,President,,"Johnson, Gary  ",Libertarian,2
-Greenwood,Pleasant Grove Township,President,,"Trump, Donald J. ",Republican,29
-Greenwood,Quincy Township,President,,"Stein, Jill  ",independent,0
-Greenwood,Quincy Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Quincy Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Quincy Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Quincy Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Quincy Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Quincy Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Quincy Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Quincy Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Quincy Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Quincy Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Quincy Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Quincy Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Quincy Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Quincy Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Quincy Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Quincy Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Quincy Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Quincy Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Quincy Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Quincy Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Quincy Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Quincy Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Greenwood,Quincy Township,President,,"Johnson, Gary  ",Libertarian,1
-Greenwood,Quincy Township,President,,"Trump, Donald J. ",Republican,49
-Greenwood,Salem Township,President,,"Stein, Jill  ",independent,1
-Greenwood,Salem Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Salem Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Salem Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Salem Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Salem Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Salem Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Salem Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Salem Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Salem Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Salem Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Salem Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Salem Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Salem Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Salem Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Salem Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Salem Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Salem Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Salem Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Salem Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Salem Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Salem Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Salem Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Greenwood,Salem Township,President,,"Johnson, Gary  ",Libertarian,1
-Greenwood,Salem Township,President,,"Trump, Donald J. ",Republican,12
-Greenwood,Salt Springs Township,President,,"Stein, Jill  ",independent,3
-Greenwood,Salt Springs Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Salt Springs Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Salt Springs Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Salt Springs Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Salt Springs Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Salt Springs Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Salt Springs Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Salt Springs Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Salt Springs Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Salt Springs Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Salt Springs Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Salt Springs Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Salt Springs Township,President,,"Clinton, Hillary Rodham ",Democratic,29
-Greenwood,Salt Springs Township,President,,"Johnson, Gary  ",Libertarian,6
-Greenwood,Salt Springs Township,President,,"Trump, Donald J. ",Republican,136
-Greenwood,Shell Rock Township,President,,"Stein, Jill  ",independent,0
-Greenwood,Shell Rock Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Shell Rock Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Shell Rock Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Shell Rock Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Shell Rock Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Shell Rock Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Shell Rock Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Shell Rock Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Shell Rock Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Shell Rock Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Shell Rock Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Shell Rock Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Shell Rock Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Greenwood,Shell Rock Township,President,,"Johnson, Gary  ",Libertarian,4
-Greenwood,Shell Rock Township,President,,"Trump, Donald J. ",Republican,68
-Greenwood,Spring Creek Township,President,,"Stein, Jill  ",independent,0
-Greenwood,Spring Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Spring Creek Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Spring Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Spring Creek Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Spring Creek Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Spring Creek Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Spring Creek Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Spring Creek Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Spring Creek Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Spring Creek Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Spring Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Spring Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Spring Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Greenwood,Spring Creek Township,President,,"Johnson, Gary  ",Libertarian,3
-Greenwood,Spring Creek Township,President,,"Trump, Donald J. ",Republican,42
-Greenwood,Twin Grove Township,President,,"Stein, Jill  ",independent,5
-Greenwood,Twin Grove Township,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Twin Grove Township,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Twin Grove Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Hedges, James A ",write - in,0
-Greenwood,Twin Grove Township,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Twin Grove Township,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Twin Grove Township,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Twin Grove Township,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Twin Grove Township,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Twin Grove Township,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Twin Grove Township,President,,"Smith, Mike  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Twin Grove Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Twin Grove Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Twin Grove Township,President,,"Clinton, Hillary Rodham ",Democratic,25
-Greenwood,Twin Grove Township,President,,"Johnson, Gary  ",Libertarian,4
-Greenwood,Twin Grove Township,President,,"Trump, Donald J. ",Republican,182
-Greenwood,South Salem Township C01,President,,"Stein, Jill  ",independent,1
-Greenwood,South Salem Township C01,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,South Salem Township C01,President,,"Castle, Darrell L ",write - in,0
-Greenwood,South Salem Township C01,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Hedges, James A ",write - in,0
-Greenwood,South Salem Township C01,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,South Salem Township C01,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,South Salem Township C01,President,,"Maturen, Michael A ",write - in,0
-Greenwood,South Salem Township C01,President,,"McMullin, Evan  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,South Salem Township C01,President,,"Perry, Darryl  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,South Salem Township C01,President,,"Schriner, Joe C ",write - in,0
-Greenwood,South Salem Township C01,President,,"Smith, Mike  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Sood, Ajay  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,South Salem Township C01,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,South Salem Township C01,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,South Salem Township C01,President,,"Clinton, Hillary Rodham ",Democratic,3
-Greenwood,South Salem Township C01,President,,"Johnson, Gary  ",Libertarian,1
-Greenwood,South Salem Township C01,President,,"Trump, Donald J. ",Republican,43
-Greenwood,South Salem Township C04,President,,"Stein, Jill  ",independent,0
-Greenwood,South Salem Township C04,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,South Salem Township C04,President,,"Castle, Darrell L ",write - in,0
-Greenwood,South Salem Township C04,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Hedges, James A ",write - in,0
-Greenwood,South Salem Township C04,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,South Salem Township C04,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,South Salem Township C04,President,,"Maturen, Michael A ",write - in,0
-Greenwood,South Salem Township C04,President,,"McMullin, Evan  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,South Salem Township C04,President,,"Perry, Darryl  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,South Salem Township C04,President,,"Schriner, Joe C ",write - in,0
-Greenwood,South Salem Township C04,President,,"Smith, Mike  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Sood, Ajay  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,South Salem Township C04,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,South Salem Township C04,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,South Salem Township C04,President,,"Clinton, Hillary Rodham ",Democratic,0
-Greenwood,South Salem Township C04,President,,"Johnson, Gary  ",Libertarian,0
-Greenwood,South Salem Township C04,President,,"Trump, Donald J. ",Republican,0
-Greenwood,Eureka Airport,President,,"Stein, Jill  ",independent,0
-Greenwood,Eureka Airport,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Eureka Airport,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Eureka Airport,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Eureka Airport,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Eureka Airport,President,,"Hedges, James A ",write - in,0
-Greenwood,Eureka Airport,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Eureka Airport,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Eureka Airport,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Eureka Airport,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Eureka Airport,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Eureka Airport,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Eureka Airport,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Eureka Airport,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Eureka Airport,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Eureka Airport,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Eureka Airport,President,,"Smith, Mike  ",write - in,0
-Greenwood,Eureka Airport,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Eureka Airport,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Eureka Airport,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Eureka Airport,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Eureka Airport,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Eureka Airport,President,,"Clinton, Hillary Rodham ",Democratic,0
-Greenwood,Eureka Airport,President,,"Johnson, Gary  ",Libertarian,0
-Greenwood,Eureka Airport,President,,"Trump, Donald J. ",Republican,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Stein, Jill  ",independent,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Basiago, Andrew D. ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Castle, Darrell L ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Giordani, Rocky  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Hedges, James A ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Hoefling, Tom  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Kahn, Lynn  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"La Riva, Gloria  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Levinson, Michael S. ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Maturen, Michael A ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"McMullin, Evan  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Moorehead, Monica G. ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Perry, Darryl  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Schoenke, Marshall R. ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Schriner, Joe C ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Smith, Mike  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Sood, Ajay  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Sterling, Shawna  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Valdivia, Anthony J ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-Greenwood,Eureka Ward 1 Exclave,President,,"Trump, Donald J. ",Republican,0
-Greenwood,Bachelor Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Bachelor Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,16
-Greenwood,Bachelor Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Greenwood,Bachelor Township,U.S. Senate,,"Moran, Jerry  ",Republican,93
-Greenwood,Eureka Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Eureka Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,45
-Greenwood,Eureka Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Greenwood,Eureka Township,U.S. Senate,,"Moran, Jerry  ",Republican,165
-Greenwood,Eureka Ward 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Eureka Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,55
-Greenwood,Eureka Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,27
-Greenwood,Eureka Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,281
-Greenwood,Eureka Ward 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Eureka Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,38
-Greenwood,Eureka Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,16
-Greenwood,Eureka Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,191
-Greenwood,Eureka Ward 3,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Eureka Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,57
-Greenwood,Eureka Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,18
-Greenwood,Eureka Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,221
-Greenwood,Fall River Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Fall River Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,22
-Greenwood,Fall River Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Greenwood,Fall River Township,U.S. Senate,,"Moran, Jerry  ",Republican,79
-Greenwood,Janesville Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Janesville Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,30
-Greenwood,Janesville Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Greenwood,Janesville Township,U.S. Senate,,"Moran, Jerry  ",Republican,171
-Greenwood,Lane Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Lane Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,14
-Greenwood,Lane Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Greenwood,Lane Township,U.S. Senate,,"Moran, Jerry  ",Republican,23
-Greenwood,Madison Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Madison Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,73
-Greenwood,Madison Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,29
-Greenwood,Madison Township,U.S. Senate,,"Moran, Jerry  ",Republican,337
-Greenwood,Otter Creek Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Otter Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,24
-Greenwood,Otter Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-Greenwood,Otter Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,63
-Greenwood,Pleasant Grove Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Pleasant Grove Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Greenwood,Pleasant Grove Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Greenwood,Pleasant Grove Township,U.S. Senate,,"Moran, Jerry  ",Republican,25
-Greenwood,Quincy Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Quincy Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,6
-Greenwood,Quincy Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Greenwood,Quincy Township,U.S. Senate,,"Moran, Jerry  ",Republican,43
-Greenwood,Salem Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Salem Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Greenwood,Salem Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Greenwood,Salem Township,U.S. Senate,,"Moran, Jerry  ",Republican,15
-Greenwood,Salt Springs Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Salt Springs Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,26
-Greenwood,Salt Springs Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,15
-Greenwood,Salt Springs Township,U.S. Senate,,"Moran, Jerry  ",Republican,131
-Greenwood,Shell Rock Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Shell Rock Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Greenwood,Shell Rock Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Greenwood,Shell Rock Township,U.S. Senate,,"Moran, Jerry  ",Republican,69
-Greenwood,Spring Creek Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Spring Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Greenwood,Spring Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Greenwood,Spring Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,47
-Greenwood,Twin Grove Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Twin Grove Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,35
-Greenwood,Twin Grove Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,14
-Greenwood,Twin Grove Township,U.S. Senate,,"Moran, Jerry  ",Republican,167
-Greenwood,South Salem Township C01,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,South Salem Township C01,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Greenwood,South Salem Township C01,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Greenwood,South Salem Township C01,U.S. Senate,,"Moran, Jerry  ",Republican,43
-Greenwood,South Salem Township C04,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,South Salem Township C04,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Greenwood,South Salem Township C04,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Greenwood,South Salem Township C04,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Greenwood,Eureka Airport,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Eureka Airport,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Greenwood,Eureka Airport,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Greenwood,Eureka Airport,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Greenwood,Eureka Ward 1 Exclave,U.S. Senate,,"Smith, DJ  ",write - in,0
-Greenwood,Eureka Ward 1 Exclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Greenwood,Eureka Ward 1 Exclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Greenwood,Eureka Ward 1 Exclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Greenwood,Bachelor Township,U.S. House,4,"Allen, Miranda  ",independent,4
-Greenwood,Bachelor Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,17
-Greenwood,Bachelor Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Greenwood,Bachelor Township,U.S. House,4,"Pompeo, Michael  ",Republican,89
-Greenwood,Eureka Township,U.S. House,4,"Allen, Miranda  ",independent,16
-Greenwood,Eureka Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,51
-Greenwood,Eureka Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,4
-Greenwood,Eureka Township,U.S. House,4,"Pompeo, Michael  ",Republican,153
-Greenwood,Eureka Ward 1,U.S. House,4,"Allen, Miranda  ",independent,30
-Greenwood,Eureka Ward 1,U.S. House,4,"Giroux, Daniel B. ",Democratic,62
-Greenwood,Eureka Ward 1,U.S. House,4,"Bakken, Gorden J. ",Libertarian,16
-Greenwood,Eureka Ward 1,U.S. House,4,"Pompeo, Michael  ",Republican,253
-Greenwood,Eureka Ward 2,U.S. House,4,"Allen, Miranda  ",independent,17
-Greenwood,Eureka Ward 2,U.S. House,4,"Giroux, Daniel B. ",Democratic,44
-Greenwood,Eureka Ward 2,U.S. House,4,"Bakken, Gorden J. ",Libertarian,10
-Greenwood,Eureka Ward 2,U.S. House,4,"Pompeo, Michael  ",Republican,177
-Greenwood,Eureka Ward 3,U.S. House,4,"Allen, Miranda  ",independent,25
-Greenwood,Eureka Ward 3,U.S. House,4,"Giroux, Daniel B. ",Democratic,54
-Greenwood,Eureka Ward 3,U.S. House,4,"Bakken, Gorden J. ",Libertarian,12
-Greenwood,Eureka Ward 3,U.S. House,4,"Pompeo, Michael  ",Republican,198
-Greenwood,Fall River Township,U.S. House,4,"Allen, Miranda  ",independent,0
-Greenwood,Fall River Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,21
-Greenwood,Fall River Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Greenwood,Fall River Township,U.S. House,4,"Pompeo, Michael  ",Republican,83
-Greenwood,Janesville Township,U.S. House,4,"Allen, Miranda  ",independent,12
-Greenwood,Janesville Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,26
-Greenwood,Janesville Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,3
-Greenwood,Janesville Township,U.S. House,4,"Pompeo, Michael  ",Republican,171
-Greenwood,Lane Township,U.S. House,4,"Allen, Miranda  ",independent,2
-Greenwood,Lane Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,7
-Greenwood,Lane Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Greenwood,Lane Township,U.S. House,4,"Pompeo, Michael  ",Republican,32
-Greenwood,Madison Township,U.S. House,4,"Allen, Miranda  ",independent,35
-Greenwood,Madison Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,70
-Greenwood,Madison Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,13
-Greenwood,Madison Township,U.S. House,4,"Pompeo, Michael  ",Republican,325
-Greenwood,Otter Creek Township,U.S. House,4,"Allen, Miranda  ",independent,5
-Greenwood,Otter Creek Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,21
-Greenwood,Otter Creek Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,4
-Greenwood,Otter Creek Township,U.S. House,4,"Pompeo, Michael  ",Republican,66
-Greenwood,Pleasant Grove Township,U.S. House,4,"Allen, Miranda  ",independent,4
-Greenwood,Pleasant Grove Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,3
-Greenwood,Pleasant Grove Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Greenwood,Pleasant Grove Township,U.S. House,4,"Pompeo, Michael  ",Republican,24
-Greenwood,Quincy Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Greenwood,Quincy Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,6
-Greenwood,Quincy Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Greenwood,Quincy Township,U.S. House,4,"Pompeo, Michael  ",Republican,46
-Greenwood,Salem Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Greenwood,Salem Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Greenwood,Salem Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Greenwood,Salem Township,U.S. House,4,"Pompeo, Michael  ",Republican,12
-Greenwood,Salt Springs Township,U.S. House,4,"Allen, Miranda  ",independent,13
-Greenwood,Salt Springs Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,24
-Greenwood,Salt Springs Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,6
-Greenwood,Salt Springs Township,U.S. House,4,"Pompeo, Michael  ",Republican,126
-Greenwood,Shell Rock Township,U.S. House,4,"Allen, Miranda  ",independent,6
-Greenwood,Shell Rock Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,6
-Greenwood,Shell Rock Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Greenwood,Shell Rock Township,U.S. House,4,"Pompeo, Michael  ",Republican,61
-Greenwood,Spring Creek Township,U.S. House,4,"Allen, Miranda  ",independent,1
-Greenwood,Spring Creek Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,7
-Greenwood,Spring Creek Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,4
-Greenwood,Spring Creek Township,U.S. House,4,"Pompeo, Michael  ",Republican,42
-Greenwood,Twin Grove Township,U.S. House,4,"Allen, Miranda  ",independent,8
-Greenwood,Twin Grove Township,U.S. House,4,"Giroux, Daniel B. ",Democratic,44
-Greenwood,Twin Grove Township,U.S. House,4,"Bakken, Gorden J. ",Libertarian,8
-Greenwood,Twin Grove Township,U.S. House,4,"Pompeo, Michael  ",Republican,158
-Greenwood,South Salem Township C01,U.S. House,4,"Allen, Miranda  ",independent,3
-Greenwood,South Salem Township C01,U.S. House,4,"Giroux, Daniel B. ",Democratic,2
-Greenwood,South Salem Township C01,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Greenwood,South Salem Township C01,U.S. House,4,"Pompeo, Michael  ",Republican,42
-Greenwood,South Salem Township C04,U.S. House,4,"Allen, Miranda  ",independent,0
-Greenwood,South Salem Township C04,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Greenwood,South Salem Township C04,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Greenwood,South Salem Township C04,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Greenwood,Eureka Airport,U.S. House,4,"Allen, Miranda  ",independent,0
-Greenwood,Eureka Airport,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Greenwood,Eureka Airport,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Greenwood,Eureka Airport,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Greenwood,Eureka Ward 1 Exclave,U.S. House,4,"Allen, Miranda  ",independent,0
-Greenwood,Eureka Ward 1 Exclave,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Greenwood,Eureka Ward 1 Exclave,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Greenwood,Eureka Ward 1 Exclave,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Greenwood,Bachelor Township,State Senate,14,"Pringle, Mark  ",Democratic,24
-Greenwood,Bachelor Township,State Senate,14,"Givens, Bruce  ",Republican,89
-Greenwood,Eureka Township,State Senate,14,"Pringle, Mark  ",Democratic,59
-Greenwood,Eureka Township,State Senate,14,"Givens, Bruce  ",Republican,163
-Greenwood,Eureka Ward 1,State Senate,14,"Pringle, Mark  ",Democratic,83
-Greenwood,Eureka Ward 1,State Senate,14,"Givens, Bruce  ",Republican,267
-Greenwood,Eureka Ward 2,State Senate,14,"Pringle, Mark  ",Democratic,61
-Greenwood,Eureka Ward 2,State Senate,14,"Givens, Bruce  ",Republican,180
-Greenwood,Eureka Ward 3,State Senate,14,"Pringle, Mark  ",Democratic,71
-Greenwood,Eureka Ward 3,State Senate,14,"Givens, Bruce  ",Republican,218
-Greenwood,Fall River Township,State Senate,14,"Pringle, Mark  ",Democratic,37
-Greenwood,Fall River Township,State Senate,14,"Givens, Bruce  ",Republican,67
-Greenwood,Janesville Township,State Senate,14,"Pringle, Mark  ",Democratic,43
-Greenwood,Janesville Township,State Senate,14,"Givens, Bruce  ",Republican,159
-Greenwood,Lane Township,State Senate,14,"Pringle, Mark  ",Democratic,20
-Greenwood,Lane Township,State Senate,14,"Givens, Bruce  ",Republican,20
-Greenwood,Madison Township,State Senate,14,"Pringle, Mark  ",Democratic,115
-Greenwood,Madison Township,State Senate,14,"Givens, Bruce  ",Republican,305
-Greenwood,Otter Creek Township,State Senate,14,"Pringle, Mark  ",Democratic,28
-Greenwood,Otter Creek Township,State Senate,14,"Givens, Bruce  ",Republican,65
-Greenwood,Pleasant Grove Township,State Senate,14,"Pringle, Mark  ",Democratic,12
-Greenwood,Pleasant Grove Township,State Senate,14,"Givens, Bruce  ",Republican,19
-Greenwood,Quincy Township,State Senate,14,"Pringle, Mark  ",Democratic,13
-Greenwood,Quincy Township,State Senate,14,"Givens, Bruce  ",Republican,37
-Greenwood,Salem Township,State Senate,14,"Pringle, Mark  ",Democratic,0
-Greenwood,Salem Township,State Senate,14,"Givens, Bruce  ",Republican,16
-Greenwood,Salt Springs Township,State Senate,14,"Pringle, Mark  ",Democratic,48
-Greenwood,Salt Springs Township,State Senate,14,"Givens, Bruce  ",Republican,123
-Greenwood,Shell Rock Township,State Senate,14,"Pringle, Mark  ",Democratic,14
-Greenwood,Shell Rock Township,State Senate,14,"Givens, Bruce  ",Republican,61
-Greenwood,Spring Creek Township,State Senate,14,"Pringle, Mark  ",Democratic,14
-Greenwood,Spring Creek Township,State Senate,14,"Givens, Bruce  ",Republican,39
-Greenwood,Twin Grove Township,State Senate,14,"Pringle, Mark  ",Democratic,59
-Greenwood,Twin Grove Township,State Senate,14,"Givens, Bruce  ",Republican,157
-Greenwood,South Salem Township C01,State Senate,14,"Pringle, Mark  ",Democratic,4
-Greenwood,South Salem Township C01,State Senate,14,"Givens, Bruce  ",Republican,42
-Greenwood,South Salem Township C04,State Senate,14,"Pringle, Mark  ",Democratic,0
-Greenwood,South Salem Township C04,State Senate,14,"Givens, Bruce  ",Republican,0
-Greenwood,Eureka Airport,State Senate,14,"Pringle, Mark  ",Democratic,0
-Greenwood,Eureka Airport,State Senate,14,"Givens, Bruce  ",Republican,0
-Greenwood,Eureka Ward 1 Exclave,State Senate,14,"Pringle, Mark  ",Democratic,0
-Greenwood,Eureka Ward 1 Exclave,State Senate,14,"Givens, Bruce  ",Republican,0
-Greenwood,Bachelor Township,State House,13,"Hibbard, Larry P. ",Republican,99
-Greenwood,Eureka Township,State House,13,"Hibbard, Larry P. ",Republican,198
-Greenwood,Eureka Ward 1,State House,13,"Hibbard, Larry P. ",Republican,316
-Greenwood,Eureka Ward 2,State House,13,"Hibbard, Larry P. ",Republican,220
-Greenwood,Eureka Ward 3,State House,13,"Hibbard, Larry P. ",Republican,263
-Greenwood,Fall River Township,State House,13,"Hibbard, Larry P. ",Republican,90
-Greenwood,Janesville Township,State House,13,"Hibbard, Larry P. ",Republican,180
-Greenwood,Lane Township,State House,13,"Hibbard, Larry P. ",Republican,36
-Greenwood,Madison Township,State House,13,"Hibbard, Larry P. ",Republican,384
-Greenwood,Otter Creek Township,State House,13,"Hibbard, Larry P. ",Republican,76
-Greenwood,Pleasant Grove Township,State House,13,"Hibbard, Larry P. ",Republican,27
-Greenwood,Quincy Township,State House,13,"Hibbard, Larry P. ",Republican,43
-Greenwood,Salem Township,State House,13,"Hibbard, Larry P. ",Republican,12
-Greenwood,Salt Springs Township,State House,13,"Hibbard, Larry P. ",Republican,150
-Greenwood,Shell Rock Township,State House,13,"Hibbard, Larry P. ",Republican,74
-Greenwood,Spring Creek Township,State House,13,"Hibbard, Larry P. ",Republican,49
-Greenwood,Twin Grove Township,State House,13,"Hibbard, Larry P. ",Republican,196
-Greenwood,South Salem Township C01,State House,13,"Hibbard, Larry P. ",Republican,44
-Greenwood,South Salem Township C04,State House,13,"Hibbard, Larry P. ",Republican,0
-Greenwood,Eureka Airport,State House,13,"Hibbard, Larry P. ",Republican,0
-Greenwood,Eureka Ward 1 Exclave,State House,13,"Hibbard, Larry P. ",Republican,0
+county,precinct,office,district,party,candidate,votes,vtd
+GREENWOOD,Bachelor Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",99,000010
+GREENWOOD,Eureka Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",198,000020
+GREENWOOD,Eureka Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",316,000030
+GREENWOOD,Eureka Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",220,000040
+GREENWOOD,Eureka Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",263,000050
+GREENWOOD,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",90,000060
+GREENWOOD,Janesville Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",180,000070
+GREENWOOD,Lane Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",36,000080
+GREENWOOD,Madison Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",384,000090
+GREENWOOD,Otter Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",76,000100
+GREENWOOD,Pleasant Grove Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",27,000110
+GREENWOOD,Quincy Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",43,000120
+GREENWOOD,Salem Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",12,000130
+GREENWOOD,Salt Springs Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",150,000140
+GREENWOOD,Shell Rock Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",74,000150
+GREENWOOD,Spring Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",49,000170
+GREENWOOD,Twin Grove Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",196,000180
+GREENWOOD,South Salem Township C01,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",44,200010
+GREENWOOD,South Salem Township C04,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,200020
+GREENWOOD,Eureka Airport,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900020
+GREENWOOD,Bachelor Township,Kansas Senate,14,Democratic,"Pringle, Mark",24,000010
+GREENWOOD,Bachelor Township,Kansas Senate,14,Republican,"Givens, Bruce",89,000010
+GREENWOOD,Eureka Township,Kansas Senate,14,Democratic,"Pringle, Mark",59,000020
+GREENWOOD,Eureka Township,Kansas Senate,14,Republican,"Givens, Bruce",163,000020
+GREENWOOD,Eureka Ward 1,Kansas Senate,14,Democratic,"Pringle, Mark",83,000030
+GREENWOOD,Eureka Ward 1,Kansas Senate,14,Republican,"Givens, Bruce",267,000030
+GREENWOOD,Eureka Ward 2,Kansas Senate,14,Democratic,"Pringle, Mark",61,000040
+GREENWOOD,Eureka Ward 2,Kansas Senate,14,Republican,"Givens, Bruce",180,000040
+GREENWOOD,Eureka Ward 3,Kansas Senate,14,Democratic,"Pringle, Mark",71,000050
+GREENWOOD,Eureka Ward 3,Kansas Senate,14,Republican,"Givens, Bruce",218,000050
+GREENWOOD,Fall River Township,Kansas Senate,14,Democratic,"Pringle, Mark",37,000060
+GREENWOOD,Fall River Township,Kansas Senate,14,Republican,"Givens, Bruce",67,000060
+GREENWOOD,Janesville Township,Kansas Senate,14,Democratic,"Pringle, Mark",43,000070
+GREENWOOD,Janesville Township,Kansas Senate,14,Republican,"Givens, Bruce",159,000070
+GREENWOOD,Lane Township,Kansas Senate,14,Democratic,"Pringle, Mark",20,000080
+GREENWOOD,Lane Township,Kansas Senate,14,Republican,"Givens, Bruce",20,000080
+GREENWOOD,Madison Township,Kansas Senate,14,Democratic,"Pringle, Mark",115,000090
+GREENWOOD,Madison Township,Kansas Senate,14,Republican,"Givens, Bruce",305,000090
+GREENWOOD,Otter Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",28,000100
+GREENWOOD,Otter Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",65,000100
+GREENWOOD,Pleasant Grove Township,Kansas Senate,14,Democratic,"Pringle, Mark",12,000110
+GREENWOOD,Pleasant Grove Township,Kansas Senate,14,Republican,"Givens, Bruce",19,000110
+GREENWOOD,Quincy Township,Kansas Senate,14,Democratic,"Pringle, Mark",13,000120
+GREENWOOD,Quincy Township,Kansas Senate,14,Republican,"Givens, Bruce",37,000120
+GREENWOOD,Salem Township,Kansas Senate,14,Democratic,"Pringle, Mark",0,000130
+GREENWOOD,Salem Township,Kansas Senate,14,Republican,"Givens, Bruce",16,000130
+GREENWOOD,Salt Springs Township,Kansas Senate,14,Democratic,"Pringle, Mark",48,000140
+GREENWOOD,Salt Springs Township,Kansas Senate,14,Republican,"Givens, Bruce",123,000140
+GREENWOOD,Shell Rock Township,Kansas Senate,14,Democratic,"Pringle, Mark",14,000150
+GREENWOOD,Shell Rock Township,Kansas Senate,14,Republican,"Givens, Bruce",61,000150
+GREENWOOD,Spring Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",14,000170
+GREENWOOD,Spring Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",39,000170
+GREENWOOD,Twin Grove Township,Kansas Senate,14,Democratic,"Pringle, Mark",59,000180
+GREENWOOD,Twin Grove Township,Kansas Senate,14,Republican,"Givens, Bruce",157,000180
+GREENWOOD,South Salem Township C01,Kansas Senate,14,Democratic,"Pringle, Mark",4,200010
+GREENWOOD,South Salem Township C01,Kansas Senate,14,Republican,"Givens, Bruce",42,200010
+GREENWOOD,South Salem Township C04,Kansas Senate,14,Democratic,"Pringle, Mark",0,200020
+GREENWOOD,South Salem Township C04,Kansas Senate,14,Republican,"Givens, Bruce",0,200020
+GREENWOOD,Eureka Airport,Kansas Senate,14,Democratic,"Pringle, Mark",0,900010
+GREENWOOD,Eureka Airport,Kansas Senate,14,Republican,"Givens, Bruce",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,Kansas Senate,14,Democratic,"Pringle, Mark",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,Kansas Senate,14,Republican,"Givens, Bruce",0,900020
+GREENWOOD,Bachelor Township,President / Vice President,,independent,"Stein, Jill",1,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+GREENWOOD,Bachelor Township,President / Vice President,,Republican,"Trump, Donald J.",95,000010
+GREENWOOD,Eureka Township,President / Vice President,,independent,"Stein, Jill",1,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+GREENWOOD,Eureka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000020
+GREENWOOD,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000020
+GREENWOOD,Eureka Township,President / Vice President,,Republican,"Trump, Donald J.",162,000020
+GREENWOOD,Eureka Ward 1,President / Vice President,,independent,"Stein, Jill",8,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",24,000030
+GREENWOOD,Eureka Ward 1,President / Vice President,,Republican,"Trump, Donald J.",268,000030
+GREENWOOD,Eureka Ward 2,President / Vice President,,independent,"Stein, Jill",7,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Castle, Darrell L",2,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000040
+GREENWOOD,Eureka Ward 2,President / Vice President,,Republican,"Trump, Donald J.",180,000040
+GREENWOOD,Eureka Ward 3,President / Vice President,,independent,"Stein, Jill",10,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Castle, Darrell L",2,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",16,000050
+GREENWOOD,Eureka Ward 3,President / Vice President,,Republican,"Trump, Donald J.",213,000050
+GREENWOOD,Fall River Township,President / Vice President,,independent,"Stein, Jill",1,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+GREENWOOD,Fall River Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000060
+GREENWOOD,Fall River Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+GREENWOOD,Fall River Township,President / Vice President,,Republican,"Trump, Donald J.",81,000060
+GREENWOOD,Janesville Township,President / Vice President,,independent,"Stein, Jill",2,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+GREENWOOD,Janesville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000070
+GREENWOOD,Janesville Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000070
+GREENWOOD,Janesville Township,President / Vice President,,Republican,"Trump, Donald J.",180,000070
+GREENWOOD,Lane Township,President / Vice President,,independent,"Stein, Jill",1,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+GREENWOOD,Lane Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+GREENWOOD,Lane Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000080
+GREENWOOD,Lane Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+GREENWOOD,Lane Township,President / Vice President,,Republican,"Trump, Donald J.",33,000080
+GREENWOOD,Madison Township,President / Vice President,,independent,"Stein, Jill",16,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Castle, Darrell L",2,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"McMullin, Evan",6,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+GREENWOOD,Madison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+GREENWOOD,Madison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000090
+GREENWOOD,Madison Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000090
+GREENWOOD,Madison Township,President / Vice President,,Republican,"Trump, Donald J.",320,000090
+GREENWOOD,Otter Creek Township,President / Vice President,,independent,"Stein, Jill",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+GREENWOOD,Otter Creek Township,President / Vice President,,Republican,"Trump, Donald J.",67,000100
+GREENWOOD,Pleasant Grove Township,President / Vice President,,independent,"Stein, Jill",2,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+GREENWOOD,Pleasant Grove Township,President / Vice President,,Republican,"Trump, Donald J.",29,000110
+GREENWOOD,Quincy Township,President / Vice President,,independent,"Stein, Jill",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+GREENWOOD,Quincy Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000120
+GREENWOOD,Quincy Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+GREENWOOD,Quincy Township,President / Vice President,,Republican,"Trump, Donald J.",49,000120
+GREENWOOD,Salem Township,President / Vice President,,independent,"Stein, Jill",1,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+GREENWOOD,Salem Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+GREENWOOD,Salem Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000130
+GREENWOOD,Salem Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+GREENWOOD,Salem Township,President / Vice President,,Republican,"Trump, Donald J.",12,000130
+GREENWOOD,Salt Springs Township,President / Vice President,,independent,"Stein, Jill",3,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+GREENWOOD,Salt Springs Township,President / Vice President,,Republican,"Trump, Donald J.",136,000140
+GREENWOOD,Shell Rock Township,President / Vice President,,independent,"Stein, Jill",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000150
+GREENWOOD,Shell Rock Township,President / Vice President,,Republican,"Trump, Donald J.",68,000150
+GREENWOOD,Spring Creek Township,President / Vice President,,independent,"Stein, Jill",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+GREENWOOD,Spring Creek Township,President / Vice President,,Republican,"Trump, Donald J.",42,000170
+GREENWOOD,Twin Grove Township,President / Vice President,,independent,"Stein, Jill",5,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000180
+GREENWOOD,Twin Grove Township,President / Vice President,,Republican,"Trump, Donald J.",182,000180
+GREENWOOD,South Salem Township C01,President / Vice President,,independent,"Stein, Jill",1,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Basiago, Andrew D.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Castle, Darrell L",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Giordani, Rocky",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Hedges, James A",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Kahn, Lynn",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"La Riva, Gloria",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Levinson, Michael S.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Maturen, Michael A",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"McMullin, Evan",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Moorehead, Monica G.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Perry, Darryl",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Schriner, Joe C",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Smith, Mike",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Sood, Ajay",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Sterling, Shawna",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Valdivia, Anthony J",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Libertarian,"Johnson, Gary",1,200010
+GREENWOOD,South Salem Township C01,President / Vice President,,Republican,"Trump, Donald J.",43,200010
+GREENWOOD,South Salem Township C04,President / Vice President,,independent,"Stein, Jill",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Basiago, Andrew D.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Castle, Darrell L",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Giordani, Rocky",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Hedges, James A",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Kahn, Lynn",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"La Riva, Gloria",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Levinson, Michael S.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Maturen, Michael A",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"McMullin, Evan",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Moorehead, Monica G.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Perry, Darryl",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Schriner, Joe C",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Smith, Mike",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Sood, Ajay",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Sterling, Shawna",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Valdivia, Anthony J",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Libertarian,"Johnson, Gary",0,200020
+GREENWOOD,South Salem Township C04,President / Vice President,,Republican,"Trump, Donald J.",0,200020
+GREENWOOD,Eureka Airport,President / Vice President,,independent,"Stein, Jill",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Hedges, James A",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"McMullin, Evan",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Perry, Darryl",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Smith, Mike",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Sood, Ajay",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+GREENWOOD,Eureka Airport,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+GREENWOOD,Bachelor Township,United States House of Representatives,4,independent,"Allen, Miranda",4,000010
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",17,000010
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000010
+GREENWOOD,Bachelor Township,United States House of Representatives,4,Republican,"Pompeo, Michael",89,000010
+GREENWOOD,Eureka Township,United States House of Representatives,4,independent,"Allen, Miranda",16,000020
+GREENWOOD,Eureka Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",51,000020
+GREENWOOD,Eureka Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000020
+GREENWOOD,Eureka Township,United States House of Representatives,4,Republican,"Pompeo, Michael",153,000020
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",30,000030
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",62,000030
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",16,000030
+GREENWOOD,Eureka Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",253,000030
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",17,000040
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",44,000040
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000040
+GREENWOOD,Eureka Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",177,000040
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,independent,"Allen, Miranda",25,000050
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",54,000050
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,000050
+GREENWOOD,Eureka Ward 3,United States House of Representatives,4,Republican,"Pompeo, Michael",198,000050
+GREENWOOD,Fall River Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000060
+GREENWOOD,Fall River Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",21,000060
+GREENWOOD,Fall River Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000060
+GREENWOOD,Fall River Township,United States House of Representatives,4,Republican,"Pompeo, Michael",83,000060
+GREENWOOD,Janesville Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000070
+GREENWOOD,Janesville Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",26,000070
+GREENWOOD,Janesville Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000070
+GREENWOOD,Janesville Township,United States House of Representatives,4,Republican,"Pompeo, Michael",171,000070
+GREENWOOD,Lane Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000080
+GREENWOOD,Lane Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,000080
+GREENWOOD,Lane Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000080
+GREENWOOD,Lane Township,United States House of Representatives,4,Republican,"Pompeo, Michael",32,000080
+GREENWOOD,Madison Township,United States House of Representatives,4,independent,"Allen, Miranda",35,000090
+GREENWOOD,Madison Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",70,000090
+GREENWOOD,Madison Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,000090
+GREENWOOD,Madison Township,United States House of Representatives,4,Republican,"Pompeo, Michael",325,000090
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000100
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",21,000100
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000100
+GREENWOOD,Otter Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",66,000100
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,independent,"Allen, Miranda",4,000110
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000110
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000110
+GREENWOOD,Pleasant Grove Township,United States House of Representatives,4,Republican,"Pompeo, Michael",24,000110
+GREENWOOD,Quincy Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000120
+GREENWOOD,Quincy Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000120
+GREENWOOD,Quincy Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000120
+GREENWOOD,Quincy Township,United States House of Representatives,4,Republican,"Pompeo, Michael",46,000120
+GREENWOOD,Salem Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000130
+GREENWOOD,Salem Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000130
+GREENWOOD,Salem Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000130
+GREENWOOD,Salem Township,United States House of Representatives,4,Republican,"Pompeo, Michael",12,000130
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,independent,"Allen, Miranda",13,000140
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,000140
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000140
+GREENWOOD,Salt Springs Township,United States House of Representatives,4,Republican,"Pompeo, Michael",126,000140
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000150
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000150
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000150
+GREENWOOD,Shell Rock Township,United States House of Representatives,4,Republican,"Pompeo, Michael",61,000150
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000170
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,000170
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000170
+GREENWOOD,Spring Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",42,000170
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000180
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",44,000180
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000180
+GREENWOOD,Twin Grove Township,United States House of Representatives,4,Republican,"Pompeo, Michael",158,000180
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,independent,"Allen, Miranda",3,200010
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,200010
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,200010
+GREENWOOD,South Salem Township C01,United States House of Representatives,4,Republican,"Pompeo, Michael",42,200010
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,independent,"Allen, Miranda",0,200020
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,200020
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,200020
+GREENWOOD,South Salem Township C04,United States House of Representatives,4,Republican,"Pompeo, Michael",0,200020
+GREENWOOD,Eureka Airport,United States House of Representatives,4,independent,"Allen, Miranda",0,900010
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900010
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900010
+GREENWOOD,Eureka Airport,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900020
+GREENWOOD,Bachelor Township,United States Senate,,write - in,"Smith, DJ",0,000010
+GREENWOOD,Bachelor Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000010
+GREENWOOD,Bachelor Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+GREENWOOD,Bachelor Township,United States Senate,,Republican,"Moran, Jerry",93,000010
+GREENWOOD,Eureka Township,United States Senate,,write - in,"Smith, DJ",0,000020
+GREENWOOD,Eureka Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000020
+GREENWOOD,Eureka Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000020
+GREENWOOD,Eureka Township,United States Senate,,Republican,"Moran, Jerry",165,000020
+GREENWOOD,Eureka Ward 1,United States Senate,,write - in,"Smith, DJ",0,000030
+GREENWOOD,Eureka Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",55,000030
+GREENWOOD,Eureka Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",27,000030
+GREENWOOD,Eureka Ward 1,United States Senate,,Republican,"Moran, Jerry",281,000030
+GREENWOOD,Eureka Ward 2,United States Senate,,write - in,"Smith, DJ",0,000040
+GREENWOOD,Eureka Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",38,000040
+GREENWOOD,Eureka Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000040
+GREENWOOD,Eureka Ward 2,United States Senate,,Republican,"Moran, Jerry",191,000040
+GREENWOOD,Eureka Ward 3,United States Senate,,write - in,"Smith, DJ",0,000050
+GREENWOOD,Eureka Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",57,000050
+GREENWOOD,Eureka Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",18,000050
+GREENWOOD,Eureka Ward 3,United States Senate,,Republican,"Moran, Jerry",221,000050
+GREENWOOD,Fall River Township,United States Senate,,write - in,"Smith, DJ",0,000060
+GREENWOOD,Fall River Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000060
+GREENWOOD,Fall River Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000060
+GREENWOOD,Fall River Township,United States Senate,,Republican,"Moran, Jerry",79,000060
+GREENWOOD,Janesville Township,United States Senate,,write - in,"Smith, DJ",0,000070
+GREENWOOD,Janesville Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000070
+GREENWOOD,Janesville Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000070
+GREENWOOD,Janesville Township,United States Senate,,Republican,"Moran, Jerry",171,000070
+GREENWOOD,Lane Township,United States Senate,,write - in,"Smith, DJ",0,000080
+GREENWOOD,Lane Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000080
+GREENWOOD,Lane Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+GREENWOOD,Lane Township,United States Senate,,Republican,"Moran, Jerry",23,000080
+GREENWOOD,Madison Township,United States Senate,,write - in,"Smith, DJ",0,000090
+GREENWOOD,Madison Township,United States Senate,,Democratic,"Wiesner, Patrick",73,000090
+GREENWOOD,Madison Township,United States Senate,,Libertarian,"Garrard, Robert D.",29,000090
+GREENWOOD,Madison Township,United States Senate,,Republican,"Moran, Jerry",337,000090
+GREENWOOD,Otter Creek Township,United States Senate,,write - in,"Smith, DJ",0,000100
+GREENWOOD,Otter Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000100
+GREENWOOD,Otter Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000100
+GREENWOOD,Otter Creek Township,United States Senate,,Republican,"Moran, Jerry",63,000100
+GREENWOOD,Pleasant Grove Township,United States Senate,,write - in,"Smith, DJ",0,000110
+GREENWOOD,Pleasant Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000110
+GREENWOOD,Pleasant Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+GREENWOOD,Pleasant Grove Township,United States Senate,,Republican,"Moran, Jerry",25,000110
+GREENWOOD,Quincy Township,United States Senate,,write - in,"Smith, DJ",0,000120
+GREENWOOD,Quincy Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000120
+GREENWOOD,Quincy Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000120
+GREENWOOD,Quincy Township,United States Senate,,Republican,"Moran, Jerry",43,000120
+GREENWOOD,Salem Township,United States Senate,,write - in,"Smith, DJ",0,000130
+GREENWOOD,Salem Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000130
+GREENWOOD,Salem Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000130
+GREENWOOD,Salem Township,United States Senate,,Republican,"Moran, Jerry",15,000130
+GREENWOOD,Salt Springs Township,United States Senate,,write - in,"Smith, DJ",0,000140
+GREENWOOD,Salt Springs Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000140
+GREENWOOD,Salt Springs Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000140
+GREENWOOD,Salt Springs Township,United States Senate,,Republican,"Moran, Jerry",131,000140
+GREENWOOD,Shell Rock Township,United States Senate,,write - in,"Smith, DJ",0,000150
+GREENWOOD,Shell Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000150
+GREENWOOD,Shell Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000150
+GREENWOOD,Shell Rock Township,United States Senate,,Republican,"Moran, Jerry",69,000150
+GREENWOOD,Spring Creek Township,United States Senate,,write - in,"Smith, DJ",0,000170
+GREENWOOD,Spring Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000170
+GREENWOOD,Spring Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+GREENWOOD,Spring Creek Township,United States Senate,,Republican,"Moran, Jerry",47,000170
+GREENWOOD,Twin Grove Township,United States Senate,,write - in,"Smith, DJ",0,000180
+GREENWOOD,Twin Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000180
+GREENWOOD,Twin Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000180
+GREENWOOD,Twin Grove Township,United States Senate,,Republican,"Moran, Jerry",167,000180
+GREENWOOD,South Salem Township C01,United States Senate,,write - in,"Smith, DJ",0,200010
+GREENWOOD,South Salem Township C01,United States Senate,,Democratic,"Wiesner, Patrick",3,200010
+GREENWOOD,South Salem Township C01,United States Senate,,Libertarian,"Garrard, Robert D.",2,200010
+GREENWOOD,South Salem Township C01,United States Senate,,Republican,"Moran, Jerry",43,200010
+GREENWOOD,South Salem Township C04,United States Senate,,write - in,"Smith, DJ",0,200020
+GREENWOOD,South Salem Township C04,United States Senate,,Democratic,"Wiesner, Patrick",0,200020
+GREENWOOD,South Salem Township C04,United States Senate,,Libertarian,"Garrard, Robert D.",0,200020
+GREENWOOD,South Salem Township C04,United States Senate,,Republican,"Moran, Jerry",0,200020
+GREENWOOD,Eureka Airport,United States Senate,,write - in,"Smith, DJ",0,900010
+GREENWOOD,Eureka Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+GREENWOOD,Eureka Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+GREENWOOD,Eureka Airport,United States Senate,,Republican,"Moran, Jerry",0,900010
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+GREENWOOD,Eureka Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900020

--- a/2016/20161108__ks__general__hamilton__precinct.csv
+++ b/2016/20161108__ks__general__hamilton__precinct.csv
@@ -1,222 +1,433 @@
-county,precinct,office,district,party,candidate,votes
-Hamilton,Total,President,,LBT,Gary Johnson,31
-Hamilton,Total,President,,IND,Jill Stein,14
-Hamilton,Total,President,,R,Donald J Trump,705
-Hamilton,Total,President,,D,Clinton & Kaine,121
-Hamilton,Total,President,,WRI,Evan McMullin,3
-Hamilton,Total,President,,WRI,Darrell Castle,2
-Hamilton,Total,U.S. Senate,,R,Jerry Moran,729
-Hamilton,Total,U.S. Senate,,D,Patrick Wiesner,87
-Hamilton,Total,U.S. Senate,,LBT,Robert D. Garrard,47
-Hamilton,Total,U.S. House,1,LBT,Kerry Burt,61
-Hamilton,Total,U.S. House,1,IND,Alan LaPolice,105
-Hamilton,Total,U.S. House,1,R,Roger Marshall,669
-Hamilton,Total,U.S. House,1,WRI,Tim Huelskamp [R],8
-Hamilton,Total,State Senate,39,D,Zacheriah Worf,85
-Hamilton,Total,State Senate,39,R,John Doll,764
-Hamilton,Total,State Senate,39,WRI,Larry Powell,4
-Hamilton,Total,State House,122,R,Russ Jennings,819
-Hamilton,Bear Cr,President,,LBT,Gary Johnson,1
-Hamilton,Bear Cr,President,,IND,Jill Stein,0
-Hamilton,Bear Cr,President,,R,Donald J Trump,16
-Hamilton,Bear Cr,President,,D,Clinton & Kaine,0
-Hamilton,Bear Cr,President,,WRI,Evan McMullin,0
-Hamilton,Bear Cr,President,,WRI,Darrell Castle,0
-Hamilton,Bear Cr,U.S. Senate,,R,Jerry Moran,12
-Hamilton,Bear Cr,U.S. Senate,,D,Patrick Wiesner,0
-Hamilton,Bear Cr,U.S. Senate,,LBT,Robert D. Garrard,2
-Hamilton,Bear Cr,U.S. House,1,LBT,Kerry Burt,1
-Hamilton,Bear Cr,U.S. House,1,IND,Alan LaPolice,2
-Hamilton,Bear Cr,U.S. House,1,R,Roger Marshall,11
-Hamilton,Bear Cr,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Bear Cr,State Senate,39,D,Zacheriah Worf,0
-Hamilton,Bear Cr,State Senate,39,R,John Doll,15
-Hamilton,Bear Cr,State Senate,39,WRI,Larry Powell,0
-Hamilton,Bear Cr,State House,122,R,Russ Jennings,16
-Hamilton,Coolidge,President,,LBT,Gary Johnson,3
-Hamilton,Coolidge,President,,IND,Jill Stein,0
-Hamilton,Coolidge,President,,R,Donald J Trump,34
-Hamilton,Coolidge,President,,D,Clinton & Kaine,9
-Hamilton,Coolidge,President,,WRI,Evan McMullin,0
-Hamilton,Coolidge,President,,WRI,Darrell Castle,0
-Hamilton,Coolidge,U.S. Senate,,R,Jerry Moran,35
-Hamilton,Coolidge,U.S. Senate,,D,Patrick Wiesner,6
-Hamilton,Coolidge,U.S. Senate,,LBT,Robert D. Garrard,5
-Hamilton,Coolidge,U.S. House,1,LBT,Kerry Burt,5
-Hamilton,Coolidge,U.S. House,1,IND,Alan LaPolice,4
-Hamilton,Coolidge,U.S. House,1,R,Roger Marshall,35
-Hamilton,Coolidge,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Coolidge,State Senate,39,D,Zacheriah Worf,5
-Hamilton,Coolidge,State Senate,39,R,John Doll,36
-Hamilton,Coolidge,State Senate,39,WRI,Larry Powell,1
-Hamilton,Coolidge,State House,122,R,Russ Jennings,39
-Hamilton,Kendall,President,,LBT,Gary Johnson,2
-Hamilton,Kendall,President,,IND,Jill Stein,2
-Hamilton,Kendall,President,,R,Donald J Trump,31
-Hamilton,Kendall,President,,D,Clinton & Kaine,2
-Hamilton,Kendall,President,,WRI,Evan McMullin,0
-Hamilton,Kendall,President,,WRI,Darrell Castle,0
-Hamilton,Kendall,U.S. Senate,,R,Jerry Moran,34
-Hamilton,Kendall,U.S. Senate,,D,Patrick Wiesner,1
-Hamilton,Kendall,U.S. Senate,,LBT,Robert D. Garrard,2
-Hamilton,Kendall,U.S. House,1,LBT,Kerry Burt,1
-Hamilton,Kendall,U.S. House,1,IND,Alan LaPolice,6
-Hamilton,Kendall,U.S. House,1,R,Roger Marshall,29
-Hamilton,Kendall,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Kendall,State Senate,39,D,Zacheriah Worf,2
-Hamilton,Kendall,State Senate,39,R,John Doll,33
-Hamilton,Kendall,State Senate,39,WRI,Larry Powell,0
-Hamilton,Kendall,State House,122,R,Russ Jennings,36
-Hamilton,Lamont,President,,LBT,Gary Johnson,1
-Hamilton,Lamont,President,,IND,Jill Stein,0
-Hamilton,Lamont,President,,R,Donald J Trump,37
-Hamilton,Lamont,President,,D,Clinton & Kaine,4
-Hamilton,Lamont,President,,WRI,Evan McMullin,0
-Hamilton,Lamont,President,,WRI,Darrell Castle,0
-Hamilton,Lamont,U.S. Senate,,R,Jerry Moran,39
-Hamilton,Lamont,U.S. Senate,,D,Patrick Wiesner,3
-Hamilton,Lamont,U.S. Senate,,LBT,Robert D. Garrard,3
-Hamilton,Lamont,U.S. House,1,LBT,Kerry Burt,1
-Hamilton,Lamont,U.S. House,1,IND,Alan LaPolice,2
-Hamilton,Lamont,U.S. House,1,R,Roger Marshall,39
-Hamilton,Lamont,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Lamont,State Senate,39,D,Zacheriah Worf,2
-Hamilton,Lamont,State Senate,39,R,John Doll,41
-Hamilton,Lamont,State Senate,39,WRI,Larry Powell,0
-Hamilton,Lamont,State House,122,R,Russ Jennings,42
-Hamilton,Liberty,President,,LBT,Gary Johnson,0
-Hamilton,Liberty,President,,IND,Jill Stein,1
-Hamilton,Liberty,President,,R,Donald J Trump,17
-Hamilton,Liberty,President,,D,Clinton & Kaine,1
-Hamilton,Liberty,President,,WRI,Evan McMullin,0
-Hamilton,Liberty,President,,WRI,Darrell Castle,0
-Hamilton,Liberty,U.S. Senate,,R,Jerry Moran,15
-Hamilton,Liberty,U.S. Senate,,D,Patrick Wiesner,2
-Hamilton,Liberty,U.S. Senate,,LBT,Robert D. Garrard,0
-Hamilton,Liberty,U.S. House,1,LBT,Kerry Burt,0
-Hamilton,Liberty,U.S. House,1,IND,Alan LaPolice,2
-Hamilton,Liberty,U.S. House,1,R,Roger Marshall,16
-Hamilton,Liberty,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Liberty,State Senate,39,D,Zacheriah Worf,1
-Hamilton,Liberty,State Senate,39,R,John Doll,18
-Hamilton,Liberty,State Senate,39,WRI,Larry Powell,0
-Hamilton,Liberty,State House,122,R,Russ Jennings,19
-Hamilton,Medway,President,,LBT,Gary Johnson,1
-Hamilton,Medway,President,,IND,Jill Stein,0
-Hamilton,Medway,President,,R,Donald J Trump,25
-Hamilton,Medway,President,,D,Clinton & Kaine,2
-Hamilton,Medway,President,,WRI,Evan McMullin,0
-Hamilton,Medway,President,,WRI,Darrell Castle,0
-Hamilton,Medway,U.S. Senate,,R,Jerry Moran,26
-Hamilton,Medway,U.S. Senate,,D,Patrick Wiesner,2
-Hamilton,Medway,U.S. Senate,,LBT,Robert D. Garrard,0
-Hamilton,Medway,U.S. House,1,LBT,Kerry Burt,1
-Hamilton,Medway,U.S. House,1,IND,Alan LaPolice,2
-Hamilton,Medway,U.S. House,1,R,Roger Marshall,23
-Hamilton,Medway,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Medway,State Senate,39,D,Zacheriah Worf,2
-Hamilton,Medway,State Senate,39,R,John Doll,26
-Hamilton,Medway,State Senate,39,WRI,Larry Powell,0
-Hamilton,Medway,State House,122,R,Russ Jennings,27
-Hamilton,Richland,President,,LBT,Gary Johnson,0
-Hamilton,Richland,President,,IND,Jill Stein,0
-Hamilton,Richland,President,,R,Donald J Trump,10
-Hamilton,Richland,President,,D,Clinton & Kaine,0
-Hamilton,Richland,President,,WRI,Evan McMullin,0
-Hamilton,Richland,President,,WRI,Darrell Castle,0
-Hamilton,Richland,U.S. Senate,,R,Jerry Moran,9
-Hamilton,Richland,U.S. Senate,,D,Patrick Wiesner,0
-Hamilton,Richland,U.S. Senate,,LBT,Robert D. Garrard,1
-Hamilton,Richland,U.S. House,1,LBT,Kerry Burt,0
-Hamilton,Richland,U.S. House,1,IND,Alan LaPolice,2
-Hamilton,Richland,U.S. House,1,R,Roger Marshall,8
-Hamilton,Richland,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Richland,State Senate,39,D,Zacheriah Worf,0
-Hamilton,Richland,State Senate,39,R,John Doll,10
-Hamilton,Richland,State Senate,39,WRI,Larry Powell,0
-Hamilton,Richland,State House,122,R,Russ Jennings,10
-Hamilton,Syr 1,President,,LBT,Gary Johnson,5
-Hamilton,Syr 1,President,,IND,Jill Stein,7
-Hamilton,Syr 1,President,,R,Donald J Trump,146
-Hamilton,Syr 1,President,,D,Clinton & Kaine,29
-Hamilton,Syr 1,President,,WRI,Evan McMullin,0
-Hamilton,Syr 1,President,,WRI,Darrell Castle,0
-Hamilton,Syr 1,U.S. Senate,,R,Jerry Moran,154
-Hamilton,Syr 1,U.S. Senate,,D,Patrick Wiesner,20
-Hamilton,Syr 1,U.S. Senate,,LBT,Robert D. Garrard,12
-Hamilton,Syr 1,U.S. House,1,LBT,Kerry Burt,15
-Hamilton,Syr 1,U.S. House,1,IND,Alan LaPolice,28
-Hamilton,Syr 1,U.S. House,1,R,Roger Marshall,137
-Hamilton,Syr 1,U.S. House,1,WRI,Tim Huelskamp [R],4
-Hamilton,Syr 1,State Senate,39,D,Zacheriah Worf,23
-Hamilton,Syr 1,State Senate,39,R,John Doll,158
-Hamilton,Syr 1,State Senate,39,WRI,Larry Powell,1
-Hamilton,Syr 1,State House,122,R,Russ Jennings,171
-Hamilton,Syr 2,President,,LBT,Gary Johnson,3
-Hamilton,Syr 2,President,,IND,Jill Stein,0
-Hamilton,Syr 2,President,,R,Donald J Trump,103
-Hamilton,Syr 2,President,,D,Clinton & Kaine,14
-Hamilton,Syr 2,President,,WRI,Evan McMullin,1
-Hamilton,Syr 2,President,,WRI,Darrell Castle,0
-Hamilton,Syr 2,U.S. Senate,,R,Jerry Moran,107
-Hamilton,Syr 2,U.S. Senate,,D,Patrick Wiesner,8
-Hamilton,Syr 2,U.S. Senate,,LBT,Robert D. Garrard,4
-Hamilton,Syr 2,U.S. House,1,LBT,Kerry Burt,6
-Hamilton,Syr 2,U.S. House,1,IND,Alan LaPolice,4
-Hamilton,Syr 2,U.S. House,1,R,Roger Marshall,101
-Hamilton,Syr 2,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Syr 2,State Senate,39,D,Zacheriah Worf,13
-Hamilton,Syr 2,State Senate,39,R,John Doll,105
-Hamilton,Syr 2,State Senate,39,WRI,Larry Powell,0
-Hamilton,Syr 2,State House,122,R,Russ Jennings,113
-Hamilton,Syr 3,President,,LBT,Gary Johnson,1
-Hamilton,Syr 3,President,,IND,Jill Stein,3
-Hamilton,Syr 3,President,,R,Donald J Trump,102
-Hamilton,Syr 3,President,,D,Clinton & Kaine,25
-Hamilton,Syr 3,President,,WRI,Evan McMullin,1
-Hamilton,Syr 3,President,,WRI,Darrell Castle,0
-Hamilton,Syr 3,U.S. Senate,,R,Jerry Moran,104
-Hamilton,Syr 3,U.S. Senate,,D,Patrick Wiesner,19
-Hamilton,Syr 3,U.S. Senate,,LBT,Robert D. Garrard,7
-Hamilton,Syr 3,U.S. House,1,LBT,Kerry Burt,14
-Hamilton,Syr 3,U.S. House,1,IND,Alan LaPolice,20
-Hamilton,Syr 3,U.S. House,1,R,Roger Marshall,95
-Hamilton,Syr 3,U.S. House,1,WRI,Tim Huelskamp [R],3
-Hamilton,Syr 3,State Senate,39,D,Zacheriah Worf,15
-Hamilton,Syr 3,State Senate,39,R,John Doll,114
-Hamilton,Syr 3,State Senate,39,WRI,Larry Powell,1
-Hamilton,Syr 3,State House,122,R,Russ Jennings,120
-Hamilton,Syr 4,President,,LBT,Gary Johnson,1
-Hamilton,Syr 4,President,,IND,Jill Stein,0
-Hamilton,Syr 4,President,,R,Donald J Trump,45
-Hamilton,Syr 4,President,,D,Clinton & Kaine,9
-Hamilton,Syr 4,President,,WRI,Evan McMullin,1
-Hamilton,Syr 4,President,,WRI,Darrell Castle,1
-Hamilton,Syr 4,U.S. Senate,,R,Jerry Moran,45
-Hamilton,Syr 4,U.S. Senate,,D,Patrick Wiesner,9
-Hamilton,Syr 4,U.S. Senate,,LBT,Robert D. Garrard,2
-Hamilton,Syr 4,U.S. House,1,LBT,Kerry Burt,7
-Hamilton,Syr 4,U.S. House,1,IND,Alan LaPolice,8
-Hamilton,Syr 4,U.S. House,1,R,Roger Marshall,41
-Hamilton,Syr 4,U.S. House,1,WRI,Tim Huelskamp [R],0
-Hamilton,Syr 4,State Senate,39,D,Zacheriah Worf,7
-Hamilton,Syr 4,State Senate,39,R,John Doll,49
-Hamilton,Syr 4,State Senate,39,WRI,Larry Powell,0
-Hamilton,Syr 4,State House,122,R,Russ Jennings,55
-Hamilton,Syr 5,President,,LBT,Gary Johnson,13
-Hamilton,Syr 5,President,,IND,Jill Stein,1
-Hamilton,Syr 5,President,,R,Donald J Trump,139
-Hamilton,Syr 5,President,,D,Clinton & Kaine,26
-Hamilton,Syr 5,President,,WRI,Evan McMullin,0
-Hamilton,Syr 5,President,,WRI,Darrell Castle,1
-Hamilton,Syr 5,U.S. Senate,,R,Jerry Moran,149
-Hamilton,Syr 5,U.S. Senate,,D,Patrick Wiesner,17
-Hamilton,Syr 5,U.S. Senate,,LBT,Robert D. Garrard,9
-Hamilton,Syr 5,U.S. House,1,LBT,Kerry Burt,10
-Hamilton,Syr 5,U.S. House,1,IND,Alan LaPolice,25
-Hamilton,Syr 5,U.S. House,1,R,Roger Marshall,134
-Hamilton,Syr 5,U.S. House,1,WRI,Tim Huelskamp [R],1
-Hamilton,Syr 5,State Senate,39,D,Zacheriah Worf,15
-Hamilton,Syr 5,State Senate,39,R,John Doll,159
-Hamilton,Syr 5,State Senate,39,WRI,Larry Powell,1
-Hamilton,Syr 5,State House,122,R,Russ Jennings,171
+county,precinct,office,district,party,candidate,votes,vtd
+HAMILTON,Bear Creek Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",16,000010
+HAMILTON,Coolidge Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",39,000020
+HAMILTON,Kendall Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",36,000030
+HAMILTON,Lamont Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",42,000040
+HAMILTON,Liberty Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",19,000050
+HAMILTON,Medway Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",27,000060
+HAMILTON,Richland Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",10,000070
+HAMILTON,Syracuse 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",171,000080
+HAMILTON,Syracuse 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",113,000090
+HAMILTON,Syracuse 3,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",120,000100
+HAMILTON,Syracuse 4,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",55,120010
+HAMILTON,Syracuse 5,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",171,120020
+HAMILTON,Bear Creek Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,000010
+HAMILTON,Bear Creek Township,Kansas Senate,39,Republican,"Doll, John",15,000010
+HAMILTON,Coolidge Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",5,000020
+HAMILTON,Coolidge Township,Kansas Senate,39,Republican,"Doll, John",36,000020
+HAMILTON,Kendall Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",2,000030
+HAMILTON,Kendall Township,Kansas Senate,39,Republican,"Doll, John",33,000030
+HAMILTON,Lamont Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",2,000040
+HAMILTON,Lamont Township,Kansas Senate,39,Republican,"Doll, John",41,000040
+HAMILTON,Liberty Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",1,000050
+HAMILTON,Liberty Township,Kansas Senate,39,Republican,"Doll, John",18,000050
+HAMILTON,Medway Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",2,000060
+HAMILTON,Medway Township,Kansas Senate,39,Republican,"Doll, John",26,000060
+HAMILTON,Richland Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,000070
+HAMILTON,Richland Township,Kansas Senate,39,Republican,"Doll, John",10,000070
+HAMILTON,Syracuse 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",23,000080
+HAMILTON,Syracuse 1,Kansas Senate,39,Republican,"Doll, John",158,000080
+HAMILTON,Syracuse 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",13,000090
+HAMILTON,Syracuse 2,Kansas Senate,39,Republican,"Doll, John",105,000090
+HAMILTON,Syracuse 3,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",15,000100
+HAMILTON,Syracuse 3,Kansas Senate,39,Republican,"Doll, John",114,000100
+HAMILTON,Syracuse 4,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",7,120010
+HAMILTON,Syracuse 4,Kansas Senate,39,Republican,"Doll, John",49,120010
+HAMILTON,Syracuse 5,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",15,120020
+HAMILTON,Syracuse 5,Kansas Senate,39,Republican,"Doll, John",159,120020
+HAMILTON,Bear Creek Township,President / Vice President,,independent,"Stein, Jill",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+HAMILTON,Bear Creek Township,President / Vice President,,Republican,"Trump, Donald J.",16,000010
+HAMILTON,Coolidge Township,President / Vice President,,independent,"Stein, Jill",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+HAMILTON,Coolidge Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000020
+HAMILTON,Coolidge Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+HAMILTON,Coolidge Township,President / Vice President,,Republican,"Trump, Donald J.",34,000020
+HAMILTON,Kendall Township,President / Vice President,,independent,"Stein, Jill",2,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+HAMILTON,Kendall Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+HAMILTON,Kendall Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+HAMILTON,Kendall Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+HAMILTON,Kendall Township,President / Vice President,,Republican,"Trump, Donald J.",31,000030
+HAMILTON,Lamont Township,President / Vice President,,independent,"Stein, Jill",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Castle, Darrell L",1,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+HAMILTON,Lamont Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+HAMILTON,Lamont Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000040
+HAMILTON,Lamont Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+HAMILTON,Lamont Township,President / Vice President,,Republican,"Trump, Donald J.",37,000040
+HAMILTON,Liberty Township,President / Vice President,,independent,"Stein, Jill",1,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+HAMILTON,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+HAMILTON,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000050
+HAMILTON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+HAMILTON,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",17,000050
+HAMILTON,Medway Township,President / Vice President,,independent,"Stein, Jill",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+HAMILTON,Medway Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+HAMILTON,Medway Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000060
+HAMILTON,Medway Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+HAMILTON,Medway Township,President / Vice President,,Republican,"Trump, Donald J.",25,000060
+HAMILTON,Richland Township,President / Vice President,,independent,"Stein, Jill",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+HAMILTON,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+HAMILTON,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000070
+HAMILTON,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+HAMILTON,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",10,000070
+HAMILTON,Syracuse 1,President / Vice President,,independent,"Stein, Jill",7,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Hedges, James A",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"McMullin, Evan",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Perry, Darryl",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Smith, Mike",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Sood, Ajay",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+HAMILTON,Syracuse 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000080
+HAMILTON,Syracuse 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+HAMILTON,Syracuse 1,President / Vice President,,Republican,"Trump, Donald J.",146,000080
+HAMILTON,Syracuse 2,President / Vice President,,independent,"Stein, Jill",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"McMullin, Evan",1,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+HAMILTON,Syracuse 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000090
+HAMILTON,Syracuse 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+HAMILTON,Syracuse 2,President / Vice President,,Republican,"Trump, Donald J.",103,000090
+HAMILTON,Syracuse 3,President / Vice President,,independent,"Stein, Jill",3,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Hedges, James A",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"McMullin, Evan",1,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Perry, Darryl",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Smith, Mike",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Sood, Ajay",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+HAMILTON,Syracuse 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000100
+HAMILTON,Syracuse 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+HAMILTON,Syracuse 3,President / Vice President,,Republican,"Trump, Donald J.",102,000100
+HAMILTON,Syracuse 4,President / Vice President,,independent,"Stein, Jill",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Castle, Darrell L",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Giordani, Rocky",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Hedges, James A",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Hoefling, Tom",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Kahn, Lynn",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"La Riva, Gloria",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Levinson, Michael S.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Maturen, Michael A",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"McMullin, Evan",1,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Perry, Darryl",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Schriner, Joe C",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Smith, Mike",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Sood, Ajay",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Sterling, Shawna",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120010
+HAMILTON,Syracuse 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,120010
+HAMILTON,Syracuse 4,President / Vice President,,Libertarian,"Johnson, Gary",1,120010
+HAMILTON,Syracuse 4,President / Vice President,,Republican,"Trump, Donald J.",45,120010
+HAMILTON,Syracuse 5,President / Vice President,,independent,"Stein, Jill",1,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Castle, Darrell L",1,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Hedges, James A",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"McMullin, Evan",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Perry, Darryl",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Smith, Mike",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Sood, Ajay",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+HAMILTON,Syracuse 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,120020
+HAMILTON,Syracuse 5,President / Vice President,,Libertarian,"Johnson, Gary",13,120020
+HAMILTON,Syracuse 5,President / Vice President,,Republican,"Trump, Donald J.",139,120020
+HAMILTON,Bear Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000010
+HAMILTON,Bear Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+HAMILTON,Bear Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+HAMILTON,Bear Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000010
+HAMILTON,Coolidge Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000020
+HAMILTON,Coolidge Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+HAMILTON,Coolidge Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000020
+HAMILTON,Coolidge Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000020
+HAMILTON,Kendall Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000030
+HAMILTON,Kendall Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+HAMILTON,Kendall Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+HAMILTON,Kendall Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000030
+HAMILTON,Lamont Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000040
+HAMILTON,Lamont Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+HAMILTON,Lamont Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+HAMILTON,Lamont Township,United States House of Representatives,1,Republican,"Marshall, Roger",39,000040
+HAMILTON,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000050
+HAMILTON,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+HAMILTON,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+HAMILTON,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000050
+HAMILTON,Medway Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000060
+HAMILTON,Medway Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+HAMILTON,Medway Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+HAMILTON,Medway Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000060
+HAMILTON,Richland Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000070
+HAMILTON,Richland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+HAMILTON,Richland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000070
+HAMILTON,Richland Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000070
+HAMILTON,Syracuse 1,United States House of Representatives,1,independent,"LaPolice, Alan",28,000080
+HAMILTON,Syracuse 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000080
+HAMILTON,Syracuse 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000080
+HAMILTON,Syracuse 1,United States House of Representatives,1,Republican,"Marshall, Roger",137,000080
+HAMILTON,Syracuse 2,United States House of Representatives,1,independent,"LaPolice, Alan",4,000090
+HAMILTON,Syracuse 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+HAMILTON,Syracuse 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000090
+HAMILTON,Syracuse 2,United States House of Representatives,1,Republican,"Marshall, Roger",101,000090
+HAMILTON,Syracuse 3,United States House of Representatives,1,independent,"LaPolice, Alan",20,000100
+HAMILTON,Syracuse 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000100
+HAMILTON,Syracuse 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000100
+HAMILTON,Syracuse 3,United States House of Representatives,1,Republican,"Marshall, Roger",95,000100
+HAMILTON,Syracuse 4,United States House of Representatives,1,independent,"LaPolice, Alan",8,120010
+HAMILTON,Syracuse 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120010
+HAMILTON,Syracuse 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,120010
+HAMILTON,Syracuse 4,United States House of Representatives,1,Republican,"Marshall, Roger",41,120010
+HAMILTON,Syracuse 5,United States House of Representatives,1,independent,"LaPolice, Alan",25,120020
+HAMILTON,Syracuse 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,120020
+HAMILTON,Syracuse 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,120020
+HAMILTON,Syracuse 5,United States House of Representatives,1,Republican,"Marshall, Roger",134,120020
+HAMILTON,Bear Creek Township,United States Senate,,write - in,"Smith, DJ",0,000010
+HAMILTON,Bear Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+HAMILTON,Bear Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+HAMILTON,Bear Creek Township,United States Senate,,Republican,"Moran, Jerry",12,000010
+HAMILTON,Coolidge Township,United States Senate,,write - in,"Smith, DJ",0,000020
+HAMILTON,Coolidge Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000020
+HAMILTON,Coolidge Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000020
+HAMILTON,Coolidge Township,United States Senate,,Republican,"Moran, Jerry",35,000020
+HAMILTON,Kendall Township,United States Senate,,write - in,"Smith, DJ",0,000030
+HAMILTON,Kendall Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000030
+HAMILTON,Kendall Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+HAMILTON,Kendall Township,United States Senate,,Republican,"Moran, Jerry",34,000030
+HAMILTON,Lamont Township,United States Senate,,write - in,"Smith, DJ",0,000040
+HAMILTON,Lamont Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000040
+HAMILTON,Lamont Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000040
+HAMILTON,Lamont Township,United States Senate,,Republican,"Moran, Jerry",39,000040
+HAMILTON,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000050
+HAMILTON,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000050
+HAMILTON,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+HAMILTON,Liberty Township,United States Senate,,Republican,"Moran, Jerry",15,000050
+HAMILTON,Medway Township,United States Senate,,write - in,"Smith, DJ",0,000060
+HAMILTON,Medway Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000060
+HAMILTON,Medway Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+HAMILTON,Medway Township,United States Senate,,Republican,"Moran, Jerry",26,000060
+HAMILTON,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000070
+HAMILTON,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000070
+HAMILTON,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+HAMILTON,Richland Township,United States Senate,,Republican,"Moran, Jerry",9,000070
+HAMILTON,Syracuse 1,United States Senate,,write - in,"Smith, DJ",0,000080
+HAMILTON,Syracuse 1,United States Senate,,Democratic,"Wiesner, Patrick",20,000080
+HAMILTON,Syracuse 1,United States Senate,,Libertarian,"Garrard, Robert D.",12,000080
+HAMILTON,Syracuse 1,United States Senate,,Republican,"Moran, Jerry",154,000080
+HAMILTON,Syracuse 2,United States Senate,,write - in,"Smith, DJ",0,000090
+HAMILTON,Syracuse 2,United States Senate,,Democratic,"Wiesner, Patrick",8,000090
+HAMILTON,Syracuse 2,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+HAMILTON,Syracuse 2,United States Senate,,Republican,"Moran, Jerry",107,000090
+HAMILTON,Syracuse 3,United States Senate,,write - in,"Smith, DJ",0,000100
+HAMILTON,Syracuse 3,United States Senate,,Democratic,"Wiesner, Patrick",19,000100
+HAMILTON,Syracuse 3,United States Senate,,Libertarian,"Garrard, Robert D.",7,000100
+HAMILTON,Syracuse 3,United States Senate,,Republican,"Moran, Jerry",104,000100
+HAMILTON,Syracuse 4,United States Senate,,write - in,"Smith, DJ",0,120010
+HAMILTON,Syracuse 4,United States Senate,,Democratic,"Wiesner, Patrick",9,120010
+HAMILTON,Syracuse 4,United States Senate,,Libertarian,"Garrard, Robert D.",2,120010
+HAMILTON,Syracuse 4,United States Senate,,Republican,"Moran, Jerry",45,120010
+HAMILTON,Syracuse 5,United States Senate,,write - in,"Smith, DJ",0,120020
+HAMILTON,Syracuse 5,United States Senate,,Democratic,"Wiesner, Patrick",17,120020
+HAMILTON,Syracuse 5,United States Senate,,Libertarian,"Garrard, Robert D.",9,120020
+HAMILTON,Syracuse 5,United States Senate,,Republican,"Moran, Jerry",149,120020

--- a/2016/20161108__ks__general__harper__precinct.csv
+++ b/2016/20161108__ks__general__harper__precinct.csv
@@ -1,254 +1,566 @@
-county,precinct,office,district,party,candidate,votes
-Harper,Anthony 1,President,,LIB,Gary Johnson,25
-Harper,Anthony 1,President,,IND,Jill Stein,13
-Harper,Anthony 1,President,,REP,Donald J Trump,352
-Harper,Anthony 1,President,,DEM,Hillary Clinton,74
-Harper,Anthony 1,President,,,Write-in,5
-Harper,Anthony 2,President,,LIB,Gary Johnson,12
-Harper,Anthony 2,President,,IND,Jill Stein,3
-Harper,Anthony 2,President,,REP,Donald J Trump,180
-Harper,Anthony 2,President,,DEM,Hillary Clinton,40
-Harper,Anthony 2,President,,,Write-in,3
-Harper,Anthony 3,President,,LIB,Gary Johnson,2
-Harper,Anthony 3,President,,IND,Jill Stein,2
-Harper,Anthony 3,President,,REP,Donald J Trump,49
-Harper,Anthony 3,President,,DEM,Hillary Clinton,9
-Harper,Anthony 3,President,,,Write-in,2
-Harper,Anthony 4,President,,LIB,Gary Johnson,10
-Harper,Anthony 4,President,,IND,Jill Stein,0
-Harper,Anthony 4,President,,REP,Donald J Trump,124
-Harper,Anthony 4,President,,DEM,Hillary Clinton,16
-Harper,Anthony 4,President,,,Write-in,3
-Harper,Harper 1,President,,LIB,Gary Johnson,13
-Harper,Harper 1,President,,IND,Jill Stein,12
-Harper,Harper 1,President,,REP,Donald J Trump,198
-Harper,Harper 1,President,,DEM,Hillary Clinton,42
-Harper,Harper 2,President,,LIB,Gary Johnson,16
-Harper,Harper 2,President,,IND,Jill Stein,10
-Harper,Harper 2,President,,REP,Donald J Trump,203
-Harper,Harper 2,President,,DEM,Hillary Clinton,65
-Harper,Harper 2,President,,,Write-in,4
-Harper,Township 1,President,,LIB,Gary Johnson,8
-Harper,Township 1,President,,IND,Jill Stein,7
-Harper,Township 1,President,,REP,Donald J Trump,307
-Harper,Township 1,President,,DEM,Hillary Clinton,60
-Harper,Township 2,President,,LIB,Gary Johnson,1
-Harper,Township 2,President,,IND,Jill Stein,0
-Harper,Township 2,President,,REP,Donald J Trump,47
-Harper,Township 2,President,,DEM,Hillary Clinton,2
-Harper,Township 3 East,President,,LIB,Gary Johnson,8
-Harper,Township 3 East,President,,IND,Jill Stein,0
-Harper,Township 3 East,President,,REP,Donald J Trump,45
-Harper,Township 3 East,President,,DEM,Hillary Clinton,9
-Harper,Township 3 West,President,,LIB,Gary Johnson,2
-Harper,Township 3 West,President,,IND,Jill Stein,1
-Harper,Township 3 West,President,,REP,Donald J Trump,75
-Harper,Township 3 West,President,,DEM,Hillary Clinton,12
-Harper,Township 3 West,President,,,Write-in,1
-Harper,Township 4,President,,LIB,Gary Johnson,4
-Harper,Township 4,President,,IND,Jill Stein,7
-Harper,Township 4,President,,REP,Donald J Trump,50
-Harper,Township 4,President,,DEM,Hillary Clinton,17
-Harper,Township 5 East,President,,LIB,Gary Johnson,4
-Harper,Township 5 East,President,,IND,Jill Stein,2
-Harper,Township 5 East,President,,REP,Donald J Trump,142
-Harper,Township 5 East,President,,DEM,Hillary Clinton,15
-Harper,Township 5 East,President,,,Write-in,2
-Harper,Township 5 West,President,,LIB,Gary Johnson,2
-Harper,Township 5 West,President,,IND,Jill Stein,1
-Harper,Township 5 West,President,,REP,Donald J Trump,49
-Harper,Township 5 West,President,,DEM,Hillary Clinton,7
-Harper,Township 6 East,President,,LIB,Gary Johnson,6
-Harper,Township 6 East,President,,IND,Jill Stein,2
-Harper,Township 6 East,President,,REP,Donald J Trump,84
-Harper,Township 6 East,President,,DEM,Hillary Clinton,16
-Harper,Township 6 West,President,,LIB,Gary Johnson,2
-Harper,Township 6 West,President,,IND,Jill Stein,0
-Harper,Township 6 West,President,,REP,Donald J Trump,45
-Harper,Township 6 West,President,,DEM,Hillary Clinton,4
-Harper,Provisional,President,,LIB,Gary Johnson,2
-Harper,Provisional,President,,IND,Jill Stein,0
-Harper,Provisional,President,,REP,Donald J Trump,46
-Harper,Provisional,President,,DEM,Hillary Clinton,5
-Harper,Provisional,President,,,Write-in,1
-Harper,Anthony 1,U.S. Senate,,REP,Jerry Moran,367
-Harper,Anthony 1,U.S. Senate,,DEM,Patrick Wiesner,66
-Harper,Anthony 1,U.S. Senate,,,Robert D Garrard,23
-Harper,Anthony 1,U.S. Senate,,,Write-in,1
-Harper,Anthony 2,U.S. Senate,,REP,Jerry Moran,182
-Harper,Anthony 2,U.S. Senate,,DEM,Patrick Wiesner,37
-Harper,Anthony 2,U.S. Senate,,,Robert D Garrard,10
-Harper,Anthony 3,U.S. Senate,,REP,Jerry Moran,50
-Harper,Anthony 3,U.S. Senate,,DEM,Patrick Wiesner,9
-Harper,Anthony 3,U.S. Senate,,,Robert D Garrard,2
-Harper,Anthony 4,U.S. Senate,,REP,Jerry Moran,118
-Harper,Anthony 4,U.S. Senate,,DEM,Patrick Wiesner,24
-Harper,Anthony 4,U.S. Senate,,,Robert D Garrard,8
-Harper,Harper 1,U.S. Senate,,REP,Jerry Moran,194
-Harper,Harper 1,U.S. Senate,,DEM,Patrick Wiesner,39
-Harper,Harper 1,U.S. Senate,,,Robert D Garrard,17
-Harper,Harper 2,U.S. Senate,,REP,Jerry Moran,218
-Harper,Harper 2,U.S. Senate,,DEM,Patrick Wiesner,57
-Harper,Harper 2,U.S. Senate,,,Robert D Garrard,17
-Harper,Township 1,U.S. Senate,,REP,Jerry Moran,297
-Harper,Township 1,U.S. Senate,,DEM,Patrick Wiesner,59
-Harper,Township 1,U.S. Senate,,,Robert D Garrard,18
-Harper,Township 2,U.S. Senate,,REP,Jerry Moran,44
-Harper,Township 2,U.S. Senate,,DEM,Patrick Wiesner,4
-Harper,Township 2,U.S. Senate,,,Robert D Garrard,2
-Harper,Township 3 East,U.S. Senate,,REP,Jerry Moran,46
-Harper,Township 3 East,U.S. Senate,,DEM,Patrick Wiesner,9
-Harper,Township 3 East,U.S. Senate,,,Robert D Garrard,2
-Harper,Township 3 West,U.S. Senate,,REP,Jerry Moran,79
-Harper,Township 3 West,U.S. Senate,,DEM,Patrick Wiesner,11
-Harper,Township 3 West,U.S. Senate,,,Robert D Garrard,1
-Harper,Township 4,U.S. Senate,,REP,Jerry Moran,55
-Harper,Township 4,U.S. Senate,,DEM,Patrick Wiesner,17
-Harper,Township 4,U.S. Senate,,,Robert D Garrard,5
-Harper,Township 5 East,U.S. Senate,,REP,Jerry Moran,142
-Harper,Township 5 East,U.S. Senate,,DEM,Patrick Wiesner,17
-Harper,Township 5 East,U.S. Senate,,,Robert D Garrard,4
-Harper,Township 5 West,U.S. Senate,,REP,Jerry Moran,50
-Harper,Township 5 West,U.S. Senate,,DEM,Patrick Wiesner,5
-Harper,Township 5 West,U.S. Senate,,,Robert D Garrard,4
-Harper,Township 6 East,U.S. Senate,,REP,Jerry Moran,92
-Harper,Township 6 East,U.S. Senate,,DEM,Patrick Wiesner,7
-Harper,Township 6 East,U.S. Senate,,,Robert D Garrard,6
-Harper,Township 6 West,U.S. Senate,,REP,Jerry Moran,42
-Harper,Township 6 East,U.S. Senate,,DEM,Patrick Wiesner,5
-Harper,Township 6 East,U.S. Senate,,,Robert D Garrard,2
-Harper,Provisional,U.S. Senate,,REP,Jerry Moran,45
-Harper,Provisional,U.S. Senate,,DEM,Patrick Wiesner,5
-Harper,Provisional,U.S. Senate,,,Robert D Garrard,5
-Harper,Anthony 1,U.S. House,4,IND,Miranda Allen,40
-Harper,Anthony 1,U.S. House,4,LIB,Gorden J Bakken,12
-Harper,Anthony 1,U.S. House,4,DEM,Daniel B Giroux,67
-Harper,Anthony 1,U.S. House,4,REP,Michael Pompeo,345
-Harper,Anthony 1,U.S. House,4,,Write-in,1
-Harper,Anthony 2,U.S. House,4,IND,Miranda Allen,42
-Harper,Anthony 2,U.S. House,4,LIB,Gorden J Bakken,5
-Harper,Anthony 2,U.S. House,4,DEM,Daniel B Giroux,30
-Harper,Anthony 2,U.S. House,4,REP,Michael Pompeo,158
-Harper,Anthony 3,U.S. House,4,IND,Miranda Allen,7
-Harper,Anthony 3,U.S. House,4,LIB,Gorden J Bakken,0
-Harper,Anthony 3,U.S. House,4,DEM,Daniel B Giroux,6
-Harper,Anthony 3,U.S. House,4,REP,Michael Pompeo,50
-Harper,Anthony 4,U.S. House,4,IND,Miranda Allen,21
-Harper,Anthony 4,U.S. House,4,LIB,Gorden J Bakken,6
-Harper,Anthony 4,U.S. House,4,DEM,Daniel B Giroux,19
-Harper,Anthony 4,U.S. House,4,REP,Michael Pompeo,104
-Harper,Harper 1,U.S. House,4,IND,Miranda Allen,29
-Harper,Harper 1,U.S. House,4,LIB,Gorden J Bakken,12
-Harper,Harper 1,U.S. House,4,DEM,Daniel B Giroux,32
-Harper,Harper 1,U.S. House,4,REP,Michael Pompeo,183
-Harper,Harper 2,U.S. House,4,IND,Miranda Allen,37
-Harper,Harper 2,U.S. House,4,LIB,Gorden J Bakken,10
-Harper,Harper 2,U.S. House,4,DEM,Daniel B Giroux,43
-Harper,Harper 2,U.S. House,4,REP,Michael Pompeo,209
-Harper,Township 1,U.S. House,4,IND,Miranda Allen,47
-Harper,Township 1,U.S. House,4,LIB,Gorden J Bakken,3
-Harper,Township 1,U.S. House,4,DEM,Daniel B Giroux,40
-Harper,Township 1,U.S. House,4,REP,Michael Pompeo,293
-Harper,Township 1,U.S. House,4,,Write-in,1
-Harper,Township 2,U.S. House,4,IND,Miranda Allen,12
-Harper,Township 2,U.S. House,4,LIB,Gorden J Bakken,1
-Harper,Township 2,U.S. House,4,DEM,Daniel B Giroux,1
-Harper,Township 2,U.S. House,4,REP,Michael Pompeo,37
-Harper,Township 3 East,U.S. House,4,IND,Miranda Allen,5
-Harper,Township 3 East,U.S. House,4,LIB,Gorden J Bakken,2
-Harper,Township 3 East,U.S. House,4,DEM,Daniel B Giroux,7
-Harper,Township 3 East,U.S. House,4,REP,Michael Pompeo,46
-Harper,Township 3 West,U.S. House,4,IND,Miranda Allen,15
-Harper,Township 3 West,U.S. House,4,LIB,Gorden J Bakken,2
-Harper,Township 3 West,U.S. House,4,DEM,Daniel B Giroux,10
-Harper,Township 3 West,U.S. House,4,REP,Michael Pompeo,64
-Harper,Township 4,U.S. House,4,IND,Miranda Allen,10
-Harper,Township 4,U.S. House,4,LIB,Gorden J Bakken,1
-Harper,Township 4,U.S. House,4,DEM,Daniel B Giroux,13
-Harper,Township 4,U.S. House,4,REP,Michael Pompeo,50
-Harper,Township 5 East,U.S. House,4,IND,Miranda Allen,23
-Harper,Township 5 East,U.S. House,4,LIB,Gorden J Bakken,2
-Harper,Township 5 East,U.S. House,4,DEM,Daniel B Giroux,13
-Harper,Township 5 East,U.S. House,4,REP,Michael Pompeo,124
-Harper,Township 5 West,U.S. House,4,IND,Miranda Allen,8
-Harper,Township 5 West,U.S. House,4,LIB,Gorden J Bakken,0
-Harper,Township 5 West,U.S. House,4,DEM,Daniel B Giroux,5
-Harper,Township 5 West,U.S. House,4,REP,Michael Pompeo,45
-Harper,Township 6 East,U.S. House,4,IND,Miranda Allen,11
-Harper,Township 6 East,U.S. House,4,LIB,Gorden J Bakken,1
-Harper,Township 6 East,U.S. House,4,DEM,Daniel B Giroux,8
-Harper,Township 6 East,U.S. House,4,REP,Michael Pompeo,87
-Harper,Township 6 West,U.S. House,4,IND,Miranda Allen,5
-Harper,Township 6 West,U.S. House,4,LIB,Gorden J Bakken,0
-Harper,Township 6 West,U.S. House,4,DEM,Daniel B Giroux,5
-Harper,Township 6 West,U.S. House,4,REP,Michael Pompeo,40
-Harper,Provisional,U.S. House,4,IND,Miranda Allen,13
-Harper,Provisional,U.S. House,4,LIB,Gorden J Bakken,2
-Harper,Provisional,U.S. House,4,DEM,Daniel B Giroux,2
-Harper,Provisional,U.S. House,4,REP,Michael Pompeo,38
-Harper,Anthony 1,State Senate,32,DEM,Don Shimkus,132
-Harper,Anthony 1,State Senate,32,REP,Larry W Alley,311
-Harper,Anthony 2,State Senate,32,DEM,Don Shimkus,59
-Harper,Anthony 2,State Senate,32,REP,Larry W Alley,171
-Harper,Anthony 3,State Senate,32,DEM,Don Shimkus,14
-Harper,Anthony 3,State Senate,32,REP,Larry W Alley,45
-Harper,Anthony 4,State Senate,32,DEM,Don Shimkus,34
-Harper,Anthony 4,State Senate,32,REP,Larry W Alley,113
-Harper,Harper 1,State Senate,32,DEM,Don Shimkus,64
-Harper,Harper 1,State Senate,32,REP,Larry W Alley,179
-Harper,Harper 2,State Senate,32,DEM,Don Shimkus,93
-Harper,Harper 2,State Senate,32,REP,Larry W Alley,196
-Harper,Township 1,State Senate,32,DEM,Don Shimkus,95
-Harper,Township 1,State Senate,32,REP,Larry W Alley,271
-Harper,Township 1,State Senate,32,,Write-in,1
-Harper,Township 2,State Senate,32,DEM,Don Shimkus,8
-Harper,Township 2,State Senate,32,REP,Larry W Alley,39
-Harper,Township 3 East,State Senate,32,DEM,Don Shimkus,13
-Harper,Township 3 East,State Senate,32,REP,Larry W Alley,45
-Harper,Township 3 West,State Senate,32,DEM,Don Shimkus,18
-Harper,Township 3 West,State Senate,32,REP,Larry W Alley,64
-Harper,Township 4,State Senate,32,DEM,Don Shimkus,30
-Harper,Township 4,State Senate,32,REP,Larry W Alley,43
-Harper,Township 5 East,State Senate,32,DEM,Don Shimkus,36
-Harper,Township 5 East,State Senate,32,REP,Larry W Alley,115
-Harper,Township 5 West,State Senate,32,DEM,Don Shimkus,13
-Harper,Township 5 West,State Senate,32,REP,Larry W Alley,42
-Harper,Township 6 East,State Senate,32,DEM,Don Shimkus,26
-Harper,Township 6 East,State Senate,32,REP,Larry W Alley,73
-Harper,Township 6 West,State Senate,32,DEM,Don Shimkus,9
-Harper,Township 6 West,State Senate,32,REP,Larry W Alley,38
-Harper,Provisional,State Senate,32,DEM,Don Shimkus,11
-Harper,Provisional,State Senate,32,REP,Larry W Alley,41
-Harper,Anthony 1,State House,116,DEM,Jolene E Roitman,157
-Harper,Anthony 1,State House,116,REP,Kyle D Hoffman,297
-Harper,Anthony 2,State House,116,DEM,Jolene E Roitman,76
-Harper,Anthony 2,State House,116,REP,Kyle D Hoffman,152
-Harper,Anthony 3,State House,116,DEM,Jolene E Roitman,18
-Harper,Anthony 3,State House,116,REP,Kyle D Hoffman,42
-Harper,Anthony 4,State House,116,DEM,Jolene E Roitman,61
-Harper,Anthony 4,State House,116,REP,Kyle D Hoffman,83
-Harper,Harper 1,State House,116,DEM,Jolene E Roitman,99
-Harper,Harper 1,State House,116,REP,Kyle D Hoffman,153
-Harper,Harper 2,State House,116,DEM,Jolene E Roitman,120
-Harper,Harper 2,State House,116,REP,Kyle D Hoffman,171
-Harper,Township 1,State House,116,DEM,Jolene E Roitman,154
-Harper,Township 1,State House,116,REP,Kyle D Hoffman,217
-Harper,Township 1,State House,116,,Write-in,1
-Harper,Township 2,State House,116,DEM,Jolene E Roitman,9
-Harper,Township 2,State House,116,REP,Kyle D Hoffman,41
-Harper,Township 3 East,State House,116,DEM,Jolene E Roitman,18
-Harper,Township 3 East,State House,116,REP,Kyle D Hoffman,40
-Harper,Township 3 West,State House,116,DEM,Jolene E Roitman,19
-Harper,Township 3 West,State House,116,REP,Kyle D Hoffman,68
-Harper,Township 4,State House,116,DEM,Jolene E Roitman,40
-Harper,Township 4,State House,116,REP,Kyle D Hoffman,35
-Harper,Township 5 East,State House,116,DEM,Jolene E Roitman,57
-Harper,Township 5 East,State House,116,REP,Kyle D Hoffman,101
-Harper,Township 5 West,State House,116,DEM,Jolene E Roitman,19
-Harper,Township 5 West,State House,116,REP,Kyle D Hoffman,37
-Harper,Township 6 East,State House,116,DEM,Jolene E Roitman,32
-Harper,Township 6 East,State House,116,REP,Kyle D Hoffman,70
-Harper,Township 6 West,State House,116,DEM,Jolene E Roitman,8
-Harper,Township 6 West,State House,116,REP,Kyle D Hoffman,41
-Harper,Provisional,State House,116,DEM,Jolene E Roitman,19
-Harper,Provisional,State House,116,REP,Kyle D Hoffman,34
+county,precinct,office,district,party,candidate,votes,vtd
+HARPER,Anthony Ward 1,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",158,000010
+HARPER,Anthony Ward 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",305,000010
+HARPER,Anthony Ward 2,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",76,000020
+HARPER,Anthony Ward 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",152,000020
+HARPER,Anthony Ward 3,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",21,000030
+HARPER,Anthony Ward 3,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",42,000030
+HARPER,Anthony Ward 4,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",64,000040
+HARPER,Anthony Ward 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",88,000040
+HARPER,Harper Ward 1,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",100,000050
+HARPER,Harper Ward 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",154,000050
+HARPER,Harper Ward 2,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",121,000060
+HARPER,Harper Ward 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",175,000060
+HARPER,Township 1,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",159,000070
+HARPER,Township 1,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",224,000070
+HARPER,Township 2,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",9,000080
+HARPER,Township 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",41,000080
+HARPER,Township 4,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",44,000100
+HARPER,Township 4,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",35,000100
+HARPER,Township 3 East,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",18,800010
+HARPER,Township 3 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",43,800010
+HARPER,Township 3 West,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",20,800020
+HARPER,Township 3 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",70,800020
+HARPER,Township 5 East,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",57,800030
+HARPER,Township 5 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",103,800030
+HARPER,Township 5 West,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",19,800040
+HARPER,Township 5 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",38,800040
+HARPER,Township 6 East,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",32,800050
+HARPER,Township 6 East,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",71,800050
+HARPER,Township 6 West,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",8,800060
+HARPER,Township 6 West,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",41,800060
+HARPER,Anthony Ward 1,Kansas Senate,32,Democratic,"Shimkus, Don",133,000010
+HARPER,Anthony Ward 1,Kansas Senate,32,Republican,"Alley, Larry W.",319,000010
+HARPER,Anthony Ward 2,Kansas Senate,32,Democratic,"Shimkus, Don",59,000020
+HARPER,Anthony Ward 2,Kansas Senate,32,Republican,"Alley, Larry W.",171,000020
+HARPER,Anthony Ward 3,Kansas Senate,32,Democratic,"Shimkus, Don",15,000030
+HARPER,Anthony Ward 3,Kansas Senate,32,Republican,"Alley, Larry W.",46,000030
+HARPER,Anthony Ward 4,Kansas Senate,32,Democratic,"Shimkus, Don",37,000040
+HARPER,Anthony Ward 4,Kansas Senate,32,Republican,"Alley, Larry W.",118,000040
+HARPER,Harper Ward 1,Kansas Senate,32,Democratic,"Shimkus, Don",65,000050
+HARPER,Harper Ward 1,Kansas Senate,32,Republican,"Alley, Larry W.",180,000050
+HARPER,Harper Ward 2,Kansas Senate,32,Democratic,"Shimkus, Don",94,000060
+HARPER,Harper Ward 2,Kansas Senate,32,Republican,"Alley, Larry W.",200,000060
+HARPER,Township 1,Kansas Senate,32,Democratic,"Shimkus, Don",96,000070
+HARPER,Township 1,Kansas Senate,32,Republican,"Alley, Larry W.",282,000070
+HARPER,Township 2,Kansas Senate,32,Democratic,"Shimkus, Don",8,000080
+HARPER,Township 2,Kansas Senate,32,Republican,"Alley, Larry W.",39,000080
+HARPER,Township 4,Kansas Senate,32,Democratic,"Shimkus, Don",32,000100
+HARPER,Township 4,Kansas Senate,32,Republican,"Alley, Larry W.",45,000100
+HARPER,Township 3 East,Kansas Senate,32,Democratic,"Shimkus, Don",13,800010
+HARPER,Township 3 East,Kansas Senate,32,Republican,"Alley, Larry W.",48,800010
+HARPER,Township 3 West,Kansas Senate,32,Democratic,"Shimkus, Don",18,800020
+HARPER,Township 3 West,Kansas Senate,32,Republican,"Alley, Larry W.",67,800020
+HARPER,Township 5 East,Kansas Senate,32,Democratic,"Shimkus, Don",37,800030
+HARPER,Township 5 East,Kansas Senate,32,Republican,"Alley, Larry W.",116,800030
+HARPER,Township 5 West,Kansas Senate,32,Democratic,"Shimkus, Don",13,800040
+HARPER,Township 5 West,Kansas Senate,32,Republican,"Alley, Larry W.",43,800040
+HARPER,Township 6 East,Kansas Senate,32,Democratic,"Shimkus, Don",26,800050
+HARPER,Township 6 East,Kansas Senate,32,Republican,"Alley, Larry W.",74,800050
+HARPER,Township 6 West,Kansas Senate,32,Democratic,"Shimkus, Don",9,800060
+HARPER,Township 6 West,Kansas Senate,32,Republican,"Alley, Larry W.",38,800060
+HARPER,Anthony Ward 2 Exclave 1,Kansas Senate,32,Democratic,"Shimkus, Don",0,900010
+HARPER,Anthony Ward 2 Exclave 1,Kansas Senate,32,Republican,"Alley, Larry W.",0,900010
+HARPER,Anthony Ward 1,President / Vice President,,independent,"Stein, Jill",13,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+HARPER,Anthony Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,000010
+HARPER,Anthony Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",25,000010
+HARPER,Anthony Ward 1,President / Vice President,,Republican,"Trump, Donald J.",361,000010
+HARPER,Anthony Ward 2,President / Vice President,,independent,"Stein, Jill",3,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+HARPER,Anthony Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000020
+HARPER,Anthony Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000020
+HARPER,Anthony Ward 2,President / Vice President,,Republican,"Trump, Donald J.",180,000020
+HARPER,Anthony Ward 3,President / Vice President,,independent,"Stein, Jill",2,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+HARPER,Anthony Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000030
+HARPER,Anthony Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+HARPER,Anthony Ward 3,President / Vice President,,Republican,"Trump, Donald J.",51,000030
+HARPER,Anthony Ward 4,President / Vice President,,independent,"Stein, Jill",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+HARPER,Anthony Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000040
+HARPER,Anthony Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",11,000040
+HARPER,Anthony Ward 4,President / Vice President,,Republican,"Trump, Donald J.",130,000040
+HARPER,Harper Ward 1,President / Vice President,,independent,"Stein, Jill",12,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+HARPER,Harper Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+HARPER,Harper Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000050
+HARPER,Harper Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",14,000050
+HARPER,Harper Ward 1,President / Vice President,,Republican,"Trump, Donald J.",199,000050
+HARPER,Harper Ward 2,President / Vice President,,independent,"Stein, Jill",10,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+HARPER,Harper Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+HARPER,Harper Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000060
+HARPER,Harper Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",16,000060
+HARPER,Harper Ward 2,President / Vice President,,Republican,"Trump, Donald J.",208,000060
+HARPER,Township 1,President / Vice President,,independent,"Stein, Jill",7,000070
+HARPER,Township 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"McMullin, Evan",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+HARPER,Township 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+HARPER,Township 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000070
+HARPER,Township 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000070
+HARPER,Township 1,President / Vice President,,Republican,"Trump, Donald J.",318,000070
+HARPER,Township 2,President / Vice President,,independent,"Stein, Jill",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"McMullin, Evan",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+HARPER,Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+HARPER,Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000080
+HARPER,Township 2,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+HARPER,Township 2,President / Vice President,,Republican,"Trump, Donald J.",47,000080
+HARPER,Township 4,President / Vice President,,independent,"Stein, Jill",7,000100
+HARPER,Township 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Hedges, James A",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"McMullin, Evan",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Perry, Darryl",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Smith, Mike",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Sood, Ajay",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+HARPER,Township 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+HARPER,Township 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000100
+HARPER,Township 4,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+HARPER,Township 4,President / Vice President,,Republican,"Trump, Donald J.",53,000100
+HARPER,Township 3 East,President / Vice President,,independent,"Stein, Jill",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Castle, Darrell L",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Giordani, Rocky",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Hedges, James A",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Kahn, Lynn",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"La Riva, Gloria",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Levinson, Michael S.",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Maturen, Michael A",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"McMullin, Evan",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Perry, Darryl",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Schriner, Joe C",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Smith, Mike",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Sood, Ajay",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Sterling, Shawna",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800010
+HARPER,Township 3 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800010
+HARPER,Township 3 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,800010
+HARPER,Township 3 East,President / Vice President,,Libertarian,"Johnson, Gary",8,800010
+HARPER,Township 3 East,President / Vice President,,Republican,"Trump, Donald J.",47,800010
+HARPER,Township 3 West,President / Vice President,,independent,"Stein, Jill",1,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Castle, Darrell L",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Giordani, Rocky",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Hedges, James A",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Hoefling, Tom",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Kahn, Lynn",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"La Riva, Gloria",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Levinson, Michael S.",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Maturen, Michael A",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"McMullin, Evan",1,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Perry, Darryl",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Schriner, Joe C",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Smith, Mike",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Sood, Ajay",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Sterling, Shawna",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800020
+HARPER,Township 3 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800020
+HARPER,Township 3 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,800020
+HARPER,Township 3 West,President / Vice President,,Libertarian,"Johnson, Gary",2,800020
+HARPER,Township 3 West,President / Vice President,,Republican,"Trump, Donald J.",78,800020
+HARPER,Township 5 East,President / Vice President,,independent,"Stein, Jill",2,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Castle, Darrell L",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Giordani, Rocky",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Hedges, James A",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Hoefling, Tom",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Kahn, Lynn",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"La Riva, Gloria",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Levinson, Michael S.",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Maturen, Michael A",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"McMullin, Evan",2,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Perry, Darryl",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Schriner, Joe C",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Smith, Mike",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Sood, Ajay",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Sterling, Shawna",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800030
+HARPER,Township 5 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800030
+HARPER,Township 5 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,800030
+HARPER,Township 5 East,President / Vice President,,Libertarian,"Johnson, Gary",4,800030
+HARPER,Township 5 East,President / Vice President,,Republican,"Trump, Donald J.",144,800030
+HARPER,Township 5 West,President / Vice President,,independent,"Stein, Jill",1,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Castle, Darrell L",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Giordani, Rocky",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Hedges, James A",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Hoefling, Tom",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Kahn, Lynn",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"La Riva, Gloria",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Levinson, Michael S.",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Maturen, Michael A",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"McMullin, Evan",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Perry, Darryl",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Schriner, Joe C",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Smith, Mike",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Sood, Ajay",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Sterling, Shawna",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800040
+HARPER,Township 5 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800040
+HARPER,Township 5 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,800040
+HARPER,Township 5 West,President / Vice President,,Libertarian,"Johnson, Gary",2,800040
+HARPER,Township 5 West,President / Vice President,,Republican,"Trump, Donald J.",50,800040
+HARPER,Township 6 East,President / Vice President,,independent,"Stein, Jill",2,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Castle, Darrell L",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Giordani, Rocky",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Hedges, James A",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Hoefling, Tom",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Kahn, Lynn",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"La Riva, Gloria",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Levinson, Michael S.",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Maturen, Michael A",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"McMullin, Evan",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Perry, Darryl",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Schriner, Joe C",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Smith, Mike",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Sood, Ajay",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Sterling, Shawna",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800050
+HARPER,Township 6 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800050
+HARPER,Township 6 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,800050
+HARPER,Township 6 East,President / Vice President,,Libertarian,"Johnson, Gary",6,800050
+HARPER,Township 6 East,President / Vice President,,Republican,"Trump, Donald J.",85,800050
+HARPER,Township 6 West,President / Vice President,,independent,"Stein, Jill",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Castle, Darrell L",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Giordani, Rocky",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Hedges, James A",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Hoefling, Tom",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Kahn, Lynn",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"La Riva, Gloria",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Levinson, Michael S.",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Maturen, Michael A",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"McMullin, Evan",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Perry, Darryl",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Schriner, Joe C",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Smith, Mike",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Sood, Ajay",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Sterling, Shawna",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800060
+HARPER,Township 6 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800060
+HARPER,Township 6 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,800060
+HARPER,Township 6 West,President / Vice President,,Libertarian,"Johnson, Gary",2,800060
+HARPER,Township 6 West,President / Vice President,,Republican,"Trump, Donald J.",45,800060
+HARPER,Anthony Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",42,000010
+HARPER,Anthony Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",67,000010
+HARPER,Anthony Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,000010
+HARPER,Anthony Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",352,000010
+HARPER,Anthony Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",42,000020
+HARPER,Anthony Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",30,000020
+HARPER,Anthony Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000020
+HARPER,Anthony Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",158,000020
+HARPER,Anthony Ward 3,United States House of Representatives,4,independent,"Allen, Miranda",9,000030
+HARPER,Anthony Ward 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000030
+HARPER,Anthony Ward 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000030
+HARPER,Anthony Ward 3,United States House of Representatives,4,Republican,"Pompeo, Michael",52,000030
+HARPER,Anthony Ward 4,United States House of Representatives,4,independent,"Allen, Miranda",24,000040
+HARPER,Anthony Ward 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,000040
+HARPER,Anthony Ward 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000040
+HARPER,Anthony Ward 4,United States House of Representatives,4,Republican,"Pompeo, Michael",109,000040
+HARPER,Harper Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",30,000050
+HARPER,Harper Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",32,000050
+HARPER,Harper Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,000050
+HARPER,Harper Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",184,000050
+HARPER,Harper Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",37,000060
+HARPER,Harper Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",43,000060
+HARPER,Harper Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",11,000060
+HARPER,Harper Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",213,000060
+HARPER,Township 1,United States House of Representatives,4,independent,"Allen, Miranda",49,000070
+HARPER,Township 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",40,000070
+HARPER,Township 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000070
+HARPER,Township 1,United States House of Representatives,4,Republican,"Pompeo, Michael",303,000070
+HARPER,Township 2,United States House of Representatives,4,independent,"Allen, Miranda",12,000080
+HARPER,Township 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000080
+HARPER,Township 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000080
+HARPER,Township 2,United States House of Representatives,4,Republican,"Pompeo, Michael",37,000080
+HARPER,Township 4,United States House of Representatives,4,independent,"Allen, Miranda",11,000100
+HARPER,Township 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",15,000100
+HARPER,Township 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000100
+HARPER,Township 4,United States House of Representatives,4,Republican,"Pompeo, Michael",51,000100
+HARPER,Township 3 East,United States House of Representatives,4,independent,"Allen, Miranda",5,800010
+HARPER,Township 3 East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,800010
+HARPER,Township 3 East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,800010
+HARPER,Township 3 East,United States House of Representatives,4,Republican,"Pompeo, Michael",49,800010
+HARPER,Township 3 West,United States House of Representatives,4,independent,"Allen, Miranda",16,800020
+HARPER,Township 3 West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",10,800020
+HARPER,Township 3 West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,800020
+HARPER,Township 3 West,United States House of Representatives,4,Republican,"Pompeo, Michael",66,800020
+HARPER,Township 5 East,United States House of Representatives,4,independent,"Allen, Miranda",24,800030
+HARPER,Township 5 East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,800030
+HARPER,Township 5 East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,800030
+HARPER,Township 5 East,United States House of Representatives,4,Republican,"Pompeo, Michael",125,800030
+HARPER,Township 5 West,United States House of Representatives,4,independent,"Allen, Miranda",8,800040
+HARPER,Township 5 West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,800040
+HARPER,Township 5 West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,800040
+HARPER,Township 5 West,United States House of Representatives,4,Republican,"Pompeo, Michael",46,800040
+HARPER,Township 6 East,United States House of Representatives,4,independent,"Allen, Miranda",11,800050
+HARPER,Township 6 East,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,800050
+HARPER,Township 6 East,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,800050
+HARPER,Township 6 East,United States House of Representatives,4,Republican,"Pompeo, Michael",88,800050
+HARPER,Township 6 West,United States House of Representatives,4,independent,"Allen, Miranda",5,800060
+HARPER,Township 6 West,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,800060
+HARPER,Township 6 West,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,800060
+HARPER,Township 6 West,United States House of Representatives,4,Republican,"Pompeo, Michael",40,800060
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,independent,"Allen, Miranda",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900010
+HARPER,Anthony Ward 2 Exclave 1,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900010
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,independent,"Allen, Miranda",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900020
+HARPER,Anthony Ward 2 Exclave 2,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900020
+HARPER,Anthony Ward 1,United States Senate,,write - in,"Smith, DJ",0,000010
+HARPER,Anthony Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",66,000010
+HARPER,Anthony Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,000010
+HARPER,Anthony Ward 1,United States Senate,,Republican,"Moran, Jerry",376,000010
+HARPER,Anthony Ward 2,United States Senate,,write - in,"Smith, DJ",0,000020
+HARPER,Anthony Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",37,000020
+HARPER,Anthony Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",10,000020
+HARPER,Anthony Ward 2,United States Senate,,Republican,"Moran, Jerry",182,000020
+HARPER,Anthony Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+HARPER,Anthony Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",10,000030
+HARPER,Anthony Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",3,000030
+HARPER,Anthony Ward 3,United States Senate,,Republican,"Moran, Jerry",52,000030
+HARPER,Anthony Ward 4,United States Senate,,write - in,"Smith, DJ",0,000040
+HARPER,Anthony Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",24,000040
+HARPER,Anthony Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",10,000040
+HARPER,Anthony Ward 4,United States Senate,,Republican,"Moran, Jerry",124,000040
+HARPER,Harper Ward 1,United States Senate,,write - in,"Smith, DJ",0,000050
+HARPER,Harper Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",40,000050
+HARPER,Harper Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000050
+HARPER,Harper Ward 1,United States Senate,,Republican,"Moran, Jerry",195,000050
+HARPER,Harper Ward 2,United States Senate,,write - in,"Smith, DJ",0,000060
+HARPER,Harper Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",58,000060
+HARPER,Harper Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,000060
+HARPER,Harper Ward 2,United States Senate,,Republican,"Moran, Jerry",222,000060
+HARPER,Township 1,United States Senate,,write - in,"Smith, DJ",0,000070
+HARPER,Township 1,United States Senate,,Democratic,"Wiesner, Patrick",59,000070
+HARPER,Township 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000070
+HARPER,Township 1,United States Senate,,Republican,"Moran, Jerry",308,000070
+HARPER,Township 2,United States Senate,,write - in,"Smith, DJ",0,000080
+HARPER,Township 2,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+HARPER,Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+HARPER,Township 2,United States Senate,,Republican,"Moran, Jerry",44,000080
+HARPER,Township 4,United States Senate,,write - in,"Smith, DJ",0,000100
+HARPER,Township 4,United States Senate,,Democratic,"Wiesner, Patrick",19,000100
+HARPER,Township 4,United States Senate,,Libertarian,"Garrard, Robert D.",5,000100
+HARPER,Township 4,United States Senate,,Republican,"Moran, Jerry",57,000100
+HARPER,Township 3 East,United States Senate,,write - in,"Smith, DJ",0,800010
+HARPER,Township 3 East,United States Senate,,Democratic,"Wiesner, Patrick",9,800010
+HARPER,Township 3 East,United States Senate,,Libertarian,"Garrard, Robert D.",2,800010
+HARPER,Township 3 East,United States Senate,,Republican,"Moran, Jerry",49,800010
+HARPER,Township 3 West,United States Senate,,write - in,"Smith, DJ",0,800020
+HARPER,Township 3 West,United States Senate,,Democratic,"Wiesner, Patrick",11,800020
+HARPER,Township 3 West,United States Senate,,Libertarian,"Garrard, Robert D.",1,800020
+HARPER,Township 3 West,United States Senate,,Republican,"Moran, Jerry",82,800020
+HARPER,Township 5 East,United States Senate,,write - in,"Smith, DJ",0,800030
+HARPER,Township 5 East,United States Senate,,Democratic,"Wiesner, Patrick",17,800030
+HARPER,Township 5 East,United States Senate,,Libertarian,"Garrard, Robert D.",4,800030
+HARPER,Township 5 East,United States Senate,,Republican,"Moran, Jerry",144,800030
+HARPER,Township 5 West,United States Senate,,write - in,"Smith, DJ",0,800040
+HARPER,Township 5 West,United States Senate,,Democratic,"Wiesner, Patrick",5,800040
+HARPER,Township 5 West,United States Senate,,Libertarian,"Garrard, Robert D.",4,800040
+HARPER,Township 5 West,United States Senate,,Republican,"Moran, Jerry",51,800040
+HARPER,Township 6 East,United States Senate,,write - in,"Smith, DJ",0,800050
+HARPER,Township 6 East,United States Senate,,Democratic,"Wiesner, Patrick",7,800050
+HARPER,Township 6 East,United States Senate,,Libertarian,"Garrard, Robert D.",6,800050
+HARPER,Township 6 East,United States Senate,,Republican,"Moran, Jerry",93,800050
+HARPER,Township 6 West,United States Senate,,write - in,"Smith, DJ",0,800060
+HARPER,Township 6 West,United States Senate,,Democratic,"Wiesner, Patrick",5,800060
+HARPER,Township 6 West,United States Senate,,Libertarian,"Garrard, Robert D.",2,800060
+HARPER,Township 6 West,United States Senate,,Republican,"Moran, Jerry",42,800060

--- a/2016/20161108__ks__general__harvey__precinct.csv
+++ b/2016/20161108__ks__general__harvey__precinct.csv
@@ -1,742 +1,1646 @@
-county,precinct,office,district,candidate,party,votes
-Harvey,Burrton City,President,,Johnson/Weld,LBT,14
-Harvey,Halstead City 1W-1P,President,,Johnson/Weld,LBT,27
-Harvey,Halstead City 1W-2P,President,,Johnson/Weld,LBT,40
-Harvey,Hesston City 1W-1P,President,,Johnson/Weld,LBT,49
-Harvey,Hesston City 1W-2P,President,,Johnson/Weld,LBT,34
-Harvey,Newton City 1W-1P,President,,Johnson/Weld,LBT,28
-Harvey,Newton City 1W-2P,President,,Johnson/Weld,LBT,23
-Harvey,Newton City 1W-3P,President,,Johnson/Weld,LBT,7
-Harvey,Newton City 2W-1P,President,,Johnson/Weld,LBT,20
-Harvey,Newton City 2W-2P,President,,Johnson/Weld,LBT,37
-Harvey,Newton City 3W-1P,President,,Johnson/Weld,LBT,22
-Harvey,Newton City 3W-2P,President,,Johnson/Weld,LBT,32
-Harvey,Newton City 3W-3P,President,,Johnson/Weld,LBT,21
-Harvey,Newton City 3W-4P,President,,Johnson/Weld,LBT,61
-Harvey,Newton City 4W-1P,President,,Johnson/Weld,LBT,23
-Harvey,Newton City 4W-2P,President,,Johnson/Weld,LBT,37
-Harvey,Newton City 4W-3P,President,,Johnson/Weld,LBT,36
-Harvey,Newton City 4W-4P,President,,Johnson/Weld,LBT,7
-Harvey,North Newton,President,,Johnson/Weld,LBT,32
-Harvey,Sedgwick City,President,,Johnson/Weld,LBT,31
-Harvey,Walton City,President,,Johnson/Weld,LBT,1
-Harvey,Alta Township,President,,Johnson/Weld,LBT,3
-Harvey,Burrton Township,President,,Johnson/Weld,LBT,3
-Harvey,Darlington Township,President,,Johnson/Weld,LBT,2
-Harvey,Darlington Twp North,President,,Johnson/Weld,LBT,3
-Harvey,Emma Township,President,,Johnson/Weld,LBT,10
-Harvey,Garden Township,President,,Johnson/Weld,LBT,8
-Harvey,Halstead Township,President,,Johnson/Weld,LBT,4
-Harvey,Highland Township,President,,Johnson/Weld,LBT,8
-Harvey,Lake Township,President,,Johnson/Weld,LBT,7
-Harvey,Lakin Township,President,,Johnson/Weld,LBT,5
-Harvey,Macon Township,President,,Johnson/Weld,LBT,6
-Harvey,Newton Township AB,President,,Johnson/Weld,LBT,8
-Harvey,Newton Township CDE,President,,Johnson/Weld,LBT,4
-Harvey,Pleasant Township,President,,Johnson/Weld,LBT,11
-Harvey,Richland Township,President,,Johnson/Weld,LBT,2
-Harvey,Sedgwick Township,President,,Johnson/Weld,LBT,11
-Harvey,Walton Township,President,,Johnson/Weld,LBT,7
-Harvey,Burrton City,President,,Stein/Baraka,IND,4
-Harvey,Halstead City 1W-1P,President,,Stein/Baraka,IND,5
-Harvey,Halstead City 1W-2P,President,,Stein/Baraka,IND,8
-Harvey,Hesston City 1W-1P,President,,Stein/Baraka,IND,16
-Harvey,Hesston City 1W-2P,President,,Stein/Baraka,IND,19
-Harvey,Newton City 1W-1P,President,,Stein/Baraka,IND,17
-Harvey,Newton City 1W-2P,President,,Stein/Baraka,IND,13
-Harvey,Newton City 1W-3P,President,,Stein/Baraka,IND,18
-Harvey,Newton City 2W-1P,President,,Stein/Baraka,IND,8
-Harvey,Newton City 2W-2P,President,,Stein/Baraka,IND,23
-Harvey,Newton City 3W-1P,President,,Stein/Baraka,IND,11
-Harvey,Newton City 3W-2P,President,,Stein/Baraka,IND,19
-Harvey,Newton City 3W-3P,President,,Stein/Baraka,IND,16
-Harvey,Newton City 3W-4P,President,,Stein/Baraka,IND,24
-Harvey,Newton City 4W-1P,President,,Stein/Baraka,IND,17
-Harvey,Newton City 4W-2P,President,,Stein/Baraka,IND,25
-Harvey,Newton City 4W-3P,President,,Stein/Baraka,IND,16
-Harvey,Newton City 4W-4P,President,,Stein/Baraka,IND,10
-Harvey,North Newton,President,,Stein/Baraka,IND,21
-Harvey,Sedgwick City,President,,Stein/Baraka,IND,19
-Harvey,Walton City,President,,Stein/Baraka,IND,10
-Harvey,Alta Township,President,,Stein/Baraka,IND,5
-Harvey,Burrton Township,President,,Stein/Baraka,IND,3
-Harvey,Darlington Township,President,,Stein/Baraka,IND,2
-Harvey,Darlington Twp North,President,,Stein/Baraka,IND,1
-Harvey,Emma Township,President,,Stein/Baraka,IND,5
-Harvey,Garden Township,President,,Stein/Baraka,IND,3
-Harvey,Halstead Township,President,,Stein/Baraka,IND,0
-Harvey,Highland Township,President,,Stein/Baraka,IND,10
-Harvey,Lake Township,President,,Stein/Baraka,IND,3
-Harvey,Lakin Township,President,,Stein/Baraka,IND,1
-Harvey,Macon Township,President,,Stein/Baraka,IND,1
-Harvey,Newton Township AB,President,,Stein/Baraka,IND,2
-Harvey,Newton Township CDE,President,,Stein/Baraka,IND,1
-Harvey,Pleasant Township,President,,Stein/Baraka,IND,4
-Harvey,Richland Township,President,,Stein/Baraka,IND,3
-Harvey,Sedgwick Township,President,,Stein/Baraka,IND,2
-Harvey,Walton Township,President,,Stein/Baraka,IND,5
-Harvey,Burrton City,President,,Trump/Pence,REP,219
-Harvey,Halstead City 1W-1P,President,,Trump/Pence,REP,221
-Harvey,Halstead City 1W-2P,President,,Trump/Pence,REP,295
-Harvey,Hesston City 1W-1P,President,,Trump/Pence,REP,459
-Harvey,Hesston City 1W-2P,President,,Trump/Pence,REP,512
-Harvey,Newton City 1W-1P,President,,Trump/Pence,REP,235
-Harvey,Newton City 1W-2P,President,,Trump/Pence,REP,181
-Harvey,Newton City 1W-3P,President,,Trump/Pence,REP,123
-Harvey,Newton City 2W-1P,President,,Trump/Pence,REP,190
-Harvey,Newton City 2W-2P,President,,Trump/Pence,REP,552
-Harvey,Newton City 3W-1P,President,,Trump/Pence,REP,223
-Harvey,Newton City 3W-2P,President,,Trump/Pence,REP,345
-Harvey,Newton City 3W-3P,President,,Trump/Pence,REP,307
-Harvey,Newton City 3W-4P,President,,Trump/Pence,REP,760
-Harvey,Newton City 4W-1P,President,,Trump/Pence,REP,257
-Harvey,Newton City 4W-2P,President,,Trump/Pence,REP,489
-Harvey,Newton City 4W-3P,President,,Trump/Pence,REP,357
-Harvey,Newton City 4W-4P,President,,Trump/Pence,REP,150
-Harvey,North Newton,President,,Trump/Pence,REP,364
-Harvey,Sedgwick City,President,,Trump/Pence,REP,423
-Harvey,Walton City,President,,Trump/Pence,REP,64
-Harvey,Alta Township,President,,Trump/Pence,REP,87
-Harvey,Burrton Township,President,,Trump/Pence,REP,64
-Harvey,Darlington Township,President,,Trump/Pence,REP,175
-Harvey,Darlington Twp North,President,,Trump/Pence,REP,50
-Harvey,Emma Township,President,,Trump/Pence,REP,198
-Harvey,Garden Township,President,,Trump/Pence,REP,97
-Harvey,Halstead Township,President,,Trump/Pence,REP,86
-Harvey,Highland Township,President,,Trump/Pence,REP,105
-Harvey,Lake Township,President,,Trump/Pence,REP,70
-Harvey,Lakin Township,President,,Trump/Pence,REP,98
-Harvey,Macon Township,President,,Trump/Pence,REP,160
-Harvey,Newton Township AB,President,,Trump/Pence,REP,120
-Harvey,Newton Township CDE,President,,Trump/Pence,REP,37
-Harvey,Pleasant Township,President,,Trump/Pence,REP,206
-Harvey,Richland Township,President,,Trump/Pence,REP,169
-Harvey,Sedgwick Township,President,,Trump/Pence,REP,118
-Harvey,Walton Township,President,,Trump/Pence,REP,102
-Harvey,Burrton City,President,,Clinton/Kaine,DEM,49
-Harvey,Halstead City 1W-1P,President,,Clinton/Kaine,DEM,77
-Harvey,Halstead City 1W-2P,President,,Clinton/Kaine,DEM,141
-Harvey,Hesston City 1W-1P,President,,Clinton/Kaine,DEM,357
-Harvey,Hesston City 1W-2P,President,,Clinton/Kaine,DEM,273
-Harvey,Newton City 1W-1P,President,,Clinton/Kaine,DEM,169
-Harvey,Newton City 1W-2P,President,,Clinton/Kaine,DEM,145
-Harvey,Newton City 1W-3P,President,,Clinton/Kaine,DEM,102
-Harvey,Newton City 2W-1P,President,,Clinton/Kaine,DEM,159
-Harvey,Newton City 2W-2P,President,,Clinton/Kaine,DEM,359
-Harvey,Newton City 3W-1P,President,,Clinton/Kaine,DEM,152
-Harvey,Newton City 3W-2P,President,,Clinton/Kaine,DEM,215
-Harvey,Newton City 3W-3P,President,,Clinton/Kaine,DEM,189
-Harvey,Newton City 3W-4P,President,,Clinton/Kaine,DEM,363
-Harvey,Newton City 4W-1P,President,,Clinton/Kaine,DEM,203
-Harvey,Newton City 4W-2P,President,,Clinton/Kaine,DEM,345
-Harvey,Newton City 4W-3P,President,,Clinton/Kaine,DEM,227
-Harvey,Newton City 4W-4P,President,,Clinton/Kaine,DEM,115
-Harvey,North Newton,President,,Clinton/Kaine,DEM,583
-Harvey,Sedgwick City,President,,Clinton/Kaine,DEM,132
-Harvey,Walton City,President,,Clinton/Kaine,DEM,27
-Harvey,Alta Township,President,,Clinton/Kaine,DEM,32
-Harvey,Burrton Township,President,,Clinton/Kaine,DEM,23
-Harvey,Darlington Township,President,,Clinton/Kaine,DEM,58
-Harvey,Darlington Twp North,President,,Clinton/Kaine,DEM,11
-Harvey,Emma Township,President,,Clinton/Kaine,DEM,59
-Harvey,Garden Township,President,,Clinton/Kaine,DEM,44
-Harvey,Halstead Township,President,,Clinton/Kaine,DEM,42
-Harvey,Highland Township,President,,Clinton/Kaine,DEM,87
-Harvey,Lake Township,President,,Clinton/Kaine,DEM,7
-Harvey,Lakin Township,President,,Clinton/Kaine,DEM,33
-Harvey,Macon Township,President,,Clinton/Kaine,DEM,71
-Harvey,Newton Township AB,President,,Clinton/Kaine,DEM,43
-Harvey,Newton Township CDE,President,,Clinton/Kaine,DEM,8
-Harvey,Pleasant Township,President,,Clinton/Kaine,DEM,70
-Harvey,Richland Township,President,,Clinton/Kaine,DEM,37
-Harvey,Sedgwick Township,President,,Clinton/Kaine,DEM,27
-Harvey,Walton Township,President,,Clinton/Kaine,DEM,34
-Harvey,Burrton City,President,,Write-ins,,6
-Harvey,Halstead City 1W-1P,President,,Write-ins,,10
-Harvey,Halstead City 1W-2P,President,,Write-ins,,8
-Harvey,Hesston City 1W-1P,President,,Write-ins,,20
-Harvey,Hesston City 1W-2P,President,,Write-ins,,32
-Harvey,Newton City 1W-1P,President,,Write-ins,,12
-Harvey,Newton City 1W-2P,President,,Write-ins,,12
-Harvey,Newton City 1W-3P,President,,Write-ins,,2
-Harvey,Newton City 2W-1P,President,,Write-ins,,4
-Harvey,Newton City 2W-2P,President,,Write-ins,,18
-Harvey,Newton City 3W-1P,President,,Write-ins,,12
-Harvey,Newton City 3W-2P,President,,Write-ins,,15
-Harvey,Newton City 3W-3P,President,,Write-ins,,8
-Harvey,Newton City 3W-4P,President,,Write-ins,,30
-Harvey,Newton City 4W-1P,President,,Write-ins,,11
-Harvey,Newton City 4W-2P,President,,Write-ins,,20
-Harvey,Newton City 4W-3P,President,,Write-ins,,20
-Harvey,Newton City 4W-4P,President,,Write-ins,,5
-Harvey,North Newton,President,,Write-ins,,17
-Harvey,Sedgwick City,President,,Write-ins,,10
-Harvey,Walton City,President,,Write-ins,,1
-Harvey,Alta Township,President,,Write-ins,,1
-Harvey,Burrton Township,President,,Write-ins,,0
-Harvey,Darlington Township,President,,Write-ins,,3
-Harvey,Darlington Twp North,President,,Write-ins,,1
-Harvey,Emma Township,President,,Write-ins,,7
-Harvey,Garden Township,President,,Write-ins,,2
-Harvey,Halstead Township,President,,Write-ins,,8
-Harvey,Highland Township,President,,Write-ins,,5
-Harvey,Lake Township,President,,Write-ins,,1
-Harvey,Lakin Township,President,,Write-ins,,1
-Harvey,Macon Township,President,,Write-ins,,6
-Harvey,Newton Township AB,President,,Write-ins,,4
-Harvey,Newton Township CDE,President,,Write-ins,,0
-Harvey,Pleasant Township,President,,Write-ins,,2
-Harvey,Richland Township,President,,Write-ins,,7
-Harvey,Sedgwick Township,President,,Write-ins,,4
-Harvey,Walton Township,President,,Write-ins,,1
-Harvey,Burrton City,U.S. Senate,,Jerry Moran,REP,218
-Harvey,Halstead City 1W-1P,U.S. Senate,,Jerry Moran,REP,249
-Harvey,Halstead City 1W-2P,U.S. Senate,,Jerry Moran,REP,353
-Harvey,Hesston City 1W-1P,U.S. Senate,,Jerry Moran,REP,610
-Harvey,Hesston City 1W-2P,U.S. Senate,,Jerry Moran,REP,613
-Harvey,Newton City 1W-1P,U.S. Senate,,Jerry Moran,REP,256
-Harvey,Newton City 1W-2P,U.S. Senate,,Jerry Moran,REP,194
-Harvey,Newton City 1W-3P,U.S. Senate,,Jerry Moran,REP,134
-Harvey,Newton City 2W-1P,U.S. Senate,,Jerry Moran,REP,193
-Harvey,Newton City 2W-2P,U.S. Senate,,Jerry Moran,REP,599
-Harvey,Newton City 3W-1P,U.S. Senate,,Jerry Moran,REP,237
-Harvey,Newton City 3W-2P,U.S. Senate,,Jerry Moran,REP,399
-Harvey,Newton City 3W-3P,U.S. Senate,,Jerry Moran,REP,346
-Harvey,Newton City 3W-4P,U.S. Senate,,Jerry Moran,REP,864
-Harvey,Newton City 4W-1P,U.S. Senate,,Jerry Moran,REP,287
-Harvey,Newton City 4W-2P,U.S. Senate,,Jerry Moran,REP,556
-Harvey,Newton City 4W-3P,U.S. Senate,,Jerry Moran,REP,419
-Harvey,Newton City 4W-4P,U.S. Senate,,Jerry Moran,REP,177
-Harvey,North Newton,U.S. Senate,,Jerry Moran,REP,476
-Harvey,Sedgwick City,U.S. Senate,,Jerry Moran,REP,447
-Harvey,Walton City,U.S. Senate,,Jerry Moran,REP,70
-Harvey,Alta Township,U.S. Senate,,Jerry Moran,REP,99
-Harvey,Burrton Township,U.S. Senate,,Jerry Moran,REP,74
-Harvey,Darlington Township,U.S. Senate,,Jerry Moran,REP,175
-Harvey,Darlington Twp North,U.S. Senate,,Jerry Moran,REP,49
-Harvey,Emma Township,U.S. Senate,,Jerry Moran,REP,214
-Harvey,Garden Township,U.S. Senate,,Jerry Moran,REP,119
-Harvey,Halstead Township,U.S. Senate,,Jerry Moran,REP,95
-Harvey,Highland Township,U.S. Senate,,Jerry Moran,REP,138
-Harvey,Lake Township,U.S. Senate,,Jerry Moran,REP,70
-Harvey,Lakin Township,U.S. Senate,,Jerry Moran,REP,109
-Harvey,Macon Township,U.S. Senate,,Jerry Moran,REP,173
-Harvey,Newton Township AB,U.S. Senate,,Jerry Moran,REP,131
-Harvey,Newton Township CDE,U.S. Senate,,Jerry Moran,REP,42
-Harvey,Pleasant Township,U.S. Senate,,Jerry Moran,REP,220
-Harvey,Richland Township,U.S. Senate,,Jerry Moran,REP,174
-Harvey,Sedgwick Township,U.S. Senate,,Jerry Moran,REP,131
-Harvey,Walton Township,U.S. Senate,,Jerry Moran,REP,105
-Harvey,Burrton City,U.S. Senate,,Patrick Wiesner,DEM,44
-Harvey,Halstead City 1W-1P,U.S. Senate,,Patrick Wiesner,DEM,64
-Harvey,Halstead City 1W-2P,U.S. Senate,,Patrick Wiesner,DEM,114
-Harvey,Hesston City 1W-1P,U.S. Senate,,Patrick Wiesner,DEM,247
-Harvey,Hesston City 1W-2P,U.S. Senate,,Patrick Wiesner,DEM,205
-Harvey,Newton City 1W-1P,U.S. Senate,,Patrick Wiesner,DEM,166
-Harvey,Newton City 1W-2P,U.S. Senate,,Patrick Wiesner,DEM,126
-Harvey,Newton City 1W-3P,U.S. Senate,,Patrick Wiesner,DEM,93
-Harvey,Newton City 2W-1P,U.S. Senate,,Patrick Wiesner,DEM,158
-Harvey,Newton City 2W-2P,U.S. Senate,,Patrick Wiesner,DEM,308
-Harvey,Newton City 3W-1P,U.S. Senate,,Patrick Wiesner,DEM,146
-Harvey,Newton City 3W-2P,U.S. Senate,,Patrick Wiesner,DEM,188
-Harvey,Newton City 3W-3P,U.S. Senate,,Patrick Wiesner,DEM,159
-Harvey,Newton City 3W-4P,U.S. Senate,,Patrick Wiesner,DEM,301
-Harvey,Newton City 4W-1P,U.S. Senate,,Patrick Wiesner,DEM,179
-Harvey,Newton City 4W-2P,U.S. Senate,,Patrick Wiesner,DEM,298
-Harvey,Newton City 4W-3P,U.S. Senate,,Patrick Wiesner,DEM,185
-Harvey,Newton City 4W-4P,U.S. Senate,,Patrick Wiesner,DEM,91
-Harvey,North Newton,U.S. Senate,,Patrick Wiesner,DEM,486
-Harvey,Sedgwick City,U.S. Senate,,Patrick Wiesner,DEM,112
-Harvey,Walton City,U.S. Senate,,Patrick Wiesner,DEM,24
-Harvey,Alta Township,U.S. Senate,,Patrick Wiesner,DEM,20
-Harvey,Burrton Township,U.S. Senate,,Patrick Wiesner,DEM,16
-Harvey,Darlington Township,U.S. Senate,,Patrick Wiesner,DEM,47
-Harvey,Darlington Twp North,U.S. Senate,,Patrick Wiesner,DEM,11
-Harvey,Emma Township,U.S. Senate,,Patrick Wiesner,DEM,49
-Harvey,Garden Township,U.S. Senate,,Patrick Wiesner,DEM,30
-Harvey,Halstead Township,U.S. Senate,,Patrick Wiesner,DEM,33
-Harvey,Highland Township,U.S. Senate,,Patrick Wiesner,DEM,62
-Harvey,Lake Township,U.S. Senate,,Patrick Wiesner,DEM,10
-Harvey,Lakin Township,U.S. Senate,,Patrick Wiesner,DEM,24
-Harvey,Macon Township,U.S. Senate,,Patrick Wiesner,DEM,54
-Harvey,Newton Township AB,U.S. Senate,,Patrick Wiesner,DEM,37
-Harvey,Newton Township CDE,U.S. Senate,,Patrick Wiesner,DEM,5
-Harvey,Pleasant Township,U.S. Senate,,Patrick Wiesner,DEM,60
-Harvey,Richland Township,U.S. Senate,,Patrick Wiesner,DEM,30
-Harvey,Sedgwick Township,U.S. Senate,,Patrick Wiesner,DEM,22
-Harvey,Walton Township,U.S. Senate,,Patrick Wiesner,DEM,33
-Harvey,Burrton City,U.S. Senate,,Robert Garrard,LBT,27
-Harvey,Halstead City 1W-1P,U.S. Senate,,Robert Garrard,LBT,26
-Harvey,Halstead City 1W-2P,U.S. Senate,,Robert Garrard,LBT,21
-Harvey,Hesston City 1W-1P,U.S. Senate,,Robert Garrard,LBT,26
-Harvey,Hesston City 1W-2P,U.S. Senate,,Robert Garrard,LBT,32
-Harvey,Newton City 1W-1P,U.S. Senate,,Robert Garrard,LBT,33
-Harvey,Newton City 1W-2P,U.S. Senate,,Robert Garrard,LBT,37
-Harvey,Newton City 1W-3P,U.S. Senate,,Robert Garrard,LBT,22
-Harvey,Newton City 2W-1P,U.S. Senate,,Robert Garrard,LBT,26
-Harvey,Newton City 2W-2P,U.S. Senate,,Robert Garrard,LBT,50
-Harvey,Newton City 3W-1P,U.S. Senate,,Robert Garrard,LBT,28
-Harvey,Newton City 3W-2P,U.S. Senate,,Robert Garrard,LBT,35
-Harvey,Newton City 3W-3P,U.S. Senate,,Robert Garrard,LBT,34
-Harvey,Newton City 3W-4P,U.S. Senate,,Robert Garrard,LBT,53
-Harvey,Newton City 4W-1P,U.S. Senate,,Robert Garrard,LBT,39
-Harvey,Newton City 4W-2P,U.S. Senate,,Robert Garrard,LBT,36
-Harvey,Newton City 4W-3P,U.S. Senate,,Robert Garrard,LBT,47
-Harvey,Newton City 4W-4P,U.S. Senate,,Robert Garrard,LBT,13
-Harvey,North Newton,U.S. Senate,,Robert Garrard,LBT,37
-Harvey,Sedgwick City,U.S. Senate,,Robert Garrard,LBT,48
-Harvey,Walton City,U.S. Senate,,Robert Garrard,LBT,6
-Harvey,Alta Township,U.S. Senate,,Robert Garrard,LBT,9
-Harvey,Burrton Township,U.S. Senate,,Robert Garrard,LBT,4
-Harvey,Darlington Township,U.S. Senate,,Robert Garrard,LBT,11
-Harvey,Darlington Twp North,U.S. Senate,,Robert Garrard,LBT,6
-Harvey,Emma Township,U.S. Senate,,Robert Garrard,LBT,14
-Harvey,Garden Township,U.S. Senate,,Robert Garrard,LBT,5
-Harvey,Halstead Township,U.S. Senate,,Robert Garrard,LBT,8
-Harvey,Highland Township,U.S. Senate,,Robert Garrard,LBT,14
-Harvey,Lake Township,U.S. Senate,,Robert Garrard,LBT,7
-Harvey,Lakin Township,U.S. Senate,,Robert Garrard,LBT,4
-Harvey,Macon Township,U.S. Senate,,Robert Garrard,LBT,16
-Harvey,Newton Township AB,U.S. Senate,,Robert Garrard,LBT,6
-Harvey,Newton Township CDE,U.S. Senate,,Robert Garrard,LBT,6
-Harvey,Pleasant Township,U.S. Senate,,Robert Garrard,LBT,10
-Harvey,Richland Township,U.S. Senate,,Robert Garrard,LBT,12
-Harvey,Sedgwick Township,U.S. Senate,,Robert Garrard,LBT,7
-Harvey,Walton Township,U.S. Senate,,Robert Garrard,LBT,10
-Harvey,Burrton City,U.S. Senate,,Write-ins,,0
-Harvey,Halstead City 1W-1P,U.S. Senate,,Write-ins,,1
-Harvey,Halstead City 1W-2P,U.S. Senate,,Write-ins,,0
-Harvey,Hesston City 1W-1P,U.S. Senate,,Write-ins,,1
-Harvey,Hesston City 1W-2P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 1W-1P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 1W-2P,U.S. Senate,,Write-ins,,1
-Harvey,Newton City 1W-3P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 2W-1P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 2W-2P,U.S. Senate,,Write-ins,,3
-Harvey,Newton City 3W-1P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 3W-2P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 3W-3P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 3W-4P,U.S. Senate,,Write-ins,,1
-Harvey,Newton City 4W-1P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 4W-2P,U.S. Senate,,Write-ins,,1
-Harvey,Newton City 4W-3P,U.S. Senate,,Write-ins,,0
-Harvey,Newton City 4W-4P,U.S. Senate,,Write-ins,,0
-Harvey,North Newton,U.S. Senate,,Write-ins,,1
-Harvey,Sedgwick City,U.S. Senate,,Write-ins,,0
-Harvey,Walton City,U.S. Senate,,Write-ins,,1
-Harvey,Alta Township,U.S. Senate,,Write-ins,,0
-Harvey,Burrton Township,U.S. Senate,,Write-ins,,0
-Harvey,Darlington Township,U.S. Senate,,Write-ins,,1
-Harvey,Darlington Twp North,U.S. Senate,,Write-ins,,0
-Harvey,Emma Township,U.S. Senate,,Write-ins,,0
-Harvey,Garden Township,U.S. Senate,,Write-ins,,0
-Harvey,Halstead Township,U.S. Senate,,Write-ins,,0
-Harvey,Highland Township,U.S. Senate,,Write-ins,,0
-Harvey,Lake Township,U.S. Senate,,Write-ins,,0
-Harvey,Lakin Township,U.S. Senate,,Write-ins,,0
-Harvey,Macon Township,U.S. Senate,,Write-ins,,0
-Harvey,Newton Township AB,U.S. Senate,,Write-ins,,0
-Harvey,Newton Township CDE,U.S. Senate,,Write-ins,,0
-Harvey,Pleasant Township,U.S. Senate,,Write-ins,,0
-Harvey,Richland Township,U.S. Senate,,Write-ins,,0
-Harvey,Sedgwick Township,U.S. Senate,,Write-ins,,2
-Harvey,Walton Township,U.S. Senate,,Write-ins,,0
-Harvey,Burrton City,U.S. House,4,Daniel Giroux,DEM,42
-Harvey,Halstead City 1W-1P,U.S. House,4,Daniel Giroux,DEM,71
-Harvey,Halstead City 1W-2P,U.S. House,4,Daniel Giroux,DEM,129
-Harvey,Hesston City 1W-1P,U.S. House,4,Daniel Giroux,DEM,274
-Harvey,Hesston City 1W-2P,U.S. House,4,Daniel Giroux,DEM,223
-Harvey,Newton City 1W-1P,U.S. House,4,Daniel Giroux,DEM,155
-Harvey,Newton City 1W-2P,U.S. House,4,Daniel Giroux,DEM,132
-Harvey,Newton City 1W-3P,U.S. House,4,Daniel Giroux,DEM,84
-Harvey,Newton City 2W-1P,U.S. House,4,Daniel Giroux,DEM,150
-Harvey,Newton City 2W-2P,U.S. House,4,Daniel Giroux,DEM,301
-Harvey,Newton City 3W-1P,U.S. House,4,Daniel Giroux,DEM,143
-Harvey,Newton City 3W-2P,U.S. House,4,Daniel Giroux,DEM,186
-Harvey,Newton City 3W-3P,U.S. House,4,Daniel Giroux,DEM,167
-Harvey,Newton City 3W-4P,U.S. House,4,Daniel Giroux,DEM,325
-Harvey,Newton City 4W-1P,U.S. House,4,Daniel Giroux,DEM,198
-Harvey,Newton City 4W-2P,U.S. House,4,Daniel Giroux,DEM,294
-Harvey,Newton City 4W-3P,U.S. House,4,Daniel Giroux,DEM,198
-Harvey,Newton City 4W-4P,U.S. House,4,Daniel Giroux,DEM,88
-Harvey,North Newton,U.S. House,4,Daniel Giroux,DEM,564
-Harvey,Sedgwick City,U.S. House,4,Daniel Giroux,DEM,123
-Harvey,Walton City,U.S. House,4,Daniel Giroux,DEM,24
-Harvey,Alta Township,U.S. House,4,Daniel Giroux,DEM,23
-Harvey,Burrton Township,U.S. House,4,Daniel Giroux,DEM,16
-Harvey,Darlington Township,U.S. House,4,Daniel Giroux,DEM,43
-Harvey,Darlington Twp North,U.S. House,4,Daniel Giroux,DEM,10
-Harvey,Emma Township,U.S. House,4,Daniel Giroux,DEM,52
-Harvey,Garden Township,U.S. House,4,Daniel Giroux,DEM,30
-Harvey,Halstead Township,U.S. House,4,Daniel Giroux,DEM,38
-Harvey,Highland Township,U.S. House,4,Daniel Giroux,DEM,66
-Harvey,Lake Township,U.S. House,4,Daniel Giroux,DEM,11
-Harvey,Lakin Township,U.S. House,4,Daniel Giroux,DEM,22
-Harvey,Macon Township,U.S. House,4,Daniel Giroux,DEM,58
-Harvey,Newton Township AB,U.S. House,4,Daniel Giroux,DEM,42
-Harvey,Newton Township CDE,U.S. House,4,Daniel Giroux,DEM,11
-Harvey,Pleasant Township,U.S. House,4,Daniel Giroux,DEM,71
-Harvey,Richland Township,U.S. House,4,Daniel Giroux,DEM,36
-Harvey,Sedgwick Township,U.S. House,4,Daniel Giroux,DEM,17
-Harvey,Walton Township,U.S. House,4,Daniel Giroux,DEM,29
-Harvey,Burrton City,U.S. House,4,Mike Pompeo,REP,217
-Harvey,Halstead City 1W-1P,U.S. House,4,Mike Pompeo,REP,241
-Harvey,Halstead City 1W-2P,U.S. House,4,Mike Pompeo,REP,314
-Harvey,Hesston City 1W-1P,U.S. House,4,Mike Pompeo,REP,541
-Harvey,Hesston City 1W-2P,U.S. House,4,Mike Pompeo,REP,574
-Harvey,Newton City 1W-1P,U.S. House,4,Mike Pompeo,REP,249
-Harvey,Newton City 1W-2P,U.S. House,4,Mike Pompeo,REP,181
-Harvey,Newton City 1W-3P,U.S. House,4,Mike Pompeo,REP,137
-Harvey,Newton City 2W-1P,U.S. House,4,Mike Pompeo,REP,180
-Harvey,Newton City 2W-2P,U.S. House,4,Mike Pompeo,REP,589
-Harvey,Newton City 3W-1P,U.S. House,4,Mike Pompeo,REP,218
-Harvey,Newton City 3W-2P,U.S. House,4,Mike Pompeo,REP,380
-Harvey,Newton City 3W-3P,U.S. House,4,Mike Pompeo,REP,312
-Harvey,Newton City 3W-4P,U.S. House,4,Mike Pompeo,REP,818
-Harvey,Newton City 4W-1P,U.S. House,4,Mike Pompeo,REP,260
-Harvey,Newton City 4W-2P,U.S. House,4,Mike Pompeo,REP,528
-Harvey,Newton City 4W-3P,U.S. House,4,Mike Pompeo,REP,384
-Harvey,Newton City 4W-4P,U.S. House,4,Mike Pompeo,REP,159
-Harvey,North Newton,U.S. House,4,Mike Pompeo,REP,403
-Harvey,Sedgwick City,U.S. House,4,Mike Pompeo,REP,435
-Harvey,Walton City,U.S. House,4,Mike Pompeo,REP,62
-Harvey,Alta Township,U.S. House,4,Mike Pompeo,REP,97
-Harvey,Burrton Township,U.S. House,4,Mike Pompeo,REP,70
-Harvey,Darlington Township,U.S. House,4,Mike Pompeo,REP,181
-Harvey,Darlington Twp North,U.S. House,4,Mike Pompeo,REP,46
-Harvey,Emma Township,U.S. House,4,Mike Pompeo,REP,211
-Harvey,Garden Township,U.S. House,4,Mike Pompeo,REP,115
-Harvey,Halstead Township,U.S. House,4,Mike Pompeo,REP,89
-Harvey,Highland Township,U.S. House,4,Mike Pompeo,REP,130
-Harvey,Lake Township,U.S. House,4,Mike Pompeo,REP,65
-Harvey,Lakin Township,U.S. House,4,Mike Pompeo,REP,103
-Harvey,Macon Township,U.S. House,4,Mike Pompeo,REP,164
-Harvey,Newton Township AB,U.S. House,4,Mike Pompeo,REP,123
-Harvey,Newton Township CDE,U.S. House,4,Mike Pompeo,REP,37
-Harvey,Pleasant Township,U.S. House,4,Mike Pompeo,REP,208
-Harvey,Richland Township,U.S. House,4,Mike Pompeo,REP,178
-Harvey,Sedgwick Township,U.S. House,4,Mike Pompeo,REP,131
-Harvey,Walton Township,U.S. House,4,Mike Pompeo,REP,103
-Harvey,Burrton City,U.S. House,4,Gorden Bakken,LBT,6
-Harvey,Halstead City 1W-1P,U.S. House,4,Gorden Bakken,LBT,13
-Harvey,Halstead City 1W-2P,U.S. House,4,Gorden Bakken,LBT,14
-Harvey,Hesston City 1W-1P,U.S. House,4,Gorden Bakken,LBT,8
-Harvey,Hesston City 1W-2P,U.S. House,4,Gorden Bakken,LBT,12
-Harvey,Newton City 1W-1P,U.S. House,4,Gorden Bakken,LBT,14
-Harvey,Newton City 1W-2P,U.S. House,4,Gorden Bakken,LBT,9
-Harvey,Newton City 1W-3P,U.S. House,4,Gorden Bakken,LBT,10
-Harvey,Newton City 2W-1P,U.S. House,4,Gorden Bakken,LBT,11
-Harvey,Newton City 2W-2P,U.S. House,4,Gorden Bakken,LBT,25
-Harvey,Newton City 3W-1P,U.S. House,4,Gorden Bakken,LBT,21
-Harvey,Newton City 3W-2P,U.S. House,4,Gorden Bakken,LBT,11
-Harvey,Newton City 3W-3P,U.S. House,4,Gorden Bakken,LBT,15
-Harvey,Newton City 3W-4P,U.S. House,4,Gorden Bakken,LBT,22
-Harvey,Newton City 4W-1P,U.S. House,4,Gorden Bakken,LBT,11
-Harvey,Newton City 4W-2P,U.S. House,4,Gorden Bakken,LBT,14
-Harvey,Newton City 4W-3P,U.S. House,4,Gorden Bakken,LBT,22
-Harvey,Newton City 4W-4P,U.S. House,4,Gorden Bakken,LBT,7
-Harvey,North Newton,U.S. House,4,Gorden Bakken,LBT,16
-Harvey,Sedgwick City,U.S. House,4,Gorden Bakken,LBT,13
-Harvey,Walton City,U.S. House,4,Gorden Bakken,LBT,7
-Harvey,Alta Township,U.S. House,4,Gorden Bakken,LBT,4
-Harvey,Burrton Township,U.S. House,4,Gorden Bakken,LBT,3
-Harvey,Darlington Township,U.S. House,4,Gorden Bakken,LBT,1
-Harvey,Darlington Twp North,U.S. House,4,Gorden Bakken,LBT,2
-Harvey,Emma Township,U.S. House,4,Gorden Bakken,LBT,2
-Harvey,Garden Township,U.S. House,4,Gorden Bakken,LBT,2
-Harvey,Halstead Township,U.S. House,4,Gorden Bakken,LBT,4
-Harvey,Highland Township,U.S. House,4,Gorden Bakken,LBT,7
-Harvey,Lake Township,U.S. House,4,Gorden Bakken,LBT,1
-Harvey,Lakin Township,U.S. House,4,Gorden Bakken,LBT,5
-Harvey,Macon Township,U.S. House,4,Gorden Bakken,LBT,4
-Harvey,Newton Township AB,U.S. House,4,Gorden Bakken,LBT,2
-Harvey,Newton Township CDE,U.S. House,4,Gorden Bakken,LBT,3
-Harvey,Pleasant Township,U.S. House,4,Gorden Bakken,LBT,4
-Harvey,Richland Township,U.S. House,4,Gorden Bakken,LBT,2
-Harvey,Sedgwick Township,U.S. House,4,Gorden Bakken,LBT,4
-Harvey,Walton Township,U.S. House,4,Gorden Bakken,LBT,6
-Harvey,Burrton City,U.S. House,4,Miranda Allen,IND,26
-Harvey,Halstead City 1W-1P,U.S. House,4,Miranda Allen,IND,20
-Harvey,Halstead City 1W-2P,U.S. House,4,Miranda Allen,IND,33
-Harvey,Hesston City 1W-1P,U.S. House,4,Miranda Allen,IND,56
-Harvey,Hesston City 1W-2P,U.S. House,4,Miranda Allen,IND,34
-Harvey,Newton City 1W-1P,U.S. House,4,Miranda Allen,IND,38
-Harvey,Newton City 1W-2P,U.S. House,4,Miranda Allen,IND,41
-Harvey,Newton City 1W-3P,U.S. House,4,Miranda Allen,IND,18
-Harvey,Newton City 2W-1P,U.S. House,4,Miranda Allen,IND,34
-Harvey,Newton City 2W-2P,U.S. House,4,Miranda Allen,IND,48
-Harvey,Newton City 3W-1P,U.S. House,4,Miranda Allen,IND,31
-Harvey,Newton City 3W-2P,U.S. House,4,Miranda Allen,IND,43
-Harvey,Newton City 3W-3P,U.S. House,4,Miranda Allen,IND,45
-Harvey,Newton City 3W-4P,U.S. House,4,Miranda Allen,IND,55
-Harvey,Newton City 4W-1P,U.S. House,4,Miranda Allen,IND,39
-Harvey,Newton City 4W-2P,U.S. House,4,Miranda Allen,IND,63
-Harvey,Newton City 4W-3P,U.S. House,4,Miranda Allen,IND,49
-Harvey,Newton City 4W-4P,U.S. House,4,Miranda Allen,IND,27
-Harvey,North Newton,U.S. House,4,Miranda Allen,IND,25
-Harvey,Sedgwick City,U.S. House,4,Miranda Allen,IND,35
-Harvey,Walton City,U.S. House,4,Miranda Allen,IND,9
-Harvey,Alta Township,U.S. House,4,Miranda Allen,IND,5
-Harvey,Burrton Township,U.S. House,4,Miranda Allen,IND,5
-Harvey,Darlington Township,U.S. House,4,Miranda Allen,IND,10
-Harvey,Darlington Twp North,U.S. House,4,Miranda Allen,IND,6
-Harvey,Emma Township,U.S. House,4,Miranda Allen,IND,12
-Harvey,Garden Township,U.S. House,4,Miranda Allen,IND,8
-Harvey,Halstead Township,U.S. House,4,Miranda Allen,IND,4
-Harvey,Highland Township,U.S. House,4,Miranda Allen,IND,9
-Harvey,Lake Township,U.S. House,4,Miranda Allen,IND,8
-Harvey,Lakin Township,U.S. House,4,Miranda Allen,IND,5
-Harvey,Macon Township,U.S. House,4,Miranda Allen,IND,16
-Harvey,Newton Township AB,U.S. House,4,Miranda Allen,IND,9
-Harvey,Newton Township CDE,U.S. House,4,Miranda Allen,IND,1
-Harvey,Pleasant Township,U.S. House,4,Miranda Allen,IND,10
-Harvey,Richland Township,U.S. House,4,Miranda Allen,IND,2
-Harvey,Sedgwick Township,U.S. House,4,Miranda Allen,IND,9
-Harvey,Walton Township,U.S. House,4,Miranda Allen,IND,10
-Harvey,Burrton City,U.S. House,4,Write-ins,,0
-Harvey,Halstead City 1W-1P,U.S. House,4,Write-ins,,0
-Harvey,Halstead City 1W-2P,U.S. House,4,Write-ins,,1
-Harvey,Hesston City 1W-1P,U.S. House,4,Write-ins,,2
-Harvey,Hesston City 1W-2P,U.S. House,4,Write-ins,,2
-Harvey,Newton City 1W-1P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 1W-2P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 1W-3P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 2W-1P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 2W-2P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 3W-1P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 3W-2P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 3W-3P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 3W-4P,U.S. House,4,Write-ins,,1
-Harvey,Newton City 4W-1P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 4W-2P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 4W-3P,U.S. House,4,Write-ins,,0
-Harvey,Newton City 4W-4P,U.S. House,4,Write-ins,,1
-Harvey,North Newton,U.S. House,4,Write-ins,,0
-Harvey,Sedgwick City,U.S. House,4,Write-ins,,0
-Harvey,Walton City,U.S. House,4,Write-ins,,0
-Harvey,Alta Township,U.S. House,4,Write-ins,,0
-Harvey,Burrton Township,U.S. House,4,Write-ins,,0
-Harvey,Darlington Township,U.S. House,4,Write-ins,,0
-Harvey,Darlington Twp North,U.S. House,4,Write-ins,,0
-Harvey,Emma Township,U.S. House,4,Write-ins,,0
-Harvey,Garden Township,U.S. House,4,Write-ins,,0
-Harvey,Halstead Township,U.S. House,4,Write-ins,,0
-Harvey,Highland Township,U.S. House,4,Write-ins,,0
-Harvey,Lake Township,U.S. House,4,Write-ins,,0
-Harvey,Lakin Township,U.S. House,4,Write-ins,,0
-Harvey,Macon Township,U.S. House,4,Write-ins,,0
-Harvey,Newton Township AB,U.S. House,4,Write-ins,,0
-Harvey,Newton Township CDE,U.S. House,4,Write-ins,,0
-Harvey,Pleasant Township,U.S. House,4,Write-ins,,0
-Harvey,Richland Township,U.S. House,4,Write-ins,,0
-Harvey,Sedgwick Township,U.S. House,4,Write-ins,,1
-Harvey,Walton Township,U.S. House,4,Write-ins,,0
-Harvey,Burrton City,State Senate,31,Carolyn McGinn,REP,231
-Harvey,Halstead City 1W-1P,State Senate,31,Carolyn McGinn,REP,283
-Harvey,Halstead City 1W-2P,State Senate,31,Carolyn McGinn,REP,387
-Harvey,Hesston City 1W-1P,State Senate,31,Carolyn McGinn,REP,699
-Harvey,Hesston City 1W-2P,State Senate,31,Carolyn McGinn,REP,713
-Harvey,Newton City 1W-1P,State Senate,31,Carolyn McGinn,REP,302
-Harvey,Newton City 1W-2P,State Senate,31,Carolyn McGinn,REP,230
-Harvey,Newton City 1W-3P,State Senate,31,Carolyn McGinn,REP,151
-Harvey,Newton City 2W-1P,State Senate,31,Carolyn McGinn,REP,212
-Harvey,Newton City 2W-2P,State Senate,31,Carolyn McGinn,REP,684
-Harvey,Newton City 3W-1P,State Senate,31,Carolyn McGinn,REP,270
-Harvey,Newton City 3W-2P,State Senate,31,Carolyn McGinn,REP,431
-Harvey,Newton City 3W-3P,State Senate,31,Carolyn McGinn,REP,400
-Harvey,Newton City 3W-4P,State Senate,31,Carolyn McGinn,REP,933
-Harvey,Newton City 4W-1P,State Senate,31,Carolyn McGinn,REP,342
-Harvey,Newton City 4W-2P,State Senate,31,Carolyn McGinn,REP,691
-Harvey,Newton City 4W-3P,State Senate,31,Carolyn McGinn,REP,484
-Harvey,Newton City 4W-4P,State Senate,31,Carolyn McGinn,REP,211
-Harvey,North Newton,State Senate,31,Carolyn McGinn,REP,757
-Harvey,Sedgwick City,State Senate,31,Carolyn McGinn,REP,531
-Harvey,Walton City,State Senate,31,Carolyn McGinn,REP,65
-Harvey,Alta Township,State Senate,31,Carolyn McGinn,REP,107
-Harvey,Burrton Township,State Senate,31,Carolyn McGinn,REP,80
-Harvey,Darlington Township,State Senate,31,Carolyn McGinn,REP,186
-Harvey,Darlington Twp North,State Senate,31,Carolyn McGinn,REP,51
-Harvey,Emma Township,State Senate,31,Carolyn McGinn,REP,227
-Harvey,Garden Township,State Senate,31,Carolyn McGinn,REP,126
-Harvey,Halstead Township,State Senate,31,Carolyn McGinn,REP,109
-Harvey,Highland Township,State Senate,31,Carolyn McGinn,REP,176
-Harvey,Lake Township,State Senate,31,Carolyn McGinn,REP,75
-Harvey,Lakin Township,State Senate,31,Carolyn McGinn,REP,112
-Harvey,Macon Township,State Senate,31,Carolyn McGinn,REP,186
-Harvey,Newton Township AB,State Senate,31,Carolyn McGinn,REP,131
-Harvey,Newton Township CDE,State Senate,31,Carolyn McGinn,REP,47
-Harvey,Pleasant Township,State Senate,31,Carolyn McGinn,REP,235
-Harvey,Richland Township,State Senate,31,Carolyn McGinn,REP,171
-Harvey,Sedgwick Township,State Senate,31,Carolyn McGinn,REP,134
-Harvey,Walton Township,State Senate,31,Carolyn McGinn,REP,113
-Harvey,Burrton City,State Senate,31,Michelle Vann,DEM,58
-Harvey,Halstead City 1W-1P,State Senate,31,Michelle Vann,DEM,56
-Harvey,Halstead City 1W-2P,State Senate,31,Michelle Vann,DEM,100
-Harvey,Hesston City 1W-1P,State Senate,31,Michelle Vann,DEM,173
-Harvey,Hesston City 1W-2P,State Senate,31,Michelle Vann,DEM,126
-Harvey,Newton City 1W-1P,State Senate,31,Michelle Vann,DEM,143
-Harvey,Newton City 1W-2P,State Senate,31,Michelle Vann,DEM,122
-Harvey,Newton City 1W-3P,State Senate,31,Michelle Vann,DEM,87
-Harvey,Newton City 2W-1P,State Senate,31,Michelle Vann,DEM,156
-Harvey,Newton City 2W-2P,State Senate,31,Michelle Vann,DEM,250
-Harvey,Newton City 3W-1P,State Senate,31,Michelle Vann,DEM,117
-Harvey,Newton City 3W-2P,State Senate,31,Michelle Vann,DEM,169
-Harvey,Newton City 3W-3P,State Senate,31,Michelle Vann,DEM,131
-Harvey,Newton City 3W-4P,State Senate,31,Michelle Vann,DEM,260
-Harvey,Newton City 4W-1P,State Senate,31,Michelle Vann,DEM,150
-Harvey,Newton City 4W-2P,State Senate,31,Michelle Vann,DEM,193
-Harvey,Newton City 4W-3P,State Senate,31,Michelle Vann,DEM,163
-Harvey,Newton City 4W-4P,State Senate,31,Michelle Vann,DEM,62
-Harvey,North Newton,State Senate,31,Michelle Vann,DEM,236
-Harvey,Sedgwick City,State Senate,31,Michelle Vann,DEM,76
-Harvey,Walton City,State Senate,31,Michelle Vann,DEM,35
-Harvey,Alta Township,State Senate,31,Michelle Vann,DEM,22
-Harvey,Burrton Township,State Senate,31,Michelle Vann,DEM,12
-Harvey,Darlington Township,State Senate,31,Michelle Vann,DEM,37
-Harvey,Darlington Twp North,State Senate,31,Michelle Vann,DEM,14
-Harvey,Emma Township,State Senate,31,Michelle Vann,DEM,46
-Harvey,Garden Township,State Senate,31,Michelle Vann,DEM,27
-Harvey,Halstead Township,State Senate,31,Michelle Vann,DEM,29
-Harvey,Highland Township,State Senate,31,Michelle Vann,DEM,35
-Harvey,Lake Township,State Senate,31,Michelle Vann,DEM,9
-Harvey,Lakin Township,State Senate,31,Michelle Vann,DEM,19
-Harvey,Macon Township,State Senate,31,Michelle Vann,DEM,51
-Harvey,Newton Township AB,State Senate,31,Michelle Vann,DEM,28
-Harvey,Newton Township CDE,State Senate,31,Michelle Vann,DEM,4
-Harvey,Pleasant Township,State Senate,31,Michelle Vann,DEM,38
-Harvey,Richland Township,State Senate,31,Michelle Vann,DEM,34
-Harvey,Sedgwick Township,State Senate,31,Michelle Vann,DEM,25
-Harvey,Walton Township,State Senate,31,Michelle Vann,DEM,29
-Harvey,Burrton City,State Senate,31,Write-ins,,0
-Harvey,Halstead City 1W-1P,State Senate,31,Write-ins,,1
-Harvey,Halstead City 1W-2P,State Senate,31,Write-ins,,1
-Harvey,Hesston City 1W-1P,State Senate,31,Write-ins,,0
-Harvey,Hesston City 1W-2P,State Senate,31,Write-ins,,4
-Harvey,Newton City 1W-1P,State Senate,31,Write-ins,,3
-Harvey,Newton City 1W-2P,State Senate,31,Write-ins,,2
-Harvey,Newton City 1W-3P,State Senate,31,Write-ins,,7
-Harvey,Newton City 2W-1P,State Senate,31,Write-ins,,4
-Harvey,Newton City 2W-2P,State Senate,31,Write-ins,,9
-Harvey,Newton City 3W-1P,State Senate,31,Write-ins,,6
-Harvey,Newton City 3W-2P,State Senate,31,Write-ins,,3
-Harvey,Newton City 3W-3P,State Senate,31,Write-ins,,1
-Harvey,Newton City 3W-4P,State Senate,31,Write-ins,,6
-Harvey,Newton City 4W-1P,State Senate,31,Write-ins,,1
-Harvey,Newton City 4W-2P,State Senate,31,Write-ins,,2
-Harvey,Newton City 4W-3P,State Senate,31,Write-ins,,2
-Harvey,Newton City 4W-4P,State Senate,31,Write-ins,,3
-Harvey,North Newton,State Senate,31,Write-ins,,4
-Harvey,Sedgwick City,State Senate,31,Write-ins,,0
-Harvey,Walton City,State Senate,31,Write-ins,,0
-Harvey,Alta Township,State Senate,31,Write-ins,,0
-Harvey,Burrton Township,State Senate,31,Write-ins,,2
-Harvey,Darlington Township,State Senate,31,Write-ins,,4
-Harvey,Darlington Twp North,State Senate,31,Write-ins,,0
-Harvey,Emma Township,State Senate,31,Write-ins,,0
-Harvey,Garden Township,State Senate,31,Write-ins,,0
-Harvey,Halstead Township,State Senate,31,Write-ins,,0
-Harvey,Highland Township,State Senate,31,Write-ins,,2
-Harvey,Lake Township,State Senate,31,Write-ins,,1
-Harvey,Lakin Township,State Senate,31,Write-ins,,1
-Harvey,Macon Township,State Senate,31,Write-ins,,4
-Harvey,Newton Township AB,State Senate,31,Write-ins,,0
-Harvey,Newton Township CDE,State Senate,31,Write-ins,,0
-Harvey,Pleasant Township,State Senate,31,Write-ins,,8
-Harvey,Richland Township,State Senate,31,Write-ins,,4
-Harvey,Sedgwick Township,State Senate,31,Write-ins,,1
-Harvey,Walton Township,State Senate,31,Write-ins,,6
-Harvey,Newton City 1W-1P,State House,72,Marc Rhoades,REP,189
-Harvey,Newton City 1W-2P,State House,72,Marc Rhoades,REP,154
-Harvey,Newton City 1W-3P,State House,72,Marc Rhoades,REP,130
-Harvey,Newton City 2W-1P,State House,72,Marc Rhoades,REP,162
-Harvey,Newton City 2W-2P,State House,72,Marc Rhoades,REP,470
-Harvey,Newton City 3W-1P,State House,72,Marc Rhoades,REP,206
-Harvey,Newton City 3W-2P,State House,72,Marc Rhoades,REP,321
-Harvey,Newton City 3W-3P,State House,72,Marc Rhoades,REP,272
-Harvey,Newton City 3W-4P,State House,72,Marc Rhoades,REP,655
-Harvey,Newton City 4W-1P,State House,72,Marc Rhoades,REP,227
-Harvey,Newton City 4W-2P,State House,72,Marc Rhoades,REP,396
-Harvey,Newton City 4W-3P,State House,72,Marc Rhoades,REP,304
-Harvey,Newton City 4W-4P,State House,72,Marc Rhoades,REP,145
-Harvey,North Newton,State House,72,Marc Rhoades,REP,305
-Harvey,Darlington Twp North,State House,72,Marc Rhoades,REP,44
-Harvey,Newton Township AB,State House,72,Marc Rhoades,REP,112
-Harvey,Newton Township CDE,State House,72,Marc Rhoades,REP,36
-Harvey,Pleasant Township,State House,72,Marc Rhoades,REP,195
-Harvey,Richland Township,State House,72,Marc Rhoades,REP,171
-Harvey,Newton City 1W-1P,State House,72,Tim Hodge,DEM,267
-Harvey,Newton City 1W-2P,State House,72,Tim Hodge,DEM,205
-Harvey,Newton City 1W-3P,State House,72,Tim Hodge,DEM,118
-Harvey,Newton City 2W-1P,State House,72,Tim Hodge,DEM,211
-Harvey,Newton City 2W-2P,State House,72,Tim Hodge,DEM,499
-Harvey,Newton City 3W-1P,State House,72,Tim Hodge,DEM,209
-Harvey,Newton City 3W-2P,State House,72,Tim Hodge,DEM,300
-Harvey,Newton City 3W-3P,State House,72,Tim Hodge,DEM,265
-Harvey,Newton City 3W-4P,State House,72,Tim Hodge,DEM,567
-Harvey,Newton City 4W-1P,State House,72,Tim Hodge,DEM,283
-Harvey,Newton City 4W-2P,State House,72,Tim Hodge,DEM,504
-Harvey,Newton City 4W-3P,State House,72,Tim Hodge,DEM,350
-Harvey,Newton City 4W-4P,State House,72,Tim Hodge,DEM,140
-Harvey,North Newton,State House,72,Tim Hodge,DEM,712
-Harvey,Darlington Twp North,State House,72,Tim Hodge,DEM,22
-Harvey,Newton Township AB,State House,72,Tim Hodge,DEM,64
-Harvey,Newton Township CDE,State House,72,Tim Hodge,DEM,17
-Harvey,Pleasant Township,State House,72,Tim Hodge,DEM,98
-Harvey,Richland Township,State House,72,Tim Hodge,DEM,41
-Harvey,Newton City 1W-1P,State House,72,Write-ins,,0
-Harvey,Newton City 1W-2P,State House,72,Write-ins,,0
-Harvey,Newton City 1W-3P,State House,72,Write-ins,,0
-Harvey,Newton City 2W-1P,State House,72,Write-ins,,0
-Harvey,Newton City 2W-2P,State House,72,Write-ins,,1
-Harvey,Newton City 3W-1P,State House,72,Write-ins,,0
-Harvey,Newton City 3W-2P,State House,72,Write-ins,,1
-Harvey,Newton City 3W-3P,State House,72,Write-ins,,2
-Harvey,Newton City 3W-4P,State House,72,Write-ins,,1
-Harvey,Newton City 4W-1P,State House,72,Write-ins,,0
-Harvey,Newton City 4W-2P,State House,72,Write-ins,,3
-Harvey,Newton City 4W-3P,State House,72,Write-ins,,1
-Harvey,Newton City 4W-4P,State House,72,Write-ins,,0
-Harvey,North Newton,State House,72,Write-ins,,0
-Harvey,Darlington Twp North,State House,72,Write-ins,,0
-Harvey,Newton Township AB,State House,72,Write-ins,,0
-Harvey,Newton Township CDE,State House,72,Write-ins,,0
-Harvey,Pleasant Township,State House,72,Write-ins,,0
-Harvey,Richland Township,State House,72,Write-ins,,0
-Harvey,Burrton City,State House,74,Don Schroeder,REP,258
-Harvey,Halstead City 1W-1P,State House,74,Don Schroeder,REP,314
-Harvey,Halstead City 1W-2P,State House,74,Don Schroeder,REP,433
-Harvey,Hesston City 1W-1P,State House,74,Don Schroeder,REP,792
-Harvey,Hesston City 1W-2P,State House,74,Don Schroeder,REP,779
-Harvey,Sedgwick City,State House,74,Don Schroeder,REP,538
-Harvey,Walton City,State House,74,Don Schroeder,REP,93
-Harvey,Alta Township,State House,74,Don Schroeder,REP,112
-Harvey,Burrton Township,State House,74,Don Schroeder,REP,89
-Harvey,Darlington Township,State House,74,Don Schroeder,REP,194
-Harvey,Emma Township,State House,74,Don Schroeder,REP,254
-Harvey,Garden Township,State House,74,Don Schroeder,REP,138
-Harvey,Halstead Township,State House,74,Don Schroeder,REP,118
-Harvey,Highland Township,State House,74,Don Schroeder,REP,183
-Harvey,Lake Township,State House,74,Don Schroeder,REP,78
-Harvey,Lakin Township,State House,74,Don Schroeder,REP,119
-Harvey,Macon Township,State House,74,Don Schroeder,REP,216
-Harvey,Sedgwick Township,State House,74,Don Schroeder,REP,145
-Harvey,Walton Township,State House,74,Don Schroeder,REP,134
-Harvey,Burrton City,State House,74,Write-ins,,1
-Harvey,Halstead City 1W-1P,State House,74,Write-ins,,2
-Harvey,Halstead City 1W-2P,State House,74,Write-ins,,11
-Harvey,Hesston City 1W-1P,State House,74,Write-ins,,7
-Harvey,Hesston City 1W-2P,State House,74,Write-ins,,5
-Harvey,Sedgwick City,State House,74,Write-ins,,3
-Harvey,Walton City,State House,74,Write-ins,,0
-Harvey,Alta Township,State House,74,Write-ins,,2
-Harvey,Burrton Township,State House,74,Write-ins,,2
-Harvey,Darlington Township,State House,74,Write-ins,,0
-Harvey,Emma Township,State House,74,Write-ins,,3
-Harvey,Garden Township,State House,74,Write-ins,,1
-Harvey,Halstead Township,State House,74,Write-ins,,1
-Harvey,Highland Township,State House,74,Write-ins,,4
-Harvey,Lake Township,State House,74,Write-ins,,1
-Harvey,Lakin Township,State House,74,Write-ins,,0
-Harvey,Macon Township,State House,74,Write-ins,,0
-Harvey,Sedgwick Township,State House,74,Write-ins,,3
-Harvey,Walton Township,State House,74,Write-ins,,2
+county,precinct,office,district,party,candidate,votes,vtd
+HARVEY,Alta Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",112,000010
+HARVEY,Burrton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",89,000020
+HARVEY,Emma Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",254,000040
+HARVEY,Garden Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",138,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",314,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",433,000070
+HARVEY,Halstead Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",118,000080
+HARVEY,Hesston Precinct 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",792,000090
+HARVEY,Hesston Precinct 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",779,00010A
+HARVEY,Highland Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",183,000110
+HARVEY,Lake Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",78,000120
+HARVEY,Lakin Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",119,000130
+HARVEY,Macon Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",216,000140
+HARVEY,Newton City Ward 1 Precinct 1,Kansas House of Representatives,72,Democratic,"Hodge, Tim",267,000150
+HARVEY,Newton City Ward 1 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",189,000150
+HARVEY,Newton City Ward 1 Precinct 2,Kansas House of Representatives,72,Democratic,"Hodge, Tim",205,000160
+HARVEY,Newton City Ward 1 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",154,000160
+HARVEY,Newton City Ward 1 Precinct 3,Kansas House of Representatives,72,Democratic,"Hodge, Tim",118,000170
+HARVEY,Newton City Ward 1 Precinct 3,Kansas House of Representatives,72,Republican,"Rhoades, Marc",130,000170
+HARVEY,Newton City Ward 2 Precinct 1,Kansas House of Representatives,72,Democratic,"Hodge, Tim",211,000180
+HARVEY,Newton City Ward 2 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",162,000180
+HARVEY,Newton City Ward 2 Precinct 2,Kansas House of Representatives,72,Democratic,"Hodge, Tim",499,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",470,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Kansas House of Representatives,72,Democratic,"Hodge, Tim",209,000200
+HARVEY,Newton City Ward 3 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",206,000200
+HARVEY,Newton City Ward 3 Precinct 2,Kansas House of Representatives,72,Democratic,"Hodge, Tim",300,000210
+HARVEY,Newton City Ward 3 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",321,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas House of Representatives,72,Democratic,"Hodge, Tim",265,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas House of Representatives,72,Republican,"Rhoades, Marc",272,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Kansas House of Representatives,72,Democratic,"Hodge, Tim",283,000230
+HARVEY,Newton City Ward 4 Precinct 1,Kansas House of Representatives,72,Republican,"Rhoades, Marc",227,000230
+HARVEY,Newton City Ward 4 Precinct 2,Kansas House of Representatives,72,Democratic,"Hodge, Tim",504,000240
+HARVEY,Newton City Ward 4 Precinct 2,Kansas House of Representatives,72,Republican,"Rhoades, Marc",396,000240
+HARVEY,Newton City Ward 4 Precinct 3,Kansas House of Representatives,72,Democratic,"Hodge, Tim",350,000250
+HARVEY,Newton City Ward 4 Precinct 3,Kansas House of Representatives,72,Republican,"Rhoades, Marc",304,000250
+HARVEY,Newton City Ward 4 Precinct 4,Kansas House of Representatives,72,Democratic,"Hodge, Tim",140,000260
+HARVEY,Newton City Ward 4 Precinct 4,Kansas House of Representatives,72,Republican,"Rhoades, Marc",145,000260
+HARVEY,Newton Township Part A,Kansas House of Representatives,72,Democratic,"Hodge, Tim",1,00027A
+HARVEY,Newton Township Part A,Kansas House of Representatives,72,Republican,"Rhoades, Marc",2,00027A
+HARVEY,Newton Township Part B,Kansas House of Representatives,72,Democratic,"Hodge, Tim",63,00027B
+HARVEY,Newton Township Part B,Kansas House of Representatives,72,Republican,"Rhoades, Marc",110,00027B
+HARVEY,Newton Township Part B Exclave,Kansas House of Representatives,72,Democratic,"Hodge, Tim",0,00027C
+HARVEY,Newton Township Part B Exclave,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,00027C
+HARVEY,Newton Township Part C,Kansas House of Representatives,72,Democratic,"Hodge, Tim",1,00027D
+HARVEY,Newton Township Part C,Kansas House of Representatives,72,Republican,"Rhoades, Marc",3,00027D
+HARVEY,North Newton City,Kansas House of Representatives,72,Democratic,"Hodge, Tim",712,000280
+HARVEY,North Newton City,Kansas House of Representatives,72,Republican,"Rhoades, Marc",305,000280
+HARVEY,Pleasant Township,Kansas House of Representatives,72,Democratic,"Hodge, Tim",98,000290
+HARVEY,Pleasant Township,Kansas House of Representatives,72,Republican,"Rhoades, Marc",195,000290
+HARVEY,Richland Township,Kansas House of Representatives,72,Democratic,"Hodge, Tim",41,000300
+HARVEY,Richland Township,Kansas House of Representatives,72,Republican,"Rhoades, Marc",171,000300
+HARVEY,Sedgwick Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",145,000310
+HARVEY,Walton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",134,000320
+HARVEY,Darlington Township H72,Kansas House of Representatives,72,Democratic,"Hodge, Tim",22,120020
+HARVEY,Darlington Township H72,Kansas House of Representatives,72,Republican,"Rhoades, Marc",44,120020
+HARVEY,Darlington Township H74,Kansas House of Representatives,74,Republican,"Schroeder, Don",194,120030
+HARVEY,Newton City Ward 3 Precinct 4,Kansas House of Representatives,72,Democratic,"Hodge, Tim",567,800010
+HARVEY,Newton City Ward 3 Precinct 4,Kansas House of Representatives,72,Republican,"Rhoades, Marc",655,800010
+HARVEY,Burrton City,Kansas House of Representatives,74,Republican,"Schroeder, Don",258,900010
+HARVEY,Sedgwick City,Kansas House of Representatives,74,Republican,"Schroeder, Don",538,900020
+HARVEY,Walton City,Kansas House of Representatives,74,Republican,"Schroeder, Don",93,900030
+HARVEY,Burrton City Exclave,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,900040
+HARVEY,Newton Township Part D,Kansas House of Representatives,72,Democratic,"Hodge, Tim",16,900050
+HARVEY,Newton Township Part D,Kansas House of Representatives,72,Republican,"Rhoades, Marc",32,900050
+HARVEY,Newton Township Part E,Kansas House of Representatives,72,Democratic,"Hodge, Tim",0,900060
+HARVEY,Newton Township Part E,Kansas House of Representatives,72,Republican,"Rhoades, Marc",1,900060
+HARVEY,Newton Township Part F,Kansas House of Representatives,72,Democratic,"Hodge, Tim",0,900070
+HARVEY,Newton Township Part F,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900070
+HARVEY,Newton Township Part G,Kansas House of Representatives,72,Democratic,"Hodge, Tim",0,900080
+HARVEY,Newton Township Part G,Kansas House of Representatives,72,Republican,"Rhoades, Marc",0,900080
+HARVEY,Alta Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",22,000010
+HARVEY,Alta Township,Kansas Senate,31,Republican,"McGinn, Carolyn",107,000010
+HARVEY,Burrton Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",12,000020
+HARVEY,Burrton Township,Kansas Senate,31,Republican,"McGinn, Carolyn",80,000020
+HARVEY,Emma Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",46,000040
+HARVEY,Emma Township,Kansas Senate,31,Republican,"McGinn, Carolyn",227,000040
+HARVEY,Garden Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",27,000050
+HARVEY,Garden Township,Kansas Senate,31,Republican,"McGinn, Carolyn",126,000050
+HARVEY,Halstead City Ward 1 Precinct 1,Kansas Senate,31,Democratic,"Vann, J. Michelle",56,000060
+HARVEY,Halstead City Ward 1 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",283,000060
+HARVEY,Halstead City Ward 1 Precinct 2,Kansas Senate,31,Democratic,"Vann, J. Michelle",100,000070
+HARVEY,Halstead City Ward 1 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",387,000070
+HARVEY,Halstead Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",29,000080
+HARVEY,Halstead Township,Kansas Senate,31,Republican,"McGinn, Carolyn",109,000080
+HARVEY,Hesston Precinct 1,Kansas Senate,31,Democratic,"Vann, J. Michelle",173,000090
+HARVEY,Hesston Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",699,000090
+HARVEY,Hesston Precinct 2,Kansas Senate,31,Democratic,"Vann, J. Michelle",126,00010A
+HARVEY,Hesston Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",713,00010A
+HARVEY,Highland Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",35,000110
+HARVEY,Highland Township,Kansas Senate,31,Republican,"McGinn, Carolyn",176,000110
+HARVEY,Lake Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",9,000120
+HARVEY,Lake Township,Kansas Senate,31,Republican,"McGinn, Carolyn",75,000120
+HARVEY,Lakin Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",19,000130
+HARVEY,Lakin Township,Kansas Senate,31,Republican,"McGinn, Carolyn",112,000130
+HARVEY,Macon Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",51,000140
+HARVEY,Macon Township,Kansas Senate,31,Republican,"McGinn, Carolyn",186,000140
+HARVEY,Newton City Ward 1 Precinct 1,Kansas Senate,31,Democratic,"Vann, J. Michelle",143,000150
+HARVEY,Newton City Ward 1 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",302,000150
+HARVEY,Newton City Ward 1 Precinct 2,Kansas Senate,31,Democratic,"Vann, J. Michelle",122,000160
+HARVEY,Newton City Ward 1 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",230,000160
+HARVEY,Newton City Ward 1 Precinct 3,Kansas Senate,31,Democratic,"Vann, J. Michelle",87,000170
+HARVEY,Newton City Ward 1 Precinct 3,Kansas Senate,31,Republican,"McGinn, Carolyn",151,000170
+HARVEY,Newton City Ward 2 Precinct 1,Kansas Senate,31,Democratic,"Vann, J. Michelle",156,000180
+HARVEY,Newton City Ward 2 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",212,000180
+HARVEY,Newton City Ward 2 Precinct 2,Kansas Senate,31,Democratic,"Vann, J. Michelle",250,00019A
+HARVEY,Newton City Ward 2 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",684,00019A
+HARVEY,Newton City Ward 3 Precinct 1,Kansas Senate,31,Democratic,"Vann, J. Michelle",117,000200
+HARVEY,Newton City Ward 3 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",270,000200
+HARVEY,Newton City Ward 3 Precinct 2,Kansas Senate,31,Democratic,"Vann, J. Michelle",169,000210
+HARVEY,Newton City Ward 3 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",431,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas Senate,31,Democratic,"Vann, J. Michelle",131,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,Kansas Senate,31,Republican,"McGinn, Carolyn",400,00022A
+HARVEY,Newton City Ward 4 Precinct 1,Kansas Senate,31,Democratic,"Vann, J. Michelle",150,000230
+HARVEY,Newton City Ward 4 Precinct 1,Kansas Senate,31,Republican,"McGinn, Carolyn",342,000230
+HARVEY,Newton City Ward 4 Precinct 2,Kansas Senate,31,Democratic,"Vann, J. Michelle",193,000240
+HARVEY,Newton City Ward 4 Precinct 2,Kansas Senate,31,Republican,"McGinn, Carolyn",691,000240
+HARVEY,Newton City Ward 4 Precinct 3,Kansas Senate,31,Democratic,"Vann, J. Michelle",163,000250
+HARVEY,Newton City Ward 4 Precinct 3,Kansas Senate,31,Republican,"McGinn, Carolyn",484,000250
+HARVEY,Newton City Ward 4 Precinct 4,Kansas Senate,31,Democratic,"Vann, J. Michelle",62,000260
+HARVEY,Newton City Ward 4 Precinct 4,Kansas Senate,31,Republican,"McGinn, Carolyn",211,000260
+HARVEY,Newton Township Part A,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,00027A
+HARVEY,Newton Township Part A,Kansas Senate,31,Republican,"McGinn, Carolyn",3,00027A
+HARVEY,Newton Township Part B,Kansas Senate,31,Democratic,"Vann, J. Michelle",28,00027B
+HARVEY,Newton Township Part B,Kansas Senate,31,Republican,"McGinn, Carolyn",128,00027B
+HARVEY,Newton Township Part B Exclave,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,00027C
+HARVEY,Newton Township Part B Exclave,Kansas Senate,31,Republican,"McGinn, Carolyn",0,00027C
+HARVEY,Newton Township Part C,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,00027D
+HARVEY,Newton Township Part C,Kansas Senate,31,Republican,"McGinn, Carolyn",4,00027D
+HARVEY,North Newton City,Kansas Senate,31,Democratic,"Vann, J. Michelle",236,000280
+HARVEY,North Newton City,Kansas Senate,31,Republican,"McGinn, Carolyn",757,000280
+HARVEY,Pleasant Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",38,000290
+HARVEY,Pleasant Township,Kansas Senate,31,Republican,"McGinn, Carolyn",235,000290
+HARVEY,Richland Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",34,000300
+HARVEY,Richland Township,Kansas Senate,31,Republican,"McGinn, Carolyn",171,000300
+HARVEY,Sedgwick Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",25,000310
+HARVEY,Sedgwick Township,Kansas Senate,31,Republican,"McGinn, Carolyn",134,000310
+HARVEY,Walton Township,Kansas Senate,31,Democratic,"Vann, J. Michelle",29,000320
+HARVEY,Walton Township,Kansas Senate,31,Republican,"McGinn, Carolyn",113,000320
+HARVEY,Darlington Township H72,Kansas Senate,31,Democratic,"Vann, J. Michelle",14,120020
+HARVEY,Darlington Township H72,Kansas Senate,31,Republican,"McGinn, Carolyn",51,120020
+HARVEY,Darlington Township H74,Kansas Senate,31,Democratic,"Vann, J. Michelle",37,120030
+HARVEY,Darlington Township H74,Kansas Senate,31,Republican,"McGinn, Carolyn",186,120030
+HARVEY,Newton City Ward 3 Precinct 4,Kansas Senate,31,Democratic,"Vann, J. Michelle",260,800010
+HARVEY,Newton City Ward 3 Precinct 4,Kansas Senate,31,Republican,"McGinn, Carolyn",933,800010
+HARVEY,Burrton City,Kansas Senate,31,Democratic,"Vann, J. Michelle",58,900010
+HARVEY,Burrton City,Kansas Senate,31,Republican,"McGinn, Carolyn",231,900010
+HARVEY,Sedgwick City,Kansas Senate,31,Democratic,"Vann, J. Michelle",76,900020
+HARVEY,Sedgwick City,Kansas Senate,31,Republican,"McGinn, Carolyn",531,900020
+HARVEY,Walton City,Kansas Senate,31,Democratic,"Vann, J. Michelle",35,900030
+HARVEY,Walton City,Kansas Senate,31,Republican,"McGinn, Carolyn",65,900030
+HARVEY,Burrton City Exclave,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,900040
+HARVEY,Burrton City Exclave,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900040
+HARVEY,Newton Township Part D,Kansas Senate,31,Democratic,"Vann, J. Michelle",4,900050
+HARVEY,Newton Township Part D,Kansas Senate,31,Republican,"McGinn, Carolyn",42,900050
+HARVEY,Newton Township Part E,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,900060
+HARVEY,Newton Township Part E,Kansas Senate,31,Republican,"McGinn, Carolyn",1,900060
+HARVEY,Newton Township Part F,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,900070
+HARVEY,Newton Township Part F,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900070
+HARVEY,Newton Township Part G,Kansas Senate,31,Democratic,"Vann, J. Michelle",0,900080
+HARVEY,Newton Township Part G,Kansas Senate,31,Republican,"McGinn, Carolyn",0,900080
+HARVEY,Alta Township,President / Vice President,,independent,"Stein, Jill",5,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"McMullin, Evan",1,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+HARVEY,Alta Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+HARVEY,Alta Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000010
+HARVEY,Alta Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+HARVEY,Alta Township,President / Vice President,,Republican,"Trump, Donald J.",87,000010
+HARVEY,Burrton Township,President / Vice President,,independent,"Stein, Jill",3,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+HARVEY,Burrton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+HARVEY,Burrton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000020
+HARVEY,Burrton Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+HARVEY,Burrton Township,President / Vice President,,Republican,"Trump, Donald J.",64,000020
+HARVEY,Emma Township,President / Vice President,,independent,"Stein, Jill",5,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"McMullin, Evan",3,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+HARVEY,Emma Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+HARVEY,Emma Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000040
+HARVEY,Emma Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000040
+HARVEY,Emma Township,President / Vice President,,Republican,"Trump, Donald J.",198,000040
+HARVEY,Garden Township,President / Vice President,,independent,"Stein, Jill",3,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+HARVEY,Garden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+HARVEY,Garden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000050
+HARVEY,Garden Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+HARVEY,Garden Township,President / Vice President,,Republican,"Trump, Donald J.",97,000050
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",2,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",3,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",27,000060
+HARVEY,Halstead City Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",221,000060
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",3,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",141,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",40,000070
+HARVEY,Halstead City Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",295,000070
+HARVEY,Halstead Township,President / Vice President,,independent,"Stein, Jill",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"McMullin, Evan",1,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+HARVEY,Halstead Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+HARVEY,Halstead Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000080
+HARVEY,Halstead Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+HARVEY,Halstead Township,President / Vice President,,Republican,"Trump, Donald J.",86,000080
+HARVEY,Hesston Precinct 1,President / Vice President,,independent,"Stein, Jill",16,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"McMullin, Evan",10,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",357,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",49,000090
+HARVEY,Hesston Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",459,000090
+HARVEY,Hesston Precinct 2,President / Vice President,,independent,"Stein, Jill",19,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",1,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",1,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"McMullin, Evan",17,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",273,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",34,00010A
+HARVEY,Hesston Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",512,00010A
+HARVEY,Highland Township,President / Vice President,,independent,"Stein, Jill",10,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"McMullin, Evan",1,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+HARVEY,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+HARVEY,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",87,000110
+HARVEY,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000110
+HARVEY,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",105,000110
+HARVEY,Lake Township,President / Vice President,,independent,"Stein, Jill",3,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+HARVEY,Lake Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+HARVEY,Lake Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000120
+HARVEY,Lake Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000120
+HARVEY,Lake Township,President / Vice President,,Republican,"Trump, Donald J.",70,000120
+HARVEY,Lakin Township,President / Vice President,,independent,"Stein, Jill",1,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+HARVEY,Lakin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+HARVEY,Lakin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000130
+HARVEY,Lakin Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000130
+HARVEY,Lakin Township,President / Vice President,,Republican,"Trump, Donald J.",98,000130
+HARVEY,Macon Township,President / Vice President,,independent,"Stein, Jill",1,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Castle, Darrell L",1,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"McMullin, Evan",4,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+HARVEY,Macon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+HARVEY,Macon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000140
+HARVEY,Macon Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000140
+HARVEY,Macon Township,President / Vice President,,Republican,"Trump, Donald J.",160,000140
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",17,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",4,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",169,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",28,000150
+HARVEY,Newton City Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",235,000150
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",13,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",2,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",145,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",23,000160
+HARVEY,Newton City Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",181,000160
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,independent,"Stein, Jill",18,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",1,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",102,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000170
+HARVEY,Newton City Ward 1 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",123,000170
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",8,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",159,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",20,000180
+HARVEY,Newton City Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",190,000180
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",23,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",3,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",359,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",37,00019A
+HARVEY,Newton City Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",552,00019A
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",11,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",4,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",152,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",22,000200
+HARVEY,Newton City Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",223,000200
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",19,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",8,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",215,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",32,000210
+HARVEY,Newton City Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",345,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,independent,"Stein, Jill",16,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Hedges, James A",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"McMullin, Evan",2,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Smith, Mike",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",189,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Libertarian,"Johnson, Gary",21,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,President / Vice President,,Republican,"Trump, Donald J.",307,00022A
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",17,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",203,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",23,000230
+HARVEY,Newton City Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",257,000230
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",25,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",6,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",345,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",37,000240
+HARVEY,Newton City Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",489,000240
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",16,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",7,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",227,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",36,000250
+HARVEY,Newton City Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",357,000250
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,independent,"Stein, Jill",10,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",1,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",115,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",7,000260
+HARVEY,Newton City Ward 4 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",150,000260
+HARVEY,Newton Township Part A,President / Vice President,,independent,"Stein, Jill",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Hedges, James A",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"McMullin, Evan",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Perry, Darryl",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Smith, Mike",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Sood, Ajay",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00027A
+HARVEY,Newton Township Part A,President / Vice President,,Republican,"Trump, Donald J.",3,00027A
+HARVEY,Newton Township Part B,President / Vice President,,independent,"Stein, Jill",2,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Hedges, James A",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"McMullin, Evan",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Perry, Darryl",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Smith, Mike",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Sood, Ajay",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",8,00027B
+HARVEY,Newton Township Part B,President / Vice President,,Republican,"Trump, Donald J.",117,00027B
+HARVEY,Newton Township Part B Exclave,President / Vice President,,independent,"Stein, Jill",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Hedges, James A",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Smith, Mike",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027C
+HARVEY,Newton Township Part B Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00027C
+HARVEY,Newton Township Part C,President / Vice President,,independent,"Stein, Jill",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Castle, Darrell L",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Giordani, Rocky",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Hedges, James A",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Hoefling, Tom",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Kahn, Lynn",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"La Riva, Gloria",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Levinson, Michael S.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Maturen, Michael A",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"McMullin, Evan",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Perry, Darryl",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Schriner, Joe C",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Smith, Mike",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Sood, Ajay",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Sterling, Shawna",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,00027D
+HARVEY,Newton Township Part C,President / Vice President,,Republican,"Trump, Donald J.",3,00027D
+HARVEY,North Newton City,President / Vice President,,independent,"Stein, Jill",21,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Hedges, James A",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"McMullin, Evan",5,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Perry, Darryl",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Smith, Mike",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Sood, Ajay",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+HARVEY,North Newton City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+HARVEY,North Newton City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",583,000280
+HARVEY,North Newton City,President / Vice President,,Libertarian,"Johnson, Gary",32,000280
+HARVEY,North Newton City,President / Vice President,,Republican,"Trump, Donald J.",364,000280
+HARVEY,Pleasant Township,President / Vice President,,independent,"Stein, Jill",4,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",1,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+HARVEY,Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+HARVEY,Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,000290
+HARVEY,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000290
+HARVEY,Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",206,000290
+HARVEY,Richland Township,President / Vice President,,independent,"Stein, Jill",3,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"McMullin, Evan",4,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+HARVEY,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+HARVEY,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000300
+HARVEY,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000300
+HARVEY,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",169,000300
+HARVEY,Sedgwick Township,President / Vice President,,independent,"Stein, Jill",2,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"McMullin, Evan",3,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+HARVEY,Sedgwick Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000310
+HARVEY,Sedgwick Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000310
+HARVEY,Sedgwick Township,President / Vice President,,Republican,"Trump, Donald J.",118,000310
+HARVEY,Walton Township,President / Vice President,,independent,"Stein, Jill",5,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"McMullin, Evan",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+HARVEY,Walton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+HARVEY,Walton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000320
+HARVEY,Walton Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000320
+HARVEY,Walton Township,President / Vice President,,Republican,"Trump, Donald J.",102,000320
+HARVEY,Darlington Township H72,President / Vice President,,independent,"Stein, Jill",1,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Hedges, James A",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"McMullin, Evan",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Perry, Darryl",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Smith, Mike",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Sood, Ajay",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+HARVEY,Darlington Township H72,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,120020
+HARVEY,Darlington Township H72,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+HARVEY,Darlington Township H72,President / Vice President,,Republican,"Trump, Donald J.",50,120020
+HARVEY,Darlington Township H74,President / Vice President,,independent,"Stein, Jill",2,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Hedges, James A",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"McMullin, Evan",2,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Perry, Darryl",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Smith, Mike",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Sood, Ajay",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+HARVEY,Darlington Township H74,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,120030
+HARVEY,Darlington Township H74,President / Vice President,,Libertarian,"Johnson, Gary",2,120030
+HARVEY,Darlington Township H74,President / Vice President,,Republican,"Trump, Donald J.",175,120030
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,independent,"Stein, Jill",24,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",14,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",363,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",61,800010
+HARVEY,Newton City Ward 3 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",760,800010
+HARVEY,Burrton City,President / Vice President,,independent,"Stein, Jill",4,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Hedges, James A",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"McMullin, Evan",2,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Perry, Darryl",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Smith, Mike",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Sood, Ajay",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+HARVEY,Burrton City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+HARVEY,Burrton City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,900010
+HARVEY,Burrton City,President / Vice President,,Libertarian,"Johnson, Gary",14,900010
+HARVEY,Burrton City,President / Vice President,,Republican,"Trump, Donald J.",219,900010
+HARVEY,Sedgwick City,President / Vice President,,independent,"Stein, Jill",19,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Hedges, James A",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"McMullin, Evan",2,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Perry, Darryl",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Smith, Mike",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Sood, Ajay",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+HARVEY,Sedgwick City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+HARVEY,Sedgwick City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",132,900020
+HARVEY,Sedgwick City,President / Vice President,,Libertarian,"Johnson, Gary",31,900020
+HARVEY,Sedgwick City,President / Vice President,,Republican,"Trump, Donald J.",423,900020
+HARVEY,Walton City,President / Vice President,,independent,"Stein, Jill",10,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Hedges, James A",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"McMullin, Evan",1,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Perry, Darryl",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Smith, Mike",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Sood, Ajay",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+HARVEY,Walton City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+HARVEY,Walton City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,900030
+HARVEY,Walton City,President / Vice President,,Libertarian,"Johnson, Gary",1,900030
+HARVEY,Walton City,President / Vice President,,Republican,"Trump, Donald J.",64,900030
+HARVEY,Burrton City Exclave,President / Vice President,,independent,"Stein, Jill",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Hedges, James A",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Smith, Mike",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+HARVEY,Burrton City Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+HARVEY,Newton Township Part D,President / Vice President,,independent,"Stein, Jill",1,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Hedges, James A",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"McMullin, Evan",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Perry, Darryl",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Smith, Mike",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Sood, Ajay",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+HARVEY,Newton Township Part D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,900050
+HARVEY,Newton Township Part D,President / Vice President,,Libertarian,"Johnson, Gary",4,900050
+HARVEY,Newton Township Part D,President / Vice President,,Republican,"Trump, Donald J.",33,900050
+HARVEY,Newton Township Part E,President / Vice President,,independent,"Stein, Jill",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Hedges, James A",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"McMullin, Evan",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Perry, Darryl",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Smith, Mike",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Sood, Ajay",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+HARVEY,Newton Township Part E,President / Vice President,,Republican,"Trump, Donald J.",1,900060
+HARVEY,Newton Township Part F,President / Vice President,,independent,"Stein, Jill",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Basiago, Andrew D.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Castle, Darrell L",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Giordani, Rocky",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Hedges, James A",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Kahn, Lynn",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"La Riva, Gloria",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Levinson, Michael S.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Maturen, Michael A",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"McMullin, Evan",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Moorehead, Monica G.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Perry, Darryl",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Schriner, Joe C",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Smith, Mike",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Sood, Ajay",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Sterling, Shawna",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Valdivia, Anthony J",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+HARVEY,Newton Township Part F,President / Vice President,,Republican,"Trump, Donald J.",0,900070
+HARVEY,Newton Township Part G,President / Vice President,,independent,"Stein, Jill",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Basiago, Andrew D.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Castle, Darrell L",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Giordani, Rocky",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Hedges, James A",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Kahn, Lynn",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"La Riva, Gloria",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Levinson, Michael S.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Maturen, Michael A",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"McMullin, Evan",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Moorehead, Monica G.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Perry, Darryl",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Schriner, Joe C",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Smith, Mike",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Sood, Ajay",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Sterling, Shawna",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Valdivia, Anthony J",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+HARVEY,Newton Township Part G,President / Vice President,,Republican,"Trump, Donald J.",0,900080
+HARVEY,Alta Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000010
+HARVEY,Alta Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,000010
+HARVEY,Alta Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000010
+HARVEY,Alta Township,United States House of Representatives,4,Republican,"Pompeo, Michael",97,000010
+HARVEY,Burrton Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000020
+HARVEY,Burrton Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",16,000020
+HARVEY,Burrton Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000020
+HARVEY,Burrton Township,United States House of Representatives,4,Republican,"Pompeo, Michael",70,000020
+HARVEY,Emma Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000040
+HARVEY,Emma Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",52,000040
+HARVEY,Emma Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000040
+HARVEY,Emma Township,United States House of Representatives,4,Republican,"Pompeo, Michael",211,000040
+HARVEY,Garden Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000050
+HARVEY,Garden Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",30,000050
+HARVEY,Garden Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000050
+HARVEY,Garden Township,United States House of Representatives,4,Republican,"Pompeo, Michael",115,000050
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",20,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",71,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",241,000060
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",33,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",129,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",314,000070
+HARVEY,Halstead Township,United States House of Representatives,4,independent,"Allen, Miranda",4,000080
+HARVEY,Halstead Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",38,000080
+HARVEY,Halstead Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000080
+HARVEY,Halstead Township,United States House of Representatives,4,Republican,"Pompeo, Michael",89,000080
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",56,000090
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",274,000090
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000090
+HARVEY,Hesston Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",541,000090
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",34,00010A
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",223,00010A
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,00010A
+HARVEY,Hesston Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",574,00010A
+HARVEY,Highland Township,United States House of Representatives,4,independent,"Allen, Miranda",9,000110
+HARVEY,Highland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",66,000110
+HARVEY,Highland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,000110
+HARVEY,Highland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",130,000110
+HARVEY,Lake Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000120
+HARVEY,Lake Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000120
+HARVEY,Lake Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000120
+HARVEY,Lake Township,United States House of Representatives,4,Republican,"Pompeo, Michael",65,000120
+HARVEY,Lakin Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000130
+HARVEY,Lakin Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",22,000130
+HARVEY,Lakin Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000130
+HARVEY,Lakin Township,United States House of Representatives,4,Republican,"Pompeo, Michael",103,000130
+HARVEY,Macon Township,United States House of Representatives,4,independent,"Allen, Miranda",16,000140
+HARVEY,Macon Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",58,000140
+HARVEY,Macon Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000140
+HARVEY,Macon Township,United States House of Representatives,4,Republican,"Pompeo, Michael",164,000140
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",38,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",155,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",249,000150
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",41,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",132,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",9,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",181,000160
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,independent,"Allen, Miranda",18,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",84,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Michael",137,000170
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",34,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",150,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",11,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",180,000180
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",48,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",301,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",25,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",589,00019A
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",31,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",143,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",21,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",218,000200
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",43,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",186,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",11,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",380,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,independent,"Allen, Miranda",45,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",167,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",15,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States House of Representatives,4,Republican,"Pompeo, Michael",312,00022A
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",39,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",198,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",11,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",260,000230
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",63,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",294,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",528,000240
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,independent,"Allen, Miranda",49,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",198,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",22,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States House of Representatives,4,Republican,"Pompeo, Michael",384,000250
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,independent,"Allen, Miranda",27,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",88,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Michael",159,000260
+HARVEY,Newton Township Part A,United States House of Representatives,4,independent,"Allen, Miranda",0,00027A
+HARVEY,Newton Township Part A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,00027A
+HARVEY,Newton Township Part A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00027A
+HARVEY,Newton Township Part A,United States House of Representatives,4,Republican,"Pompeo, Michael",3,00027A
+HARVEY,Newton Township Part B,United States House of Representatives,4,independent,"Allen, Miranda",9,00027B
+HARVEY,Newton Township Part B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",41,00027B
+HARVEY,Newton Township Part B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,00027B
+HARVEY,Newton Township Part B,United States House of Representatives,4,Republican,"Pompeo, Michael",120,00027B
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00027C
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00027C
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00027C
+HARVEY,Newton Township Part B Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00027C
+HARVEY,Newton Township Part C,United States House of Representatives,4,independent,"Allen, Miranda",0,00027D
+HARVEY,Newton Township Part C,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,00027D
+HARVEY,Newton Township Part C,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00027D
+HARVEY,Newton Township Part C,United States House of Representatives,4,Republican,"Pompeo, Michael",3,00027D
+HARVEY,North Newton City,United States House of Representatives,4,independent,"Allen, Miranda",25,000280
+HARVEY,North Newton City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",564,000280
+HARVEY,North Newton City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",16,000280
+HARVEY,North Newton City,United States House of Representatives,4,Republican,"Pompeo, Michael",403,000280
+HARVEY,Pleasant Township,United States House of Representatives,4,independent,"Allen, Miranda",10,000290
+HARVEY,Pleasant Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",71,000290
+HARVEY,Pleasant Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000290
+HARVEY,Pleasant Township,United States House of Representatives,4,Republican,"Pompeo, Michael",208,000290
+HARVEY,Richland Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000300
+HARVEY,Richland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",36,000300
+HARVEY,Richland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000300
+HARVEY,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",178,000300
+HARVEY,Sedgwick Township,United States House of Representatives,4,independent,"Allen, Miranda",9,000310
+HARVEY,Sedgwick Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",17,000310
+HARVEY,Sedgwick Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000310
+HARVEY,Sedgwick Township,United States House of Representatives,4,Republican,"Pompeo, Michael",131,000310
+HARVEY,Walton Township,United States House of Representatives,4,independent,"Allen, Miranda",10,000320
+HARVEY,Walton Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",29,000320
+HARVEY,Walton Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000320
+HARVEY,Walton Township,United States House of Representatives,4,Republican,"Pompeo, Michael",103,000320
+HARVEY,Darlington Township H72,United States House of Representatives,4,independent,"Allen, Miranda",6,120020
+HARVEY,Darlington Township H72,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",10,120020
+HARVEY,Darlington Township H72,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,120020
+HARVEY,Darlington Township H72,United States House of Representatives,4,Republican,"Pompeo, Michael",46,120020
+HARVEY,Darlington Township H74,United States House of Representatives,4,independent,"Allen, Miranda",10,120030
+HARVEY,Darlington Township H74,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",43,120030
+HARVEY,Darlington Township H74,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,120030
+HARVEY,Darlington Township H74,United States House of Representatives,4,Republican,"Pompeo, Michael",181,120030
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,independent,"Allen, Miranda",55,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",325,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",22,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States House of Representatives,4,Republican,"Pompeo, Michael",818,800010
+HARVEY,Burrton City,United States House of Representatives,4,independent,"Allen, Miranda",26,900010
+HARVEY,Burrton City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",42,900010
+HARVEY,Burrton City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,900010
+HARVEY,Burrton City,United States House of Representatives,4,Republican,"Pompeo, Michael",217,900010
+HARVEY,Sedgwick City,United States House of Representatives,4,independent,"Allen, Miranda",35,900020
+HARVEY,Sedgwick City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",123,900020
+HARVEY,Sedgwick City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,900020
+HARVEY,Sedgwick City,United States House of Representatives,4,Republican,"Pompeo, Michael",435,900020
+HARVEY,Walton City,United States House of Representatives,4,independent,"Allen, Miranda",9,900030
+HARVEY,Walton City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,900030
+HARVEY,Walton City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,900030
+HARVEY,Walton City,United States House of Representatives,4,Republican,"Pompeo, Michael",62,900030
+HARVEY,Burrton City Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,900040
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900040
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900040
+HARVEY,Burrton City Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900040
+HARVEY,Newton Township Part D,United States House of Representatives,4,independent,"Allen, Miranda",1,900050
+HARVEY,Newton Township Part D,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",10,900050
+HARVEY,Newton Township Part D,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,900050
+HARVEY,Newton Township Part D,United States House of Representatives,4,Republican,"Pompeo, Michael",33,900050
+HARVEY,Newton Township Part E,United States House of Representatives,4,independent,"Allen, Miranda",0,900060
+HARVEY,Newton Township Part E,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900060
+HARVEY,Newton Township Part E,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900060
+HARVEY,Newton Township Part E,United States House of Representatives,4,Republican,"Pompeo, Michael",1,900060
+HARVEY,Newton Township Part F,United States House of Representatives,4,independent,"Allen, Miranda",0,900070
+HARVEY,Newton Township Part F,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900070
+HARVEY,Newton Township Part F,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900070
+HARVEY,Newton Township Part F,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900070
+HARVEY,Newton Township Part G,United States House of Representatives,4,independent,"Allen, Miranda",0,900080
+HARVEY,Newton Township Part G,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900080
+HARVEY,Newton Township Part G,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900080
+HARVEY,Newton Township Part G,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900080
+HARVEY,Alta Township,United States Senate,,write - in,"Smith, DJ",0,000010
+HARVEY,Alta Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000010
+HARVEY,Alta Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000010
+HARVEY,Alta Township,United States Senate,,Republican,"Moran, Jerry",99,000010
+HARVEY,Burrton Township,United States Senate,,write - in,"Smith, DJ",0,000020
+HARVEY,Burrton Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000020
+HARVEY,Burrton Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+HARVEY,Burrton Township,United States Senate,,Republican,"Moran, Jerry",74,000020
+HARVEY,Emma Township,United States Senate,,write - in,"Smith, DJ",0,000040
+HARVEY,Emma Township,United States Senate,,Democratic,"Wiesner, Patrick",49,000040
+HARVEY,Emma Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000040
+HARVEY,Emma Township,United States Senate,,Republican,"Moran, Jerry",214,000040
+HARVEY,Garden Township,United States Senate,,write - in,"Smith, DJ",0,000050
+HARVEY,Garden Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000050
+HARVEY,Garden Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000050
+HARVEY,Garden Township,United States Senate,,Republican,"Moran, Jerry",119,000050
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",64,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",26,000060
+HARVEY,Halstead City Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",249,000060
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",114,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",21,000070
+HARVEY,Halstead City Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",353,000070
+HARVEY,Halstead Township,United States Senate,,write - in,"Smith, DJ",0,000080
+HARVEY,Halstead Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000080
+HARVEY,Halstead Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+HARVEY,Halstead Township,United States Senate,,Republican,"Moran, Jerry",95,000080
+HARVEY,Hesston Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000090
+HARVEY,Hesston Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",247,000090
+HARVEY,Hesston Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",26,000090
+HARVEY,Hesston Precinct 1,United States Senate,,Republican,"Moran, Jerry",610,000090
+HARVEY,Hesston Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00010A
+HARVEY,Hesston Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",205,00010A
+HARVEY,Hesston Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",32,00010A
+HARVEY,Hesston Precinct 2,United States Senate,,Republican,"Moran, Jerry",613,00010A
+HARVEY,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000110
+HARVEY,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",62,000110
+HARVEY,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000110
+HARVEY,Highland Township,United States Senate,,Republican,"Moran, Jerry",138,000110
+HARVEY,Lake Township,United States Senate,,write - in,"Smith, DJ",0,000120
+HARVEY,Lake Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000120
+HARVEY,Lake Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000120
+HARVEY,Lake Township,United States Senate,,Republican,"Moran, Jerry",70,000120
+HARVEY,Lakin Township,United States Senate,,write - in,"Smith, DJ",0,000130
+HARVEY,Lakin Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000130
+HARVEY,Lakin Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+HARVEY,Lakin Township,United States Senate,,Republican,"Moran, Jerry",109,000130
+HARVEY,Macon Township,United States Senate,,write - in,"Smith, DJ",0,000140
+HARVEY,Macon Township,United States Senate,,Democratic,"Wiesner, Patrick",54,000140
+HARVEY,Macon Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000140
+HARVEY,Macon Township,United States Senate,,Republican,"Moran, Jerry",173,000140
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",166,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",33,000150
+HARVEY,Newton City Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",256,000150
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",126,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",37,000160
+HARVEY,Newton City Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",194,000160
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",93,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",22,000170
+HARVEY,Newton City Ward 1 Precinct 3,United States Senate,,Republican,"Moran, Jerry",134,000170
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",158,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",26,000180
+HARVEY,Newton City Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",193,000180
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",308,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",50,00019A
+HARVEY,Newton City Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",599,00019A
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",146,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",28,000200
+HARVEY,Newton City Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",237,000200
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",188,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",35,000210
+HARVEY,Newton City Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",399,000210
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,write - in,"Smith, DJ",0,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,Democratic,"Wiesner, Patrick",159,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",34,00022A
+HARVEY,Newton City Ward 3 Precinct 3 Part A,United States Senate,,Republican,"Moran, Jerry",346,00022A
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",179,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",39,000230
+HARVEY,Newton City Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",287,000230
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",298,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",36,000240
+HARVEY,Newton City Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",556,000240
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",185,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",47,000250
+HARVEY,Newton City Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",419,000250
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",91,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",13,000260
+HARVEY,Newton City Ward 4 Precinct 4,United States Senate,,Republican,"Moran, Jerry",177,000260
+HARVEY,Newton Township Part A,United States Senate,,write - in,"Smith, DJ",0,00027A
+HARVEY,Newton Township Part A,United States Senate,,Democratic,"Wiesner, Patrick",1,00027A
+HARVEY,Newton Township Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00027A
+HARVEY,Newton Township Part A,United States Senate,,Republican,"Moran, Jerry",3,00027A
+HARVEY,Newton Township Part B,United States Senate,,write - in,"Smith, DJ",0,00027B
+HARVEY,Newton Township Part B,United States Senate,,Democratic,"Wiesner, Patrick",36,00027B
+HARVEY,Newton Township Part B,United States Senate,,Libertarian,"Garrard, Robert D.",6,00027B
+HARVEY,Newton Township Part B,United States Senate,,Republican,"Moran, Jerry",128,00027B
+HARVEY,Newton Township Part B Exclave,United States Senate,,write - in,"Smith, DJ",0,00027C
+HARVEY,Newton Township Part B Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00027C
+HARVEY,Newton Township Part B Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00027C
+HARVEY,Newton Township Part B Exclave,United States Senate,,Republican,"Moran, Jerry",0,00027C
+HARVEY,Newton Township Part C,United States Senate,,write - in,"Smith, DJ",0,00027D
+HARVEY,Newton Township Part C,United States Senate,,Democratic,"Wiesner, Patrick",0,00027D
+HARVEY,Newton Township Part C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00027D
+HARVEY,Newton Township Part C,United States Senate,,Republican,"Moran, Jerry",3,00027D
+HARVEY,North Newton City,United States Senate,,write - in,"Smith, DJ",0,000280
+HARVEY,North Newton City,United States Senate,,Democratic,"Wiesner, Patrick",486,000280
+HARVEY,North Newton City,United States Senate,,Libertarian,"Garrard, Robert D.",37,000280
+HARVEY,North Newton City,United States Senate,,Republican,"Moran, Jerry",476,000280
+HARVEY,Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,000290
+HARVEY,Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",60,000290
+HARVEY,Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000290
+HARVEY,Pleasant Township,United States Senate,,Republican,"Moran, Jerry",220,000290
+HARVEY,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000300
+HARVEY,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000300
+HARVEY,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000300
+HARVEY,Richland Township,United States Senate,,Republican,"Moran, Jerry",174,000300
+HARVEY,Sedgwick Township,United States Senate,,write - in,"Smith, DJ",0,000310
+HARVEY,Sedgwick Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000310
+HARVEY,Sedgwick Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000310
+HARVEY,Sedgwick Township,United States Senate,,Republican,"Moran, Jerry",131,000310
+HARVEY,Walton Township,United States Senate,,write - in,"Smith, DJ",0,000320
+HARVEY,Walton Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000320
+HARVEY,Walton Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000320
+HARVEY,Walton Township,United States Senate,,Republican,"Moran, Jerry",105,000320
+HARVEY,Darlington Township H72,United States Senate,,write - in,"Smith, DJ",0,120020
+HARVEY,Darlington Township H72,United States Senate,,Democratic,"Wiesner, Patrick",11,120020
+HARVEY,Darlington Township H72,United States Senate,,Libertarian,"Garrard, Robert D.",6,120020
+HARVEY,Darlington Township H72,United States Senate,,Republican,"Moran, Jerry",49,120020
+HARVEY,Darlington Township H74,United States Senate,,write - in,"Smith, DJ",0,120030
+HARVEY,Darlington Township H74,United States Senate,,Democratic,"Wiesner, Patrick",47,120030
+HARVEY,Darlington Township H74,United States Senate,,Libertarian,"Garrard, Robert D.",11,120030
+HARVEY,Darlington Township H74,United States Senate,,Republican,"Moran, Jerry",175,120030
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",301,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",53,800010
+HARVEY,Newton City Ward 3 Precinct 4,United States Senate,,Republican,"Moran, Jerry",864,800010
+HARVEY,Burrton City,United States Senate,,write - in,"Smith, DJ",0,900010
+HARVEY,Burrton City,United States Senate,,Democratic,"Wiesner, Patrick",44,900010
+HARVEY,Burrton City,United States Senate,,Libertarian,"Garrard, Robert D.",27,900010
+HARVEY,Burrton City,United States Senate,,Republican,"Moran, Jerry",218,900010
+HARVEY,Sedgwick City,United States Senate,,write - in,"Smith, DJ",0,900020
+HARVEY,Sedgwick City,United States Senate,,Democratic,"Wiesner, Patrick",112,900020
+HARVEY,Sedgwick City,United States Senate,,Libertarian,"Garrard, Robert D.",48,900020
+HARVEY,Sedgwick City,United States Senate,,Republican,"Moran, Jerry",447,900020
+HARVEY,Walton City,United States Senate,,write - in,"Smith, DJ",0,900030
+HARVEY,Walton City,United States Senate,,Democratic,"Wiesner, Patrick",24,900030
+HARVEY,Walton City,United States Senate,,Libertarian,"Garrard, Robert D.",6,900030
+HARVEY,Walton City,United States Senate,,Republican,"Moran, Jerry",70,900030
+HARVEY,Burrton City Exclave,United States Senate,,write - in,"Smith, DJ",0,900040
+HARVEY,Burrton City Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+HARVEY,Burrton City Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+HARVEY,Burrton City Exclave,United States Senate,,Republican,"Moran, Jerry",0,900040
+HARVEY,Newton Township Part D,United States Senate,,write - in,"Smith, DJ",0,900050
+HARVEY,Newton Township Part D,United States Senate,,Democratic,"Wiesner, Patrick",5,900050
+HARVEY,Newton Township Part D,United States Senate,,Libertarian,"Garrard, Robert D.",6,900050
+HARVEY,Newton Township Part D,United States Senate,,Republican,"Moran, Jerry",38,900050
+HARVEY,Newton Township Part E,United States Senate,,write - in,"Smith, DJ",0,900060
+HARVEY,Newton Township Part E,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+HARVEY,Newton Township Part E,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+HARVEY,Newton Township Part E,United States Senate,,Republican,"Moran, Jerry",1,900060
+HARVEY,Newton Township Part F,United States Senate,,write - in,"Smith, DJ",0,900070
+HARVEY,Newton Township Part F,United States Senate,,Democratic,"Wiesner, Patrick",0,900070
+HARVEY,Newton Township Part F,United States Senate,,Libertarian,"Garrard, Robert D.",0,900070
+HARVEY,Newton Township Part F,United States Senate,,Republican,"Moran, Jerry",0,900070
+HARVEY,Newton Township Part G,United States Senate,,write - in,"Smith, DJ",0,900080
+HARVEY,Newton Township Part G,United States Senate,,Democratic,"Wiesner, Patrick",0,900080
+HARVEY,Newton Township Part G,United States Senate,,Libertarian,"Garrard, Robert D.",0,900080
+HARVEY,Newton Township Part G,United States Senate,,Republican,"Moran, Jerry",0,900080

--- a/2016/20161108__ks__general__haskell__precinct.csv
+++ b/2016/20161108__ks__general__haskell__precinct.csv
@@ -1,148 +1,397 @@
-county,precinct,office,district,party,candidate,votes
-Haskell,N. Lockport,President,,DEM,Clinton / Kaine,5
-Haskell,N. Lockport,President,,REP,Trump/Pence,47
-Haskell,N. Lockport,President,,LBT,Johnson/Weld,0
-Haskell,N. Lockport,President,,IND,Stein/Baraka,0
-Haskell,N. Lockport,U.S. Senate,,LBT,Robert D. Garrard,1
-Haskell,N. Lockport,U.S. Senate,,DEM,Patrick Wiesner,2
-Haskell,N. Lockport,U.S. Senate,,REP,Jerry Moran ,50
-Haskell,N. Lockport,U.S. House,1,REP,Roger Marshall,41
-Haskell,N. Lockport,U.S. House,1,LBT,Kerry Burt,1
-Haskell,N. Lockport,U.S. House,1,IND,Alan LaPolice,11
-Haskell,N. Lockport,State Senate,39,DEM,A. Zacheriah Worf,4
-Haskell,N. Lockport,State Senate,39,REP,John Doll,46
-Haskell,N. Lockport,State House,115,REP,Boyd Orr,48
-Haskell,N. Lockport,President,,,McMullin/Johnson,2
-Haskell,S. Lockport,President,,DEM,Clinton / Kaine,9
-Haskell,S. Lockport,President,,REP,Trump/Pence,44
-Haskell,S. Lockport,President,,LBT,Johnson/Weld,3
-Haskell,S. Lockport,President,,IND,Stein/Baraka,1
-Haskell,S. Lockport,U.S. Senate,,LBT,Robert D. Garrard,6
-Haskell,S. Lockport,U.S. Senate,,DEM,Patrick Wiesner,7
-Haskell,S. Lockport,U.S. Senate,,REP,Jerry Moran ,44
-Haskell,S. Lockport,U.S. House,1,REP,Roger Marshall,41
-Haskell,S. Lockport,U.S. House,1,LBT,Kerry Burt,7
-Haskell,S. Lockport,U.S. House,1,IND,Alan LaPolice,9
-Haskell,S. Lockport,State Senate,39,DEM,A. Zacheriah Worf,9
-Haskell,S. Lockport,State Senate,39,REP,John Doll,46
-Haskell,S. Lockport,State House,115,REP,Boyd Orr,55
-Haskell,S. Lockport,President,,,McMullin/Johnson,2
-Haskell,Sub. 1 H122,President,,DEM,Clinton / Kaine,5
-Haskell,Sub. 1 H122,President,,REP,Trump/Pence,20
-Haskell,Sub. 1 H122,President,,LBT,Johnson/Weld,0
-Haskell,Sub. 1 H122,President,,IND,Stein/Baraka,0
-Haskell,Sub. 1 H122,U.S. Senate,,LBT,Robert D. Garrard,1
-Haskell,Sub. 1 H122,U.S. Senate,,DEM,Patrick Wiesner,6
-Haskell,Sub. 1 H122,U.S. Senate,,REP,Jerry Moran ,18
-Haskell,Sub. 1 H122,U.S. House,1,REP,Roger Marshall,14
-Haskell,Sub. 1 H122,U.S. House,1,LBT,Kerry Burt,2
-Haskell,Sub. 1 H122,U.S. House,1,IND,Alan LaPolice,6
-Haskell,Sub. 1 H122,State Senate,39,DEM,A. Zacheriah Worf,4
-Haskell,Sub. 1 H122,State Senate,39,REP,John Doll,19
-Haskell,Sub. 1 H122,State House,122,REP,"J. Russell ""Russ"" Jennings",23
-Haskell,Sub. 1 H124,President,,DEM,Clinton / Kaine,59
-Haskell,Sub. 1 H124,President,,REP,Trump/Pence,306
-Haskell,Sub. 1 H124,President,,LBT,Johnson/Weld,15
-Haskell,Sub. 1 H124,President,,IND,Stein/Baraka,4
-Haskell,Sub. 1 H124,U.S. Senate,,LBT,Robert D. Garrard,16
-Haskell,Sub. 1 H124,U.S. Senate,,DEM,Patrick Wiesner,32
-Haskell,Sub. 1 H124,U.S. Senate,,REP,Jerry Moran ,337
-Haskell,Sub. 1 H124,U.S. House,1,REP,Roger Marshall,277
-Haskell,Sub. 1 H124,U.S. House,1,LBT,Kerry Burt,22
-Haskell,Sub. 1 H124,U.S. House,1,IND,Alan LaPolice,59
-Haskell,Sub. 1 H124,State Senate,39,DEM,A. Zacheriah Worf,40
-Haskell,Sub. 1 H124,State Senate,39,REP,John Doll,322
-Haskell,Sub. 1 H124,State House,124,REP,J. Stephen Alford,330
-Haskell,Sub. 1 H124,President,,,Castle/Bradley,1
-Haskell,Sub. 3 H122,President,,DEM,Clinton / Kaine,0
-Haskell,Sub. 3 H122,President,,REP,Trump/Pence,3
-Haskell,Sub. 3 H122,President,,LBT,Johnson/Weld,0
-Haskell,Sub. 3 H122,President,,IND,Stein/Baraka,1
-Haskell,Sub. 3 H122,U.S. Senate,,LBT,Robert D. Garrard,1
-Haskell,Sub. 3 H122,U.S. Senate,,DEM,Patrick Wiesner,0
-Haskell,Sub. 3 H122,U.S. Senate,,REP,Jerry Moran ,4
-Haskell,Sub. 3 H122,U.S. House,1,REP,Roger Marshall,3
-Haskell,Sub. 3 H122,U.S. House,1,LBT,Kerry Burt,0
-Haskell,Sub. 3 H122,U.S. House,1,IND,Alan LaPolice,2
-Haskell,Sub. 3 H122,State Senate,39,DEM,A. Zacheriah Worf,0
-Haskell,Sub. 3 H122,State Senate,39,REP,John Doll,4
-Haskell,Sub. 3 H122,State House,122,REP,"J. Russell ""Russ"" Jennings",5
-Haskell,Sub. 3 H124,President,,DEM,Clinton / Kaine,42
-Haskell,Sub. 3 H124,President,,REP,Trump/Pence,183
-Haskell,Sub. 3 H124,President,,LBT,Johnson/Weld,4
-Haskell,Sub. 3 H124,President,,IND,Stein/Baraka,3
-Haskell,Sub. 3 H124,U.S. Senate,,LBT,Robert D. Garrard,4
-Haskell,Sub. 3 H124,U.S. Senate,,DEM,Patrick Wiesner,22
-Haskell,Sub. 3 H124,U.S. Senate,,REP,Jerry Moran ,206
-Haskell,Sub. 3 H124,U.S. House,1,REP,Roger Marshall,173
-Haskell,Sub. 3 H124,U.S. House,1,LBT,Kerry Burt,16
-Haskell,Sub. 3 H124,U.S. House,1,IND,Alan LaPolice,38
-Haskell,Sub. 3 H124,State Senate,39,DEM,A. Zacheriah Worf,17
-Haskell,Sub. 3 H124,State Senate,39,REP,John Doll,201
-Haskell,Sub. 3 H124,State House,124,REP,J. Stephen Alford,191
-Haskell,Sub. 3 H124,President,,,McMullin/Johnson,1
-Haskell,Ivanhoe,President,,DEM,Clinton / Kaine,17
-Haskell,Ivanhoe,President,,REP,Trump/Pence,50
-Haskell,Ivanhoe,President,,LBT,Johnson/Weld,2
-Haskell,Ivanhoe,President,,IND,Stein/Baraka,0
-Haskell,Ivanhoe,U.S. Senate,,LBT,Robert D. Garrard,2
-Haskell,Ivanhoe,U.S. Senate,,DEM,Patrick Wiesner,15
-Haskell,Ivanhoe,U.S. Senate,,REP,Jerry Moran ,53
-Haskell,Ivanhoe,U.S. House,1,REP,Roger Marshall,53
-Haskell,Ivanhoe,U.S. House,1,LBT,Kerry Burt,3
-Haskell,Ivanhoe,U.S. House,1,IND,Alan LaPolice,8
-Haskell,Ivanhoe,State Senate,39,DEM,A. Zacheriah Worf,13
-Haskell,Ivanhoe,State Senate,39,REP,John Doll,56
-Haskell,Ivanhoe,State House,122,REP,"J. Russell ""Russ"" Jennings",57
-Haskell,N Dudley,President,,DEM,Clinton / Kaine,4
-Haskell,N Dudley,President,,REP,Trump/Pence,40
-Haskell,N Dudley,President,,LBT,Johnson/Weld,1
-Haskell,N Dudley,President,,IND,Stein/Baraka,1
-Haskell,N Dudley,U.S. Senate,,LBT,Robert D. Garrard,3
-Haskell,N Dudley,U.S. Senate,,DEM,Patrick Wiesner,2
-Haskell,N Dudley,U.S. Senate,,REP,Jerry Moran ,40
-Haskell,N Dudley,U.S. House,1,REP,Roger Marshall,35
-Haskell,N Dudley,U.S. House,1,LBT,Kerry Burt,0
-Haskell,N Dudley,U.S. House,1,IND,Alan LaPolice,10
-Haskell,N Dudley,State Senate,39,DEM,A. Zacheriah Worf,1
-Haskell,N Dudley,State Senate,39,REP,John Doll,43
-Haskell,N Dudley,State House,122,REP,"J. Russell ""Russ"" Jennings",42
-Haskell,Sat 1 H124,President,,DEM,Clinton / Kaine,17
-Haskell,Sat 1 H124,President,,REP,Trump/Pence,58
-Haskell,Sat 1 H124,President,,LBT,Johnson/Weld,2
-Haskell,Sat 1 H124,President,,IND,Stein/Baraka,2
-Haskell,Sat 1 H124,U.S. Senate,,LBT,Robert D. Garrard,4
-Haskell,Sat 1 H124,U.S. Senate,,DEM,Patrick Wiesner,14
-Haskell,Sat 1 H124,U.S. Senate,,REP,Jerry Moran ,58
-Haskell,Sat 1 H124,U.S. House,1,REP,Roger Marshall,55
-Haskell,Sat 1 H124,U.S. House,1,LBT,Kerry Burt,4
-Haskell,Sat 1 H124,U.S. House,1,IND,Alan LaPolice,14
-Haskell,Sat 1 H124,State Senate,39,DEM,A. Zacheriah Worf,18
-Haskell,Sat 1 H124,State Senate,39,REP,John Doll,56
-Haskell,Sat 1 H124,State House,124,REP,J. Stephen Alford,66
-Haskell,Sat. 2 H122,President,,DEM,Clinton / Kaine,2
-Haskell,Sat. 2 H122,President,,REP,Trump/Pence,22
-Haskell,Sat. 2 H122,President,,LBT,Johnson/Weld,3
-Haskell,Sat. 2 H122,President,,IND,Stein/Baraka,0
-Haskell,Sat. 2 H122,U.S. Senate,,LBT,Robert D. Garrard,1
-Haskell,Sat. 2 H122,U.S. Senate,,DEM,Patrick Wiesner,2
-Haskell,Sat. 2 H122,U.S. Senate,,REP,Jerry Moran ,22
-Haskell,Sat. 2 H122,U.S. House,1,REP,Roger Marshall,23
-Haskell,Sat. 2 H122,U.S. House,1,LBT,Kerry Burt,1
-Haskell,Sat. 2 H122,U.S. House,1,IND,Alan LaPolice,2
-Haskell,Sat. 2 H122,State Senate,39,DEM,A. Zacheriah Worf,3
-Haskell,Sat. 2 H122,State Senate,39,REP,John Doll,21
-Haskell,Sat. 2 H122,State House,122,REP,"J. Russell ""Russ"" Jennings",22
-Haskell,Sat. 2 H124,President,,DEM,Clinton / Kaine,85
-Haskell,Sat. 2 H124,President,,REP,Trump/Pence,267
-Haskell,Sat. 2 H124,President,,LBT,Johnson/Weld,11
-Haskell,Sat. 2 H124,President,,IND,Stein/Baraka,10
-Haskell,Sat. 2 H124,U.S. Senate,,LBT,Robert D. Garrard,10
-Haskell,Sat. 2 H124,U.S. Senate,,DEM,Patrick Wiesner,56
-Haskell,Sat. 2 H124,U.S. Senate,,REP,Jerry Moran ,305
-Haskell,Sat. 2 H124,U.S. House,1,REP,Roger Marshall,285
-Haskell,Sat. 2 H124,U.S. House,1,LBT,Kerry Burt,25
-Haskell,Sat. 2 H124,U.S. House,1,IND,Alan LaPolice,57
-Haskell,Sat. 2 H124,State Senate,39,DEM,A. Zacheriah Worf,58
-Haskell,Sat. 2 H124,State Senate,39,REP,John Doll,306
-Haskell,Sat. 2 H124,State House,124,REP,J. Stephen Alford,328
+county,precinct,office,district,party,candidate,votes,vtd
+HASKELL,Ivanhoe Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",57,000010
+HASKELL,North Dudley,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",42,000020
+HASKELL,North Lockport,Kansas House of Representatives,115,Republican,"Orr, Boyd",48,000030
+HASKELL,Satanta 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",66,000040
+HASKELL,South Lockport,Kansas House of Representatives,115,Republican,"Orr, Boyd",55,000060
+HASKELL,Satanta 2 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",22,120020
+HASKELL,Satanta 2 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",328,120030
+HASKELL,Sublette 1 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",23,120040
+HASKELL,Sublette 1 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",330,120050
+HASKELL,Sublette 3 H122,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",5,120060
+HASKELL,Sublette 3 H124,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",191,120070
+HASKELL,Ivanhoe Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",13,000010
+HASKELL,Ivanhoe Township,Kansas Senate,39,Republican,"Doll, John",56,000010
+HASKELL,North Dudley,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",1,000020
+HASKELL,North Dudley,Kansas Senate,39,Republican,"Doll, John",43,000020
+HASKELL,North Lockport,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",4,000030
+HASKELL,North Lockport,Kansas Senate,39,Republican,"Doll, John",46,000030
+HASKELL,Satanta 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",18,000040
+HASKELL,Satanta 1,Kansas Senate,39,Republican,"Doll, John",56,000040
+HASKELL,South Lockport,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",9,000060
+HASKELL,South Lockport,Kansas Senate,39,Republican,"Doll, John",46,000060
+HASKELL,Satanta 2 H122,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",3,120020
+HASKELL,Satanta 2 H122,Kansas Senate,39,Republican,"Doll, John",21,120020
+HASKELL,Satanta 2 H124,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",58,120030
+HASKELL,Satanta 2 H124,Kansas Senate,39,Republican,"Doll, John",306,120030
+HASKELL,Sublette 1 H122,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",4,120040
+HASKELL,Sublette 1 H122,Kansas Senate,39,Republican,"Doll, John",19,120040
+HASKELL,Sublette 1 H124,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",40,120050
+HASKELL,Sublette 1 H124,Kansas Senate,39,Republican,"Doll, John",322,120050
+HASKELL,Sublette 3 H122,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,120060
+HASKELL,Sublette 3 H122,Kansas Senate,39,Republican,"Doll, John",4,120060
+HASKELL,Sublette 3 H124,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",17,120070
+HASKELL,Sublette 3 H124,Kansas Senate,39,Republican,"Doll, John",201,120070
+HASKELL,Ivanhoe Township,President / Vice President,,independent,"Stein, Jill",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+HASKELL,Ivanhoe Township,President / Vice President,,Republican,"Trump, Donald J.",50,000010
+HASKELL,North Dudley,President / Vice President,,independent,"Stein, Jill",1,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Hedges, James A",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"McMullin, Evan",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Perry, Darryl",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Smith, Mike",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Sood, Ajay",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+HASKELL,North Dudley,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+HASKELL,North Dudley,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000020
+HASKELL,North Dudley,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+HASKELL,North Dudley,President / Vice President,,Republican,"Trump, Donald J.",40,000020
+HASKELL,North Lockport,President / Vice President,,independent,"Stein, Jill",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Hedges, James A",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"McMullin, Evan",2,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Perry, Darryl",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Smith, Mike",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Sood, Ajay",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+HASKELL,North Lockport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+HASKELL,North Lockport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+HASKELL,North Lockport,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+HASKELL,North Lockport,President / Vice President,,Republican,"Trump, Donald J.",47,000030
+HASKELL,Satanta 1,President / Vice President,,independent,"Stein, Jill",2,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Hedges, James A",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"McMullin, Evan",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Perry, Darryl",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Smith, Mike",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Sood, Ajay",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+HASKELL,Satanta 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+HASKELL,Satanta 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000040
+HASKELL,Satanta 1,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+HASKELL,Satanta 1,President / Vice President,,Republican,"Trump, Donald J.",58,000040
+HASKELL,South Lockport,President / Vice President,,independent,"Stein, Jill",1,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Hedges, James A",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"McMullin, Evan",2,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Perry, Darryl",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Smith, Mike",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Sood, Ajay",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+HASKELL,South Lockport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+HASKELL,South Lockport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000060
+HASKELL,South Lockport,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+HASKELL,South Lockport,President / Vice President,,Republican,"Trump, Donald J.",44,000060
+HASKELL,Satanta 2 H122,President / Vice President,,independent,"Stein, Jill",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Hedges, James A",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"McMullin, Evan",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Perry, Darryl",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Smith, Mike",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Sood, Ajay",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Libertarian,"Johnson, Gary",3,120020
+HASKELL,Satanta 2 H122,President / Vice President,,Republican,"Trump, Donald J.",22,120020
+HASKELL,Satanta 2 H124,President / Vice President,,independent,"Stein, Jill",10,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Hedges, James A",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"McMullin, Evan",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Perry, Darryl",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Smith, Mike",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Sood, Ajay",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Democratic,"Clinton, Hillary Rodham",85,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Libertarian,"Johnson, Gary",11,120030
+HASKELL,Satanta 2 H124,President / Vice President,,Republican,"Trump, Donald J.",267,120030
+HASKELL,Sublette 1 H122,President / Vice President,,independent,"Stein, Jill",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Hedges, James A",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"McMullin, Evan",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Perry, Darryl",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Smith, Mike",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Sood, Ajay",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+HASKELL,Sublette 1 H122,President / Vice President,,Republican,"Trump, Donald J.",20,120040
+HASKELL,Sublette 1 H124,President / Vice President,,independent,"Stein, Jill",4,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Castle, Darrell L",1,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Hedges, James A",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"McMullin, Evan",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Perry, Darryl",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Smith, Mike",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Sood, Ajay",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Libertarian,"Johnson, Gary",15,120050
+HASKELL,Sublette 1 H124,President / Vice President,,Republican,"Trump, Donald J.",306,120050
+HASKELL,Sublette 3 H122,President / Vice President,,independent,"Stein, Jill",1,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Hedges, James A",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"McMullin, Evan",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Perry, Darryl",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Smith, Mike",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Sood, Ajay",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+HASKELL,Sublette 3 H122,President / Vice President,,Republican,"Trump, Donald J.",3,120060
+HASKELL,Sublette 3 H124,President / Vice President,,independent,"Stein, Jill",3,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Hedges, James A",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"McMullin, Evan",1,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Perry, Darryl",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Smith, Mike",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Sood, Ajay",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Libertarian,"Johnson, Gary",4,120070
+HASKELL,Sublette 3 H124,President / Vice President,,Republican,"Trump, Donald J.",183,120070
+HASKELL,Ivanhoe Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000010
+HASKELL,Ivanhoe Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+HASKELL,Ivanhoe Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000010
+HASKELL,Ivanhoe Township,United States House of Representatives,1,Republican,"Marshall, Roger",53,000010
+HASKELL,North Dudley,United States House of Representatives,1,independent,"LaPolice, Alan",10,000020
+HASKELL,North Dudley,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+HASKELL,North Dudley,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+HASKELL,North Dudley,United States House of Representatives,1,Republican,"Marshall, Roger",35,000020
+HASKELL,North Lockport,United States House of Representatives,1,independent,"LaPolice, Alan",11,000030
+HASKELL,North Lockport,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+HASKELL,North Lockport,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+HASKELL,North Lockport,United States House of Representatives,1,Republican,"Marshall, Roger",41,000030
+HASKELL,Satanta 1,United States House of Representatives,1,independent,"LaPolice, Alan",14,000040
+HASKELL,Satanta 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+HASKELL,Satanta 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000040
+HASKELL,Satanta 1,United States House of Representatives,1,Republican,"Marshall, Roger",55,000040
+HASKELL,South Lockport,United States House of Representatives,1,independent,"LaPolice, Alan",9,000060
+HASKELL,South Lockport,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+HASKELL,South Lockport,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000060
+HASKELL,South Lockport,United States House of Representatives,1,Republican,"Marshall, Roger",41,000060
+HASKELL,Satanta 2 H122,United States House of Representatives,1,independent,"LaPolice, Alan",2,120020
+HASKELL,Satanta 2 H122,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+HASKELL,Satanta 2 H122,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120020
+HASKELL,Satanta 2 H122,United States House of Representatives,1,Republican,"Marshall, Roger",23,120020
+HASKELL,Satanta 2 H124,United States House of Representatives,1,independent,"LaPolice, Alan",57,120030
+HASKELL,Satanta 2 H124,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+HASKELL,Satanta 2 H124,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,120030
+HASKELL,Satanta 2 H124,United States House of Representatives,1,Republican,"Marshall, Roger",285,120030
+HASKELL,Sublette 1 H122,United States House of Representatives,1,independent,"LaPolice, Alan",6,120040
+HASKELL,Sublette 1 H122,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+HASKELL,Sublette 1 H122,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120040
+HASKELL,Sublette 1 H122,United States House of Representatives,1,Republican,"Marshall, Roger",14,120040
+HASKELL,Sublette 1 H124,United States House of Representatives,1,independent,"LaPolice, Alan",59,120050
+HASKELL,Sublette 1 H124,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,120050
+HASKELL,Sublette 1 H124,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,120050
+HASKELL,Sublette 1 H124,United States House of Representatives,1,Republican,"Marshall, Roger",277,120050
+HASKELL,Sublette 3 H122,United States House of Representatives,1,independent,"LaPolice, Alan",2,120060
+HASKELL,Sublette 3 H122,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120060
+HASKELL,Sublette 3 H122,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120060
+HASKELL,Sublette 3 H122,United States House of Representatives,1,Republican,"Marshall, Roger",3,120060
+HASKELL,Sublette 3 H124,United States House of Representatives,1,independent,"LaPolice, Alan",38,120070
+HASKELL,Sublette 3 H124,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,120070
+HASKELL,Sublette 3 H124,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,120070
+HASKELL,Sublette 3 H124,United States House of Representatives,1,Republican,"Marshall, Roger",173,120070
+HASKELL,Ivanhoe Township,United States Senate,,write - in,"Smith, DJ",0,000010
+HASKELL,Ivanhoe Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000010
+HASKELL,Ivanhoe Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+HASKELL,Ivanhoe Township,United States Senate,,Republican,"Moran, Jerry",53,000010
+HASKELL,North Dudley,United States Senate,,write - in,"Smith, DJ",0,000020
+HASKELL,North Dudley,United States Senate,,Democratic,"Wiesner, Patrick",2,000020
+HASKELL,North Dudley,United States Senate,,Libertarian,"Garrard, Robert D.",3,000020
+HASKELL,North Dudley,United States Senate,,Republican,"Moran, Jerry",40,000020
+HASKELL,North Lockport,United States Senate,,write - in,"Smith, DJ",0,000030
+HASKELL,North Lockport,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+HASKELL,North Lockport,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+HASKELL,North Lockport,United States Senate,,Republican,"Moran, Jerry",50,000030
+HASKELL,Satanta 1,United States Senate,,write - in,"Smith, DJ",0,000040
+HASKELL,Satanta 1,United States Senate,,Democratic,"Wiesner, Patrick",14,000040
+HASKELL,Satanta 1,United States Senate,,Libertarian,"Garrard, Robert D.",4,000040
+HASKELL,Satanta 1,United States Senate,,Republican,"Moran, Jerry",58,000040
+HASKELL,South Lockport,United States Senate,,write - in,"Smith, DJ",0,000060
+HASKELL,South Lockport,United States Senate,,Democratic,"Wiesner, Patrick",7,000060
+HASKELL,South Lockport,United States Senate,,Libertarian,"Garrard, Robert D.",6,000060
+HASKELL,South Lockport,United States Senate,,Republican,"Moran, Jerry",44,000060
+HASKELL,Satanta 2 H122,United States Senate,,write - in,"Smith, DJ",0,120020
+HASKELL,Satanta 2 H122,United States Senate,,Democratic,"Wiesner, Patrick",2,120020
+HASKELL,Satanta 2 H122,United States Senate,,Libertarian,"Garrard, Robert D.",1,120020
+HASKELL,Satanta 2 H122,United States Senate,,Republican,"Moran, Jerry",22,120020
+HASKELL,Satanta 2 H124,United States Senate,,write - in,"Smith, DJ",0,120030
+HASKELL,Satanta 2 H124,United States Senate,,Democratic,"Wiesner, Patrick",56,120030
+HASKELL,Satanta 2 H124,United States Senate,,Libertarian,"Garrard, Robert D.",10,120030
+HASKELL,Satanta 2 H124,United States Senate,,Republican,"Moran, Jerry",305,120030
+HASKELL,Sublette 1 H122,United States Senate,,write - in,"Smith, DJ",0,120040
+HASKELL,Sublette 1 H122,United States Senate,,Democratic,"Wiesner, Patrick",6,120040
+HASKELL,Sublette 1 H122,United States Senate,,Libertarian,"Garrard, Robert D.",1,120040
+HASKELL,Sublette 1 H122,United States Senate,,Republican,"Moran, Jerry",18,120040
+HASKELL,Sublette 1 H124,United States Senate,,write - in,"Smith, DJ",0,120050
+HASKELL,Sublette 1 H124,United States Senate,,Democratic,"Wiesner, Patrick",32,120050
+HASKELL,Sublette 1 H124,United States Senate,,Libertarian,"Garrard, Robert D.",16,120050
+HASKELL,Sublette 1 H124,United States Senate,,Republican,"Moran, Jerry",337,120050
+HASKELL,Sublette 3 H122,United States Senate,,write - in,"Smith, DJ",0,120060
+HASKELL,Sublette 3 H122,United States Senate,,Democratic,"Wiesner, Patrick",0,120060
+HASKELL,Sublette 3 H122,United States Senate,,Libertarian,"Garrard, Robert D.",1,120060
+HASKELL,Sublette 3 H122,United States Senate,,Republican,"Moran, Jerry",4,120060
+HASKELL,Sublette 3 H124,United States Senate,,write - in,"Smith, DJ",0,120070
+HASKELL,Sublette 3 H124,United States Senate,,Democratic,"Wiesner, Patrick",22,120070
+HASKELL,Sublette 3 H124,United States Senate,,Libertarian,"Garrard, Robert D.",4,120070
+HASKELL,Sublette 3 H124,United States Senate,,Republican,"Moran, Jerry",206,120070

--- a/2016/20161108__ks__general__hodgeman__precinct.csv
+++ b/2016/20161108__ks__general__hodgeman__precinct.csv
@@ -1,218 +1,577 @@
-county,precinct,office,district,party,candidate,votes
-Hodgeman,01 N Marena,President,,LBT,Gary Johnson,4
-Hodgeman,01 N Marena,President,,IND,Jill Stein,3
-Hodgeman,01 N Marena,President,,R,Donald Trump,133
-Hodgeman,01 N Marena,President,,D,Hillary Clinton,20
-Hodgeman,01 N Marena,U.S. Senate,,R,Jerry Moran,140
-Hodgeman,01 N Marena,U.S. Senate,,D,Patrick Wiesner,13
-Hodgeman,01 N Marena,U.S. Senate,,LBT,Robert D. Garrard,5
-Hodgeman,01 N Marena,U.S. Senate,,,Larry Salmans,2
-Hodgeman,01 N Marena,U.S. House,1,LBT,Kerry Burt,13
-Hodgeman,01 N Marena,U.S. House,1,IND,Alan LaPolice,36
-Hodgeman,01 N Marena,U.S. House,1,R,Roger Marshall,108
-Hodgeman,01 N Marena,U.S. House,1,write-in,Tim Huelskamp [R],1
-Hodgeman,01 N Marena,State Senate,33,R,Mary Jo Taylor,132
-Hodgeman,01 N Marena,State Senate,33,D,Matt Bristow,23
-Hodgeman,01 N Marena,State House,117,R,Leonard Mastroni,141
-Hodgeman,02 S Marena,President,,LBT,Gary Johnson,2
-Hodgeman,02 S Marena,President,,IND,Jill Stein,2
-Hodgeman,02 S Marena,President,,R,Donald Trump,68
-Hodgeman,02 S Marena,President,,D,Hillary Clinton,11
-Hodgeman,02 S Marena,U.S. Senate,,R,Jerry Moran,70
-Hodgeman,02 S Marena,U.S. Senate,,D,Patrick Wiesner,7
-Hodgeman,02 S Marena,U.S. Senate,,LBT,Robert D. Garrard,7
-Hodgeman,02 S Marena,U.S. House,1,LBT,Kerry Burt,5
-Hodgeman,02 S Marena,U.S. House,1,IND,Alan LaPolice,16
-Hodgeman,02 S Marena,U.S. House,1,R,Roger Marshall,61
-Hodgeman,02 S Marena,State Senate,33,R,Mary Jo Taylor,65
-Hodgeman,02 S Marena,State Senate,33,D,Matt Bristow,15
-Hodgeman,02 S Marena,State House,117,R,Leonard Mastroni,77
-Hodgeman,02 S Marena,State Senate,33,,Larry Salmans,1
-Hodgeman,03 Benton,President,,LBT,Gary Johnson,0
-Hodgeman,03 Benton,President,,IND,Jill Stein,0
-Hodgeman,03 Benton,President,,R,Donald Trump,27
-Hodgeman,03 Benton,President,,D,Hillary Clinton,3
-Hodgeman,03 Benton,U.S. Senate,,R,Jerry Moran,26
-Hodgeman,03 Benton,U.S. Senate,,D,Patrick Wiesner,3
-Hodgeman,03 Benton,U.S. Senate,,LBT,Robert D. Garrard,0
-Hodgeman,03 Benton,U.S. House,1,LBT,Kerry Burt,0
-Hodgeman,03 Benton,U.S. House,1,IND,Alan LaPolice,4
-Hodgeman,03 Benton,U.S. House,1,R,Roger Marshall,23
-Hodgeman,03 Benton,State Senate,38,R,Bud Estes,29
-Hodgeman,03 Benton,State Senate,38,D,Miguel Rodriguez,0
-Hodgeman,03 Benton,State House,117,R,Leonard Mastroni,26
-Hodgeman,04 S Hallet,President,,LBT,Gary Johnson,1
-Hodgeman,04 S Hallet,President,,IND,Jill Stein,0
-Hodgeman,04 S Hallet,President,,R,Donald Trump,19
-Hodgeman,04 S Hallet,President,,D,Hillary Clinton,0
-Hodgeman,04 S Hallet,U.S. Senate,,R,Jerry Moran,18
-Hodgeman,04 S Hallet,U.S. Senate,,D,Patrick Wiesner,0
-Hodgeman,04 S Hallet,U.S. Senate,,LBT,Robert D. Garrard,1
-Hodgeman,04 S Hallet,U.S. House,1,LBT,Kerry Burt,1
-Hodgeman,04 S Hallet,U.S. House,1,IND,Alan LaPolice,6
-Hodgeman,04 S Hallet,U.S. House,1,R,Roger Marshall,11
-Hodgeman,04 S Hallet,State Senate,38,R,Bud Estes,17
-Hodgeman,04 S Hallet,State Senate,38,D,Miguel Rodriguez,1
-Hodgeman,04 S Hallet,State House,117,R,Leonard Mastroni,18
-Hodgeman,05 N Hallet,President,,LBT,Gary Johnson,0
-Hodgeman,05 N Hallet,President,,IND,Jill Stein,0
-Hodgeman,05 N Hallet,President,,R,Donald Trump,7
-Hodgeman,05 N Hallet,President,,D,Hillary Clinton,0
-Hodgeman,05 N Hallet,U.S. Senate,,R,Jerry Moran,6
-Hodgeman,05 N Hallet,U.S. Senate,,D,Patrick Wiesner,1
-Hodgeman,05 N Hallet,U.S. Senate,,LBT,Robert D. Garrard,0
-Hodgeman,05 N Hallet,U.S. House,1,LBT,Kerry Burt,1
-Hodgeman,05 N Hallet,U.S. House,1,IND,Alan LaPolice,3
-Hodgeman,05 N Hallet,U.S. House,1,R,Roger Marshall,2
-Hodgeman,05 N Hallet,State Senate,33,R,Mary Jo Taylor,4
-Hodgeman,05 N Hallet,State Senate,33,D,Matt Bristow,3
-Hodgeman,05 N Hallet,State House,117,R,Leonard Mastroni,6
-Hodgeman,06 N Roscoe,President,,LBT,Gary Johnson,0
-Hodgeman,06 N Roscoe,President,,IND,Jill Stein,0
-Hodgeman,06 N Roscoe,President,,R,Donald Trump,27
-Hodgeman,06 N Roscoe,President,,D,Hillary Clinton,1
-Hodgeman,06 N Roscoe,U.S. Senate,,R,Jerry Moran,25
-Hodgeman,06 N Roscoe,U.S. Senate,,D,Patrick Wiesner,1
-Hodgeman,06 N Roscoe,U.S. Senate,,LBT,Robert D. Garrard,1
-Hodgeman,06 N Roscoe,U.S. House,1,LBT,Kerry Burt,0
-Hodgeman,06 N Roscoe,U.S. House,1,IND,Alan LaPolice,4
-Hodgeman,06 N Roscoe,U.S. House,1,R,Roger Marshall,23
-Hodgeman,06 N Roscoe,State Senate,33,R,Mary Jo Taylor,22
-Hodgeman,06 N Roscoe,State Senate,33,D,Matt Bristow,3
-Hodgeman,06 N Roscoe,State House,117,R,Leonard Mastroni,14
-Hodgeman,07 S Roscoe,President,,LBT,Gary Johnson,1
-Hodgeman,07 S Roscoe,President,,IND,Jill Stein,0
-Hodgeman,07 S Roscoe,President,,R,Donald Trump,29
-Hodgeman,07 S Roscoe,President,,D,Hillary Clinton,4
-Hodgeman,07 S Roscoe,U.S. Senate,,R,Jerry Moran,31
-Hodgeman,07 S Roscoe,U.S. Senate,,D,Patrick Wiesner,3
-Hodgeman,07 S Roscoe,U.S. Senate,,LBT,Robert D. Garrard,0
-Hodgeman,07 S Roscoe,U.S. House,1,LBT,Kerry Burt,2
-Hodgeman,07 S Roscoe,U.S. House,1,IND,Alan LaPolice,3
-Hodgeman,07 S Roscoe,U.S. House,1,R,Roger Marshall,27
-Hodgeman,07 S Roscoe,U.S. House,1,,Tim Huelskamp [R],1
-Hodgeman,07 S Roscoe,State Senate,38,R,Bud Estes,30
-Hodgeman,07 S Roscoe,State Senate,38,D,Miguel Rodriguez,3
-Hodgeman,07 S Roscoe,State House,117,R,Leonard Mastroni,26
-Hodgeman,08 E Sawlog,President,,LBT,Gary Johnson,0
-Hodgeman,08 E Sawlog,President,,IND,Jill Stein,0
-Hodgeman,08 E Sawlog,President,,R,Donald Trump,18
-Hodgeman,08 E Sawlog,President,,D,Hillary Clinton,3
-Hodgeman,08 E Sawlog,U.S. Senate,,R,Jerry Moran,18
-Hodgeman,08 E Sawlog,U.S. Senate,,D,Patrick Wiesner,3
-Hodgeman,08 E Sawlog,U.S. Senate,,LBT,Robert D. Garrard,1
-Hodgeman,08 E Sawlog,U.S. House,1,LBT,Kerry Burt,2
-Hodgeman,08 E Sawlog,U.S. House,1,IND,Alan LaPolice,3
-Hodgeman,08 E Sawlog,U.S. House,1,R,Roger Marshall,15
-Hodgeman,08 E Sawlog,State Senate,38,R,Bud Estes,17
-Hodgeman,08 E Sawlog,State Senate,38,D,Miguel Rodriguez,3
-Hodgeman,08 E Sawlog,State House,117,R,Leonard Mastroni,15
-Hodgeman,09 Sterling,President,,LBT,Gary Johnson,1
-Hodgeman,09 Sterling,President,,IND,Jill Stein,1
-Hodgeman,09 Sterling,President,,R,Donald Trump,52
-Hodgeman,09 Sterling,President,,D,Hillary Clinton,5
-Hodgeman,09 Sterling,U.S. Senate,,R,Jerry Moran,57
-Hodgeman,09 Sterling,U.S. Senate,,D,Patrick Wiesner,6
-Hodgeman,09 Sterling,U.S. Senate,,LBT,Robert D. Garrard,1
-Hodgeman,09 Sterling,U.S. House,1,LBT,Kerry Burt,1
-Hodgeman,09 Sterling,U.S. House,1,IND,Alan LaPolice,11
-Hodgeman,09 Sterling,U.S. House,1,R,Roger Marshall,50
-Hodgeman,09 Sterling,State Senate,38,R,Bud Estes,54
-Hodgeman,09 Sterling,State Senate,38,D,Miguel Rodriguez,7
-Hodgeman,09 Sterling,State House,117,R,Leonard Mastroni,51
-Hodgeman,09 Sterling,State House,117,,Dorthy Ziesch,1
-Hodgeman,09 Sterling,State House,117,,Denny Burke,1
-Hodgeman,10 Valley,President,,LBT,Gary Johnson,1
-Hodgeman,10 Valley,President,,IND,Jill Stein,1
-Hodgeman,10 Valley,President,,R,Donald Trump,23
-Hodgeman,10 Valley,President,,D,Hillary Clinton,3
-Hodgeman,10 Valley,U.S. Senate,,R,Jerry Moran,26
-Hodgeman,10 Valley,U.S. Senate,,D,Patrick Wiesner,1
-Hodgeman,10 Valley,U.S. Senate,,LBT,Robert D. Garrard,0
-Hodgeman,10 Valley,U.S. House,1,LBT,Kerry Burt,0
-Hodgeman,10 Valley,U.S. House,1,IND,Alan LaPolice,6
-Hodgeman,10 Valley,U.S. House,1,R,Roger Marshall,18
-Hodgeman,10 Valley,U.S. House,1,,Tim Huelskamp [R],1
-Hodgeman,10 Valley,State Senate,33,R,Mary Jo Taylor,21
-Hodgeman,10 Valley,State Senate,33,D,Matt Bristow,5
-Hodgeman,10 Valley,State House,117,R,Leonard Mastroni,23
-Hodgeman,11 W Sawlog,President,,LBT,Gary Johnson,0
-Hodgeman,11 W Sawlog,President,,IND,Jill Stein,0
-Hodgeman,11 W Sawlog,President,,R,Donald Trump,32
-Hodgeman,11 W Sawlog,President,,D,Hillary Clinton,1
-Hodgeman,11 W Sawlog,U.S. Senate,,R,Jerry Moran,29
-Hodgeman,11 W Sawlog,U.S. Senate,,D,Patrick Wiesner,2
-Hodgeman,11 W Sawlog,U.S. Senate,,LBT,Robert D. Garrard,1
-Hodgeman,11 W Sawlog,U.S. House,1,LBT,Kerry Burt,0
-Hodgeman,11 W Sawlog,U.S. House,1,IND,Alan LaPolice,9
-Hodgeman,11 W Sawlog,U.S. House,1,R,Roger Marshall,21
-Hodgeman,11 W Sawlog,State Senate,38,R,Bud Estes,29
-Hodgeman,11 W Sawlog,State Senate,38,D,Miguel Rodriguez,2
-Hodgeman,11 W Sawlog,State House,117,R,Leonard Mastroni,23
-Hodgeman,12 City of Jetmore N,President,,LBT,Gary Johnson,7
-Hodgeman,12 City of Jetmore N,President,,IND,Jill Stein,7
-Hodgeman,12 City of Jetmore N,President,,R,Donald Trump,146
-Hodgeman,12 City of Jetmore N,President,,D,Hillary Clinton,24
-Hodgeman,12 City of Jetmore N,U.S. Senate,,R,Jerry Moran,159
-Hodgeman,12 City of Jetmore N,U.S. Senate,,D,Patrick Wiesner,15
-Hodgeman,12 City of Jetmore N,U.S. Senate,,LBT,Robert D. Garrard,11
-Hodgeman,12 City of Jetmore N,U.S. House,1,LBT,Kerry Burt,11
-Hodgeman,12 City of Jetmore N,U.S. House,1,IND,Alan LaPolice,27
-Hodgeman,12 City of Jetmore N,U.S. House,1,R,Roger Marshall,140
-Hodgeman,12 City of Jetmore N,U.S. House,1,,Tim Huelskamp [R],1
-Hodgeman,12 City of Jetmore N,State Senate,33,R,Mary Jo Taylor,140
-Hodgeman,12 City of Jetmore N,State Senate,33,D,Matt Bristow,35
-Hodgeman,12 City of Jetmore N,State House,117,R,Leonard Mastroni,154
-Hodgeman,13 City of Jetmore S,President,,LBT,Gary Johnson,2
-Hodgeman,13 City of Jetmore S,President,,IND,Jill Stein,2
-Hodgeman,13 City of Jetmore S,President,,R,Donald Trump,143
-Hodgeman,13 City of Jetmore S,President,,D,Hillary Clinton,34
-Hodgeman,13 City of Jetmore S,U.S. Senate,,R,Jerry Moran,154
-Hodgeman,13 City of Jetmore S,U.S. Senate,,D,Patrick Wiesner,16
-Hodgeman,13 City of Jetmore S,U.S. Senate,,LBT,Robert D. Garrard,7
-Hodgeman,13 City of Jetmore S,U.S. House,1,LBT,Kerry Burt,9
-Hodgeman,13 City of Jetmore S,U.S. House,1,IND,Alan LaPolice,31
-Hodgeman,13 City of Jetmore S,U.S. House,1,R,Roger Marshall,133
-Hodgeman,13 City of Jetmore S,State Senate,33,R,Mary Jo Taylor,122
-Hodgeman,13 City of Jetmore S,State Senate,33,D,Matt Bristow,44
-Hodgeman,13 City of Jetmore S,State House,117,R,Leonard Mastroni,144
-Hodgeman,14 City of Jetmore NWSW,President,,LBT,Gary Johnson,1
-Hodgeman,14 City of Jetmore NWSW,President,,IND,Jill Stein,0
-Hodgeman,14 City of Jetmore NWSW,President,,R,Donald Trump,79
-Hodgeman,14 City of Jetmore NWSW,President,,D,Hillary Clinton,7
-Hodgeman,14 City of Jetmore NWSW,U.S. Senate,,R,Jerry Moran,77
-Hodgeman,14 City of Jetmore NWSW,U.S. Senate,,D,Patrick Wiesner,7
-Hodgeman,14 City of Jetmore NWSW,U.S. Senate,,LBT,Robert D. Garrard,3
-Hodgeman,14 City of Jetmore NWSW,U.S. House,1,LBT,Kerry Burt,2
-Hodgeman,14 City of Jetmore NWSW,U.S. House,1,IND,Alan LaPolice,20
-Hodgeman,14 City of Jetmore NWSW,U.S. House,1,R,Roger Marshall,60
-Hodgeman,14 City of Jetmore NWSW,State Senate,33,R,Mary Jo Taylor,61
-Hodgeman,14 City of Jetmore NWSW,State Senate,33,D,Matt Bristow,18
-Hodgeman,14 City of Jetmore NWSW,State House,117,R,Leonard Mastroni,67
-Hodgeman,15 SE Center,President,,LBT,Gary Johnson,0
-Hodgeman,15 SE Center,President,,IND,Jill Stein,1
-Hodgeman,15 SE Center,President,,R,Donald Trump,16
-Hodgeman,15 SE Center,President,,D,Hillary Clinton,2
-Hodgeman,15 SE Center,U.S. Senate,,R,Jerry Moran,19
-Hodgeman,15 SE Center,U.S. Senate,,D,Patrick Wiesner,0
-Hodgeman,15 SE Center,U.S. Senate,,LBT,Robert D. Garrard,0
-Hodgeman,15 SE Center,U.S. House,1,LBT,Kerry Burt,1
-Hodgeman,15 SE Center,U.S. House,1,IND,Alan LaPolice,2
-Hodgeman,15 SE Center,U.S. House,1,R,Roger Marshall,13
-Hodgeman,15 SE Center,State Senate,33,R,Mary Jo Taylor,10
-Hodgeman,15 SE Center,State Senate,33,D,Matt Bristow,6
-Hodgeman,15 SE Center,State House,117,R,Leonard Mastroni,17
-Hodgeman,16 N Center,President,,LBT,Gary Johnson,1
-Hodgeman,16 N Center,President,,IND,Jill Stein,0
-Hodgeman,16 N Center,President,,R,Donald Trump,36
-Hodgeman,16 N Center,President,,D,Hillary Clinton,6
-Hodgeman,16 N Center,U.S. Senate,,R,Jerry Moran,34
-Hodgeman,16 N Center,U.S. Senate,,D,Patrick Wiesner,5
-Hodgeman,16 N Center,U.S. Senate,,LBT,Robert D. Garrard,2
-Hodgeman,16 N Center,U.S. House,1,LBT,Kerry Burt,1
-Hodgeman,16 N Center,U.S. House,1,IND,Alan LaPolice,9
-Hodgeman,16 N Center,U.S. House,1,R,Roger Marshall,25
-Hodgeman,16 N Center,State Senate,33,R,Mary Jo Taylor,33
-Hodgeman,16 N Center,State Senate,33,D,Matt Bristow,5
-Hodgeman,16 N Center,State House,117,R,Leonard Mastroni,32
-Hodgeman,16 N Center,U.S. House,1,,Tim Huelskamp [R],1
+county,precinct,office,district,party,candidate,votes,vtd
+HODGEMAN,Benton Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",26,000010
+HODGEMAN,North Hallet,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",6,000040
+HODGEMAN,North Roscoe,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",14,000050
+HODGEMAN,South Hallet,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",18,000080
+HODGEMAN,South Roscoe,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",26,000090
+HODGEMAN,Sterling Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",51,000100
+HODGEMAN,Valley Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",23,000110
+HODGEMAN,North Marena,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",141,150010
+HODGEMAN,South Marena,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",77,150020
+HODGEMAN,East Sawlog,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",15,150030
+HODGEMAN,West Sawlog,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",23,150040
+HODGEMAN,City of Jetmore - North,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",154,150050
+HODGEMAN,City of Jetmore - South,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",144,150060
+HODGEMAN,City of Jetmore - NW / SW Center,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",67,150070
+HODGEMAN,Southeast Center,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",17,150080
+HODGEMAN,North Center,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",32,150090
+HODGEMAN,Benton Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,000010
+HODGEMAN,Benton Township,Kansas Senate,38,Republican,"Estes, Bud",29,000010
+HODGEMAN,North Hallet,Kansas Senate,33,Democratic,"Bristow, Matt",3,000040
+HODGEMAN,North Hallet,Kansas Senate,33,Republican,"Taylor, Mary Jo",4,000040
+HODGEMAN,North Roscoe,Kansas Senate,33,Democratic,"Bristow, Matt",3,000050
+HODGEMAN,North Roscoe,Kansas Senate,33,Republican,"Taylor, Mary Jo",22,000050
+HODGEMAN,South Hallet,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",1,000080
+HODGEMAN,South Hallet,Kansas Senate,38,Republican,"Estes, Bud",17,000080
+HODGEMAN,South Roscoe,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",3,000090
+HODGEMAN,South Roscoe,Kansas Senate,38,Republican,"Estes, Bud",30,000090
+HODGEMAN,Sterling Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000100
+HODGEMAN,Sterling Township,Kansas Senate,38,Republican,"Estes, Bud",54,000100
+HODGEMAN,Valley Township,Kansas Senate,33,Democratic,"Bristow, Matt",5,000110
+HODGEMAN,Valley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",21,000110
+HODGEMAN,North Marena,Kansas Senate,33,Democratic,"Bristow, Matt",23,150010
+HODGEMAN,North Marena,Kansas Senate,33,Republican,"Taylor, Mary Jo",132,150010
+HODGEMAN,South Marena,Kansas Senate,33,Democratic,"Bristow, Matt",15,150020
+HODGEMAN,South Marena,Kansas Senate,33,Republican,"Taylor, Mary Jo",65,150020
+HODGEMAN,East Sawlog,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",3,150030
+HODGEMAN,East Sawlog,Kansas Senate,38,Republican,"Estes, Bud",17,150030
+HODGEMAN,West Sawlog,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",2,150040
+HODGEMAN,West Sawlog,Kansas Senate,38,Republican,"Estes, Bud",29,150040
+HODGEMAN,City of Jetmore - North,Kansas Senate,33,Democratic,"Bristow, Matt",35,150050
+HODGEMAN,City of Jetmore - North,Kansas Senate,33,Republican,"Taylor, Mary Jo",140,150050
+HODGEMAN,City of Jetmore - South,Kansas Senate,33,Democratic,"Bristow, Matt",44,150060
+HODGEMAN,City of Jetmore - South,Kansas Senate,33,Republican,"Taylor, Mary Jo",122,150060
+HODGEMAN,City of Jetmore - NW / SW Center,Kansas Senate,33,Democratic,"Bristow, Matt",18,150070
+HODGEMAN,City of Jetmore - NW / SW Center,Kansas Senate,33,Republican,"Taylor, Mary Jo",61,150070
+HODGEMAN,Southeast Center,Kansas Senate,33,Democratic,"Bristow, Matt",6,150080
+HODGEMAN,Southeast Center,Kansas Senate,33,Republican,"Taylor, Mary Jo",10,150080
+HODGEMAN,North Center,Kansas Senate,33,Democratic,"Bristow, Matt",5,150090
+HODGEMAN,North Center,Kansas Senate,33,Republican,"Taylor, Mary Jo",33,150090
+HODGEMAN,Benton Township,President / Vice President,,independent,"Stein, Jill",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+HODGEMAN,Benton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+HODGEMAN,Benton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000010
+HODGEMAN,Benton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+HODGEMAN,Benton Township,President / Vice President,,Republican,"Trump, Donald J.",27,000010
+HODGEMAN,North Hallet,President / Vice President,,independent,"Stein, Jill",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Hedges, James A",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"McMullin, Evan",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Perry, Darryl",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Smith, Mike",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Sood, Ajay",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+HODGEMAN,North Hallet,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+HODGEMAN,North Hallet,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+HODGEMAN,North Hallet,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+HODGEMAN,North Hallet,President / Vice President,,Republican,"Trump, Donald J.",7,000040
+HODGEMAN,North Roscoe,President / Vice President,,independent,"Stein, Jill",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Hedges, James A",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"McMullin, Evan",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Perry, Darryl",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Smith, Mike",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Sood, Ajay",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000050
+HODGEMAN,North Roscoe,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+HODGEMAN,North Roscoe,President / Vice President,,Republican,"Trump, Donald J.",27,000050
+HODGEMAN,South Hallet,President / Vice President,,independent,"Stein, Jill",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Hedges, James A",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"McMullin, Evan",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Perry, Darryl",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Smith, Mike",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Sood, Ajay",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+HODGEMAN,South Hallet,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+HODGEMAN,South Hallet,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+HODGEMAN,South Hallet,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+HODGEMAN,South Hallet,President / Vice President,,Republican,"Trump, Donald J.",19,000080
+HODGEMAN,South Roscoe,President / Vice President,,independent,"Stein, Jill",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Hedges, James A",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"McMullin, Evan",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Perry, Darryl",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Smith, Mike",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Sood, Ajay",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+HODGEMAN,South Roscoe,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000090
+HODGEMAN,South Roscoe,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+HODGEMAN,South Roscoe,President / Vice President,,Republican,"Trump, Donald J.",29,000090
+HODGEMAN,Sterling Township,President / Vice President,,independent,"Stein, Jill",1,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+HODGEMAN,Sterling Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000100
+HODGEMAN,Sterling Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+HODGEMAN,Sterling Township,President / Vice President,,Republican,"Trump, Donald J.",52,000100
+HODGEMAN,Valley Township,President / Vice President,,independent,"Stein, Jill",1,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+HODGEMAN,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+HODGEMAN,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000110
+HODGEMAN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+HODGEMAN,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",23,000110
+HODGEMAN,North Marena,President / Vice President,,independent,"Stein, Jill",3,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Basiago, Andrew D.",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Castle, Darrell L",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Giordani, Rocky",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Hedges, James A",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Hoefling, Tom",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Kahn, Lynn",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"La Riva, Gloria",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Levinson, Michael S.",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Maturen, Michael A",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"McMullin, Evan",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Moorehead, Monica G.",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Perry, Darryl",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Schriner, Joe C",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Smith, Mike",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Sood, Ajay",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Sterling, Shawna",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Valdivia, Anthony J",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150010
+HODGEMAN,North Marena,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150010
+HODGEMAN,North Marena,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,150010
+HODGEMAN,North Marena,President / Vice President,,Libertarian,"Johnson, Gary",4,150010
+HODGEMAN,North Marena,President / Vice President,,Republican,"Trump, Donald J.",133,150010
+HODGEMAN,South Marena,President / Vice President,,independent,"Stein, Jill",2,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Basiago, Andrew D.",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Castle, Darrell L",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Giordani, Rocky",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Hedges, James A",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Hoefling, Tom",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Kahn, Lynn",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"La Riva, Gloria",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Levinson, Michael S.",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Maturen, Michael A",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"McMullin, Evan",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Moorehead, Monica G.",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Perry, Darryl",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Schriner, Joe C",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Smith, Mike",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Sood, Ajay",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Sterling, Shawna",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Valdivia, Anthony J",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150020
+HODGEMAN,South Marena,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150020
+HODGEMAN,South Marena,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,150020
+HODGEMAN,South Marena,President / Vice President,,Libertarian,"Johnson, Gary",2,150020
+HODGEMAN,South Marena,President / Vice President,,Republican,"Trump, Donald J.",68,150020
+HODGEMAN,East Sawlog,President / Vice President,,independent,"Stein, Jill",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Basiago, Andrew D.",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Castle, Darrell L",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Giordani, Rocky",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Hedges, James A",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Hoefling, Tom",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Kahn, Lynn",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"La Riva, Gloria",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Levinson, Michael S.",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Maturen, Michael A",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"McMullin, Evan",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Moorehead, Monica G.",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Perry, Darryl",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Schriner, Joe C",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Smith, Mike",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Sood, Ajay",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Sterling, Shawna",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Valdivia, Anthony J",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,150030
+HODGEMAN,East Sawlog,President / Vice President,,Libertarian,"Johnson, Gary",0,150030
+HODGEMAN,East Sawlog,President / Vice President,,Republican,"Trump, Donald J.",18,150030
+HODGEMAN,West Sawlog,President / Vice President,,independent,"Stein, Jill",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Basiago, Andrew D.",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Castle, Darrell L",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Giordani, Rocky",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Hedges, James A",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Hoefling, Tom",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Kahn, Lynn",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"La Riva, Gloria",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Levinson, Michael S.",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Maturen, Michael A",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"McMullin, Evan",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Moorehead, Monica G.",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Perry, Darryl",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Schriner, Joe C",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Smith, Mike",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Sood, Ajay",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Sterling, Shawna",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Valdivia, Anthony J",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,150040
+HODGEMAN,West Sawlog,President / Vice President,,Libertarian,"Johnson, Gary",0,150040
+HODGEMAN,West Sawlog,President / Vice President,,Republican,"Trump, Donald J.",32,150040
+HODGEMAN,City of Jetmore - North,President / Vice President,,independent,"Stein, Jill",7,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Basiago, Andrew D.",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Castle, Darrell L",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Giordani, Rocky",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Hedges, James A",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Hoefling, Tom",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Kahn, Lynn",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"La Riva, Gloria",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Levinson, Michael S.",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Maturen, Michael A",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"McMullin, Evan",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Moorehead, Monica G.",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Perry, Darryl",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Schriner, Joe C",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Smith, Mike",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Sood, Ajay",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Sterling, Shawna",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Valdivia, Anthony J",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,Libertarian,"Johnson, Gary",7,150050
+HODGEMAN,City of Jetmore - North,President / Vice President,,Republican,"Trump, Donald J.",146,150050
+HODGEMAN,City of Jetmore - South,President / Vice President,,independent,"Stein, Jill",2,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Basiago, Andrew D.",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Castle, Darrell L",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Giordani, Rocky",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Hedges, James A",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Hoefling, Tom",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Kahn, Lynn",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"La Riva, Gloria",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Levinson, Michael S.",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Maturen, Michael A",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"McMullin, Evan",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Moorehead, Monica G.",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Perry, Darryl",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Schriner, Joe C",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Smith, Mike",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Sood, Ajay",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Sterling, Shawna",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Valdivia, Anthony J",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,Libertarian,"Johnson, Gary",2,150060
+HODGEMAN,City of Jetmore - South,President / Vice President,,Republican,"Trump, Donald J.",143,150060
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,independent,"Stein, Jill",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Castle, Darrell L",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Giordani, Rocky",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Hedges, James A",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Hoefling, Tom",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Kahn, Lynn",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"La Riva, Gloria",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Levinson, Michael S.",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Maturen, Michael A",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"McMullin, Evan",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Perry, Darryl",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Schriner, Joe C",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Smith, Mike",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Sood, Ajay",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Sterling, Shawna",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,Libertarian,"Johnson, Gary",1,150070
+HODGEMAN,City of Jetmore - NW / SW Center,President / Vice President,,Republican,"Trump, Donald J.",79,150070
+HODGEMAN,Southeast Center,President / Vice President,,independent,"Stein, Jill",1,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Castle, Darrell L",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Giordani, Rocky",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Hedges, James A",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Hoefling, Tom",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Kahn, Lynn",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"La Riva, Gloria",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Levinson, Michael S.",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Maturen, Michael A",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"McMullin, Evan",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Perry, Darryl",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Schriner, Joe C",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Smith, Mike",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Sood, Ajay",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Sterling, Shawna",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,150080
+HODGEMAN,Southeast Center,President / Vice President,,Libertarian,"Johnson, Gary",0,150080
+HODGEMAN,Southeast Center,President / Vice President,,Republican,"Trump, Donald J.",16,150080
+HODGEMAN,North Center,President / Vice President,,independent,"Stein, Jill",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Castle, Darrell L",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Giordani, Rocky",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Hedges, James A",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Hoefling, Tom",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Kahn, Lynn",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"La Riva, Gloria",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Levinson, Michael S.",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Maturen, Michael A",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"McMullin, Evan",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Perry, Darryl",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Schriner, Joe C",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Smith, Mike",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Sood, Ajay",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Sterling, Shawna",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,150090
+HODGEMAN,North Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,150090
+HODGEMAN,North Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,150090
+HODGEMAN,North Center,President / Vice President,,Libertarian,"Johnson, Gary",1,150090
+HODGEMAN,North Center,President / Vice President,,Republican,"Trump, Donald J.",36,150090
+HODGEMAN,Benton Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000010
+HODGEMAN,Benton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+HODGEMAN,Benton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+HODGEMAN,Benton Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000010
+HODGEMAN,North Hallet,United States House of Representatives,1,independent,"LaPolice, Alan",3,000040
+HODGEMAN,North Hallet,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+HODGEMAN,North Hallet,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+HODGEMAN,North Hallet,United States House of Representatives,1,Republican,"Marshall, Roger",2,000040
+HODGEMAN,North Roscoe,United States House of Representatives,1,independent,"LaPolice, Alan",4,000050
+HODGEMAN,North Roscoe,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+HODGEMAN,North Roscoe,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+HODGEMAN,North Roscoe,United States House of Representatives,1,Republican,"Marshall, Roger",23,000050
+HODGEMAN,South Hallet,United States House of Representatives,1,independent,"LaPolice, Alan",6,000080
+HODGEMAN,South Hallet,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+HODGEMAN,South Hallet,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+HODGEMAN,South Hallet,United States House of Representatives,1,Republican,"Marshall, Roger",11,000080
+HODGEMAN,South Roscoe,United States House of Representatives,1,independent,"LaPolice, Alan",3,000090
+HODGEMAN,South Roscoe,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000090
+HODGEMAN,South Roscoe,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+HODGEMAN,South Roscoe,United States House of Representatives,1,Republican,"Marshall, Roger",27,000090
+HODGEMAN,Sterling Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000100
+HODGEMAN,Sterling Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+HODGEMAN,Sterling Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+HODGEMAN,Sterling Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000100
+HODGEMAN,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000110
+HODGEMAN,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000110
+HODGEMAN,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+HODGEMAN,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000110
+HODGEMAN,North Marena,United States House of Representatives,1,independent,"LaPolice, Alan",36,150010
+HODGEMAN,North Marena,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,150010
+HODGEMAN,North Marena,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,150010
+HODGEMAN,North Marena,United States House of Representatives,1,Republican,"Marshall, Roger",108,150010
+HODGEMAN,South Marena,United States House of Representatives,1,independent,"LaPolice, Alan",16,150020
+HODGEMAN,South Marena,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,150020
+HODGEMAN,South Marena,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,150020
+HODGEMAN,South Marena,United States House of Representatives,1,Republican,"Marshall, Roger",61,150020
+HODGEMAN,East Sawlog,United States House of Representatives,1,independent,"LaPolice, Alan",3,150030
+HODGEMAN,East Sawlog,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,150030
+HODGEMAN,East Sawlog,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,150030
+HODGEMAN,East Sawlog,United States House of Representatives,1,Republican,"Marshall, Roger",15,150030
+HODGEMAN,West Sawlog,United States House of Representatives,1,independent,"LaPolice, Alan",9,150040
+HODGEMAN,West Sawlog,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,150040
+HODGEMAN,West Sawlog,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,150040
+HODGEMAN,West Sawlog,United States House of Representatives,1,Republican,"Marshall, Roger",21,150040
+HODGEMAN,City of Jetmore - North,United States House of Representatives,1,independent,"LaPolice, Alan",27,150050
+HODGEMAN,City of Jetmore - North,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,150050
+HODGEMAN,City of Jetmore - North,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,150050
+HODGEMAN,City of Jetmore - North,United States House of Representatives,1,Republican,"Marshall, Roger",140,150050
+HODGEMAN,City of Jetmore - South,United States House of Representatives,1,independent,"LaPolice, Alan",31,150060
+HODGEMAN,City of Jetmore - South,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,150060
+HODGEMAN,City of Jetmore - South,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,150060
+HODGEMAN,City of Jetmore - South,United States House of Representatives,1,Republican,"Marshall, Roger",133,150060
+HODGEMAN,City of Jetmore - NW / SW Center,United States House of Representatives,1,independent,"LaPolice, Alan",20,150070
+HODGEMAN,City of Jetmore - NW / SW Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,150070
+HODGEMAN,City of Jetmore - NW / SW Center,United States House of Representatives,1,Republican,"Marshall, Roger",60,150070
+HODGEMAN,Southeast Center,United States House of Representatives,1,independent,"LaPolice, Alan",2,150080
+HODGEMAN,Southeast Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,150080
+HODGEMAN,Southeast Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,150080
+HODGEMAN,Southeast Center,United States House of Representatives,1,Republican,"Marshall, Roger",13,150080
+HODGEMAN,North Center,United States House of Representatives,1,independent,"LaPolice, Alan",9,150090
+HODGEMAN,North Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,150090
+HODGEMAN,North Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,150090
+HODGEMAN,North Center,United States House of Representatives,1,Republican,"Marshall, Roger",25,150090
+HODGEMAN,Benton Township,United States Senate,,write - in,"Smith, DJ",0,000010
+HODGEMAN,Benton Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000010
+HODGEMAN,Benton Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+HODGEMAN,Benton Township,United States Senate,,Republican,"Moran, Jerry",26,000010
+HODGEMAN,North Hallet,United States Senate,,write - in,"Smith, DJ",0,000040
+HODGEMAN,North Hallet,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+HODGEMAN,North Hallet,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+HODGEMAN,North Hallet,United States Senate,,Republican,"Moran, Jerry",6,000040
+HODGEMAN,North Roscoe,United States Senate,,write - in,"Smith, DJ",0,000050
+HODGEMAN,North Roscoe,United States Senate,,Democratic,"Wiesner, Patrick",1,000050
+HODGEMAN,North Roscoe,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+HODGEMAN,North Roscoe,United States Senate,,Republican,"Moran, Jerry",25,000050
+HODGEMAN,South Hallet,United States Senate,,write - in,"Smith, DJ",0,000080
+HODGEMAN,South Hallet,United States Senate,,Democratic,"Wiesner, Patrick",0,000080
+HODGEMAN,South Hallet,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+HODGEMAN,South Hallet,United States Senate,,Republican,"Moran, Jerry",18,000080
+HODGEMAN,South Roscoe,United States Senate,,write - in,"Smith, DJ",0,000090
+HODGEMAN,South Roscoe,United States Senate,,Democratic,"Wiesner, Patrick",3,000090
+HODGEMAN,South Roscoe,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+HODGEMAN,South Roscoe,United States Senate,,Republican,"Moran, Jerry",31,000090
+HODGEMAN,Sterling Township,United States Senate,,write - in,"Smith, DJ",0,000100
+HODGEMAN,Sterling Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000100
+HODGEMAN,Sterling Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+HODGEMAN,Sterling Township,United States Senate,,Republican,"Moran, Jerry",57,000100
+HODGEMAN,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000110
+HODGEMAN,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+HODGEMAN,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+HODGEMAN,Valley Township,United States Senate,,Republican,"Moran, Jerry",26,000110
+HODGEMAN,North Marena,United States Senate,,write - in,"Smith, DJ",0,150010
+HODGEMAN,North Marena,United States Senate,,Democratic,"Wiesner, Patrick",13,150010
+HODGEMAN,North Marena,United States Senate,,Libertarian,"Garrard, Robert D.",5,150010
+HODGEMAN,North Marena,United States Senate,,Republican,"Moran, Jerry",140,150010
+HODGEMAN,South Marena,United States Senate,,write - in,"Smith, DJ",0,150020
+HODGEMAN,South Marena,United States Senate,,Democratic,"Wiesner, Patrick",7,150020
+HODGEMAN,South Marena,United States Senate,,Libertarian,"Garrard, Robert D.",7,150020
+HODGEMAN,South Marena,United States Senate,,Republican,"Moran, Jerry",70,150020
+HODGEMAN,East Sawlog,United States Senate,,write - in,"Smith, DJ",0,150030
+HODGEMAN,East Sawlog,United States Senate,,Democratic,"Wiesner, Patrick",3,150030
+HODGEMAN,East Sawlog,United States Senate,,Libertarian,"Garrard, Robert D.",1,150030
+HODGEMAN,East Sawlog,United States Senate,,Republican,"Moran, Jerry",18,150030
+HODGEMAN,West Sawlog,United States Senate,,write - in,"Smith, DJ",0,150040
+HODGEMAN,West Sawlog,United States Senate,,Democratic,"Wiesner, Patrick",2,150040
+HODGEMAN,West Sawlog,United States Senate,,Libertarian,"Garrard, Robert D.",1,150040
+HODGEMAN,West Sawlog,United States Senate,,Republican,"Moran, Jerry",29,150040
+HODGEMAN,City of Jetmore - North,United States Senate,,write - in,"Smith, DJ",0,150050
+HODGEMAN,City of Jetmore - North,United States Senate,,Democratic,"Wiesner, Patrick",15,150050
+HODGEMAN,City of Jetmore - North,United States Senate,,Libertarian,"Garrard, Robert D.",11,150050
+HODGEMAN,City of Jetmore - North,United States Senate,,Republican,"Moran, Jerry",159,150050
+HODGEMAN,City of Jetmore - South,United States Senate,,write - in,"Smith, DJ",0,150060
+HODGEMAN,City of Jetmore - South,United States Senate,,Democratic,"Wiesner, Patrick",16,150060
+HODGEMAN,City of Jetmore - South,United States Senate,,Libertarian,"Garrard, Robert D.",7,150060
+HODGEMAN,City of Jetmore - South,United States Senate,,Republican,"Moran, Jerry",154,150060
+HODGEMAN,City of Jetmore - NW / SW Center,United States Senate,,write - in,"Smith, DJ",0,150070
+HODGEMAN,City of Jetmore - NW / SW Center,United States Senate,,Democratic,"Wiesner, Patrick",7,150070
+HODGEMAN,City of Jetmore - NW / SW Center,United States Senate,,Libertarian,"Garrard, Robert D.",3,150070
+HODGEMAN,City of Jetmore - NW / SW Center,United States Senate,,Republican,"Moran, Jerry",77,150070
+HODGEMAN,Southeast Center,United States Senate,,write - in,"Smith, DJ",0,150080
+HODGEMAN,Southeast Center,United States Senate,,Democratic,"Wiesner, Patrick",0,150080
+HODGEMAN,Southeast Center,United States Senate,,Libertarian,"Garrard, Robert D.",0,150080
+HODGEMAN,Southeast Center,United States Senate,,Republican,"Moran, Jerry",19,150080
+HODGEMAN,North Center,United States Senate,,write - in,"Smith, DJ",0,150090
+HODGEMAN,North Center,United States Senate,,Democratic,"Wiesner, Patrick",5,150090
+HODGEMAN,North Center,United States Senate,,Libertarian,"Garrard, Robert D.",2,150090
+HODGEMAN,North Center,United States Senate,,Republican,"Moran, Jerry",34,150090

--- a/2016/20161108__ks__general__jackson__precinct.csv
+++ b/2016/20161108__ks__general__jackson__precinct.csv
@@ -1,256 +1,694 @@
-county,precinct,office,district,candidate,party,votes
-Jackson,Adrian,President,,JOHNSON/WELD,L,2
-Jackson,Adrian,President,,STEIN/BARAKA,I,1
-Jackson,Adrian,President,,TRUMP/PENCE,R,55
-Jackson,Adrian,President,,CLINTON/KAINE,D,11
-Jackson,Adrian,U.S. Senate,,JERRY MORAN,R,55
-Jackson,Adrian,U.S. Senate,,PATRICK WEISNER,D,10
-Jackson,Adrian,U.S. Senate,,ROBERT D. GARRARD,L,1
-Jackson,Adrian,U.S. House,2,JAMES HOUSTON BALES,L,3
-Jackson,Adrian,U.S. House,2,LYNN JENKINS,R,50
-Jackson,Adrian,U.S. House,2,BRITANI POTTER,D,10
-Jackson,Adrian,State Senate,1,DENNIS D. PYLE,R,47
-Jackson,Adrian,State Senate,1,JERRY HENRY,D,17
-Jackson,Adrian,State House,61,FRANCES AWERKAMP,R,41
-Jackson,Adrian,State House,61,LAUREN VANWAGONER,D,26
-Jackson,Banner,President,,JOHNSON/WELD,L,9
-Jackson,Banner,President,,STEIN/BARAKA,I,3
-Jackson,Banner,President,,TRUMP/PENCE,R,139
-Jackson,Banner,President,,CLINTON/KAINE,D,27
-Jackson,Banner,U.S. Senate,,JERRY MORAN,R,144
-Jackson,Banner,U.S. Senate,,PATRICK WEISNER,D,25
-Jackson,Banner,U.S. Senate,,ROBERT D. GARRARD,L,9
-Jackson,Banner,U.S. House,2,JAMES HOUSTON BALES,L,9
-Jackson,Banner,U.S. House,2,LYNN JENKINS,R,134
-Jackson,Banner,U.S. House,2,BRITANI POTTER,D,34
-Jackson,Banner,State Senate,1,DENNIS D. PYLE,R,109
-Jackson,Banner,State Senate,1,JERRY HENRY,D,69
-Jackson,Banner,State House,61,FRANCES AWERKAMP,R,96
-Jackson,Banner,State House,61,LAUREN VANWAGONER,D,79
-Jackson,Cedar,President,,JOHNSON/WELD,L,26
-Jackson,Cedar,President,,STEIN/BARAKA,I,15
-Jackson,Cedar,President,,TRUMP/PENCE,R,381
-Jackson,Cedar,President,,CLINTON/KAINE,D,134
-Jackson,Cedar,U.S. Senate,,JERRY MORAN,R,395
-Jackson,Cedar,U.S. Senate,,PATRICK WEISNER,D,127
-Jackson,Cedar,U.S. Senate,,ROBERT D. GARRARD,L,39
-Jackson,Cedar,U.S. House,2,JAMES HOUSTON BALES,L,31
-Jackson,Cedar,U.S. House,2,LYNN JENKINS,R,380
-Jackson,Cedar,U.S. House,2,BRITANI POTTER,D,148
-Jackson,Cedar,State Senate,1,DENNIS D. PYLE,R,350
-Jackson,Cedar,State Senate,1,JERRY HENRY,D,209
-Jackson,Cedar,State House,61,FRANCES AWERKAMP,R,287
-Jackson,Cedar,State House,61,LAUREN VANWAGONER,D,266
-Jackson,Douglas,President,,JOHNSON/WELD,L,38
-Jackson,Douglas,President,,STEIN/BARAKA,I,34
-Jackson,Douglas,President,,TRUMP/PENCE,R,728
-Jackson,Douglas,President,,CLINTON/KAINE,D,293
-Jackson,Douglas,U.S. Senate,,JERRY MORAN,R,729
-Jackson,Douglas,U.S. Senate,,PATRICK WEISNER,D,303
-Jackson,Douglas,U.S. Senate,,ROBERT D. GARRARD,L,67
-Jackson,Douglas,U.S. House,2,JAMES HOUSTON BALES,L,69
-Jackson,Douglas,U.S. House,2,LYNN JENKINS,R,741
-Jackson,Douglas,U.S. House,2,BRITANI POTTER,D,296
-Jackson,Douglas,State Senate,1,DENNIS D. PYLE,R,676
-Jackson,Douglas,State Senate,1,JERRY HENRY,D,422
-Jackson,Douglas,State House,61,FRANCES AWERKAMP,R,503
-Jackson,Douglas,State House,61,LAUREN VANWAGONER,D,586
-Jackson,Franklin,President,,JOHNSON/WELD,L,20
-Jackson,Franklin,President,,STEIN/BARAKA,I,10
-Jackson,Franklin,President,,TRUMP/PENCE,R,351
-Jackson,Franklin,President,,CLINTON/KAINE,D,110
-Jackson,Franklin,U.S. Senate,,JERRY MORAN,R,378
-Jackson,Franklin,U.S. Senate,,PATRICK WEISNER,D,97
-Jackson,Franklin,U.S. Senate,,ROBERT D. GARRARD,L,17
-Jackson,Franklin,U.S. House,2,JAMES HOUSTON BALES,L,26
-Jackson,Franklin,U.S. House,2,LYNN JENKINS,R,370
-Jackson,Franklin,U.S. House,2,BRITANI POTTER,D,102
-Jackson,Franklin,State Senate,1,DENNIS D. PYLE,R,253
-Jackson,Franklin,State Senate,1,JERRY HENRY,D,230
-Jackson,Franklin,State House,61,FRANCES AWERKAMP,R,246
-Jackson,Franklin,State House,61,LAUREN VANWAGONER,D,232
-Jackson,Garfield,President,,JOHNSON/WELD,L,13
-Jackson,Garfield,President,,STEIN/BARAKA,I,4
-Jackson,Garfield,President,,TRUMP/PENCE,R,189
-Jackson,Garfield,President,,CLINTON/KAINE,D,57
-Jackson,Garfield,U.S. Senate,,JERRY MORAN,R,206
-Jackson,Garfield,U.S. Senate,,PATRICK WEISNER,D,55
-Jackson,Garfield,U.S. Senate,,ROBERT D. GARRARD,L,7
-Jackson,Garfield,U.S. House,2,JAMES HOUSTON BALES,L,6
-Jackson,Garfield,U.S. House,2,LYNN JENKINS,R,206
-Jackson,Garfield,U.S. House,2,BRITANI POTTER,D,56
-Jackson,Garfield,State Senate,1,DENNIS D. PYLE,R,182
-Jackson,Garfield,State Senate,1,JERRY HENRY,D,87
-Jackson,Garfield,State House,61,FRANCES AWERKAMP,R,151
-Jackson,Garfield,State House,61,LAUREN VANWAGONER,D,110
-Jackson,GRANT,President,,JOHNSON/WELD,L,3
-Jackson,GRANT,President,,STEIN/BARAKA,I,4
-Jackson,GRANT,President,,TRUMP/PENCE,R,53
-Jackson,GRANT,President,,CLINTON/KAINE,D,16
-Jackson,GRANT,U.S. Senate,,JERRY MORAN,R,61
-Jackson,GRANT,U.S. Senate,,PATRICK WEISNER,D,18
-Jackson,GRANT,U.S. Senate,,ROBERT D. GARRARD,L,1
-Jackson,GRANT,U.S. House,2,JAMES HOUSTON BALES,L,3
-Jackson,GRANT,U.S. House,2,LYNN JENKINS,R,60
-Jackson,GRANT,U.S. House,2,BRITANI POTTER,D,19
-Jackson,GRANT,State Senate,1,DENNIS D. PYLE,R,48
-Jackson,GRANT,State Senate,1,JERRY HENRY,D,33
-Jackson,GRANT,State House,61,FRANCES AWERKAMP,R,44
-Jackson,GRANT,State House,61,LAUREN VANWAGONER,D,36
-Jackson,Holton Wd 1,President,,JOHNSON/WELD,L,21
-Jackson,Holton Wd 1,President,,STEIN/BARAKA,I,10
-Jackson,Holton Wd 1,President,,TRUMP/PENCE,R,277
-Jackson,Holton Wd 1,President,,CLINTON/KAINE,D,131
-Jackson,Holton Wd 1,U.S. Senate,,JERRY MORAN,R,284
-Jackson,Holton Wd 1,U.S. Senate,,PATRICK WEISNER,D,119
-Jackson,Holton Wd 1,U.S. Senate,,ROBERT D. GARRARD,L,31
-Jackson,Holton Wd 1,U.S. House,2,JAMES HOUSTON BALES,L,25
-Jackson,Holton Wd 1,U.S. House,2,LYNN JENKINS,R,291
-Jackson,Holton Wd 1,U.S. House,2,BRITANI POTTER,D,126
-Jackson,Holton Wd 1,State Senate,1,DENNIS D. PYLE,R,250
-Jackson,Holton Wd 1,State Senate,1,JERRY HENRY,D,188
-Jackson,Holton Wd 1,State House,61,FRANCES AWERKAMP,R,219
-Jackson,Holton Wd 1,State House,61,LAUREN VANWAGONER,D,217
-Jackson,Holton Wd 2,President,,JOHNSON/WELD,L,15
-Jackson,Holton Wd 2,President,,STEIN/BARAKA,I,14
-Jackson,Holton Wd 2,President,,TRUMP/PENCE,R,306
-Jackson,Holton Wd 2,President,,CLINTON/KAINE,D,150
-Jackson,Holton Wd 2,U.S. Senate,,JERRY MORAN,R,344
-Jackson,Holton Wd 2,U.S. Senate,,PATRICK WEISNER,D,123
-Jackson,Holton Wd 2,U.S. Senate,,ROBERT D. GARRARD,L,18
-Jackson,Holton Wd 2,U.S. House,2,JAMES HOUSTON BALES,L,31
-Jackson,Holton Wd 2,U.S. House,2,LYNN JENKINS,R,323
-Jackson,Holton Wd 2,U.S. House,2,BRITANI POTTER,D,131
-Jackson,Holton Wd 2,State Senate,1,DENNIS D. PYLE,R,269
-Jackson,Holton Wd 2,State Senate,1,JERRY HENRY,D,216
-Jackson,Holton Wd 2,State House,61,FRANCES AWERKAMP,R,213
-Jackson,Holton Wd 2,State House,61,LAUREN VANWAGONER,D,266
-Jackson,Holton Wd 3,President,,JOHNSON/WELD,L,8
-Jackson,Holton Wd 3,President,,STEIN/BARAKA,I,7
-Jackson,Holton Wd 3,President,,TRUMP/PENCE,R,245
-Jackson,Holton Wd 3,President,,CLINTON/KAINE,D,127
-Jackson,Holton Wd 3,U.S. Senate,,JERRY MORAN,R,270
-Jackson,Holton Wd 3,U.S. Senate,,PATRICK WEISNER,D,105
-Jackson,Holton Wd 3,U.S. Senate,,ROBERT D. GARRARD,L,14
-Jackson,Holton Wd 3,U.S. House,2,JAMES HOUSTON BALES,L,14
-Jackson,Holton Wd 3,U.S. House,2,LYNN JENKINS,R,251
-Jackson,Holton Wd 3,U.S. House,2,BRITANI POTTER,D,124
-Jackson,Holton Wd 3,State Senate,1,DENNIS D. PYLE,R,211
-Jackson,Holton Wd 3,State Senate,1,JERRY HENRY,D,176
-Jackson,Holton Wd 3,State House,61,FRANCES AWERKAMP,R,179
-Jackson,Holton Wd 3,State House,61,LAUREN VANWAGONER,D,205
-Jackson,Jefferson,President,,JOHNSON/WELD,L,5
-Jackson,Jefferson,President,,STEIN/BARAKA,I,4
-Jackson,Jefferson,President,,TRUMP/PENCE,R,199
-Jackson,Jefferson,President,,CLINTON/KAINE,D,45
-Jackson,Jefferson,U.S. Senate,,JERRY MORAN,R,194
-Jackson,Jefferson,U.S. Senate,,PATRICK WEISNER,D,44
-Jackson,Jefferson,U.S. Senate,,ROBERT D. GARRARD,L,15
-Jackson,Jefferson,U.S. House,2,JAMES HOUSTON BALES,L,9
-Jackson,Jefferson,U.S. House,2,LYNN JENKINS,R,195
-Jackson,Jefferson,U.S. House,2,BRITANI POTTER,D,51
-Jackson,Jefferson,State Senate,1,DENNIS D. PYLE,R,182
-Jackson,Jefferson,State Senate,1,JERRY HENRY,D,71
-Jackson,Jefferson,State House,61,FRANCES AWERKAMP,R,148
-Jackson,Jefferson,State House,61,LAUREN VANWAGONER,D,102
-Jackson,Liberty,President,,JOHNSON/WELD,L,5
-Jackson,Liberty,President,,STEIN/BARAKA,I,3
-Jackson,Liberty,President,,TRUMP/PENCE,R,197
-Jackson,Liberty,President,,CLINTON/KAINE,D,75
-Jackson,Liberty,U.S. Senate,,JERRY MORAN,R,197
-Jackson,Liberty,U.S. Senate,,PATRICK WEISNER,D,66
-Jackson,Liberty,U.S. Senate,,ROBERT D. GARRARD,L,15
-Jackson,Liberty,U.S. House,2,JAMES HOUSTON BALES,L,13
-Jackson,Liberty,U.S. House,2,LYNN JENKINS,R,198
-Jackson,Liberty,U.S. House,2,BRITANI POTTER,D,67
-Jackson,Liberty,State Senate,1,DENNIS D. PYLE,R,150
-Jackson,Liberty,State Senate,1,JERRY HENRY,D,130
-Jackson,Liberty,State House,61,FRANCES AWERKAMP,R,146
-Jackson,Liberty,State House,61,LAUREN VANWAGONER,D,130
-Jackson,Lincoln,President,,JOHNSON/WELD,L,14
-Jackson,Lincoln,President,,STEIN/BARAKA,I,25
-Jackson,Lincoln,President,,TRUMP/PENCE,R,176
-Jackson,Lincoln,President,,CLINTON/KAINE,D,201
-Jackson,Lincoln,U.S. Senate,,JERRY MORAN,R,204
-Jackson,Lincoln,U.S. Senate,,PATRICK WEISNER,D,194
-Jackson,Lincoln,U.S. Senate,,ROBERT D. GARRARD,L,23
-Jackson,Lincoln,U.S. House,2,JAMES HOUSTON BALES,L,38
-Jackson,Lincoln,U.S. House,2,LYNN JENKINS,R,205
-Jackson,Lincoln,U.S. House,2,BRITANI POTTER,D,182
-Jackson,Lincoln,State Senate,1,DENNIS D. PYLE,R,173
-Jackson,Lincoln,State Senate,1,JERRY HENRY,D,243
-Jackson,Lincoln,State House,61,FRANCES AWERKAMP,R,128
-Jackson,Lincoln,State House,61,LAUREN VANWAGONER,D,291
-Jackson,Netawaka,President,,JOHNSON/WELD,L,5
-Jackson,Netawaka,President,,STEIN/BARAKA,I,0
-Jackson,Netawaka,President,,TRUMP/PENCE,R,131
-Jackson,Netawaka,President,,CLINTON/KAINE,D,23
-Jackson,Netawaka,U.S. Senate,,JERRY MORAN,R,133
-Jackson,Netawaka,U.S. Senate,,PATRICK WEISNER,D,26
-Jackson,Netawaka,U.S. Senate,,ROBERT D. GARRARD,L,4
-Jackson,Netawaka,U.S. House,2,JAMES HOUSTON BALES,L,5
-Jackson,Netawaka,U.S. House,2,LYNN JENKINS,R,125
-Jackson,Netawaka,U.S. House,2,BRITANI POTTER,D,32
-Jackson,Netawaka,State Senate,1,DENNIS D. PYLE,R,116
-Jackson,Netawaka,State Senate,1,JERRY HENRY,D,44
-Jackson,Netawaka,State House,62,RANDY GARBER,R,139
-Jackson,Soldier,President,,JOHNSON/WELD,L,12
-Jackson,Soldier,President,,STEIN/BARAKA,I,5
-Jackson,Soldier,President,,TRUMP/PENCE,R,142
-Jackson,Soldier,President,,CLINTON/KAINE,D,35
-Jackson,Soldier,U.S. Senate,,JERRY MORAN,R,147
-Jackson,Soldier,U.S. Senate,,PATRICK WEISNER,D,41
-Jackson,Soldier,U.S. Senate,,ROBERT D. GARRARD,L,9
-Jackson,Soldier,U.S. House,2,JAMES HOUSTON BALES,L,7
-Jackson,Soldier,U.S. House,2,LYNN JENKINS,R,143
-Jackson,Soldier,U.S. House,2,BRITANI POTTER,D,49
-Jackson,Soldier,State Senate,1,DENNIS D. PYLE,R,131
-Jackson,Soldier,State Senate,1,JERRY HENRY,D,64
-Jackson,Soldier,State House,61,FRANCES AWERKAMP,R,122
-Jackson,Soldier,State House,61,LAUREN VANWAGONER,D,73
-Jackson,St Creek,President,,JOHNSON/WELD,L,3
-Jackson,St Creek,President,,STEIN/BARAKA,I,0
-Jackson,St Creek,President,,TRUMP/PENCE,R,69
-Jackson,St Creek,President,,CLINTON/KAINE,D,8
-Jackson,St Creek,U.S. Senate,,JERRY MORAN,R,62
-Jackson,St Creek,U.S. Senate,,PATRICK WEISNER,D,15
-Jackson,St Creek,U.S. Senate,,ROBERT D. GARRARD,L,4
-Jackson,St Creek,U.S. House,2,JAMES HOUSTON BALES,L,4
-Jackson,St Creek,U.S. House,2,LYNN JENKINS,R,64
-Jackson,St Creek,U.S. House,2,BRITANI POTTER,D,14
-Jackson,St Creek,State Senate,1,DENNIS D. PYLE,R,50
-Jackson,St Creek,State Senate,1,JERRY HENRY,D,29
-Jackson,St Creek,State House,61,FRANCES AWERKAMP,R,42
-Jackson,St Creek,State House,61,LAUREN VANWAGONER,D,33
-Jackson,Washington,President,,JOHNSON/WELD,L,8
-Jackson,Washington,President,,STEIN/BARAKA,I,2
-Jackson,Washington,President,,TRUMP/PENCE,R,180
-Jackson,Washington,President,,CLINTON/KAINE,D,42
-Jackson,Washington,U.S. Senate,,JERRY MORAN,R,189
-Jackson,Washington,U.S. Senate,,PATRICK WEISNER,D,33
-Jackson,Washington,U.S. Senate,,ROBERT D. GARRARD,L,11
-Jackson,Washington,U.S. House,2,JAMES HOUSTON BALES,L,14
-Jackson,Washington,U.S. House,2,LYNN JENKINS,R,183
-Jackson,Washington,U.S. House,2,BRITANI POTTER,D,35
-Jackson,Washington,State Senate,1,DENNIS D. PYLE,R,182
-Jackson,Washington,State Senate,1,JERRY HENRY,D,53
-Jackson,Washington,State House,61,FRANCES AWERKAMP,R,157
-Jackson,Washington,State House,61,LAUREN VANWAGONER,D,76
-Jackson,Whiting,President,,JOHNSON/WELD,L,6
-Jackson,Whiting,President,,STEIN/BARAKA,I,2
-Jackson,Whiting,President,,TRUMP/PENCE,R,121
-Jackson,Whiting,President,,CLINTON/KAINE,D,27
-Jackson,Whiting,U.S. Senate,,JERRY MORAN,R,123
-Jackson,Whiting,U.S. Senate,,PATRICK WEISNER,D,24
-Jackson,Whiting,U.S. Senate,,ROBERT D. GARRARD,L,6
-Jackson,Whiting,U.S. House,2,JAMES HOUSTON BALES,L,13
-Jackson,Whiting,U.S. House,2,LYNN JENKINS,R,120
-Jackson,Whiting,U.S. House,2,BRITANI POTTER,D,21
-Jackson,Whiting,State Senate,1,DENNIS D. PYLE,R,95
-Jackson,Whiting,State Senate,1,JERRY HENRY,D,55
-Jackson,Whiting,State House,62,RANDY GARBER,R,129
-Jackson,Banner,President,,Evan McMullin,,2
-Jackson,Cedar,President,,Evan McMullin,,3
-Jackson,Douglas,President,,Evan McMullin,,2
-Jackson,Holton Wd 1,President,,Evan McMullin,,2
-Jackson,Lincoln,President,,Darrell Castle,,2
+county,precinct,office,district,party,candidate,votes,vtd
+JACKSON,Adrian Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",26,000010
+JACKSON,Adrian Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",41,000010
+JACKSON,Banner Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",79,000020
+JACKSON,Banner Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",96,000020
+JACKSON,Cedar Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",266,000030
+JACKSON,Cedar Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",287,000030
+JACKSON,Douglas Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",586,000040
+JACKSON,Douglas Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",503,000040
+JACKSON,Franklin Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",232,000050
+JACKSON,Franklin Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",246,000050
+JACKSON,Garfield Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",110,000060
+JACKSON,Garfield Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",151,000060
+JACKSON,Grant Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",36,000070
+JACKSON,Grant Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",44,000070
+JACKSON,Holton Ward 1,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",217,00008A
+JACKSON,Holton Ward 1,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",219,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",0,00008B
+JACKSON,Holton Ward 2,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",266,000090
+JACKSON,Holton Ward 2,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",213,000090
+JACKSON,Holton Ward 3,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",205,00010A
+JACKSON,Holton Ward 3,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",179,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",0,00010B
+JACKSON,Jefferson Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",102,000110
+JACKSON,Jefferson Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",148,000110
+JACKSON,Liberty Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",130,000120
+JACKSON,Liberty Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",146,000120
+JACKSON,Lincoln Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",291,000130
+JACKSON,Lincoln Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",128,000130
+JACKSON,Netawaka Township,Kansas House of Representatives,62,Republican,"Garber, Randy",139,000140
+JACKSON,Soldier Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",73,000150
+JACKSON,Soldier Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",122,000150
+JACKSON,Straight Creek Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",33,000160
+JACKSON,Straight Creek Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",42,000160
+JACKSON,Washington Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",76,000170
+JACKSON,Washington Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",157,000170
+JACKSON,Whiting Township,Kansas House of Representatives,62,Republican,"Garber, Randy",129,000180
+JACKSON,Adrian Township,Kansas Senate,1,Democratic,"Henry, Jerry",17,000010
+JACKSON,Adrian Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",47,000010
+JACKSON,Banner Township,Kansas Senate,1,Democratic,"Henry, Jerry",69,000020
+JACKSON,Banner Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",109,000020
+JACKSON,Cedar Township,Kansas Senate,1,Democratic,"Henry, Jerry",209,000030
+JACKSON,Cedar Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",350,000030
+JACKSON,Douglas Township,Kansas Senate,1,Democratic,"Henry, Jerry",422,000040
+JACKSON,Douglas Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",676,000040
+JACKSON,Franklin Township,Kansas Senate,1,Democratic,"Henry, Jerry",230,000050
+JACKSON,Franklin Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",253,000050
+JACKSON,Garfield Township,Kansas Senate,1,Democratic,"Henry, Jerry",87,000060
+JACKSON,Garfield Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",182,000060
+JACKSON,Grant Township,Kansas Senate,1,Democratic,"Henry, Jerry",33,000070
+JACKSON,Grant Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",48,000070
+JACKSON,Holton Ward 1,Kansas Senate,1,Democratic,"Henry, Jerry",188,00008A
+JACKSON,Holton Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",250,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas Senate,1,Democratic,"Henry, Jerry",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00008B
+JACKSON,Holton Ward 2,Kansas Senate,1,Democratic,"Henry, Jerry",216,000090
+JACKSON,Holton Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",269,000090
+JACKSON,Holton Ward 3,Kansas Senate,1,Democratic,"Henry, Jerry",176,00010A
+JACKSON,Holton Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",211,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas Senate,1,Democratic,"Henry, Jerry",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00010B
+JACKSON,Jefferson Township,Kansas Senate,1,Democratic,"Henry, Jerry",71,000110
+JACKSON,Jefferson Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",182,000110
+JACKSON,Liberty Township,Kansas Senate,1,Democratic,"Henry, Jerry",130,000120
+JACKSON,Liberty Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",150,000120
+JACKSON,Lincoln Township,Kansas Senate,1,Democratic,"Henry, Jerry",243,000130
+JACKSON,Lincoln Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",173,000130
+JACKSON,Netawaka Township,Kansas Senate,1,Democratic,"Henry, Jerry",44,000140
+JACKSON,Netawaka Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",116,000140
+JACKSON,Soldier Township,Kansas Senate,1,Democratic,"Henry, Jerry",64,000150
+JACKSON,Soldier Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",131,000150
+JACKSON,Straight Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",29,000160
+JACKSON,Straight Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",50,000160
+JACKSON,Washington Township,Kansas Senate,1,Democratic,"Henry, Jerry",53,000170
+JACKSON,Washington Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",182,000170
+JACKSON,Whiting Township,Kansas Senate,1,Democratic,"Henry, Jerry",55,000180
+JACKSON,Whiting Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",95,000180
+JACKSON,Adrian Township,President / Vice President,,independent,"Stein, Jill",1,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+JACKSON,Adrian Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+JACKSON,Adrian Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000010
+JACKSON,Adrian Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+JACKSON,Adrian Township,President / Vice President,,Republican,"Trump, Donald J.",55,000010
+JACKSON,Banner Township,President / Vice President,,independent,"Stein, Jill",3,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"McMullin, Evan",2,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+JACKSON,Banner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+JACKSON,Banner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000020
+JACKSON,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000020
+JACKSON,Banner Township,President / Vice President,,Republican,"Trump, Donald J.",139,000020
+JACKSON,Cedar Township,President / Vice President,,independent,"Stein, Jill",15,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"McMullin, Evan",3,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+JACKSON,Cedar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+JACKSON,Cedar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",134,000030
+JACKSON,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",26,000030
+JACKSON,Cedar Township,President / Vice President,,Republican,"Trump, Donald J.",381,000030
+JACKSON,Douglas Township,President / Vice President,,independent,"Stein, Jill",34,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"McMullin, Evan",2,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+JACKSON,Douglas Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+JACKSON,Douglas Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",293,000040
+JACKSON,Douglas Township,President / Vice President,,Libertarian,"Johnson, Gary",38,000040
+JACKSON,Douglas Township,President / Vice President,,Republican,"Trump, Donald J.",728,000040
+JACKSON,Franklin Township,President / Vice President,,independent,"Stein, Jill",10,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+JACKSON,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+JACKSON,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,000050
+JACKSON,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000050
+JACKSON,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",351,000050
+JACKSON,Garfield Township,President / Vice President,,independent,"Stein, Jill",4,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+JACKSON,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+JACKSON,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000060
+JACKSON,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000060
+JACKSON,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",189,000060
+JACKSON,Grant Township,President / Vice President,,independent,"Stein, Jill",4,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+JACKSON,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+JACKSON,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000070
+JACKSON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+JACKSON,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",53,000070
+JACKSON,Holton Ward 1,President / Vice President,,independent,"Stein, Jill",10,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",131,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",21,00008A
+JACKSON,Holton Ward 1,President / Vice President,,Republican,"Trump, Donald J.",277,00008A
+JACKSON,Holton Ward 2,President / Vice President,,independent,"Stein, Jill",14,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+JACKSON,Holton Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",150,000090
+JACKSON,Holton Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000090
+JACKSON,Holton Ward 2,President / Vice President,,Republican,"Trump, Donald J.",306,000090
+JACKSON,Holton Ward 3,President / Vice President,,independent,"Stein, Jill",7,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",127,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",8,00010A
+JACKSON,Holton Ward 3,President / Vice President,,Republican,"Trump, Donald J.",245,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,independent,"Stein, Jill",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Castle, Darrell L",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Giordani, Rocky",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Hedges, James A",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Kahn, Lynn",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"La Riva, Gloria",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Levinson, Michael S.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Maturen, Michael A",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"McMullin, Evan",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Perry, Darryl",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Schriner, Joe C",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Smith, Mike",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Sood, Ajay",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Sterling, Shawna",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,President / Vice President,,Republican,"Trump, Donald J.",0,00010B
+JACKSON,Jefferson Township,President / Vice President,,independent,"Stein, Jill",4,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+JACKSON,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+JACKSON,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000110
+JACKSON,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+JACKSON,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",199,000110
+JACKSON,Liberty Township,President / Vice President,,independent,"Stein, Jill",3,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+JACKSON,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+JACKSON,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,000120
+JACKSON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+JACKSON,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",197,000120
+JACKSON,Lincoln Township,President / Vice President,,independent,"Stein, Jill",25,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",2,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+JACKSON,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+JACKSON,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",201,000130
+JACKSON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000130
+JACKSON,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",176,000130
+JACKSON,Netawaka Township,President / Vice President,,independent,"Stein, Jill",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+JACKSON,Netawaka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+JACKSON,Netawaka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000140
+JACKSON,Netawaka Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000140
+JACKSON,Netawaka Township,President / Vice President,,Republican,"Trump, Donald J.",131,000140
+JACKSON,Soldier Township,President / Vice President,,independent,"Stein, Jill",5,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+JACKSON,Soldier Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+JACKSON,Soldier Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000150
+JACKSON,Soldier Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000150
+JACKSON,Soldier Township,President / Vice President,,Republican,"Trump, Donald J.",142,000150
+JACKSON,Straight Creek Township,President / Vice President,,independent,"Stein, Jill",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+JACKSON,Straight Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000160
+JACKSON,Straight Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+JACKSON,Straight Creek Township,President / Vice President,,Republican,"Trump, Donald J.",69,000160
+JACKSON,Washington Township,President / Vice President,,independent,"Stein, Jill",2,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+JACKSON,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+JACKSON,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000170
+JACKSON,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000170
+JACKSON,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",180,000170
+JACKSON,Whiting Township,President / Vice President,,independent,"Stein, Jill",2,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+JACKSON,Whiting Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+JACKSON,Whiting Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000180
+JACKSON,Whiting Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+JACKSON,Whiting Township,President / Vice President,,Republican,"Trump, Donald J.",121,000180
+JACKSON,Adrian Township,United States House of Representatives,2,Democratic,"Potter, Britani",10,000010
+JACKSON,Adrian Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000010
+JACKSON,Adrian Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000010
+JACKSON,Banner Township,United States House of Representatives,2,Democratic,"Potter, Britani",34,000020
+JACKSON,Banner Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000020
+JACKSON,Banner Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,000020
+JACKSON,Cedar Township,United States House of Representatives,2,Democratic,"Potter, Britani",148,000030
+JACKSON,Cedar Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",31,000030
+JACKSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",380,000030
+JACKSON,Douglas Township,United States House of Representatives,2,Democratic,"Potter, Britani",296,000040
+JACKSON,Douglas Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",69,000040
+JACKSON,Douglas Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",741,000040
+JACKSON,Franklin Township,United States House of Representatives,2,Democratic,"Potter, Britani",102,000050
+JACKSON,Franklin Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",26,000050
+JACKSON,Franklin Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",370,000050
+JACKSON,Garfield Township,United States House of Representatives,2,Democratic,"Potter, Britani",56,000060
+JACKSON,Garfield Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000060
+JACKSON,Garfield Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",206,000060
+JACKSON,Grant Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,000070
+JACKSON,Grant Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000070
+JACKSON,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000070
+JACKSON,Holton Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",126,00008A
+JACKSON,Holton Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,00008A
+JACKSON,Holton Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",291,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Democratic,"Potter, Britani",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+JACKSON,Holton Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",131,000090
+JACKSON,Holton Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",31,000090
+JACKSON,Holton Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",323,000090
+JACKSON,Holton Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",124,00010A
+JACKSON,Holton Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,00010A
+JACKSON,Holton Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",251,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Democratic,"Potter, Britani",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+JACKSON,Jefferson Township,United States House of Representatives,2,Democratic,"Potter, Britani",51,000110
+JACKSON,Jefferson Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000110
+JACKSON,Jefferson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",195,000110
+JACKSON,Liberty Township,United States House of Representatives,2,Democratic,"Potter, Britani",67,000120
+JACKSON,Liberty Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000120
+JACKSON,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",198,000120
+JACKSON,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",182,000130
+JACKSON,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",38,000130
+JACKSON,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",205,000130
+JACKSON,Netawaka Township,United States House of Representatives,2,Democratic,"Potter, Britani",32,000140
+JACKSON,Netawaka Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000140
+JACKSON,Netawaka Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",125,000140
+JACKSON,Soldier Township,United States House of Representatives,2,Democratic,"Potter, Britani",49,000150
+JACKSON,Soldier Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000150
+JACKSON,Soldier Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000150
+JACKSON,Straight Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000160
+JACKSON,Straight Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000160
+JACKSON,Straight Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",64,000160
+JACKSON,Washington Township,United States House of Representatives,2,Democratic,"Potter, Britani",35,000170
+JACKSON,Washington Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000170
+JACKSON,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",183,000170
+JACKSON,Whiting Township,United States House of Representatives,2,Democratic,"Potter, Britani",21,000180
+JACKSON,Whiting Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000180
+JACKSON,Whiting Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,000180
+JACKSON,Adrian Township,United States Senate,,write - in,"Smith, DJ",0,000010
+JACKSON,Adrian Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000010
+JACKSON,Adrian Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+JACKSON,Adrian Township,United States Senate,,Republican,"Moran, Jerry",55,000010
+JACKSON,Banner Township,United States Senate,,write - in,"Smith, DJ",0,000020
+JACKSON,Banner Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000020
+JACKSON,Banner Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000020
+JACKSON,Banner Township,United States Senate,,Republican,"Moran, Jerry",144,000020
+JACKSON,Cedar Township,United States Senate,,write - in,"Smith, DJ",0,000030
+JACKSON,Cedar Township,United States Senate,,Democratic,"Wiesner, Patrick",127,000030
+JACKSON,Cedar Township,United States Senate,,Libertarian,"Garrard, Robert D.",39,000030
+JACKSON,Cedar Township,United States Senate,,Republican,"Moran, Jerry",395,000030
+JACKSON,Douglas Township,United States Senate,,write - in,"Smith, DJ",0,000040
+JACKSON,Douglas Township,United States Senate,,Democratic,"Wiesner, Patrick",303,000040
+JACKSON,Douglas Township,United States Senate,,Libertarian,"Garrard, Robert D.",67,000040
+JACKSON,Douglas Township,United States Senate,,Republican,"Moran, Jerry",729,000040
+JACKSON,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000050
+JACKSON,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",97,000050
+JACKSON,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000050
+JACKSON,Franklin Township,United States Senate,,Republican,"Moran, Jerry",378,000050
+JACKSON,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000060
+JACKSON,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",55,000060
+JACKSON,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000060
+JACKSON,Garfield Township,United States Senate,,Republican,"Moran, Jerry",206,000060
+JACKSON,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000070
+JACKSON,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000070
+JACKSON,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+JACKSON,Grant Township,United States Senate,,Republican,"Moran, Jerry",61,000070
+JACKSON,Holton Ward 1,United States Senate,,write - in,"Smith, DJ",0,00008A
+JACKSON,Holton Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",119,00008A
+JACKSON,Holton Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",31,00008A
+JACKSON,Holton Ward 1,United States Senate,,Republican,"Moran, Jerry",284,00008A
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,write - in,"Smith, DJ",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,Democratic,"Wiesner, Patrick",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008B
+JACKSON,Holton Ward 1 Exclave City Lake,United States Senate,,Republican,"Moran, Jerry",0,00008B
+JACKSON,Holton Ward 2,United States Senate,,write - in,"Smith, DJ",0,000090
+JACKSON,Holton Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",123,000090
+JACKSON,Holton Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,000090
+JACKSON,Holton Ward 2,United States Senate,,Republican,"Moran, Jerry",344,000090
+JACKSON,Holton Ward 3,United States Senate,,write - in,"Smith, DJ",0,00010A
+JACKSON,Holton Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",105,00010A
+JACKSON,Holton Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",14,00010A
+JACKSON,Holton Ward 3,United States Senate,,Republican,"Moran, Jerry",270,00010A
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,write - in,"Smith, DJ",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,Democratic,"Wiesner, Patrick",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,Libertarian,"Garrard, Robert D.",0,00010B
+JACKSON,Holton Ward 3 Exclave Industrial Park,United States Senate,,Republican,"Moran, Jerry",0,00010B
+JACKSON,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000110
+JACKSON,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",44,000110
+JACKSON,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000110
+JACKSON,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",194,000110
+JACKSON,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000120
+JACKSON,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",66,000120
+JACKSON,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000120
+JACKSON,Liberty Township,United States Senate,,Republican,"Moran, Jerry",197,000120
+JACKSON,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000130
+JACKSON,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",194,000130
+JACKSON,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,000130
+JACKSON,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",204,000130
+JACKSON,Netawaka Township,United States Senate,,write - in,"Smith, DJ",0,000140
+JACKSON,Netawaka Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000140
+JACKSON,Netawaka Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000140
+JACKSON,Netawaka Township,United States Senate,,Republican,"Moran, Jerry",133,000140
+JACKSON,Soldier Township,United States Senate,,write - in,"Smith, DJ",0,000150
+JACKSON,Soldier Township,United States Senate,,Democratic,"Wiesner, Patrick",41,000150
+JACKSON,Soldier Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000150
+JACKSON,Soldier Township,United States Senate,,Republican,"Moran, Jerry",147,000150
+JACKSON,Straight Creek Township,United States Senate,,write - in,"Smith, DJ",0,000160
+JACKSON,Straight Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000160
+JACKSON,Straight Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000160
+JACKSON,Straight Creek Township,United States Senate,,Republican,"Moran, Jerry",62,000160
+JACKSON,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000170
+JACKSON,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000170
+JACKSON,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000170
+JACKSON,Washington Township,United States Senate,,Republican,"Moran, Jerry",189,000170
+JACKSON,Whiting Township,United States Senate,,write - in,"Smith, DJ",0,000180
+JACKSON,Whiting Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000180
+JACKSON,Whiting Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000180
+JACKSON,Whiting Township,United States Senate,,Republican,"Moran, Jerry",123,000180

--- a/2016/20161108__ks__general__jefferson__precinct.csv
+++ b/2016/20161108__ks__general__jefferson__precinct.csv
@@ -1,248 +1,469 @@
-county,precinct,office,district,party,candidate,votes
-Jefferson,Delaware,President,,LIB,Gary Johnson,30
-Jefferson,East Fairview,President,,LIB,Gary Johnson,25
-Jefferson,Jefferson,President,,LIB,Gary Johnson,23
-Jefferson,Kaw,President,,LIB,Gary Johnson,28
-Jefferson,Kentucky,President,,LIB,Gary Johnson,46
-Jefferson,Norton,President,,LIB,Gary Johnson,25
-Jefferson,Oskaloosa,President,,LIB,Gary Johnson,42
-Jefferson,Ozawkie,President,,LIB,Gary Johnson,25
-Jefferson,Rock Creek,President,,LIB,Gary Johnson,55
-Jefferson,Rural,President,,LIB,Gary Johnson,13
-Jefferson,Sarcoxie,President,,LIB,Gary Johnson,29
-Jefferson,Union,President,,LIB,Gary Johnson,36
-Jefferson,West Fairview,President,,LIB,Gary Johnson,7
-Jefferson,Delaware,President,,IND,Jill Stein,13
-Jefferson,East Fairview,President,,IND,Jill Stein,5
-Jefferson,Jefferson,President,,IND,Jill Stein,7
-Jefferson,Kaw,President,,IND,Jill Stein,21
-Jefferson,Kentucky,President,,IND,Jill Stein,11
-Jefferson,Norton,President,,IND,Jill Stein,8
-Jefferson,Oskaloosa,President,,IND,Jill Stein,17
-Jefferson,Ozawkie,President,,IND,Jill Stein,11
-Jefferson,Rock Creek,President,,IND,Jill Stein,39
-Jefferson,Rural,President,,IND,Jill Stein,14
-Jefferson,Sarcoxie,President,,IND,Jill Stein,16
-Jefferson,Union,President,,IND,Jill Stein,15
-Jefferson,West Fairview,President,,IND,Jill Stein,8
-Jefferson,Delaware,President,,REP,Donald J Trump,504
-Jefferson,East Fairview,President,,REP,Donald J Trump,230
-Jefferson,Jefferson,President,,REP,Donald J Trump,319
-Jefferson,Kaw,President,,REP,Donald J Trump,420
-Jefferson,Kentucky,President,,REP,Donald J Trump,410
-Jefferson,Norton,President,,REP,Donald J Trump,250
-Jefferson,Oskaloosa,President,,REP,Donald J Trump,577
-Jefferson,Ozawkie,President,,REP,Donald J Trump,506
-Jefferson,Rock Creek,President,,REP,Donald J Trump,825
-Jefferson,Rural,President,,REP,Donald J Trump,184
-Jefferson,Sarcoxie,President,,REP,Donald J Trump,231
-Jefferson,Union,President,,REP,Donald J Trump,517
-Jefferson,West Fairview,President,,REP,Donald J Trump,240
-Jefferson,Delaware,President,,DEM,Hillary Clinton,219
-Jefferson,East Fairview,President,,DEM,Hillary Clinton,145
-Jefferson,Jefferson,President,,DEM,Hillary Clinton,123
-Jefferson,Kaw,President,,DEM,Hillary Clinton,232
-Jefferson,Kentucky,President,,DEM,Hillary Clinton,253
-Jefferson,Norton,President,,DEM,Hillary Clinton,84
-Jefferson,Oskaloosa,President,,DEM,Hillary Clinton,245
-Jefferson,Ozawkie,President,,DEM,Hillary Clinton,207
-Jefferson,Rock Creek,President,,DEM,Hillary Clinton,317
-Jefferson,Rural,President,,DEM,Hillary Clinton,136
-Jefferson,Sarcoxie,President,,DEM,Hillary Clinton,262
-Jefferson,Union,President,,DEM,Hillary Clinton,194
-Jefferson,West Fairview,President,,DEM,Hillary Clinton,101
-Jefferson,Delaware,President,,,Write-ins,8
-Jefferson,East Fairview,President,,,Write-ins,6
-Jefferson,Jefferson,President,,,Write-ins,6
-Jefferson,Kaw,President,,,Write-ins,13
-Jefferson,Kentucky,President,,,Write-ins,15
-Jefferson,Norton,President,,,Write-ins,6
-Jefferson,Oskaloosa,President,,,Write-ins,11
-Jefferson,Ozawkie,President,,,Write-ins,17
-Jefferson,Rock Creek,President,,,Write-ins,19
-Jefferson,Rural,President,,,Write-ins,9
-Jefferson,Sarcoxie,President,,,Write-ins,20
-Jefferson,Union,President,,,Write-ins,6
-Jefferson,West Fairview,President,,,Write-ins,4
-Jefferson,Delaware,U.S. Senate,,REP,Jerry Moran,547
-Jefferson,East Fairview,U.S. Senate,,REP,Jerry Moran,225
-Jefferson,Jefferson,U.S. Senate,,REP,Jerry Moran,356
-Jefferson,Kaw,U.S. Senate,,REP,Jerry Moran,452
-Jefferson,Kentucky,U.S. Senate,,REP,Jerry Moran,426
-Jefferson,Norton,U.S. Senate,,REP,Jerry Moran,267
-Jefferson,Oskaloosa,U.S. Senate,,REP,Jerry Moran,598
-Jefferson,Ozawkie,U.S. Senate,,REP,Jerry Moran,508
-Jefferson,Rock Creek,U.S. Senate,,REP,Jerry Moran,857
-Jefferson,Rural,U.S. Senate,,REP,Jerry Moran,201
-Jefferson,Sarcoxie,U.S. Senate,,REP,Jerry Moran,254
-Jefferson,Union,U.S. Senate,,REP,Jerry Moran,504
-Jefferson,West Fairview,U.S. Senate,,REP,Jerry Moran,261
-Jefferson,Delaware,U.S. Senate,,DEM,Patrick Wiesner,188
-Jefferson,East Fairview,U.S. Senate,,DEM,Patrick Wiesner,150
-Jefferson,Jefferson,U.S. Senate,,DEM,Patrick Wiesner,102
-Jefferson,Kaw,U.S. Senate,,DEM,Patrick Wiesner,231
-Jefferson,Kentucky,U.S. Senate,,DEM,Patrick Wiesner,257
-Jefferson,Norton,U.S. Senate,,DEM,Patrick Wiesner,94
-Jefferson,Oskaloosa,U.S. Senate,,DEM,Patrick Wiesner,239
-Jefferson,Ozawkie,U.S. Senate,,DEM,Patrick Wiesner,215
-Jefferson,Rock Creek,U.S. Senate,,DEM,Patrick Wiesner,320
-Jefferson,Rural,U.S. Senate,,DEM,Patrick Wiesner,137
-Jefferson,Sarcoxie,U.S. Senate,,DEM,Patrick Wiesner,277
-Jefferson,Union,U.S. Senate,,DEM,Patrick Wiesner,206
-Jefferson,West Fairview,U.S. Senate,,DEM,Patrick Wiesner,88
-Jefferson,Delaware,U.S. Senate,,LIB,Robert D. Garrard,39
-Jefferson,East Fairview,U.S. Senate,,LIB,Robert D. Garrard,25
-Jefferson,Jefferson,U.S. Senate,,LIB,Robert D. Garrard,18
-Jefferson,Kaw,U.S. Senate,,LIB,Robert D. Garrard,29
-Jefferson,Kentucky,U.S. Senate,,LIB,Robert D. Garrard,40
-Jefferson,Norton,U.S. Senate,,LIB,Robert D. Garrard,13
-Jefferson,Oskaloosa,U.S. Senate,,LIB,Robert D. Garrard,42
-Jefferson,Ozawkie,U.S. Senate,,LIB,Robert D. Garrard,35
-Jefferson,Rock Creek,U.S. Senate,,LIB,Robert D. Garrard,76
-Jefferson,Rural,U.S. Senate,,LIB,Robert D. Garrard,16
-Jefferson,Sarcoxie,U.S. Senate,,LIB,Robert D. Garrard,24
-Jefferson,Union,U.S. Senate,,LIB,Robert D. Garrard,38
-Jefferson,West Fairview,U.S. Senate,,LIB,Robert D. Garrard,9
-Jefferson,Delaware,U.S. Senate,,,Write-ins,0
-Jefferson,East Fairview,U.S. Senate,,,Write-ins,0
-Jefferson,Jefferson,U.S. Senate,,,Write-ins,0
-Jefferson,Kaw,U.S. Senate,,,Write-ins,1
-Jefferson,Kentucky,U.S. Senate,,,Write-ins,1
-Jefferson,Norton,U.S. Senate,,,Write-ins,0
-Jefferson,Oskaloosa,U.S. Senate,,,Write-ins,1
-Jefferson,Ozawkie,U.S. Senate,,,Write-ins,2
-Jefferson,Rock Creek,U.S. Senate,,,Write-ins,2
-Jefferson,Rural,U.S. Senate,,,Write-ins,0
-Jefferson,Sarcoxie,U.S. Senate,,,Write-ins,0
-Jefferson,Union,U.S. Senate,,,Write-ins,0
-Jefferson,West Fairview,U.S. Senate,,,Write-ins,0
-Jefferson,Delaware,U.S. House,2,REP,Lynn Jenkins,540
-Jefferson,East Fairview,U.S. House,2,REP,Lynn Jenkins,253
-Jefferson,Jefferson,U.S. House,2,REP,Lynn Jenkins,363
-Jefferson,Kaw,U.S. House,2,REP,Lynn Jenkins,454
-Jefferson,Kentucky,U.S. House,2,REP,Lynn Jenkins,444
-Jefferson,Norton,U.S. House,2,REP,Lynn Jenkins,283
-Jefferson,Oskaloosa,U.S. House,2,REP,Lynn Jenkins,620
-Jefferson,Ozawkie,U.S. House,2,REP,Lynn Jenkins,523
-Jefferson,Rock Creek,U.S. House,2,REP,Lynn Jenkins,866
-Jefferson,Rural,U.S. House,2,REP,Lynn Jenkins,206
-Jefferson,Sarcoxie,U.S. House,2,REP,Lynn Jenkins,274
-Jefferson,Union,U.S. House,2,REP,Lynn Jenkins,532
-Jefferson,West Fairview,U.S. House,2,REP,Lynn Jenkins,268
-Jefferson,Delaware,U.S. House,2,DEM,Britani Potter,199
-Jefferson,East Fairview,U.S. House,2,DEM,Britani Potter,122
-Jefferson,Jefferson,U.S. House,2,DEM,Britani Potter,93
-Jefferson,Kaw,U.S. House,2,DEM,Britani Potter,222
-Jefferson,Kentucky,U.S. House,2,DEM,Britani Potter,238
-Jefferson,Norton,U.S. House,2,DEM,Britani Potter,70
-Jefferson,Oskaloosa,U.S. House,2,DEM,Britani Potter,214
-Jefferson,Ozawkie,U.S. House,2,DEM,Britani Potter,188
-Jefferson,Rock Creek,U.S. House,2,DEM,Britani Potter,313
-Jefferson,Rural,U.S. House,2,DEM,Britani Potter,122
-Jefferson,Sarcoxie,U.S. House,2,DEM,Britani Potter,229
-Jefferson,Union,U.S. House,2,DEM,Britani Potter,175
-Jefferson,West Fairview,U.S. House,2,DEM,Britani Potter,79
-Jefferson,Delaware,U.S. House,2,LIB,James Houston Bales,38
-Jefferson,East Fairview,U.S. House,2,LIB,James Houston Bales,32
-Jefferson,Jefferson,U.S. House,2,LIB,James Houston Bales,22
-Jefferson,Kaw,U.S. House,2,LIB,James Houston Bales,41
-Jefferson,Kentucky,U.S. House,2,LIB,James Houston Bales,44
-Jefferson,Norton,U.S. House,2,LIB,James Houston Bales,17
-Jefferson,Oskaloosa,U.S. House,2,LIB,James Houston Bales,57
-Jefferson,Ozawkie,U.S. House,2,LIB,James Houston Bales,48
-Jefferson,Rock Creek,U.S. House,2,LIB,James Houston Bales,83
-Jefferson,Rural,U.S. House,2,LIB,James Houston Bales,29
-Jefferson,Sarcoxie,U.S. House,2,LIB,James Houston Bales,52
-Jefferson,Union,U.S. House,2,LIB,James Houston Bales,49
-Jefferson,West Fairview,U.S. House,2,LIB,James Houston Bales,15
-Jefferson,Delaware,U.S. House,2,,Write-ins,0
-Jefferson,East Fairview,U.S. House,2,,Write-ins,0
-Jefferson,Jefferson,U.S. House,2,,Write-ins,0
-Jefferson,Kaw,U.S. House,2,,Write-ins,0
-Jefferson,Kentucky,U.S. House,2,,Write-ins,1
-Jefferson,Norton,U.S. House,2,,Write-ins,0
-Jefferson,Oskaloosa,U.S. House,2,,Write-ins,0
-Jefferson,Ozawkie,U.S. House,2,,Write-ins,0
-Jefferson,Rock Creek,U.S. House,2,,Write-ins,1
-Jefferson,Rural,U.S. House,2,,Write-ins,0
-Jefferson,Sarcoxie,U.S. House,2,,Write-ins,0
-Jefferson,Union,U.S. House,2,,Write-ins,0
-Jefferson,West Fairview,U.S. House,2,,Write-ins,0
-Jefferson,Delaware,State Senate,2,,Marci Francisco,259
-Jefferson,East Fairview,State Senate,2,,Marci Francisco,155
-Jefferson,Jefferson,State Senate,2,,Marci Francisco,133
-Jefferson,Kentucky,State Senate,2,,Marci Francisco,253
-Jefferson,Norton,State Senate,2,,Marci Francisco,105
-Jefferson,Oskaloosa,State Senate,2,,Marci Francisco,265
-Jefferson,Ozawkie,State Senate,2,,Marci Francisco,253
-Jefferson,Rock Creek,State Senate,2,,Marci Francisco,380
-Jefferson,Rural,State Senate,2,,Marci Francisco,145
-Jefferson,Sarcoxie,State Senate,2,,Marci Francisco,300
-Jefferson,Union,State Senate,2,,Marci Francisco,260
-Jefferson,West Fairview,State Senate,2,,Marci Francisco,103
-Jefferson,Delaware,State Senate,2,REP,Meredith Richey,507
-Jefferson,East Fairview,State Senate,2,REP,Meredith Richey,246
-Jefferson,Jefferson,State Senate,2,REP,Meredith Richey,341
-Jefferson,Kentucky,State Senate,2,REP,Meredith Richey,474
-Jefferson,Norton,State Senate,2,REP,Meredith Richey,256
-Jefferson,Oskaloosa,State Senate,2,REP,Meredith Richey,610
-Jefferson,Ozawkie,State Senate,2,REP,Meredith Richey,497
-Jefferson,Rock Creek,State Senate,2,REP,Meredith Richey,849
-Jefferson,Rural,State Senate,2,REP,Meredith Richey,214
-Jefferson,Sarcoxie,State Senate,2,REP,Meredith Richey,248
-Jefferson,Union,State Senate,2,REP,Meredith Richey,481
-Jefferson,West Fairview,State Senate,2,REP,Meredith Richey,253
-Jefferson,Delaware,State Senate,2,,Write-ins,1
-Jefferson,East Fairview,State Senate,2,,Write-ins,0
-Jefferson,Jefferson,State Senate,2,,Write-ins,1
-Jefferson,Kentucky,State Senate,2,,Write-ins,0
-Jefferson,Norton,State Senate,2,,Write-ins,1
-Jefferson,Oskaloosa,State Senate,2,,Write-ins,1
-Jefferson,Ozawkie,State Senate,2,,Write-ins,0
-Jefferson,Rock Creek,State Senate,2,,Write-ins,4
-Jefferson,Rural,State Senate,2,,Write-ins,0
-Jefferson,Sarcoxie,State Senate,2,,Write-ins,1
-Jefferson,Union,State Senate,2,,Write-ins,0
-Jefferson,West Fairview,State Senate,2,,Write-ins,0
-Jefferson,Kaw,State Senate,19,REP,Zach Haney,364
-Jefferson,Kaw,State Senate,19,DEM,Anthony Hensley,343
-Jefferson,Kaw,State Senate,19,,Write-ins,0
-Jefferson,Delaware,State House,47,,Michael D. Caddell,241
-Jefferson,East Fairview,State House,47,,Michael D. Caddell,147
-Jefferson,Jefferson,State House,47,,Michael D. Caddell,136
-Jefferson,Kaw,State House,47,,Michael D. Caddell,222
-Jefferson,Kentucky,State House,47,,Michael D. Caddell,225
-Jefferson,Norton,State House,47,,Michael D. Caddell,106
-Jefferson,Oskaloosa,State House,47,,Michael D. Caddell,206
-Jefferson,Ozawkie,State House,47,,Michael D. Caddell,191
-Jefferson,Rock Creek,State House,47,,Michael D. Caddell,284
-Jefferson,Rural,State House,47,,Michael D. Caddell,144
-Jefferson,Sarcoxie,State House,47,,Michael D. Caddell,287
-Jefferson,Union,State House,47,,Michael D. Caddell,224
-Jefferson,West Fairview,State House,47,,Michael D. Caddell,86
-Jefferson,Delaware,State House,47,REP,Ronald B. Ellis,523
-Jefferson,East Fairview,State House,47,REP,Ronald B. Ellis,251
-Jefferson,Jefferson,State House,47,REP,Ronald B. Ellis,337
-Jefferson,Kaw,State House,47,REP,Ronald B. Ellis,480
-Jefferson,Kentucky,State House,47,REP,Ronald B. Ellis,492
-Jefferson,Norton,State House,47,REP,Ronald B. Ellis,262
-Jefferson,Oskaloosa,State House,47,REP,Ronald B. Ellis,689
-Jefferson,Ozawkie,State House,47,REP,Ronald B. Ellis,556
-Jefferson,Rock Creek,State House,47,REP,Ronald B. Ellis,961
-Jefferson,Rural,State House,47,REP,Ronald B. Ellis,213
-Jefferson,Sarcoxie,State House,47,REP,Ronald B. Ellis,261
-Jefferson,Union,State House,47,REP,Ronald B. Ellis,517
-Jefferson,West Fairview,State House,47,REP,Ronald B. Ellis,271
-Jefferson,Delaware,State House,47,,Write-ins,0
-Jefferson,East Fairview,State House,47,,Write-ins,0
-Jefferson,Jefferson,State House,47,,Write-ins,0
-Jefferson,Kaw,State House,47,,Write-ins,1
-Jefferson,Kentucky,State House,47,,Write-ins,0
-Jefferson,Norton,State House,47,,Write-ins,1
-Jefferson,Oskaloosa,State House,47,,Write-ins,1
-Jefferson,Ozawkie,State House,47,,Write-ins,1
-Jefferson,Rock Creek,State House,47,,Write-ins,0
-Jefferson,Rural,State House,47,,Write-ins,0
-Jefferson,Sarcoxie,State House,47,,Write-ins,0
-Jefferson,Union,State House,47,,Write-ins,0
-Jefferson,West Fairview,State House,47,,Write-ins,0
+county,precinct,office,district,party,candidate,votes,vtd
+JEFFERSON,Delaware Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",241,000010
+JEFFERSON,Delaware Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",523,000010
+JEFFERSON,East Fairview,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",147,000020
+JEFFERSON,East Fairview,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",251,000020
+JEFFERSON,Jefferson Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",136,000030
+JEFFERSON,Jefferson Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",337,000030
+JEFFERSON,Kaw Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",222,000040
+JEFFERSON,Kaw Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",480,000040
+JEFFERSON,Kentucky Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",225,000050
+JEFFERSON,Kentucky Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",492,000050
+JEFFERSON,Norton Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",106,000060
+JEFFERSON,Norton Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",262,000060
+JEFFERSON,Oskaloosa Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",206,000070
+JEFFERSON,Oskaloosa Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",689,000070
+JEFFERSON,Ozawkie Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",191,000080
+JEFFERSON,Ozawkie Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",556,000080
+JEFFERSON,Rock Creek Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",284,000090
+JEFFERSON,Rock Creek Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",961,000090
+JEFFERSON,Rural Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",144,000100
+JEFFERSON,Rural Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",213,000100
+JEFFERSON,Sarcoxie Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",287,000110
+JEFFERSON,Sarcoxie Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",261,000110
+JEFFERSON,Union Township,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",224,000120
+JEFFERSON,Union Township,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",517,000120
+JEFFERSON,West Fairview,Kansas House of Representatives,47,Democratic,"Caddell, Michael D.",86,000130
+JEFFERSON,West Fairview,Kansas House of Representatives,47,Republican,"Ellis, Ronald B.",271,000130
+JEFFERSON,Delaware Township,Kansas Senate,2,Democratic,"Francisco, Marci",259,000010
+JEFFERSON,Delaware Township,Kansas Senate,2,Republican,"Richey, Meredith",507,000010
+JEFFERSON,East Fairview,Kansas Senate,2,Democratic,"Francisco, Marci",155,000020
+JEFFERSON,East Fairview,Kansas Senate,2,Republican,"Richey, Meredith",246,000020
+JEFFERSON,Jefferson Township,Kansas Senate,2,Democratic,"Francisco, Marci",133,000030
+JEFFERSON,Jefferson Township,Kansas Senate,2,Republican,"Richey, Meredith",341,000030
+JEFFERSON,Kaw Township,Kansas Senate,19,Democratic,"Hensley, Anthony",343,000040
+JEFFERSON,Kaw Township,Kansas Senate,19,Republican,"Haney, Zach",364,000040
+JEFFERSON,Kentucky Township,Kansas Senate,2,Democratic,"Francisco, Marci",253,000050
+JEFFERSON,Kentucky Township,Kansas Senate,2,Republican,"Richey, Meredith",474,000050
+JEFFERSON,Norton Township,Kansas Senate,2,Democratic,"Francisco, Marci",105,000060
+JEFFERSON,Norton Township,Kansas Senate,2,Republican,"Richey, Meredith",256,000060
+JEFFERSON,Oskaloosa Township,Kansas Senate,2,Democratic,"Francisco, Marci",265,000070
+JEFFERSON,Oskaloosa Township,Kansas Senate,2,Republican,"Richey, Meredith",610,000070
+JEFFERSON,Ozawkie Township,Kansas Senate,2,Democratic,"Francisco, Marci",253,000080
+JEFFERSON,Ozawkie Township,Kansas Senate,2,Republican,"Richey, Meredith",497,000080
+JEFFERSON,Rock Creek Township,Kansas Senate,2,Democratic,"Francisco, Marci",380,000090
+JEFFERSON,Rock Creek Township,Kansas Senate,2,Republican,"Richey, Meredith",849,000090
+JEFFERSON,Rural Township,Kansas Senate,2,Democratic,"Francisco, Marci",145,000100
+JEFFERSON,Rural Township,Kansas Senate,2,Republican,"Richey, Meredith",214,000100
+JEFFERSON,Sarcoxie Township,Kansas Senate,2,Democratic,"Francisco, Marci",300,000110
+JEFFERSON,Sarcoxie Township,Kansas Senate,2,Republican,"Richey, Meredith",248,000110
+JEFFERSON,Union Township,Kansas Senate,2,Democratic,"Francisco, Marci",260,000120
+JEFFERSON,Union Township,Kansas Senate,2,Republican,"Richey, Meredith",481,000120
+JEFFERSON,West Fairview,Kansas Senate,2,Democratic,"Francisco, Marci",103,000130
+JEFFERSON,West Fairview,Kansas Senate,2,Republican,"Richey, Meredith",253,000130
+JEFFERSON,Delaware Township,President / Vice President,,independent,"Stein, Jill",13,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Hoefling, Tom",2,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"McMullin, Evan",2,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+JEFFERSON,Delaware Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",219,000010
+JEFFERSON,Delaware Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000010
+JEFFERSON,Delaware Township,President / Vice President,,Republican,"Trump, Donald J.",504,000010
+JEFFERSON,East Fairview,President / Vice President,,independent,"Stein, Jill",5,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Hedges, James A",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"McMullin, Evan",1,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Perry, Darryl",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Smith, Mike",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Sood, Ajay",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+JEFFERSON,East Fairview,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+JEFFERSON,East Fairview,President / Vice President,,Democratic,"Clinton, Hillary Rodham",145,000020
+JEFFERSON,East Fairview,President / Vice President,,Libertarian,"Johnson, Gary",25,000020
+JEFFERSON,East Fairview,President / Vice President,,Republican,"Trump, Donald J.",230,000020
+JEFFERSON,Jefferson Township,President / Vice President,,independent,"Stein, Jill",7,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",1,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",3,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000030
+JEFFERSON,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",319,000030
+JEFFERSON,Kaw Township,President / Vice President,,independent,"Stein, Jill",21,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"McMullin, Evan",5,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+JEFFERSON,Kaw Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",232,000040
+JEFFERSON,Kaw Township,President / Vice President,,Libertarian,"Johnson, Gary",28,000040
+JEFFERSON,Kaw Township,President / Vice President,,Republican,"Trump, Donald J.",420,000040
+JEFFERSON,Kentucky Township,President / Vice President,,independent,"Stein, Jill",11,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Castle, Darrell L",4,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"McMullin, Evan",1,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",253,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Libertarian,"Johnson, Gary",46,000050
+JEFFERSON,Kentucky Township,President / Vice President,,Republican,"Trump, Donald J.",410,000050
+JEFFERSON,Norton Township,President / Vice President,,independent,"Stein, Jill",8,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+JEFFERSON,Norton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+JEFFERSON,Norton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,000060
+JEFFERSON,Norton Township,President / Vice President,,Libertarian,"Johnson, Gary",25,000060
+JEFFERSON,Norton Township,President / Vice President,,Republican,"Trump, Donald J.",250,000060
+JEFFERSON,Oskaloosa Township,President / Vice President,,independent,"Stein, Jill",17,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"McMullin, Evan",2,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",245,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Libertarian,"Johnson, Gary",42,000070
+JEFFERSON,Oskaloosa Township,President / Vice President,,Republican,"Trump, Donald J.",577,000070
+JEFFERSON,Ozawkie Township,President / Vice President,,independent,"Stein, Jill",11,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Castle, Darrell L",1,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"McMullin, Evan",4,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",207,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Libertarian,"Johnson, Gary",25,000080
+JEFFERSON,Ozawkie Township,President / Vice President,,Republican,"Trump, Donald J.",506,000080
+JEFFERSON,Rock Creek Township,President / Vice President,,independent,"Stein, Jill",39,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"McMullin, Evan",4,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",317,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",55,000090
+JEFFERSON,Rock Creek Township,President / Vice President,,Republican,"Trump, Donald J.",825,000090
+JEFFERSON,Rural Township,President / Vice President,,independent,"Stein, Jill",14,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Castle, Darrell L",1,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Maturen, Michael A",1,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+JEFFERSON,Rural Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+JEFFERSON,Rural Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",136,000100
+JEFFERSON,Rural Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000100
+JEFFERSON,Rural Township,President / Vice President,,Republican,"Trump, Donald J.",184,000100
+JEFFERSON,Sarcoxie Township,President / Vice President,,independent,"Stein, Jill",16,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Castle, Darrell L",1,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"McMullin, Evan",2,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",262,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Libertarian,"Johnson, Gary",29,000110
+JEFFERSON,Sarcoxie Township,President / Vice President,,Republican,"Trump, Donald J.",231,000110
+JEFFERSON,Union Township,President / Vice President,,independent,"Stein, Jill",15,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"McMullin, Evan",1,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+JEFFERSON,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+JEFFERSON,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",194,000120
+JEFFERSON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",36,000120
+JEFFERSON,Union Township,President / Vice President,,Republican,"Trump, Donald J.",517,000120
+JEFFERSON,West Fairview,President / Vice President,,independent,"Stein, Jill",8,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Castle, Darrell L",1,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Hedges, James A",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"McMullin, Evan",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Perry, Darryl",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Smith, Mike",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Sood, Ajay",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+JEFFERSON,West Fairview,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+JEFFERSON,West Fairview,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000130
+JEFFERSON,West Fairview,President / Vice President,,Libertarian,"Johnson, Gary",7,000130
+JEFFERSON,West Fairview,President / Vice President,,Republican,"Trump, Donald J.",240,000130
+JEFFERSON,Delaware Township,United States House of Representatives,2,Democratic,"Potter, Britani",199,000010
+JEFFERSON,Delaware Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",38,000010
+JEFFERSON,Delaware Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",540,000010
+JEFFERSON,East Fairview,United States House of Representatives,2,Democratic,"Potter, Britani",122,000020
+JEFFERSON,East Fairview,United States House of Representatives,2,Libertarian,"Bales, James Houston",32,000020
+JEFFERSON,East Fairview,United States House of Representatives,2,Republican,"Jenkins, Lynn",253,000020
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Democratic,"Potter, Britani",93,000030
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000030
+JEFFERSON,Jefferson Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",363,000030
+JEFFERSON,Kaw Township,United States House of Representatives,2,Democratic,"Potter, Britani",222,000040
+JEFFERSON,Kaw Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",41,000040
+JEFFERSON,Kaw Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",454,000040
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Democratic,"Potter, Britani",238,000050
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",44,000050
+JEFFERSON,Kentucky Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",444,000050
+JEFFERSON,Norton Township,United States House of Representatives,2,Democratic,"Potter, Britani",70,000060
+JEFFERSON,Norton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000060
+JEFFERSON,Norton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",283,000060
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Democratic,"Potter, Britani",214,000070
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",57,000070
+JEFFERSON,Oskaloosa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",620,000070
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Democratic,"Potter, Britani",188,000080
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",48,000080
+JEFFERSON,Ozawkie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",523,000080
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",313,000090
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",83,000090
+JEFFERSON,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",866,000090
+JEFFERSON,Rural Township,United States House of Representatives,2,Democratic,"Potter, Britani",122,000100
+JEFFERSON,Rural Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",29,000100
+JEFFERSON,Rural Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",206,000100
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Democratic,"Potter, Britani",229,000110
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",52,000110
+JEFFERSON,Sarcoxie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",274,000110
+JEFFERSON,Union Township,United States House of Representatives,2,Democratic,"Potter, Britani",175,000120
+JEFFERSON,Union Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",49,000120
+JEFFERSON,Union Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",532,000120
+JEFFERSON,West Fairview,United States House of Representatives,2,Democratic,"Potter, Britani",79,000130
+JEFFERSON,West Fairview,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000130
+JEFFERSON,West Fairview,United States House of Representatives,2,Republican,"Jenkins, Lynn",268,000130
+JEFFERSON,Delaware Township,United States Senate,,write - in,"Smith, DJ",0,000010
+JEFFERSON,Delaware Township,United States Senate,,Democratic,"Wiesner, Patrick",188,000010
+JEFFERSON,Delaware Township,United States Senate,,Libertarian,"Garrard, Robert D.",39,000010
+JEFFERSON,Delaware Township,United States Senate,,Republican,"Moran, Jerry",547,000010
+JEFFERSON,East Fairview,United States Senate,,write - in,"Smith, DJ",0,000020
+JEFFERSON,East Fairview,United States Senate,,Democratic,"Wiesner, Patrick",150,000020
+JEFFERSON,East Fairview,United States Senate,,Libertarian,"Garrard, Robert D.",25,000020
+JEFFERSON,East Fairview,United States Senate,,Republican,"Moran, Jerry",225,000020
+JEFFERSON,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000030
+JEFFERSON,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",102,000030
+JEFFERSON,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000030
+JEFFERSON,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",356,000030
+JEFFERSON,Kaw Township,United States Senate,,write - in,"Smith, DJ",0,000040
+JEFFERSON,Kaw Township,United States Senate,,Democratic,"Wiesner, Patrick",231,000040
+JEFFERSON,Kaw Township,United States Senate,,Libertarian,"Garrard, Robert D.",29,000040
+JEFFERSON,Kaw Township,United States Senate,,Republican,"Moran, Jerry",452,000040
+JEFFERSON,Kentucky Township,United States Senate,,write - in,"Smith, DJ",0,000050
+JEFFERSON,Kentucky Township,United States Senate,,Democratic,"Wiesner, Patrick",257,000050
+JEFFERSON,Kentucky Township,United States Senate,,Libertarian,"Garrard, Robert D.",40,000050
+JEFFERSON,Kentucky Township,United States Senate,,Republican,"Moran, Jerry",426,000050
+JEFFERSON,Norton Township,United States Senate,,write - in,"Smith, DJ",0,000060
+JEFFERSON,Norton Township,United States Senate,,Democratic,"Wiesner, Patrick",94,000060
+JEFFERSON,Norton Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000060
+JEFFERSON,Norton Township,United States Senate,,Republican,"Moran, Jerry",267,000060
+JEFFERSON,Oskaloosa Township,United States Senate,,write - in,"Smith, DJ",0,000070
+JEFFERSON,Oskaloosa Township,United States Senate,,Democratic,"Wiesner, Patrick",239,000070
+JEFFERSON,Oskaloosa Township,United States Senate,,Libertarian,"Garrard, Robert D.",42,000070
+JEFFERSON,Oskaloosa Township,United States Senate,,Republican,"Moran, Jerry",598,000070
+JEFFERSON,Ozawkie Township,United States Senate,,write - in,"Smith, DJ",0,000080
+JEFFERSON,Ozawkie Township,United States Senate,,Democratic,"Wiesner, Patrick",215,000080
+JEFFERSON,Ozawkie Township,United States Senate,,Libertarian,"Garrard, Robert D.",35,000080
+JEFFERSON,Ozawkie Township,United States Senate,,Republican,"Moran, Jerry",508,000080
+JEFFERSON,Rock Creek Township,United States Senate,,write - in,"Smith, DJ",0,000090
+JEFFERSON,Rock Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",320,000090
+JEFFERSON,Rock Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",76,000090
+JEFFERSON,Rock Creek Township,United States Senate,,Republican,"Moran, Jerry",857,000090
+JEFFERSON,Rural Township,United States Senate,,write - in,"Smith, DJ",0,000100
+JEFFERSON,Rural Township,United States Senate,,Democratic,"Wiesner, Patrick",137,000100
+JEFFERSON,Rural Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000100
+JEFFERSON,Rural Township,United States Senate,,Republican,"Moran, Jerry",201,000100
+JEFFERSON,Sarcoxie Township,United States Senate,,write - in,"Smith, DJ",0,000110
+JEFFERSON,Sarcoxie Township,United States Senate,,Democratic,"Wiesner, Patrick",277,000110
+JEFFERSON,Sarcoxie Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000110
+JEFFERSON,Sarcoxie Township,United States Senate,,Republican,"Moran, Jerry",254,000110
+JEFFERSON,Union Township,United States Senate,,write - in,"Smith, DJ",0,000120
+JEFFERSON,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",206,000120
+JEFFERSON,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",38,000120
+JEFFERSON,Union Township,United States Senate,,Republican,"Moran, Jerry",504,000120
+JEFFERSON,West Fairview,United States Senate,,write - in,"Smith, DJ",0,000130
+JEFFERSON,West Fairview,United States Senate,,Democratic,"Wiesner, Patrick",88,000130
+JEFFERSON,West Fairview,United States Senate,,Libertarian,"Garrard, Robert D.",9,000130
+JEFFERSON,West Fairview,United States Senate,,Republican,"Moran, Jerry",261,000130

--- a/2016/20161108__ks__general__jewell__precinct.csv
+++ b/2016/20161108__ks__general__jewell__precinct.csv
@@ -1,357 +1,911 @@
-county,precinct,office,district,party,candidate,votes
-Jewell,Allen,President,,independent,Jill Stein,0
-Jewell,Allen,President,,Republican,Donald Trump,16
-Jewell,Allen,President,,Democratic,Hillary Clinton,0
-Jewell,Allen,President,,Libertarian,Gary Johnson,0
-Jewell,Allen,U.S. Senate,,Republican,Jerry Moran,14
-Jewell,Allen,U.S. Senate,,Democratic,Patrick Wiesner,0
-Jewell,Allen,U.S. Senate,,Libertarian,Robert Garrard,2
-Jewell,Allen,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Allen,U.S. House,1,independent,Alan LaPolice,2
-Jewell,Allen,U.S. House,1,Republican,Roger Marshall,14
-Jewell,Allen,State Senate,36,Democratic,Brian Angevine,0
-Jewell,Allen,State Senate,36,Republican,Elaine Bowers,15
-Jewell,Allen,State House,106,Democratic,Todd Frye,1
-Jewell,Allen,State House,106,Republican,Clay Aurand,13
-Jewell,Athens,President,,independent,Jill Stein,0
-Jewell,Athens,President,,Republican,Donald Trump,19
-Jewell,Athens,President,,Democratic,Hillary Clinton,3
-Jewell,Athens,President,,Libertarian,Gary Johnson,0
-Jewell,Athens,U.S. Senate,,Republican,Jerry Moran,20
-Jewell,Athens,U.S. Senate,,Democratic,Patrick Wiesner,2
-Jewell,Athens,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Athens,U.S. House,1,Libertarian,Kerry Burt,1
-Jewell,Athens,U.S. House,1,independent,Alan LaPolice,5
-Jewell,Athens,U.S. House,1,Republican,Roger Marshall,16
-Jewell,Athens,State Senate,36,Democratic,Brian Angevine,1
-Jewell,Athens,State Senate,36,Republican,Elaine Bowers,21
-Jewell,Athens,State House,109,Republican,Troy Waymaster,19
-Jewell,Browncreek,President,,independent,Jill Stein,2
-Jewell,Browncreek,President,,Republican,Donald Trump,27
-Jewell,Browncreek,President,,Democratic,Hillary Clinton,3
-Jewell,Browncreek,President,,Libertarian,Gary Johnson,0
-Jewell,Browncreek,U.S. Senate,,Republican,Jerry Moran,25
-Jewell,Browncreek,U.S. Senate,,Democratic,Patrick Wiesner,2
-Jewell,Browncreek,U.S. Senate,,Libertarian,Robert Garrard,4
-Jewell,Browncreek,U.S. House,1,Libertarian,Kerry Burt,2
-Jewell,Browncreek,U.S. House,1,independent,Alan LaPolice,7
-Jewell,Browncreek,U.S. House,1,Republican,Roger Marshall,21
-Jewell,Browncreek,State Senate,36,Democratic,Brian Angevine,4
-Jewell,Browncreek,State Senate,36,Republican,Elaine Bowers,27
-Jewell,Browncreek,State House,109,Republican,Troy Waymaster,26
-Jewell,Buffalo,President,,independent,Jill Stein,2
-Jewell,Buffalo,President,,Republican,Donald Trump,182
-Jewell,Buffalo,President,,Democratic,Hillary Clinton,20
-Jewell,Buffalo,President,,Libertarian,Gary Johnson,4
-Jewell,Buffalo,U.S. Senate,,Republican,Jerry Moran,185
-Jewell,Buffalo,U.S. Senate,,Democratic,Patrick Wiesner,11
-Jewell,Buffalo,U.S. Senate,,Libertarian,Robert Garrard,13
-Jewell,Buffalo,U.S. House,1,Libertarian,Kerry Burt,5
-Jewell,Buffalo,U.S. House,1,independent,Alan LaPolice,61
-Jewell,Buffalo,U.S. House,1,Republican,Roger Marshall,144
-Jewell,Buffalo,State Senate,36,Democratic,Brian Angevine,19
-Jewell,Buffalo,State Senate,36,Republican,Elaine Bowers,190
-Jewell,Buffalo,State House,106,Democratic,Todd Frye,55
-Jewell,Buffalo,State House,106,Republican,Clay Aurand,149
-Jewell,Burr Oak,President,,independent,Jill Stein,2
-Jewell,Burr Oak,President,,Republican,Donald Trump,85
-Jewell,Burr Oak,President,,Democratic,Hillary Clinton,9
-Jewell,Burr Oak,President,,Libertarian,Gary Johnson,9
-Jewell,Burr Oak,U.S. Senate,,Republican,Jerry Moran,89
-Jewell,Burr Oak,U.S. Senate,,Democratic,Patrick Wiesner,8
-Jewell,Burr Oak,U.S. Senate,,Libertarian,Robert Garrard,7
-Jewell,Burr Oak,U.S. House,1,Libertarian,Kerry Burt,8
-Jewell,Burr Oak,U.S. House,1,independent,Alan LaPolice,16
-Jewell,Burr Oak,U.S. House,1,Republican,Roger Marshall,75
-Jewell,Burr Oak,State Senate,36,Democratic,Brian Angevine,11
-Jewell,Burr Oak,State Senate,36,Republican,Elaine Bowers,87
-Jewell,Burr Oak,State House,109,Republican,Troy Waymaster,88
-Jewell,Calvin,President,,independent,Jill Stein,1
-Jewell,Calvin,President,,Republican,Donald Trump,26
-Jewell,Calvin,President,,Democratic,Hillary Clinton,2
-Jewell,Calvin,President,,Libertarian,Gary Johnson,1
-Jewell,Calvin,U.S. Senate,,Republican,Jerry Moran,30
-Jewell,Calvin,U.S. Senate,,Democratic,Patrick Wiesner,0
-Jewell,Calvin,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Calvin,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Calvin,U.S. House,1,independent,Alan LaPolice,7
-Jewell,Calvin,U.S. House,1,Republican,Roger Marshall,22
-Jewell,Calvin,State Senate,36,Democratic,Brian Angevine,1
-Jewell,Calvin,State Senate,36,Republican,Elaine Bowers,29
-Jewell,Calvin,State House,109,Republican,Troy Waymaster,28
-Jewell,Center,President,,independent,Jill Stein,23
-Jewell,Center,President,,Republican,Donald Trump,336
-Jewell,Center,President,,Democratic,Hillary Clinton,74
-Jewell,Center,President,,Libertarian,Gary Johnson,13
-Jewell,Center,U.S. Senate,,Republican,Jerry Moran,353
-Jewell,Center,U.S. Senate,,Democratic,Patrick Wiesner,61
-Jewell,Center,U.S. Senate,,Libertarian,Robert Garrard,21
-Jewell,Center,U.S. House,1,Libertarian,Kerry Burt,15
-Jewell,Center,U.S. House,1,independent,Alan LaPolice,140
-Jewell,Center,U.S. House,1,Republican,Roger Marshall,276
-Jewell,Center,State Senate,36,Democratic,Brian Angevine,73
-Jewell,Center,State Senate,36,Republican,Elaine Bowers,355
-Jewell,Center,State House,109,Republican,Troy Waymaster,379
-Jewell,Erving,President,,independent,Jill Stein,0
-Jewell,Erving,President,,Republican,Donald Trump,15
-Jewell,Erving,President,,Democratic,Hillary Clinton,0
-Jewell,Erving,President,,Libertarian,Gary Johnson,1
-Jewell,Erving,U.S. Senate,,Republican,Jerry Moran,16
-Jewell,Erving,U.S. Senate,,Democratic,Patrick Wiesner,1
-Jewell,Erving,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Erving,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Erving,U.S. House,1,independent,Alan LaPolice,0
-Jewell,Erving,U.S. House,1,Republican,Roger Marshall,15
-Jewell,Erving,State Senate,36,Democratic,Brian Angevine,2
-Jewell,Erving,State Senate,36,Republican,Elaine Bowers,15
-Jewell,Erving,State House,109,Republican,Troy Waymaster,16
-Jewell,Esbon,President,,independent,Jill Stein,2
-Jewell,Esbon,President,,Republican,Donald Trump,63
-Jewell,Esbon,President,,Democratic,Hillary Clinton,8
-Jewell,Esbon,President,,Libertarian,Gary Johnson,7
-Jewell,Esbon,U.S. Senate,,Republican,Jerry Moran,67
-Jewell,Esbon,U.S. Senate,,Democratic,Patrick Wiesner,8
-Jewell,Esbon,U.S. Senate,,Libertarian,Robert Garrard,7
-Jewell,Esbon,U.S. House,1,Libertarian,Kerry Burt,10
-Jewell,Esbon,U.S. House,1,independent,Alan LaPolice,17
-Jewell,Esbon,U.S. House,1,Republican,Roger Marshall,50
-Jewell,Esbon,State Senate,36,Democratic,Brian Angevine,13
-Jewell,Esbon,State Senate,36,Republican,Elaine Bowers,65
-Jewell,Esbon,State House,109,Republican,Troy Waymaster,65
-Jewell,Grant,President,,independent,Jill Stein,2
-Jewell,Grant,President,,Republican,Donald Trump,72
-Jewell,Grant,President,,Democratic,Hillary Clinton,11
-Jewell,Grant,President,,Libertarian,Gary Johnson,5
-Jewell,Grant,U.S. Senate,,Republican,Jerry Moran,74
-Jewell,Grant,U.S. Senate,,Democratic,Patrick Wiesner,7
-Jewell,Grant,U.S. Senate,,Libertarian,Robert Garrard,8
-Jewell,Grant,U.S. House,1,Libertarian,Kerry Burt,4
-Jewell,Grant,U.S. House,1,independent,Alan LaPolice,35
-Jewell,Grant,U.S. House,1,Republican,Roger Marshall,48
-Jewell,Grant,State Senate,36,Democratic,Brian Angevine,7
-Jewell,Grant,State Senate,36,Republican,Elaine Bowers,82
-Jewell,Grant,State House,106,Democratic,Todd Frye,33
-Jewell,Grant,State House,106,Republican,Clay Aurand,58
-Jewell,Harrison,President,,independent,Jill Stein,0
-Jewell,Harrison,President,,Republican,Donald Trump,12
-Jewell,Harrison,President,,Democratic,Hillary Clinton,1
-Jewell,Harrison,President,,Libertarian,Gary Johnson,0
-Jewell,Harrison,U.S. Senate,,Republican,Jerry Moran,12
-Jewell,Harrison,U.S. Senate,,Democratic,Patrick Wiesner,1
-Jewell,Harrison,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Harrison,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Harrison,U.S. House,1,independent,Alan LaPolice,3
-Jewell,Harrison,U.S. House,1,Republican,Roger Marshall,9
-Jewell,Harrison,State Senate,36,Democratic,Brian Angevine,2
-Jewell,Harrison,State Senate,36,Republican,Elaine Bowers,11
-Jewell,Harrison,State House,109,Republican,Troy Waymaster,12
-Jewell,Highland,President,,independent,Jill Stein,0
-Jewell,Highland,President,,Republican,Donald Trump,16
-Jewell,Highland,President,,Democratic,Hillary Clinton,6
-Jewell,Highland,President,,Libertarian,Gary Johnson,1
-Jewell,Highland,U.S. Senate,,Republican,Jerry Moran,18
-Jewell,Highland,U.S. Senate,,Democratic,Patrick Wiesner,5
-Jewell,Highland,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Highland,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Highland,U.S. House,1,independent,Alan LaPolice,5
-Jewell,Highland,U.S. House,1,Republican,Roger Marshall,18
-Jewell,Highland,State Senate,36,Democratic,Brian Angevine,7
-Jewell,Highland,State Senate,36,Republican,Elaine Bowers,16
-Jewell,Highland,State House,109,Republican,Troy Waymaster,21
-Jewell,Hornwood,President,,independent,Jill Stein,0
-Jewell,Hornwood,President,,Republican,Donald Trump,17
-Jewell,Hornwood,President,,Democratic,Hillary Clinton,1
-Jewell,Hornwood,President,,Libertarian,Gary Johnson,0
-Jewell,Hornwood,U.S. Senate,,Republican,Jerry Moran,14
-Jewell,Hornwood,U.S. Senate,,Democratic,Patrick Wiesner,1
-Jewell,Hornwood,U.S. Senate,,Libertarian,Robert Garrard,2
-Jewell,Hornwood,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Hornwood,U.S. House,1,independent,Alan LaPolice,4
-Jewell,Hornwood,U.S. House,1,Republican,Roger Marshall,13
-Jewell,Hornwood,State Senate,36,Democratic,Brian Angevine,2
-Jewell,Hornwood,State Senate,36,Republican,Elaine Bowers,13
-Jewell,Hornwood,State House,109,Republican,Troy Waymaster,13
-Jewell,Ionia,President,,independent,Jill Stein,0
-Jewell,Ionia,President,,Republican,Donald Trump,34
-Jewell,Ionia,President,,Democratic,Hillary Clinton,2
-Jewell,Ionia,President,,Libertarian,Gary Johnson,0
-Jewell,Ionia,U.S. Senate,,Republican,Jerry Moran,32
-Jewell,Ionia,U.S. Senate,,Democratic,Patrick Wiesner,1
-Jewell,Ionia,U.S. Senate,,Libertarian,Robert Garrard,1
-Jewell,Ionia,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Ionia,U.S. House,1,independent,Alan LaPolice,8
-Jewell,Ionia,U.S. House,1,Republican,Roger Marshall,26
-Jewell,Ionia,State Senate,36,Democratic,Brian Angevine,2
-Jewell,Ionia,State Senate,36,Republican,Elaine Bowers,32
-Jewell,Ionia,State House,109,Republican,Troy Waymaster,31
-Jewell,Jackson,President,,independent,Jill Stein,2
-Jewell,Jackson,President,,Republican,Donald Trump,53
-Jewell,Jackson,President,,Democratic,Hillary Clinton,9
-Jewell,Jackson,President,,Libertarian,Gary Johnson,0
-Jewell,Jackson,U.S. Senate,,Republican,Jerry Moran,52
-Jewell,Jackson,U.S. Senate,,Democratic,Patrick Wiesner,4
-Jewell,Jackson,U.S. Senate,,Libertarian,Robert Garrard,4
-Jewell,Jackson,U.S. House,1,Libertarian,Kerry Burt,1
-Jewell,Jackson,U.S. House,1,independent,Alan LaPolice,12
-Jewell,Jackson,U.S. House,1,Republican,Roger Marshall,46
-Jewell,Jackson,State Senate,36,Democratic,Brian Angevine,10
-Jewell,Jackson,State Senate,36,Republican,Elaine Bowers,51
-Jewell,Jackson,State House,106,Democratic,Todd Frye,8
-Jewell,Jackson,State House,106,Republican,Clay Aurand,48
-Jewell,Limestone,President,,independent,Jill Stein,0
-Jewell,Limestone,President,,Republican,Donald Trump,29
-Jewell,Limestone,President,,Democratic,Hillary Clinton,6
-Jewell,Limestone,President,,Libertarian,Gary Johnson,0
-Jewell,Limestone,U.S. Senate,,Republican,Jerry Moran,30
-Jewell,Limestone,U.S. Senate,,Democratic,Patrick Wiesner,3
-Jewell,Limestone,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Limestone,U.S. House,1,Libertarian,Kerry Burt,2
-Jewell,Limestone,U.S. House,1,independent,Alan LaPolice,6
-Jewell,Limestone,U.S. House,1,Republican,Roger Marshall,22
-Jewell,Limestone,State Senate,36,Democratic,Brian Angevine,6
-Jewell,Limestone,State Senate,36,Republican,Elaine Bowers,24
-Jewell,Limestone,State House,109,Republican,Troy Waymaster,29
-Jewell,Montana,President,,independent,Jill Stein,0
-Jewell,Montana,President,,Republican,Donald Trump,26
-Jewell,Montana,President,,Democratic,Hillary Clinton,8
-Jewell,Montana,President,,Libertarian,Gary Johnson,2
-Jewell,Montana,U.S. Senate,,Republican,Jerry Moran,28
-Jewell,Montana,U.S. Senate,,Democratic,Patrick Wiesner,4
-Jewell,Montana,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Montana,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Montana,U.S. House,1,independent,Alan LaPolice,9
-Jewell,Montana,U.S. House,1,Republican,Roger Marshall,25
-Jewell,Montana,State Senate,36,Democratic,Brian Angevine,4
-Jewell,Montana,State Senate,36,Republican,Elaine Bowers,28
-Jewell,Montana,State House,106,Democratic,Todd Frye,6
-Jewell,Montana,State House,106,Republican,Clay Aurand,25
-Jewell,Odessa,President,,independent,Jill Stein,0
-Jewell,Odessa,President,,Republican,Donald Trump,4
-Jewell,Odessa,President,,Democratic,Hillary Clinton,0
-Jewell,Odessa,President,,Libertarian,Gary Johnson,0
-Jewell,Odessa,U.S. Senate,,Republican,Jerry Moran,5
-Jewell,Odessa,U.S. Senate,,Democratic,Patrick Wiesner,0
-Jewell,Odessa,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Odessa,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Odessa,U.S. House,1,independent,Alan LaPolice,1
-Jewell,Odessa,U.S. House,1,Republican,Roger Marshall,4
-Jewell,Odessa,State Senate,36,Democratic,Brian Angevine,1
-Jewell,Odessa,State Senate,36,Republican,Elaine Bowers,4
-Jewell,Odessa,State House,109,Republican,Troy Waymaster,5
-Jewell,Prairie,President,,independent,Jill Stein,1
-Jewell,Prairie,President,,Republican,Donald Trump,61
-Jewell,Prairie,President,,Democratic,Hillary Clinton,5
-Jewell,Prairie,President,,Libertarian,Gary Johnson,0
-Jewell,Prairie,U.S. Senate,,Republican,Jerry Moran,63
-Jewell,Prairie,U.S. Senate,,Democratic,Patrick Wiesner,2
-Jewell,Prairie,U.S. Senate,,Libertarian,Robert Garrard,1
-Jewell,Prairie,U.S. House,1,Libertarian,Kerry Burt,2
-Jewell,Prairie,U.S. House,1,independent,Alan LaPolice,13
-Jewell,Prairie,U.S. House,1,Republican,Roger Marshall,49
-Jewell,Prairie,State Senate,36,Democratic,Brian Angevine,4
-Jewell,Prairie,State Senate,36,Republican,Elaine Bowers,63
-Jewell,Prairie,State House,106,Democratic,Todd Frye,14
-Jewell,Prairie,State House,106,Republican,Clay Aurand,49
-Jewell,Richland,President,,independent,Jill Stein,1
-Jewell,Richland,President,,Republican,Donald Trump,17
-Jewell,Richland,President,,Democratic,Hillary Clinton,5
-Jewell,Richland,President,,Libertarian,Gary Johnson,0
-Jewell,Richland,U.S. Senate,,Republican,Jerry Moran,15
-Jewell,Richland,U.S. Senate,,Democratic,Patrick Wiesner,1
-Jewell,Richland,U.S. Senate,,Libertarian,Robert Garrard,3
-Jewell,Richland,U.S. House,1,Libertarian,Kerry Burt,2
-Jewell,Richland,U.S. House,1,independent,Alan LaPolice,3
-Jewell,Richland,U.S. House,1,Republican,Roger Marshall,13
-Jewell,Richland,State Senate,36,Democratic,Brian Angevine,2
-Jewell,Richland,State Senate,36,Republican,Elaine Bowers,16
-Jewell,Richland,State House,106,Democratic,Todd Frye,4
-Jewell,Richland,State House,106,Republican,Clay Aurand,15
-Jewell,Sinclair,President,,independent,Jill Stein,0
-Jewell,Sinclair,President,,Republican,Donald Trump,23
-Jewell,Sinclair,President,,Democratic,Hillary Clinton,0
-Jewell,Sinclair,President,,Libertarian,Gary Johnson,2
-Jewell,Sinclair,U.S. Senate,,Republican,Jerry Moran,24
-Jewell,Sinclair,U.S. Senate,,Democratic,Patrick Wiesner,0
-Jewell,Sinclair,U.S. Senate,,Libertarian,Robert Garrard,1
-Jewell,Sinclair,U.S. House,1,Libertarian,Kerry Burt,1
-Jewell,Sinclair,U.S. House,1,independent,Alan LaPolice,3
-Jewell,Sinclair,U.S. House,1,Republican,Roger Marshall,21
-Jewell,Sinclair,State Senate,36,Democratic,Brian Angevine,5
-Jewell,Sinclair,State Senate,36,Republican,Elaine Bowers,20
-Jewell,Sinclair,State House,106,Democratic,Todd Frye,6
-Jewell,Sinclair,State House,106,Republican,Clay Aurand,19
-Jewell,Vicksburg,President,,independent,Jill Stein,0
-Jewell,Vicksburg,President,,Republican,Donald Trump,14
-Jewell,Vicksburg,President,,Democratic,Hillary Clinton,0
-Jewell,Vicksburg,President,,Libertarian,Gary Johnson,0
-Jewell,Vicksburg,U.S. Senate,,Republican,Jerry Moran,14
-Jewell,Vicksburg,U.S. Senate,,Democratic,Patrick Wiesner,0
-Jewell,Vicksburg,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Vicksburg,U.S. House,1,Libertarian,Kerry Burt,0
-Jewell,Vicksburg,U.S. House,1,independent,Alan LaPolice,2
-Jewell,Vicksburg,U.S. House,1,Republican,Roger Marshall,12
-Jewell,Vicksburg,State Senate,36,Democratic,Brian Angevine,1
-Jewell,Vicksburg,State Senate,36,Republican,Elaine Bowers,13
-Jewell,Vicksburg,State House,106,Democratic,Todd Frye,2
-Jewell,Vicksburg,State House,106,Republican,Clay Aurand,12
-Jewell,Walnut,President,,independent,Jill Stein,0
-Jewell,Walnut,President,,Republican,Donald Trump,36
-Jewell,Walnut,President,,Democratic,Hillary Clinton,0
-Jewell,Walnut,President,,Libertarian,Gary Johnson,1
-Jewell,Walnut,U.S. Senate,,Republican,Jerry Moran,39
-Jewell,Walnut,U.S. Senate,,Democratic,Patrick Wiesner,0
-Jewell,Walnut,U.S. Senate,,Libertarian,Robert Garrard,1
-Jewell,Walnut,U.S. House,1,Libertarian,Kerry Burt,2
-Jewell,Walnut,U.S. House,1,independent,Alan LaPolice,6
-Jewell,Walnut,U.S. House,1,Republican,Roger Marshall,32
-Jewell,Walnut,State Senate,36,Democratic,Brian Angevine,0
-Jewell,Walnut,State Senate,36,Republican,Elaine Bowers,41
-Jewell,Walnut,State House,109,Republican,Troy Waymaster,40
-Jewell,Washington,President,,independent,Jill Stein,3
-Jewell,Washington,President,,Republican,Donald Trump,17
-Jewell,Washington,President,,Democratic,Hillary Clinton,4
-Jewell,Washington,President,,Libertarian,Gary Johnson,2
-Jewell,Washington,U.S. Senate,,Republican,Jerry Moran,20
-Jewell,Washington,U.S. Senate,,Democratic,Patrick Wiesner,3
-Jewell,Washington,U.S. Senate,,Libertarian,Robert Garrard,2
-Jewell,Washington,U.S. House,1,Libertarian,Kerry Burt,1
-Jewell,Washington,U.S. House,1,independent,Alan LaPolice,6
-Jewell,Washington,U.S. House,1,Republican,Roger Marshall,18
-Jewell,Washington,State Senate,36,Democratic,Brian Angevine,7
-Jewell,Washington,State Senate,36,Republican,Elaine Bowers,18
-Jewell,Washington,State House,106,Democratic,Todd Frye,7
-Jewell,Washington,State House,106,Republican,Clay Aurand,18
-Jewell,Whitemound,President,,independent,Jill Stein,0
-Jewell,Whitemound,President,,Republican,Donald Trump,23
-Jewell,Whitemound,President,,Democratic,Hillary Clinton,3
-Jewell,Whitemound,President,,Libertarian,Gary Johnson,0
-Jewell,Whitemound,U.S. Senate,,Republican,Jerry Moran,24
-Jewell,Whitemound,U.S. Senate,,Democratic,Patrick Wiesner,2
-Jewell,Whitemound,U.S. Senate,,Libertarian,Robert Garrard,0
-Jewell,Whitemound,U.S. House,1,Libertarian,Kerry Burt,1
-Jewell,Whitemound,U.S. House,1,independent,Alan LaPolice,4
-Jewell,Whitemound,U.S. House,1,Republican,Roger Marshall,19
-Jewell,Whitemound,State Senate,36,Democratic,Brian Angevine,3
-Jewell,Whitemound,State Senate,36,Republican,Elaine Bowers,22
-Jewell,Whitemound,State House,109,Republican,Troy Waymaster,24
-Jewell,JEWELL KS,President,,independent,Jill Stein,41
-Jewell,JEWELL KS,President,,Republican,Donald Trump,1223
-Jewell,JEWELL KS,President,,Democratic,Hillary Clinton,180
-Jewell,JEWELL KS,President,,Libertarian,Gary Johnson,48
-Jewell,JEWELL KS,U.S. Senate,,Republican,Jerry Moran,1263
-Jewell,JEWELL KS,U.S. Senate,,Democratic,Patrick Wiesner,127
-Jewell,JEWELL KS,U.S. Senate,,Libertarian,Robert Garrard,77
-Jewell,JEWELL KS,U.S. House,1,Libertarian,Kerry Burt,57
-Jewell,JEWELL KS,U.S. House,1,independent,Alan LaPolice,375
-Jewell,JEWELL KS,U.S. House,1,Republican,Roger Marshall,1008
-Jewell,JEWELL KS,State Senate,36,Democratic,Brian Angevine,187
-Jewell,JEWELL KS,State Senate,36,Republican,Elaine Bowers,1258
-Jewell,JEWELL KS,State House,106,Democratic,Todd Frye,136
-Jewell,JEWELL KS,State House,106,Republican,Clay Aurand,406
-Jewell,JEWELL KS,State House,109,Republican,Troy Waymaster,796
-Jewell,Grant,President,,,Evan McMullin,1
-Jewell,Jackson,President,,,Evan McMullin,1
-Jewell,Burr Oak,U.S. House,1,,Tim Huelskamp [R],1
-Jewell,Esbon,U.S. House,1,,Tim Huelskamp [R],2
-Jewell,Jackson,U.S. House,1,,Tim Huelskamp [R],1
-Jewell,Limestone,U.S. House,1,,Tim Huelskamp [R],1
+county,precinct,office,district,party,candidate,votes,vtd
+JEWELL,Allen Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",1,000010
+JEWELL,Allen Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",13,000010
+JEWELL,Athens Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000020
+JEWELL,Browns Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",26,000030
+JEWELL,Buffalo Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",55,000040
+JEWELL,Buffalo Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",149,000040
+JEWELL,Burr Oak Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",88,000050
+JEWELL,Calvin Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",28,000060
+JEWELL,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",379,000070
+JEWELL,Erving Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000080
+JEWELL,Esbon Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",65,000090
+JEWELL,Grant Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",33,000100
+JEWELL,Grant Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",58,000100
+JEWELL,Harrison Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000110
+JEWELL,Highland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000120
+JEWELL,Holmwood Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000130
+JEWELL,Ionia Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",31,000140
+JEWELL,Jackson Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",8,000150
+JEWELL,Jackson Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",48,000150
+JEWELL,Limestone Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",29,000160
+JEWELL,Montana Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",6,000170
+JEWELL,Montana Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",25,000170
+JEWELL,Odessa Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",5,000180
+JEWELL,Prairie Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",14,000190
+JEWELL,Prairie Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",49,000190
+JEWELL,Richland Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",4,000200
+JEWELL,Richland Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",15,000200
+JEWELL,Sinclair Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",6,000210
+JEWELL,Sinclair Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",19,000210
+JEWELL,Vicksburg Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",2,000220
+JEWELL,Vicksburg Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",12,000220
+JEWELL,Walnut Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",40,000230
+JEWELL,Washington Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",7,000240
+JEWELL,Washington Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",18,000240
+JEWELL,White Mound Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000250
+JEWELL,Allen Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000010
+JEWELL,Allen Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000010
+JEWELL,Athens Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000020
+JEWELL,Athens Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000020
+JEWELL,Browns Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000030
+JEWELL,Browns Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000030
+JEWELL,Buffalo Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",19,000040
+JEWELL,Buffalo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",190,000040
+JEWELL,Burr Oak Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",11,000050
+JEWELL,Burr Oak Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",87,000050
+JEWELL,Calvin Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000060
+JEWELL,Calvin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000060
+JEWELL,Center Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",73,000070
+JEWELL,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",355,000070
+JEWELL,Erving Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000080
+JEWELL,Erving Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000080
+JEWELL,Esbon Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",13,000090
+JEWELL,Esbon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",65,000090
+JEWELL,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000100
+JEWELL,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",82,000100
+JEWELL,Harrison Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000110
+JEWELL,Harrison Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000110
+JEWELL,Highland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000120
+JEWELL,Highland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000120
+JEWELL,Holmwood Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000130
+JEWELL,Holmwood Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000130
+JEWELL,Ionia Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000140
+JEWELL,Ionia Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",32,000140
+JEWELL,Jackson Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000150
+JEWELL,Jackson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",51,000150
+JEWELL,Limestone Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000160
+JEWELL,Limestone Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000160
+JEWELL,Montana Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000170
+JEWELL,Montana Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",28,000170
+JEWELL,Odessa Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000180
+JEWELL,Odessa Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",4,000180
+JEWELL,Prairie Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000190
+JEWELL,Prairie Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",63,000190
+JEWELL,Richland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000200
+JEWELL,Richland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000200
+JEWELL,Sinclair Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000210
+JEWELL,Sinclair Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000210
+JEWELL,Vicksburg Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000220
+JEWELL,Vicksburg Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000220
+JEWELL,Walnut Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000230
+JEWELL,Walnut Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000230
+JEWELL,Washington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000240
+JEWELL,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000240
+JEWELL,White Mound Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000250
+JEWELL,White Mound Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",22,000250
+JEWELL,Allen Township,President / Vice President,,independent,"Stein, Jill",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+JEWELL,Allen Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+JEWELL,Allen Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+JEWELL,Allen Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+JEWELL,Allen Township,President / Vice President,,Republican,"Trump, Donald J.",16,000010
+JEWELL,Athens Township,President / Vice President,,independent,"Stein, Jill",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+JEWELL,Athens Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+JEWELL,Athens Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000020
+JEWELL,Athens Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+JEWELL,Athens Township,President / Vice President,,Republican,"Trump, Donald J.",19,000020
+JEWELL,Browns Creek Township,President / Vice President,,independent,"Stein, Jill",2,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+JEWELL,Browns Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+JEWELL,Browns Creek Township,President / Vice President,,Republican,"Trump, Donald J.",27,000030
+JEWELL,Buffalo Township,President / Vice President,,independent,"Stein, Jill",2,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+JEWELL,Buffalo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+JEWELL,Buffalo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000040
+JEWELL,Buffalo Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+JEWELL,Buffalo Township,President / Vice President,,Republican,"Trump, Donald J.",182,000040
+JEWELL,Burr Oak Township,President / Vice President,,independent,"Stein, Jill",2,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+JEWELL,Burr Oak Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000050
+JEWELL,Burr Oak Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000050
+JEWELL,Burr Oak Township,President / Vice President,,Republican,"Trump, Donald J.",85,000050
+JEWELL,Calvin Township,President / Vice President,,independent,"Stein, Jill",1,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+JEWELL,Calvin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+JEWELL,Calvin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000060
+JEWELL,Calvin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+JEWELL,Calvin Township,President / Vice President,,Republican,"Trump, Donald J.",26,000060
+JEWELL,Center Township,President / Vice President,,independent,"Stein, Jill",23,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+JEWELL,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+JEWELL,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000070
+JEWELL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000070
+JEWELL,Center Township,President / Vice President,,Republican,"Trump, Donald J.",336,000070
+JEWELL,Erving Township,President / Vice President,,independent,"Stein, Jill",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+JEWELL,Erving Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+JEWELL,Erving Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+JEWELL,Erving Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+JEWELL,Erving Township,President / Vice President,,Republican,"Trump, Donald J.",15,000080
+JEWELL,Esbon Township,President / Vice President,,independent,"Stein, Jill",2,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+JEWELL,Esbon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+JEWELL,Esbon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000090
+JEWELL,Esbon Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000090
+JEWELL,Esbon Township,President / Vice President,,Republican,"Trump, Donald J.",63,000090
+JEWELL,Grant Township,President / Vice President,,independent,"Stein, Jill",2,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"McMullin, Evan",1,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+JEWELL,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+JEWELL,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000100
+JEWELL,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+JEWELL,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",72,000100
+JEWELL,Harrison Township,President / Vice President,,independent,"Stein, Jill",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+JEWELL,Harrison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+JEWELL,Harrison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000110
+JEWELL,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+JEWELL,Harrison Township,President / Vice President,,Republican,"Trump, Donald J.",12,000110
+JEWELL,Highland Township,President / Vice President,,independent,"Stein, Jill",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+JEWELL,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+JEWELL,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000120
+JEWELL,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+JEWELL,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",16,000120
+JEWELL,Holmwood Township,President / Vice President,,independent,"Stein, Jill",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+JEWELL,Holmwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+JEWELL,Holmwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000130
+JEWELL,Holmwood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+JEWELL,Holmwood Township,President / Vice President,,Republican,"Trump, Donald J.",17,000130
+JEWELL,Ionia Township,President / Vice President,,independent,"Stein, Jill",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+JEWELL,Ionia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+JEWELL,Ionia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000140
+JEWELL,Ionia Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+JEWELL,Ionia Township,President / Vice President,,Republican,"Trump, Donald J.",34,000140
+JEWELL,Jackson Township,President / Vice President,,independent,"Stein, Jill",2,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",1,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+JEWELL,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+JEWELL,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000150
+JEWELL,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+JEWELL,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",53,000150
+JEWELL,Limestone Township,President / Vice President,,independent,"Stein, Jill",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+JEWELL,Limestone Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+JEWELL,Limestone Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000160
+JEWELL,Limestone Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+JEWELL,Limestone Township,President / Vice President,,Republican,"Trump, Donald J.",29,000160
+JEWELL,Montana Township,President / Vice President,,independent,"Stein, Jill",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+JEWELL,Montana Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+JEWELL,Montana Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000170
+JEWELL,Montana Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+JEWELL,Montana Township,President / Vice President,,Republican,"Trump, Donald J.",26,000170
+JEWELL,Odessa Township,President / Vice President,,independent,"Stein, Jill",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+JEWELL,Odessa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+JEWELL,Odessa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000180
+JEWELL,Odessa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+JEWELL,Odessa Township,President / Vice President,,Republican,"Trump, Donald J.",4,000180
+JEWELL,Prairie Township,President / Vice President,,independent,"Stein, Jill",1,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+JEWELL,Prairie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+JEWELL,Prairie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000190
+JEWELL,Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+JEWELL,Prairie Township,President / Vice President,,Republican,"Trump, Donald J.",61,000190
+JEWELL,Richland Township,President / Vice President,,independent,"Stein, Jill",1,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+JEWELL,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+JEWELL,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000200
+JEWELL,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+JEWELL,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",17,000200
+JEWELL,Sinclair Township,President / Vice President,,independent,"Stein, Jill",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+JEWELL,Sinclair Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+JEWELL,Sinclair Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000210
+JEWELL,Sinclair Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+JEWELL,Sinclair Township,President / Vice President,,Republican,"Trump, Donald J.",23,000210
+JEWELL,Vicksburg Township,President / Vice President,,independent,"Stein, Jill",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+JEWELL,Vicksburg Township,President / Vice President,,Republican,"Trump, Donald J.",14,000220
+JEWELL,Walnut Township,President / Vice President,,independent,"Stein, Jill",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+JEWELL,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+JEWELL,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000230
+JEWELL,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+JEWELL,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",36,000230
+JEWELL,Washington Township,President / Vice President,,independent,"Stein, Jill",3,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+JEWELL,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+JEWELL,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000240
+JEWELL,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+JEWELL,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",17,000240
+JEWELL,White Mound Township,President / Vice President,,independent,"Stein, Jill",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+JEWELL,White Mound Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+JEWELL,White Mound Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000250
+JEWELL,White Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+JEWELL,White Mound Township,President / Vice President,,Republican,"Trump, Donald J.",23,000250
+JEWELL,Allen Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000010
+JEWELL,Allen Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+JEWELL,Allen Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+JEWELL,Allen Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000010
+JEWELL,Athens Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000020
+JEWELL,Athens Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+JEWELL,Athens Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000020
+JEWELL,Athens Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000020
+JEWELL,Browns Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000030
+JEWELL,Browns Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+JEWELL,Browns Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000030
+JEWELL,Browns Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000030
+JEWELL,Buffalo Township,United States House of Representatives,1,independent,"LaPolice, Alan",61,000040
+JEWELL,Buffalo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+JEWELL,Buffalo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000040
+JEWELL,Buffalo Township,United States House of Representatives,1,Republican,"Marshall, Roger",144,000040
+JEWELL,Burr Oak Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000050
+JEWELL,Burr Oak Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+JEWELL,Burr Oak Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000050
+JEWELL,Burr Oak Township,United States House of Representatives,1,Republican,"Marshall, Roger",75,000050
+JEWELL,Calvin Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000060
+JEWELL,Calvin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+JEWELL,Calvin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+JEWELL,Calvin Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000060
+JEWELL,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",140,000070
+JEWELL,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+JEWELL,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000070
+JEWELL,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",276,000070
+JEWELL,Erving Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000080
+JEWELL,Erving Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+JEWELL,Erving Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+JEWELL,Erving Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000080
+JEWELL,Esbon Township,United States House of Representatives,1,independent,"LaPolice, Alan",17,000090
+JEWELL,Esbon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000090
+JEWELL,Esbon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000090
+JEWELL,Esbon Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000090
+JEWELL,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",35,000100
+JEWELL,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+JEWELL,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000100
+JEWELL,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000100
+JEWELL,Harrison Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000110
+JEWELL,Harrison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+JEWELL,Harrison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+JEWELL,Harrison Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000110
+JEWELL,Highland Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000120
+JEWELL,Highland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+JEWELL,Highland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+JEWELL,Highland Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000120
+JEWELL,Holmwood Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000130
+JEWELL,Holmwood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+JEWELL,Holmwood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+JEWELL,Holmwood Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000130
+JEWELL,Ionia Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000140
+JEWELL,Ionia Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+JEWELL,Ionia Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+JEWELL,Ionia Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000140
+JEWELL,Jackson Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000150
+JEWELL,Jackson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000150
+JEWELL,Jackson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000150
+JEWELL,Jackson Township,United States House of Representatives,1,Republican,"Marshall, Roger",46,000150
+JEWELL,Limestone Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000160
+JEWELL,Limestone Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+JEWELL,Limestone Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000160
+JEWELL,Limestone Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000160
+JEWELL,Montana Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000170
+JEWELL,Montana Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+JEWELL,Montana Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+JEWELL,Montana Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000170
+JEWELL,Odessa Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000180
+JEWELL,Odessa Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+JEWELL,Odessa Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000180
+JEWELL,Odessa Township,United States House of Representatives,1,Republican,"Marshall, Roger",4,000180
+JEWELL,Prairie Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000190
+JEWELL,Prairie Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+JEWELL,Prairie Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000190
+JEWELL,Prairie Township,United States House of Representatives,1,Republican,"Marshall, Roger",49,000190
+JEWELL,Richland Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000200
+JEWELL,Richland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+JEWELL,Richland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000200
+JEWELL,Richland Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000200
+JEWELL,Sinclair Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000210
+JEWELL,Sinclair Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+JEWELL,Sinclair Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000210
+JEWELL,Sinclair Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000210
+JEWELL,Vicksburg Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000220
+JEWELL,Vicksburg Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+JEWELL,Vicksburg Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+JEWELL,Vicksburg Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000220
+JEWELL,Walnut Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000230
+JEWELL,Walnut Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+JEWELL,Walnut Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000230
+JEWELL,Walnut Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000230
+JEWELL,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000240
+JEWELL,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+JEWELL,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000240
+JEWELL,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000240
+JEWELL,White Mound Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000250
+JEWELL,White Mound Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+JEWELL,White Mound Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000250
+JEWELL,White Mound Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000250
+JEWELL,Allen Township,United States Senate,,write - in,"Smith, DJ",0,000010
+JEWELL,Allen Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+JEWELL,Allen Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+JEWELL,Allen Township,United States Senate,,Republican,"Moran, Jerry",14,000010
+JEWELL,Athens Township,United States Senate,,write - in,"Smith, DJ",0,000020
+JEWELL,Athens Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000020
+JEWELL,Athens Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+JEWELL,Athens Township,United States Senate,,Republican,"Moran, Jerry",20,000020
+JEWELL,Browns Creek Township,United States Senate,,write - in,"Smith, DJ",0,000030
+JEWELL,Browns Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+JEWELL,Browns Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+JEWELL,Browns Creek Township,United States Senate,,Republican,"Moran, Jerry",25,000030
+JEWELL,Buffalo Township,United States Senate,,write - in,"Smith, DJ",0,000040
+JEWELL,Buffalo Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000040
+JEWELL,Buffalo Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000040
+JEWELL,Buffalo Township,United States Senate,,Republican,"Moran, Jerry",185,000040
+JEWELL,Burr Oak Township,United States Senate,,write - in,"Smith, DJ",0,000050
+JEWELL,Burr Oak Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000050
+JEWELL,Burr Oak Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000050
+JEWELL,Burr Oak Township,United States Senate,,Republican,"Moran, Jerry",89,000050
+JEWELL,Calvin Township,United States Senate,,write - in,"Smith, DJ",0,000060
+JEWELL,Calvin Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+JEWELL,Calvin Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+JEWELL,Calvin Township,United States Senate,,Republican,"Moran, Jerry",30,000060
+JEWELL,Center Township,United States Senate,,write - in,"Smith, DJ",0,000070
+JEWELL,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",61,000070
+JEWELL,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000070
+JEWELL,Center Township,United States Senate,,Republican,"Moran, Jerry",353,000070
+JEWELL,Erving Township,United States Senate,,write - in,"Smith, DJ",0,000080
+JEWELL,Erving Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000080
+JEWELL,Erving Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+JEWELL,Erving Township,United States Senate,,Republican,"Moran, Jerry",16,000080
+JEWELL,Esbon Township,United States Senate,,write - in,"Smith, DJ",0,000090
+JEWELL,Esbon Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000090
+JEWELL,Esbon Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000090
+JEWELL,Esbon Township,United States Senate,,Republican,"Moran, Jerry",67,000090
+JEWELL,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000100
+JEWELL,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000100
+JEWELL,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000100
+JEWELL,Grant Township,United States Senate,,Republican,"Moran, Jerry",74,000100
+JEWELL,Harrison Township,United States Senate,,write - in,"Smith, DJ",0,000110
+JEWELL,Harrison Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+JEWELL,Harrison Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+JEWELL,Harrison Township,United States Senate,,Republican,"Moran, Jerry",12,000110
+JEWELL,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000120
+JEWELL,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000120
+JEWELL,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+JEWELL,Highland Township,United States Senate,,Republican,"Moran, Jerry",18,000120
+JEWELL,Holmwood Township,United States Senate,,write - in,"Smith, DJ",0,000130
+JEWELL,Holmwood Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000130
+JEWELL,Holmwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000130
+JEWELL,Holmwood Township,United States Senate,,Republican,"Moran, Jerry",14,000130
+JEWELL,Ionia Township,United States Senate,,write - in,"Smith, DJ",0,000140
+JEWELL,Ionia Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000140
+JEWELL,Ionia Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+JEWELL,Ionia Township,United States Senate,,Republican,"Moran, Jerry",32,000140
+JEWELL,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000150
+JEWELL,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000150
+JEWELL,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000150
+JEWELL,Jackson Township,United States Senate,,Republican,"Moran, Jerry",52,000150
+JEWELL,Limestone Township,United States Senate,,write - in,"Smith, DJ",0,000160
+JEWELL,Limestone Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000160
+JEWELL,Limestone Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000160
+JEWELL,Limestone Township,United States Senate,,Republican,"Moran, Jerry",30,000160
+JEWELL,Montana Township,United States Senate,,write - in,"Smith, DJ",0,000170
+JEWELL,Montana Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000170
+JEWELL,Montana Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000170
+JEWELL,Montana Township,United States Senate,,Republican,"Moran, Jerry",28,000170
+JEWELL,Odessa Township,United States Senate,,write - in,"Smith, DJ",0,000180
+JEWELL,Odessa Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+JEWELL,Odessa Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+JEWELL,Odessa Township,United States Senate,,Republican,"Moran, Jerry",5,000180
+JEWELL,Prairie Township,United States Senate,,write - in,"Smith, DJ",0,000190
+JEWELL,Prairie Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000190
+JEWELL,Prairie Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+JEWELL,Prairie Township,United States Senate,,Republican,"Moran, Jerry",63,000190
+JEWELL,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000200
+JEWELL,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000200
+JEWELL,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000200
+JEWELL,Richland Township,United States Senate,,Republican,"Moran, Jerry",15,000200
+JEWELL,Sinclair Township,United States Senate,,write - in,"Smith, DJ",0,000210
+JEWELL,Sinclair Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000210
+JEWELL,Sinclair Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000210
+JEWELL,Sinclair Township,United States Senate,,Republican,"Moran, Jerry",24,000210
+JEWELL,Vicksburg Township,United States Senate,,write - in,"Smith, DJ",0,000220
+JEWELL,Vicksburg Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000220
+JEWELL,Vicksburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000220
+JEWELL,Vicksburg Township,United States Senate,,Republican,"Moran, Jerry",14,000220
+JEWELL,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000230
+JEWELL,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000230
+JEWELL,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000230
+JEWELL,Walnut Township,United States Senate,,Republican,"Moran, Jerry",39,000230
+JEWELL,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000240
+JEWELL,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000240
+JEWELL,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000240
+JEWELL,Washington Township,United States Senate,,Republican,"Moran, Jerry",20,000240
+JEWELL,White Mound Township,United States Senate,,write - in,"Smith, DJ",0,000250
+JEWELL,White Mound Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000250
+JEWELL,White Mound Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000250
+JEWELL,White Mound Township,United States Senate,,Republican,"Moran, Jerry",24,000250

--- a/2016/20161108__ks__general__kearny__precinct.csv
+++ b/2016/20161108__ks__general__kearny__precinct.csv
@@ -1,254 +1,325 @@
-county,precinct,office,district,party,candidate,votes
-Kearny,Total,President,,IND,Jill Stein,13
-Kearny,Total,President,,REP,Donald J. Trump,1075
-Kearny,Total,President,,DEM,Hillary Rodham Clinton,174
-Kearny,Total,President,,LIB,Gary Johnson,41
-Kearny,Total,President,,WRI,Darrell Castle,2
-Kearny,Total,President,,WRI,Evan McMullin,11
-Kearny,DEERFIELD,President,,IND,Jill Stein,5
-Kearny,DEERFIELD,President,,REP,Donald J. Trump,167
-Kearny,DEERFIELD,President,,DEM,Hillary Rodham Clinton,6
-Kearny,DEERFIELD,President,,LIB,Gary Johnson,3
-Kearny,DEERFIELD,President,,WRI,Darrell Castle,0
-Kearny,DEERFIELD,President,,WRI,Evan McMullin,1
-Kearny,HARTLAND,President,,IND,Jill Stein,0
-Kearny,HARTLAND,President,,REP,Donald J. Trump,35
-Kearny,HARTLAND,President,,DEM,Hillary Rodham Clinton,1
-Kearny,HARTLAND,President,,LIB,Gary Johnson,0
-Kearny,HARTLAND,President,,WRI,Darrell Castle,0
-Kearny,HARTLAND,President,,WRI,Evan McMullin,0
-Kearny,EAST HIBBARD,President,,IND,Jill Stein,0
-Kearny,EAST HIBBARD,President,,REP,Donald J. Trump,36
-Kearny,EAST HIBBARD,President,,DEM,Hillary Rodham Clinton,2
-Kearny,EAST HIBBARD,President,,LIB,Gary Johnson,0
-Kearny,EAST HIBBARD,President,,WRI,Darrell Castle,0
-Kearny,EAST HIBBARD,President,,WRI,Evan McMullin,0
-Kearny,WEST HIBBARD,President,,IND,Jill Stein,1
-Kearny,WEST HIBBARD,President,,REP,Donald J. Trump,11
-Kearny,WEST HIBBARD,President,,DEM,Hillary Rodham Clinton,0
-Kearny,WEST HIBBARD,President,,LIB,Gary Johnson,0
-Kearny,WEST HIBBARD,President,,WRI,Darrell Castle,0
-Kearny,WEST HIBBARD,President,,WRI,Evan McMullin,0
-Kearny,KENDALL,President,,IND,Jill Stein,0
-Kearny,KENDALL,President,,REP,Donald J. Trump,17
-Kearny,KENDALL,President,,DEM,Hillary Rodham Clinton,1
-Kearny,KENDALL,President,,LIB,Gary Johnson,0
-Kearny,KENDALL,President,,WRI,Darrell Castle,0
-Kearny,KENDALL,President,,WRI,Evan McMullin,0
-Kearny,LAKIN CITY #1,President,,IND,Jill Stein,1
-Kearny,LAKIN CITY #1,President,,REP,Donald J. Trump,232
-Kearny,LAKIN CITY #1,President,,DEM,Hillary Rodham Clinton,49
-Kearny,LAKIN CITY #1,President,,LIB,Gary Johnson,13
-Kearny,LAKIN CITY #1,President,,WRI,Darrell Castle,0
-Kearny,LAKIN CITY #1,President,,WRI,Evan McMullin,6
-Kearny,LAKIN TWP #1,President,,IND,Jill Stein,0
-Kearny,LAKIN TWP #1,President,,REP,Donald J. Trump,58
-Kearny,LAKIN TWP #1,President,,DEM,Hillary Rodham Clinton,12
-Kearny,LAKIN TWP #1,President,,LIB,Gary Johnson,3
-Kearny,LAKIN TWP #1,President,,WRI,Darrell Castle,0
-Kearny,LAKIN TWP #1,President,,WRI,Evan McMullin,0
-Kearny,LAKIN #2,President,,IND,Jill Stein,3
-Kearny,LAKIN #2,President,,REP,Donald J. Trump,193
-Kearny,LAKIN #2,President,,DEM,Hillary Rodham Clinton,49
-Kearny,LAKIN #2,President,,LIB,Gary Johnson,11
-Kearny,LAKIN #2,President,,WRI,Darrell Castle,0
-Kearny,LAKIN #2,President,,WRI,Evan McMullin,2
-Kearny,SOUTHSIDE,President,,IND,Jill Stein,1
-Kearny,SOUTHSIDE,President,,REP,Donald J. Trump,69
-Kearny,SOUTHSIDE,President,,DEM,Hillary Rodham Clinton,4
-Kearny,SOUTHSIDE,President,,LIB,Gary Johnson,0
-Kearny,SOUTHSIDE,President,,WRI,Darrell Castle,0
-Kearny,SOUTHSIDE,President,,WRI,Evan McMullin,0
-Kearny,ADVANCE,President,,IND,Jill Stein,2
-Kearny,ADVANCE,President,,REP,Donald J. Trump,257
-Kearny,ADVANCE,President,,DEM,Hillary Rodham Clinton,50
-Kearny,ADVANCE,President,,LIB,Gary Johnson,11
-Kearny,ADVANCE,President,,WRI,Darrell Castle,2
-Kearny,ADVANCE,President,,WRI,Evan McMullin,2
-Kearny,Total,U.S. Senate,,REP,Jerry Moran,1132
-Kearny,Total,U.S. Senate,,DEM,Patrick Wiesner,161
-Kearny,Total,U.S. Senate,,LIB,Robert D. Gerrard,51
-Kearny,DEERFIELD,U.S. Senate,,REP,Jerry Moran,182
-Kearny,DEERFIELD,U.S. Senate,,DEM,Patrick Wiesner,37
-Kearny,DEERFIELD,U.S. Senate,,LIB,Robert D. Gerrard,12
-Kearny,HARTLAND,U.S. Senate,,REP,Jerry Moran,33
-Kearny,HARTLAND,U.S. Senate,,DEM,Patrick Wiesner,1
-Kearny,HARTLAND,U.S. Senate,,LIB,Robert D. Gerrard,1
-Kearny,EAST HIBBARD,U.S. Senate,,REP,Jerry Moran,35
-Kearny,EAST HIBBARD,U.S. Senate,,DEM,Patrick Wiesner,0
-Kearny,EAST HIBBARD,U.S. Senate,,LIB,Robert D. Gerrard,2
-Kearny,WEST HIBBARD,U.S. Senate,,REP,Jerry Moran,13
-Kearny,WEST HIBBARD,U.S. Senate,,DEM,Patrick Wiesner,0
-Kearny,WEST HIBBARD,U.S. Senate,,LIB,Robert D. Gerrard,0
-Kearny,KENDALL,U.S. Senate,,REP,Jerry Moran,16
-Kearny,KENDALL,U.S. Senate,,DEM,Patrick Wiesner,1
-Kearny,KENDALL,U.S. Senate,,LIB,Robert D. Gerrard,1
-Kearny,LAKIN CITY #1,U.S. Senate,,REP,Jerry Moran,252
-Kearny,LAKIN CITY #1,U.S. Senate,,DEM,Patrick Wiesner,32
-Kearny,LAKIN CITY #1,U.S. Senate,,LIB,Robert D. Gerrard,12
-Kearny,LAKIN TWP #1,U.S. Senate,,REP,Jerry Moran,61
-Kearny,LAKIN TWP #1,U.S. Senate,,DEM,Patrick Wiesner,7
-Kearny,LAKIN TWP #1,U.S. Senate,,LIB,Robert D. Gerrard,5
-Kearny,LAKIN #2,U.S. Senate,,REP,Jerry Moran,204
-Kearny,LAKIN #2,U.S. Senate,,DEM,Patrick Wiesner,43
-Kearny,LAKIN #2,U.S. Senate,,LIB,Robert D. Gerrard,8
-Kearny,SOUTHSIDE,U.S. Senate,,REP,Jerry Moran,67
-Kearny,SOUTHSIDE,U.S. Senate,,DEM,Patrick Wiesner,4
-Kearny,SOUTHSIDE,U.S. Senate,,LIB,Robert D. Gerrard,2
-Kearny,ADVANCE,U.S. Senate,,REP,Jerry Moran,269
-Kearny,ADVANCE,U.S. Senate,,DEM,Patrick Wiesner,36
-Kearny,ADVANCE,U.S. Senate,,LIB,Robert D. Gerrard,8
-Kearny,Total,U.S. House,1,LIB,Kerry Burt,85
-Kearny,Total,U.S. House,1,IND,Alan La Police,214
-Kearny,Total,U.S. House,1,REP,Roger Marshall,991
-Kearny,Total,U.S. House,1,WRI,Larry Powell,1
-Kearny,Total,U.S. House,1,WRI,Tim Huelskamp,5
-Kearny,DEERFIELD,U.S. House,1,LIB,Kerry Burt,16
-Kearny,DEERFIELD,U.S. House,1,IND,Alan La Police,39
-Kearny,DEERFIELD,U.S. House,1,REP,Roger Marshall,169
-Kearny,DEERFIELD,U.S. House,1,WRI,Larry Powell,0
-Kearny,DEERFIELD,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,HARTLAND,U.S. House,1,LIB,Kerry Burt,3
-Kearny,HARTLAND,U.S. House,1,IND,Alan La Police,4
-Kearny,HARTLAND,U.S. House,1,REP,Roger Marshall,26
-Kearny,HARTLAND,U.S. House,1,WRI,Larry Powell,0
-Kearny,HARTLAND,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,EAST HIBBARD,U.S. House,1,LIB,Kerry Burt,1
-Kearny,EAST HIBBARD,U.S. House,1,IND,Alan La Police,1
-Kearny,EAST HIBBARD,U.S. House,1,REP,Roger Marshall,34
-Kearny,EAST HIBBARD,U.S. House,1,WRI,Larry Powell,0
-Kearny,EAST HIBBARD,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,WEST HIBBARD,U.S. House,1,LIB,Kerry Burt,2
-Kearny,WEST HIBBARD,U.S. House,1,IND,Alan La Police,3
-Kearny,WEST HIBBARD,U.S. House,1,REP,Roger Marshall,7
-Kearny,WEST HIBBARD,U.S. House,1,WRI,Larry Powell,0
-Kearny,WEST HIBBARD,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,KENDALL,U.S. House,1,LIB,Kerry Burt,0
-Kearny,KENDALL,U.S. House,1,IND,Alan La Police,0
-Kearny,KENDALL,U.S. House,1,REP,Roger Marshall,18
-Kearny,KENDALL,U.S. House,1,WRI,Larry Powell,0
-Kearny,KENDALL,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,LAKIN CITY #1,U.S. House,1,LIB,Kerry Burt,24
-Kearny,LAKIN CITY #1,U.S. House,1,IND,Alan La Police,45
-Kearny,LAKIN CITY #1,U.S. House,1,REP,Roger Marshall,217
-Kearny,LAKIN CITY #1,U.S. House,1,WRI,Larry Powell,0
-Kearny,LAKIN CITY #1,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,LAKIN TWP #1,U.S. House,1,LIB,Kerry Burt,4
-Kearny,LAKIN TWP #1,U.S. House,1,IND,Alan La Police,12
-Kearny,LAKIN TWP #1,U.S. House,1,REP,Roger Marshall,54
-Kearny,LAKIN TWP #1,U.S. House,1,WRI,Larry Powell,0
-Kearny,LAKIN TWP #1,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,LAKIN #2,U.S. House,1,LIB,Kerry Burt,14
-Kearny,LAKIN #2,U.S. House,1,IND,Alan La Police,49
-Kearny,LAKIN #2,U.S. House,1,REP,Roger Marshall,181
-Kearny,LAKIN #2,U.S. House,1,WRI,Larry Powell,0
-Kearny,LAKIN #2,U.S. House,1,WRI,Tim Huelskamp,0
-Kearny,SOUTHSIDE,U.S. House,1,LIB,Kerry Burt,1
-Kearny,SOUTHSIDE,U.S. House,1,IND,Alan La Police,9
-Kearny,SOUTHSIDE,U.S. House,1,REP,Roger Marshall,59
-Kearny,SOUTHSIDE,U.S. House,1,WRI,Larry Powell,1
-Kearny,SOUTHSIDE,U.S. House,1,WRI,Tim Huelskamp,1
-Kearny,ADVANCE,U.S. House,1,LIB,Kerry Burt,20
-Kearny,ADVANCE,U.S. House,1,IND,Alan La Police,52
-Kearny,ADVANCE,U.S. House,1,REP,Roger Marshall,226
-Kearny,ADVANCE,U.S. House,1,WRI,Larry Powell,0
-Kearny,ADVANCE,U.S. House,1,WRI,Tim Huelskamp,4
-Kearny,Total,State Senate,39,DEM,A. Zacheriah Worf,189
-Kearny,Total,State Senate,39,REP,John Doll,1087
-Kearny,Total,State Senate,39,WRI,Larry Powell,5
-Kearny,DEERFIELD,State Senate,39,DEM,A. Zacheriah Worf,43
-Kearny,DEERFIELD,State Senate,39,REP,John Doll,181
-Kearny,DEERFIELD,State Senate,39,WRI,Larry Powell,0
-Kearny,HARTLAND,State Senate,39,DEM,A. Zacheriah Worf,3
-Kearny,HARTLAND,State Senate,39,REP,John Doll,32
-Kearny,HARTLAND,State Senate,39,WRI,Larry Powell,0
-Kearny,EAST HIBBARD,State Senate,39,DEM,A. Zacheriah Worf,4
-Kearny,EAST HIBBARD,State Senate,39,REP,John Doll,32
-Kearny,EAST HIBBARD,State Senate,39,WRI,Larry Powell,0
-Kearny,WEST HIBBARD,State Senate,39,DEM,A. Zacheriah Worf,2
-Kearny,WEST HIBBARD,State Senate,39,REP,John Doll,8
-Kearny,WEST HIBBARD,State Senate,39,WRI,Larry Powell,2
-Kearny,KENDALL,State Senate,39,DEM,A. Zacheriah Worf,1
-Kearny,KENDALL,State Senate,39,REP,John Doll,17
-Kearny,KENDALL,State Senate,39,WRI,Larry Powell,0
-Kearny,LAKIN CITY #1,State Senate,39,DEM,A. Zacheriah Worf,34
-Kearny,LAKIN CITY #1,State Senate,39,REP,John Doll,250
-Kearny,LAKIN CITY #1,State Senate,39,WRI,Larry Powell,0
-Kearny,LAKIN TWP #1,State Senate,39,DEM,A. Zacheriah Worf,6
-Kearny,LAKIN TWP #1,State Senate,39,REP,John Doll,63
-Kearny,LAKIN TWP #1,State Senate,39,WRI,Larry Powell,0
-Kearny,LAKIN #2,State Senate,39,DEM,A. Zacheriah Worf,47
-Kearny,LAKIN #2,State Senate,39,REP,John Doll,194
-Kearny,LAKIN #2,State Senate,39,WRI,Larry Powell,0
-Kearny,SOUTHSIDE,State Senate,39,DEM,A. Zacheriah Worf,10
-Kearny,SOUTHSIDE,State Senate,39,REP,John Doll,55
-Kearny,SOUTHSIDE,State Senate,39,WRI,Larry Powell,3
-Kearny,ADVANCE,State Senate,39,DEM,A. Zacheriah Worf,39
-Kearny,ADVANCE,State Senate,39,REP,John Doll,255
-Kearny,ADVANCE,State Senate,39,WRI,Larry Powell,0
-Kearny,DEERFIELD,State House,122,REP,J. Russell (Russ) Jennings,206
-Kearny,DEERFIELD,State House,122,WRI,Randy Hayzlett,1
-Kearny,DEERFIELD,State House,122,WRI,Gene Eatinger,0
-Kearny,DEERFIELD,State House,122,WRI,Gary Hayzlett,0
-Kearny,DEERFIELD,State House,122,WRI,Stan Rice,0
-Kearny,DEERFIELD,State House,122,WRI,Robert Bryne III,0
-Kearny,HARTLAND,State House,122,REP,J. Russell (Russ) Jennings,34
-Kearny,HARTLAND,State House,122,WRI,Randy Hayzlett,1
-Kearny,HARTLAND,State House,122,WRI,Gene Eatinger,0
-Kearny,HARTLAND,State House,122,WRI,Gary Hayzlett,0
-Kearny,HARTLAND,State House,122,WRI,Stan Rice,0
-Kearny,HARTLAND,State House,122,WRI,Robert Bryne III,0
-Kearny,EAST HIBBARD,State House,122,REP,J. Russell (Russ) Jennings,36
-Kearny,EAST HIBBARD,State House,122,WRI,Randy Hayzlett,0
-Kearny,EAST HIBBARD,State House,122,WRI,Gene Eatinger,0
-Kearny,EAST HIBBARD,State House,122,WRI,Gary Hayzlett,0
-Kearny,EAST HIBBARD,State House,122,WRI,Stan Rice,0
-Kearny,EAST HIBBARD,State House,122,WRI,Robert Bryne III,0
-Kearny,WEST HIBBARD,State House,122,REP,J. Russell (Russ) Jennings,11
-Kearny,WEST HIBBARD,State House,122,WRI,Randy Hayzlett,0
-Kearny,WEST HIBBARD,State House,122,WRI,Gene Eatinger,0
-Kearny,WEST HIBBARD,State House,122,WRI,Gary Hayzlett,0
-Kearny,WEST HIBBARD,State House,122,WRI,Stan Rice,0
-Kearny,WEST HIBBARD,State House,122,WRI,Robert Bryne III,0
-Kearny,KENDALL,State House,122,REP,J. Russell (Russ) Jennings,17
-Kearny,KENDALL,State House,122,WRI,Randy Hayzlett,0
-Kearny,KENDALL,State House,122,WRI,Gene Eatinger,0
-Kearny,KENDALL,State House,122,WRI,Gary Hayzlett,0
-Kearny,KENDALL,State House,122,WRI,Stan Rice,0
-Kearny,KENDALL,State House,122,WRI,Robert Bryne III,0
-Kearny,LAKIN CITY #1,State House,122,REP,J. Russell (Russ) Jennings,267
-Kearny,LAKIN CITY #1,State House,122,WRI,Randy Hayzlett,0
-Kearny,LAKIN CITY #1,State House,122,WRI,Gene Eatinger,0
-Kearny,LAKIN CITY #1,State House,122,WRI,Gary Hayzlett,1
-Kearny,LAKIN CITY #1,State House,122,WRI,Stan Rice,1
-Kearny,LAKIN CITY #1,State House,122,WRI,Robert Bryne III,0
-Kearny,LAKIN TWP #1,State House,122,REP,J. Russell (Russ) Jennings,64
-Kearny,LAKIN TWP #1,State House,122,WRI,Randy Hayzlett,0
-Kearny,LAKIN TWP #1,State House,122,WRI,Gene Eatinger,1
-Kearny,LAKIN TWP #1,State House,122,WRI,Gary Hayzlett,0
-Kearny,LAKIN TWP #1,State House,122,WRI,Stan Rice,0
-Kearny,LAKIN TWP #1,State House,122,WRI,Robert Bryne III,0
-Kearny,LAKIN #2,State House,122,REP,J. Russell (Russ) Jennings,239
-Kearny,LAKIN #2,State House,122,WRI,Randy Hayzlett,0
-Kearny,LAKIN #2,State House,122,WRI,Gene Eatinger,0
-Kearny,LAKIN #2,State House,122,WRI,Gary Hayzlett,0
-Kearny,LAKIN #2,State House,122,WRI,Stan Rice,0
-Kearny,LAKIN #2,State House,122,WRI,Robert Bryne III,0
-Kearny,SOUTHSIDE,State House,122,REP,J. Russell (Russ) Jennings,58
-Kearny,SOUTHSIDE,State House,122,WRI,Randy Hayzlett,1
-Kearny,SOUTHSIDE,State House,122,WRI,Gene Eatinger,0
-Kearny,SOUTHSIDE,State House,122,WRI,Gary Hayzlett,0
-Kearny,SOUTHSIDE,State House,122,WRI,Stan Rice,0
-Kearny,SOUTHSIDE,State House,122,WRI,Robert Bryne III,0
-Kearny,ADVANCE,State House,122,REP,J. Russell (Russ) Jennings,265
-Kearny,ADVANCE,State House,122,WRI,Randy Hayzlett,2
-Kearny,ADVANCE,State House,122,WRI,Gene Eatinger,0
-Kearny,ADVANCE,State House,122,WRI,Gary Hayzlett,0
-Kearny,ADVANCE,State House,122,WRI,Stan Rice,0
-Kearny,ADVANCE,State House,122,WRI,Robert Bryne III,1
-Kearny,Total,State House,122,REP,J. Russell (Russ) Jennings,1197
-Kearny,Total,State House,122,WRI,Randy Hayzlett,5
-Kearny,Total,State House,122,WRI,Gene Eatinger,1
-Kearny,Total,State House,122,WRI,Gary Hayzlett,1
-Kearny,Total,State House,122,WRI,Stan Rice,1
-Kearny,Total,State House,122,WRI,Robert Bryne III,1
+county,precinct,office,district,party,candidate,votes,vtd
+KEARNY,Deerfield Precinct,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",222,000010
+KEARNY,East Hibbard Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",51,000020
+KEARNY,Hartland Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",48,000030
+KEARNY,Kendall Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",26,000040
+KEARNY,Lakin Precinct 1,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",373,000050
+KEARNY,Lakin Precinct 2,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",297,000060
+KEARNY,Lakin Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",92,000070
+KEARNY,Southside Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",69,000080
+KEARNY,West Hibbard Township,Kansas House of Representatives,122,Republican,"Jennings, J. Russell ""Russ""",19,000090
+KEARNY,Deerfield Precinct,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",47,000010
+KEARNY,Deerfield Precinct,Kansas Senate,39,Republican,"Doll, John",194,000010
+KEARNY,East Hibbard Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",5,000020
+KEARNY,East Hibbard Township,Kansas Senate,39,Republican,"Doll, John",47,000020
+KEARNY,Hartland Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",3,000030
+KEARNY,Hartland Township,Kansas Senate,39,Republican,"Doll, John",46,000030
+KEARNY,Kendall Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",1,000040
+KEARNY,Kendall Township,Kansas Senate,39,Republican,"Doll, John",26,000040
+KEARNY,Lakin Precinct 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",46,000050
+KEARNY,Lakin Precinct 1,Kansas Senate,39,Republican,"Doll, John",355,000050
+KEARNY,Lakin Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",62,000060
+KEARNY,Lakin Precinct 2,Kansas Senate,39,Republican,"Doll, John",250,000060
+KEARNY,Lakin Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",10,000070
+KEARNY,Lakin Township,Kansas Senate,39,Republican,"Doll, John",89,000070
+KEARNY,Southside Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",13,000080
+KEARNY,Southside Township,Kansas Senate,39,Republican,"Doll, John",63,000080
+KEARNY,West Hibbard Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",2,000090
+KEARNY,West Hibbard Township,Kansas Senate,39,Republican,"Doll, John",17,000090
+KEARNY,Deerfield Precinct,President / Vice President,,independent,"Stein, Jill",5,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Hedges, James A",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"McMullin, Evan",1,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Smith, Mike",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Libertarian,"Johnson, Gary",4,000010
+KEARNY,Deerfield Precinct,President / Vice President,,Republican,"Trump, Donald J.",187,000010
+KEARNY,East Hibbard Township,President / Vice President,,independent,"Stein, Jill",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000020
+KEARNY,East Hibbard Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+KEARNY,East Hibbard Township,President / Vice President,,Republican,"Trump, Donald J.",53,000020
+KEARNY,Hartland Township,President / Vice President,,independent,"Stein, Jill",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+KEARNY,Hartland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+KEARNY,Hartland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+KEARNY,Hartland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+KEARNY,Hartland Township,President / Vice President,,Republican,"Trump, Donald J.",51,000030
+KEARNY,Kendall Township,President / Vice President,,independent,"Stein, Jill",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+KEARNY,Kendall Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+KEARNY,Kendall Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000040
+KEARNY,Kendall Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+KEARNY,Kendall Township,President / Vice President,,Republican,"Trump, Donald J.",26,000040
+KEARNY,Lakin Precinct 1,President / Vice President,,independent,"Stein, Jill",2,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",2,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"McMullin, Evan",8,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",17,000050
+KEARNY,Lakin Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",323,000050
+KEARNY,Lakin Precinct 2,President / Vice President,,independent,"Stein, Jill",3,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",64,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000060
+KEARNY,Lakin Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",255,000060
+KEARNY,Lakin Township,President / Vice President,,independent,"Stein, Jill",1,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+KEARNY,Lakin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+KEARNY,Lakin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000070
+KEARNY,Lakin Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+KEARNY,Lakin Township,President / Vice President,,Republican,"Trump, Donald J.",82,000070
+KEARNY,Southside Township,President / Vice President,,independent,"Stein, Jill",1,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+KEARNY,Southside Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+KEARNY,Southside Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000080
+KEARNY,Southside Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+KEARNY,Southside Township,President / Vice President,,Republican,"Trump, Donald J.",77,000080
+KEARNY,West Hibbard Township,President / Vice President,,independent,"Stein, Jill",1,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000090
+KEARNY,West Hibbard Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+KEARNY,West Hibbard Township,President / Vice President,,Republican,"Trump, Donald J.",21,000090
+KEARNY,Deerfield Precinct,United States House of Representatives,1,independent,"LaPolice, Alan",41,000010
+KEARNY,Deerfield Precinct,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+KEARNY,Deerfield Precinct,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000010
+KEARNY,Deerfield Precinct,United States House of Representatives,1,Republican,"Marshall, Roger",184,000010
+KEARNY,East Hibbard Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000020
+KEARNY,East Hibbard Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+KEARNY,East Hibbard Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000020
+KEARNY,East Hibbard Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000020
+KEARNY,Hartland Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000030
+KEARNY,Hartland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+KEARNY,Hartland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000030
+KEARNY,Hartland Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000030
+KEARNY,Kendall Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000040
+KEARNY,Kendall Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+KEARNY,Kendall Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+KEARNY,Kendall Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000040
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",61,000050
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000050
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,000050
+KEARNY,Lakin Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",309,000050
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",64,000060
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000060
+KEARNY,Lakin Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",231,000060
+KEARNY,Lakin Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000070
+KEARNY,Lakin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+KEARNY,Lakin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000070
+KEARNY,Lakin Township,United States House of Representatives,1,Republican,"Marshall, Roger",76,000070
+KEARNY,Southside Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000080
+KEARNY,Southside Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000080
+KEARNY,Southside Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000080
+KEARNY,Southside Township,United States House of Representatives,1,Republican,"Marshall, Roger",67,000080
+KEARNY,West Hibbard Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000090
+KEARNY,West Hibbard Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+KEARNY,West Hibbard Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+KEARNY,West Hibbard Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000090
+KEARNY,Deerfield Precinct,United States Senate,,write - in,"Smith, DJ",0,000010
+KEARNY,Deerfield Precinct,United States Senate,,Democratic,"Wiesner, Patrick",38,000010
+KEARNY,Deerfield Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",13,000010
+KEARNY,Deerfield Precinct,United States Senate,,Republican,"Moran, Jerry",197,000010
+KEARNY,East Hibbard Township,United States Senate,,write - in,"Smith, DJ",0,000020
+KEARNY,East Hibbard Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+KEARNY,East Hibbard Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000020
+KEARNY,East Hibbard Township,United States Senate,,Republican,"Moran, Jerry",53,000020
+KEARNY,Hartland Township,United States Senate,,write - in,"Smith, DJ",0,000030
+KEARNY,Hartland Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+KEARNY,Hartland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+KEARNY,Hartland Township,United States Senate,,Republican,"Moran, Jerry",47,000030
+KEARNY,Kendall Township,United States Senate,,write - in,"Smith, DJ",0,000040
+KEARNY,Kendall Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+KEARNY,Kendall Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+KEARNY,Kendall Township,United States Senate,,Republican,"Moran, Jerry",25,000040
+KEARNY,Lakin Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000050
+KEARNY,Lakin Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",46,000050
+KEARNY,Lakin Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,000050
+KEARNY,Lakin Precinct 1,United States Senate,,Republican,"Moran, Jerry",356,000050
+KEARNY,Lakin Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000060
+KEARNY,Lakin Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",54,000060
+KEARNY,Lakin Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",10,000060
+KEARNY,Lakin Precinct 2,United States Senate,,Republican,"Moran, Jerry",266,000060
+KEARNY,Lakin Township,United States Senate,,write - in,"Smith, DJ",0,000070
+KEARNY,Lakin Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000070
+KEARNY,Lakin Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000070
+KEARNY,Lakin Township,United States Senate,,Republican,"Moran, Jerry",87,000070
+KEARNY,Southside Township,United States Senate,,write - in,"Smith, DJ",0,000080
+KEARNY,Southside Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000080
+KEARNY,Southside Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+KEARNY,Southside Township,United States Senate,,Republican,"Moran, Jerry",77,000080
+KEARNY,West Hibbard Township,United States Senate,,write - in,"Smith, DJ",0,000090
+KEARNY,West Hibbard Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000090
+KEARNY,West Hibbard Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+KEARNY,West Hibbard Township,United States Senate,,Republican,"Moran, Jerry",24,000090

--- a/2016/20161108__ks__general__kingman__precinct.csv
+++ b/2016/20161108__ks__general__kingman__precinct.csv
@@ -1,441 +1,1081 @@
-county,precinct,office,district,party,candidate,votes,,,,,,,,,,,
-Kingman,Allen,President,,IND,Stein/Baraka,6,,,,,,,,,,,
-Kingman,Belmont,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,Bennett,President,,IND,Stein/Baraka,2,,,,,,,,,,,
-Kingman,Canton,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Chikaskia,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,Dale,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,Dresden,President,,IND,Stein/Baraka,8,,,,,,,,,,,
-Kingman,Eagle,President,,IND,Stein/Baraka,2,,,,,,,,,,,
-Kingman,Eureka,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Evan,President,,IND,Stein/Baraka,2,,,,,,,,,,,
-Kingman,Galesburg,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,Hoosier,President,,IND,Stein/Baraka,2,,,,,,,,,,,
-Kingman,Kingman,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Liberty,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Ninnescah,President,,IND,Stein/Baraka,4,,,,,,,,,,,
-Kingman,Peters,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Richland,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Rochester,President,,IND,Stein/Baraka,2,,,,,,,,,,,
-Kingman,Rural,President,,IND,Stein/Baraka,3,,,,,,,,,,,
-Kingman,Union,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Valley,President,,IND,Stein/Baraka,0,,,,,,,,,,,
-Kingman,Vinita,President,,IND,Stein/Baraka,2,,,,,,,,,,,
-Kingman,White,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,White #3,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,President,,IND,Stein/Baraka,5,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,President,,IND,Stein/Baraka,12,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,President,,IND,Stein/Baraka,4,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,President,,IND,Stein/Baraka,8,,,,,,,,,,,
-Kingman,Totals,President,,IND,Stein/Baraka,68,,,,,,,,,,,
-Kingman,Provisionals,President,,IND,Stein/Baraka,1,,,,,,,,,,,
-Kingman,Grand Total,President,,IND,Stein/Baraka,69,,,,,,,,,,,
-Kingman,Allen,President,,REP,Trump/Pence,38,,,,,,,,,,,
-Kingman,Belmont,President,,REP,Trump/Pence,19,,,,,,,,,,,
-Kingman,Bennett,President,,REP,Trump/Pence,207,,,,,,,,,,,
-Kingman,Canton,President,,REP,Trump/Pence,42,,,,,,,,,,,
-Kingman,Chikaskia,President,,REP,Trump/Pence,35,,,,,,,,,,,
-Kingman,Dale,President,,REP,Trump/Pence,58,,,,,,,,,,,
-Kingman,Dresden,President,,REP,Trump/Pence,122,,,,,,,,,,,
-Kingman,Eagle,President,,REP,Trump/Pence,38,,,,,,,,,,,
-Kingman,Eureka,President,,REP,Trump/Pence,48,,,,,,,,,,,
-Kingman,Evan,President,,REP,Trump/Pence,217,,,,,,,,,,,
-Kingman,Galesburg,President,,REP,Trump/Pence,96,,,,,,,,,,,
-Kingman,Hoosier,President,,REP,Trump/Pence,51,,,,,,,,,,,
-Kingman,Kingman,President,,REP,Trump/Pence,45,,,,,,,,,,,
-Kingman,Liberty,President,,REP,Trump/Pence,42,,,,,,,,,,,
-Kingman,Ninnescah,President,,REP,Trump/Pence,123,,,,,,,,,,,
-Kingman,Peters,President,,REP,Trump/Pence,44,,,,,,,,,,,
-Kingman,Richland,President,,REP,Trump/Pence,46,,,,,,,,,,,
-Kingman,Rochester,President,,REP,Trump/Pence,53,,,,,,,,,,,
-Kingman,Rural,President,,REP,Trump/Pence,97,,,,,,,,,,,
-Kingman,Union,President,,REP,Trump/Pence,23,,,,,,,,,,,
-Kingman,Valley,President,,REP,Trump/Pence,41,,,,,,,,,,,
-Kingman,Vinita,President,,REP,Trump/Pence,95,,,,,,,,,,,
-Kingman,White,President,,REP,Trump/Pence,85,,,,,,,,,,,
-Kingman,White #3,President,,REP,Trump/Pence,41,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,President,,REP,Trump/Pence,216,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,President,,REP,Trump/Pence,302,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,President,,REP,Trump/Pence,128,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,President,,REP,Trump/Pence,155,,,,,,,,,,,
-Kingman,Totals,President,,REP,Trump/Pence,2507,,,,,,,,,,,
-Kingman,Provisionals,President,,REP,Trump/Pence,23,,,,,,,,,,,
-Kingman,Grand Total,President,,REP,Trump/Pence,2530,,,,,,,,,,,
-Kingman,Allen,President,,DEM,Clinton/Kaine,5,,,,,,,,,,,
-Kingman,Belmont,President,,DEM,Clinton/Kaine,5,,,,,,,,,,,
-Kingman,Bennett,President,,DEM,Clinton/Kaine,62,,,,,,,,,,,
-Kingman,Canton,President,,DEM,Clinton/Kaine,4,,,,,,,,,,,
-Kingman,Chikaskia,President,,DEM,Clinton/Kaine,8,,,,,,,,,,,
-Kingman,Dale,President,,DEM,Clinton/Kaine,14,,,,,,,,,,,
-Kingman,Dresden,President,,DEM,Clinton/Kaine,32,,,,,,,,,,,
-Kingman,Eagle,President,,DEM,Clinton/Kaine,5,,,,,,,,,,,
-Kingman,Eureka,President,,DEM,Clinton/Kaine,5,,,,,,,,,,,
-Kingman,Evan,President,,DEM,Clinton/Kaine,27,,,,,,,,,,,
-Kingman,Galesburg,President,,DEM,Clinton/Kaine,13,,,,,,,,,,,
-Kingman,Hoosier,President,,DEM,Clinton/Kaine,13,,,,,,,,,,,
-Kingman,Kingman,President,,DEM,Clinton/Kaine,5,,,,,,,,,,,
-Kingman,Liberty,President,,DEM,Clinton/Kaine,6,,,,,,,,,,,
-Kingman,Ninnescah,President,,DEM,Clinton/Kaine,11,,,,,,,,,,,
-Kingman,Peters,President,,DEM,Clinton/Kaine,4,,,,,,,,,,,
-Kingman,Richland,President,,DEM,Clinton/Kaine,3,,,,,,,,,,,
-Kingman,Rochester,President,,DEM,Clinton/Kaine,15,,,,,,,,,,,
-Kingman,Rural,President,,DEM,Clinton/Kaine,27,,,,,,,,,,,
-Kingman,Union,President,,DEM,Clinton/Kaine,8,,,,,,,,,,,
-Kingman,Valley,President,,DEM,Clinton/Kaine,11,,,,,,,,,,,
-Kingman,Vinita,President,,DEM,Clinton/Kaine,22,,,,,,,,,,,
-Kingman,White,President,,DEM,Clinton/Kaine,15,,,,,,,,,,,
-Kingman,White #3,President,,DEM,Clinton/Kaine,9,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,President,,DEM,Clinton/Kaine,81,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,President,,DEM,Clinton/Kaine,114,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,President,,DEM,Clinton/Kaine,32,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,President,,DEM,Clinton/Kaine,38,,,,,,,,,,,
-Kingman,Totals,President,,DEM,Clinton/Kaine,594,,,,,,,,,,,
-Kingman,Provisionals,President,,DEM,Clinton/Kaine,5,,,,,,,,,,,
-Kingman,Grand Total,President,,DEM,Clinton/Kaine,599,,,,,,,,,,,
-Kingman,Allen,President,,LIB,Johnson/Weld,2,,,,,,,,,,,
-Kingman,Belmont,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Bennett,President,,LIB,Johnson/Weld,7,,,,,,,,,,,
-Kingman,Canton,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Chikaskia,President,,LIB,Johnson/Weld,2,,,,,,,,,,,
-Kingman,Dale,President,,LIB,Johnson/Weld,1,,,,,,,,,,,
-Kingman,Dresden,President,,LIB,Johnson/Weld,3,,,,,,,,,,,
-Kingman,Eagle,President,,LIB,Johnson/Weld,5,,,,,,,,,,,
-Kingman,Eureka,President,,LIB,Johnson/Weld,4,,,,,,,,,,,
-Kingman,Evan,President,,LIB,Johnson/Weld,10,,,,,,,,,,,
-Kingman,Galesburg,President,,LIB,Johnson/Weld,5,,,,,,,,,,,
-Kingman,Hoosier,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Kingman,President,,LIB,Johnson/Weld,2,,,,,,,,,,,
-Kingman,Liberty,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Ninnescah,President,,LIB,Johnson/Weld,6,,,,,,,,,,,
-Kingman,Peters,President,,LIB,Johnson/Weld,1,,,,,,,,,,,
-Kingman,Richland,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Rochester,President,,LIB,Johnson/Weld,8,,,,,,,,,,,
-Kingman,Rural,President,,LIB,Johnson/Weld,3,,,,,,,,,,,
-Kingman,Union,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Valley,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,Vinita,President,,LIB,Johnson/Weld,1,,,,,,,,,,,
-Kingman,White,President,,LIB,Johnson/Weld,0,,,,,,,,,,,
-Kingman,White #3,President,,LIB,Johnson/Weld,2,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,President,,LIB,Johnson/Weld,12,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,President,,LIB,Johnson/Weld,22,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,President,,LIB,Johnson/Weld,4,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,President,,LIB,Johnson/Weld,12,,,,,,,,,,,
-Kingman,Totals,President,,LIB,Johnson/Weld,112,,,,,,,,,,,
-Kingman,Provisionals,President,,LIB,Johnson/Weld,2,,,,,,,,,,,
-Kingman,Grand Total,President,,LIB,Johnson/Weld,114,,,,,,,,,,,
-Kingman,Allen,U.S. Senate,,REP,Jerry Moran,37,,,,,,,,,,,
-Kingman,Belmont,U.S. Senate,,REP,Jerry Moran,19,,,,,,,,,,,
-Kingman,Bennett,U.S. Senate,,REP,Jerry Moran,210,,,,,,,,,,,
-Kingman,Canton,U.S. Senate,,REP,Jerry Moran,44,,,,,,,,,,,
-Kingman,Chikaskia,U.S. Senate,,REP,Jerry Moran,41,,,,,,,,,,,
-Kingman,Dale,U.S. Senate,,REP,Jerry Moran,62,,,,,,,,,,,
-Kingman,Dresden,U.S. Senate,,REP,Jerry Moran,127,,,,,,,,,,,
-Kingman,Eagle,U.S. Senate,,REP,Jerry Moran,43,,,,,,,,,,,
-Kingman,Eureka,U.S. Senate,,REP,Jerry Moran,48,,,,,,,,,,,
-Kingman,Evan,U.S. Senate,,REP,Jerry Moran,226,,,,,,,,,,,
-Kingman,Galesburg,U.S. Senate,,REP,Jerry Moran,92,,,,,,,,,,,
-Kingman,Hoosier,U.S. Senate,,REP,Jerry Moran,56,,,,,,,,,,,
-Kingman,Kingman,U.S. Senate,,REP,Jerry Moran,42,,,,,,,,,,,
-Kingman,Liberty,U.S. Senate,,REP,Jerry Moran,40,,,,,,,,,,,
-Kingman,Ninnescah,U.S. Senate,,REP,Jerry Moran,134,,,,,,,,,,,
-Kingman,Peters,U.S. Senate,,REP,Jerry Moran,43,,,,,,,,,,,
-Kingman,Richland,U.S. Senate,,REP,Jerry Moran,46,,,,,,,,,,,
-Kingman,Rochester,U.S. Senate,,REP,Jerry Moran,59,,,,,,,,,,,
-Kingman,Rural,U.S. Senate,,REP,Jerry Moran,96,,,,,,,,,,,
-Kingman,Union,U.S. Senate,,REP,Jerry Moran,27,,,,,,,,,,,
-Kingman,Valley,U.S. Senate,,REP,Jerry Moran,42,,,,,,,,,,,
-Kingman,Vinita,U.S. Senate,,REP,Jerry Moran,98,,,,,,,,,,,
-Kingman,White,U.S. Senate,,REP,Jerry Moran,87,,,,,,,,,,,
-Kingman,White #3,U.S. Senate,,REP,Jerry Moran,47,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. Senate,,REP,Jerry Moran,248,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. Senate,,REP,Jerry Moran,332,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. Senate,,REP,Jerry Moran,132,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. Senate,,REP,Jerry Moran,162,,,,,,,,,,,
-Kingman,Totals,U.S. Senate,,REP,Jerry Moran,2640,,,,,,,,,,,
-Kingman,Provisionals,U.S. Senate,,REP,Jerry Moran,21,,,,,,,,,,,
-Kingman,Grand Total,U.S. Senate,,REP,Jerry Moran,2661,,,,,,,,,,,
-Kingman,Allen,U.S. Senate,,DEM,Patrick Wiesner,9,,,,,,,,,,,
-Kingman,Belmont,U.S. Senate,,DEM,Patrick Wiesner,6,,,,,,,,,,,
-Kingman,Bennett,U.S. Senate,,DEM,Patrick Wiesner,52,,,,,,,,,,,
-Kingman,Canton,U.S. Senate,,DEM,Patrick Wiesner,1,,,,,,,,,,,
-Kingman,Chikaskia,U.S. Senate,,DEM,Patrick Wiesner,9,,,,,,,,,,,
-Kingman,Dale,U.S. Senate,,DEM,Patrick Wiesner,10,,,,,,,,,,,
-Kingman,Dresden,U.S. Senate,,DEM,Patrick Wiesner,31,,,,,,,,,,,
-Kingman,Eagle,U.S. Senate,,DEM,Patrick Wiesner,4,,,,,,,,,,,
-Kingman,Eureka,U.S. Senate,,DEM,Patrick Wiesner,4,,,,,,,,,,,
-Kingman,Evan,U.S. Senate,,DEM,Patrick Wiesner,24,,,,,,,,,,,
-Kingman,Galesburg,U.S. Senate,,DEM,Patrick Wiesner,17,,,,,,,,,,,
-Kingman,Hoosier,U.S. Senate,,DEM,Patrick Wiesner,5,,,,,,,,,,,
-Kingman,Kingman,U.S. Senate,,DEM,Patrick Wiesner,4,,,,,,,,,,,
-Kingman,Liberty,U.S. Senate,,DEM,Patrick Wiesner,4,,,,,,,,,,,
-Kingman,Ninnescah,U.S. Senate,,DEM,Patrick Wiesner,6,,,,,,,,,,,
-Kingman,Peters,U.S. Senate,,DEM,Patrick Wiesner,7,,,,,,,,,,,
-Kingman,Richland,U.S. Senate,,DEM,Patrick Wiesner,1,,,,,,,,,,,
-Kingman,Rochester,U.S. Senate,,DEM,Patrick Wiesner,20,,,,,,,,,,,
-Kingman,Rural,U.S. Senate,,DEM,Patrick Wiesner,25,,,,,,,,,,,
-Kingman,Union,U.S. Senate,,DEM,Patrick Wiesner,5,,,,,,,,,,,
-Kingman,Valley,U.S. Senate,,DEM,Patrick Wiesner,8,,,,,,,,,,,
-Kingman,Vinita,U.S. Senate,,DEM,Patrick Wiesner,19,,,,,,,,,,,
-Kingman,White,U.S. Senate,,DEM,Patrick Wiesner,9,,,,,,,,,,,
-Kingman,White #3,U.S. Senate,,DEM,Patrick Wiesner,6,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. Senate,,DEM,Patrick Wiesner,51,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. Senate,,DEM,Patrick Wiesner,88,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. Senate,,DEM,Patrick Wiesner,23,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. Senate,,DEM,Patrick Wiesner,36,,,,,,,,,,,
-Kingman,Totals,U.S. Senate,,DEM,Patrick Wiesner,484,,,,,,,,,,,
-Kingman,Provisionals,U.S. Senate,,DEM,Patrick Wiesner,6,,,,,,,,,,,
-Kingman,Grand Total,U.S. Senate,,DEM,Patrick Wiesner,490,,,,,,,,,,,
-Kingman,Allen,U.S. Senate,,LIB,Robert D. Garrard,6,,,,,,,,,,,
-Kingman,Belmont,U.S. Senate,,LIB,Robert D. Garrard,0,,,,,,,,,,,
-Kingman,Bennett,U.S. Senate,,LIB,Robert D. Garrard,21,,,,,,,,,,,
-Kingman,Canton,U.S. Senate,,LIB,Robert D. Garrard,0,,,,,,,,,,,
-Kingman,Chikaskia,U.S. Senate,,LIB,Robert D. Garrard,1,,,,,,,,,,,
-Kingman,Dale,U.S. Senate,,LIB,Robert D. Garrard,5,,,,,,,,,,,
-Kingman,Dresden,U.S. Senate,,LIB,Robert D. Garrard,12,,,,,,,,,,,
-Kingman,Eagle,U.S. Senate,,LIB,Robert D. Garrard,4,,,,,,,,,,,
-Kingman,Eureka,U.S. Senate,,LIB,Robert D. Garrard,5,,,,,,,,,,,
-Kingman,Evan,U.S. Senate,,LIB,Robert D. Garrard,15,,,,,,,,,,,
-Kingman,Galesburg,U.S. Senate,,LIB,Robert D. Garrard,8,,,,,,,,,,,
-Kingman,Hoosier,U.S. Senate,,LIB,Robert D. Garrard,8,,,,,,,,,,,
-Kingman,Kingman,U.S. Senate,,LIB,Robert D. Garrard,4,,,,,,,,,,,
-Kingman,Liberty,U.S. Senate,,LIB,Robert D. Garrard,6,,,,,,,,,,,
-Kingman,Ninnescah,U.S. Senate,,LIB,Robert D. Garrard,3,,,,,,,,,,,
-Kingman,Peters,U.S. Senate,,LIB,Robert D. Garrard,0,,,,,,,,,,,
-Kingman,Richland,U.S. Senate,,LIB,Robert D. Garrard,3,,,,,,,,,,,
-Kingman,Rochester,U.S. Senate,,LIB,Robert D. Garrard,3,,,,,,,,,,,
-Kingman,Rural,U.S. Senate,,LIB,Robert D. Garrard,9,,,,,,,,,,,
-Kingman,Union,U.S. Senate,,LIB,Robert D. Garrard,1,,,,,,,,,,,
-Kingman,Valley,U.S. Senate,,LIB,Robert D. Garrard,1,,,,,,,,,,,
-Kingman,Vinita,U.S. Senate,,LIB,Robert D. Garrard,2,,,,,,,,,,,
-Kingman,White,U.S. Senate,,LIB,Robert D. Garrard,2,,,,,,,,,,,
-Kingman,White #3,U.S. Senate,,LIB,Robert D. Garrard,1,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. Senate,,LIB,Robert D. Garrard,12,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. Senate,,LIB,Robert D. Garrard,24,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. Senate,,LIB,Robert D. Garrard,7,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. Senate,,LIB,Robert D. Garrard,19,,,,,,,,,,,
-Kingman,Totals,U.S. Senate,,LIB,Robert D. Garrard,182,,,,,,,,,,,
-Kingman,Provisionals,U.S. Senate,,LIB,Robert D. Garrard,4,,,,,,,,,,,
-Kingman,Grand Total,U.S. Senate,,LIB,Robert D. Garrard,186,,,,,,,,,,,
-Kingman,Allen,U.S. House,4,DEM,Daniel B. Giroux,8,,,,,,,,,,,
-Kingman,Belmont,U.S. House,4,DEM,Daniel B. Giroux,3,,,,,,,,,,,
-Kingman,Bennett,U.S. House,4,DEM,Daniel B. Giroux,52,,,,,,,,,,,
-Kingman,Canton,U.S. House,4,DEM,Daniel B. Giroux,3,,,,,,,,,,,
-Kingman,Chikaskia,U.S. House,4,DEM,Daniel B. Giroux,11,,,,,,,,,,,
-Kingman,Dale,U.S. House,4,DEM,Daniel B. Giroux,13,,,,,,,,,,,
-Kingman,Dresden,U.S. House,4,DEM,Daniel B. Giroux,37,,,,,,,,,,,
-Kingman,Eagle,U.S. House,4,DEM,Daniel B. Giroux,6,,,,,,,,,,,
-Kingman,Eureka,U.S. House,4,DEM,Daniel B. Giroux,3,,,,,,,,,,,
-Kingman,Evan,U.S. House,4,DEM,Daniel B. Giroux,31,,,,,,,,,,,
-Kingman,Galesburg,U.S. House,4,DEM,Daniel B. Giroux,16,,,,,,,,,,,
-Kingman,Hoosier,U.S. House,4,DEM,Daniel B. Giroux,8,,,,,,,,,,,
-Kingman,Kingman,U.S. House,4,DEM,Daniel B. Giroux,4,,,,,,,,,,,
-Kingman,Liberty,U.S. House,4,DEM,Daniel B. Giroux,4,,,,,,,,,,,
-Kingman,Ninnescah,U.S. House,4,DEM,Daniel B. Giroux,13,,,,,,,,,,,
-Kingman,Peters,U.S. House,4,DEM,Daniel B. Giroux,5,,,,,,,,,,,
-Kingman,Richland,U.S. House,4,DEM,Daniel B. Giroux,1,,,,,,,,,,,
-Kingman,Rochester,U.S. House,4,DEM,Daniel B. Giroux,13,,,,,,,,,,,
-Kingman,Rural,U.S. House,4,DEM,Daniel B. Giroux,32,,,,,,,,,,,
-Kingman,Union,U.S. House,4,DEM,Daniel B. Giroux,5,,,,,,,,,,,
-Kingman,Valley,U.S. House,4,DEM,Daniel B. Giroux,13,,,,,,,,,,,
-Kingman,Vinita,U.S. House,4,DEM,Daniel B. Giroux,23,,,,,,,,,,,
-Kingman,White,U.S. House,4,DEM,Daniel B. Giroux,21,,,,,,,,,,,
-Kingman,White #3,U.S. House,4,DEM,Daniel B. Giroux,14,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. House,4,DEM,Daniel B. Giroux,74,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. House,4,DEM,Daniel B. Giroux,100,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. House,4,DEM,Daniel B. Giroux,33,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. House,4,DEM,Daniel B. Giroux,45,,,,,,,,,,,
-Kingman,Totals,U.S. House,4,DEM,Daniel B. Giroux,591,,,,,,,,,,,
-Kingman,Provisionals,U.S. House,4,DEM,Daniel B. Giroux,4,,,,,,,,,,,
-Kingman,Grand Total,U.S. House,4,DEM,Daniel B. Giroux,595,,,,,,,,,,,
-Kingman,Allen,U.S. House,4,REP,Michael Pompeo,32,,,,,,,,,,,
-Kingman,Belmont,U.S. House,4,REP,Michael Pompeo,20,,,,,,,,,,,
-Kingman,Bennett,U.S. House,4,REP,Michael Pompeo,192,,,,,,,,,,,
-Kingman,Canton,U.S. House,4,REP,Michael Pompeo,39,,,,,,,,,,,
-Kingman,Chikaskia,U.S. House,4,REP,Michael Pompeo,35,,,,,,,,,,,
-Kingman,Dale,U.S. House,4,REP,Michael Pompeo,56,,,,,,,,,,,
-Kingman,Dresden,U.S. House,4,REP,Michael Pompeo,112,,,,,,,,,,,
-Kingman,Eagle,U.S. House,4,REP,Michael Pompeo,38,,,,,,,,,,,
-Kingman,Eureka,U.S. House,4,REP,Michael Pompeo,46,,,,,,,,,,,
-Kingman,Evan,U.S. House,4,REP,Michael Pompeo,208,,,,,,,,,,,
-Kingman,Galesburg,U.S. House,4,REP,Michael Pompeo,88,,,,,,,,,,,
-Kingman,Hoosier,U.S. House,4,REP,Michael Pompeo,55,,,,,,,,,,,
-Kingman,Kingman,U.S. House,4,REP,Michael Pompeo,37,,,,,,,,,,,
-Kingman,Liberty,U.S. House,4,REP,Michael Pompeo,35,,,,,,,,,,,
-Kingman,Ninnescah,U.S. House,4,REP,Michael Pompeo,122,,,,,,,,,,,
-Kingman,Peters,U.S. House,4,REP,Michael Pompeo,36,,,,,,,,,,,
-Kingman,Richland,U.S. House,4,REP,Michael Pompeo,43,,,,,,,,,,,
-Kingman,Rochester,U.S. House,4,REP,Michael Pompeo,52,,,,,,,,,,,
-Kingman,Rural,U.S. House,4,REP,Michael Pompeo,79,,,,,,,,,,,
-Kingman,Union,U.S. House,4,REP,Michael Pompeo,24,,,,,,,,,,,
-Kingman,Valley,U.S. House,4,REP,Michael Pompeo,35,,,,,,,,,,,
-Kingman,Vinita,U.S. House,4,REP,Michael Pompeo,81,,,,,,,,,,,
-Kingman,White,U.S. House,4,REP,Michael Pompeo,71,,,,,,,,,,,
-Kingman,White #3,U.S. House,4,REP,Michael Pompeo,34,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. House,4,REP,Michael Pompeo,216,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. House,4,REP,Michael Pompeo,298,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. House,4,REP,Michael Pompeo,118,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. House,4,REP,Michael Pompeo,151,,,,,,,,,,,
-Kingman,Totals,U.S. House,4,REP,Michael Pompeo,2353,,,,,,,,,,,
-Kingman,Provisionals,U.S. House,4,REP,Michael Pompeo,21,,,,,,,,,,,
-Kingman,Grand Total,U.S. House,4,REP,Michael Pompeo,2374,,,,,,,,,,,
-Kingman,Allen,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,Belmont,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,Bennett,U.S. House,4,LIB,Gorden J. Bakken,10,,,,,,,,,,,
-Kingman,Canton,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Chikaskia,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Dale,U.S. House,4,LIB,Gorden J. Bakken,2,,,,,,,,,,,
-Kingman,Dresden,U.S. House,4,LIB,Gorden J. Bakken,2,,,,,,,,,,,
-Kingman,Eagle,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Eureka,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Evan,U.S. House,4,LIB,Gorden J. Bakken,5,,,,,,,,,,,
-Kingman,Galesburg,U.S. House,4,LIB,Gorden J. Bakken,5,,,,,,,,,,,
-Kingman,Hoosier,U.S. House,4,LIB,Gorden J. Bakken,4,,,,,,,,,,,
-Kingman,Kingman,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Liberty,U.S. House,4,LIB,Gorden J. Bakken,2,,,,,,,,,,,
-Kingman,Ninnescah,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Peters,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,Richland,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,Rochester,U.S. House,4,LIB,Gorden J. Bakken,3,,,,,,,,,,,
-Kingman,Rural,U.S. House,4,LIB,Gorden J. Bakken,2,,,,,,,,,,,
-Kingman,Union,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Valley,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,Vinita,U.S. House,4,LIB,Gorden J. Bakken,4,,,,,,,,,,,
-Kingman,White,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,White #3,U.S. House,4,LIB,Gorden J. Bakken,1,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. House,4,LIB,Gorden J. Bakken,5,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. House,4,LIB,Gorden J. Bakken,8,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. House,4,LIB,Gorden J. Bakken,3,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. House,4,LIB,Gorden J. Bakken,4,,,,,,,,,,,
-Kingman,Totals,U.S. House,4,LIB,Gorden J. Bakken,67,,,,,,,,,,,
-Kingman,Provisionals,U.S. House,4,LIB,Gorden J. Bakken,0,,,,,,,,,,,
-Kingman,Grand Total,U.S. House,4,LIB,Gorden J. Bakken,67,,,,,,,,,,,
-Kingman,Allen,U.S. House,4,IND,Miranda Allen,12,,,,,,,,,,,
-Kingman,Belmont,U.S. House,4,IND,Miranda Allen,2,,,,,,,,,,,
-Kingman,Bennett,U.S. House,4,IND,Miranda Allen,31,,,,,,,,,,,
-Kingman,Canton,U.S. House,4,IND,Miranda Allen,2,,,,,,,,,,,
-Kingman,Chikaskia,U.S. House,4,IND,Miranda Allen,3,,,,,,,,,,,
-Kingman,Dale,U.S. House,4,IND,Miranda Allen,6,,,,,,,,,,,
-Kingman,Dresden,U.S. House,4,IND,Miranda Allen,17,,,,,,,,,,,
-Kingman,Eagle,U.S. House,4,IND,Miranda Allen,6,,,,,,,,,,,
-Kingman,Eureka,U.S. House,4,IND,Miranda Allen,6,,,,,,,,,,,
-Kingman,Evan,U.S. House,4,IND,Miranda Allen,19,,,,,,,,,,,
-Kingman,Galesburg,U.S. House,4,IND,Miranda Allen,8,,,,,,,,,,,
-Kingman,Hoosier,U.S. House,4,IND,Miranda Allen,3,,,,,,,,,,,
-Kingman,Kingman,U.S. House,4,IND,Miranda Allen,8,,,,,,,,,,,
-Kingman,Liberty,U.S. House,4,IND,Miranda Allen,9,,,,,,,,,,,
-Kingman,Ninnescah,U.S. House,4,IND,Miranda Allen,7,,,,,,,,,,,
-Kingman,Peters,U.S. House,4,IND,Miranda Allen,8,,,,,,,,,,,
-Kingman,Richland,U.S. House,4,IND,Miranda Allen,5,,,,,,,,,,,
-Kingman,Rochester,U.S. House,4,IND,Miranda Allen,15,,,,,,,,,,,
-Kingman,Rural,U.S. House,4,IND,Miranda Allen,15,,,,,,,,,,,
-Kingman,Union,U.S. House,4,IND,Miranda Allen,3,,,,,,,,,,,
-Kingman,Valley,U.S. House,4,IND,Miranda Allen,3,,,,,,,,,,,
-Kingman,Vinita,U.S. House,4,IND,Miranda Allen,11,,,,,,,,,,,
-Kingman,White,U.S. House,4,IND,Miranda Allen,9,,,,,,,,,,,
-Kingman,White #3,U.S. House,4,IND,Miranda Allen,5,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,U.S. House,4,IND,Miranda Allen,15,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,U.S. House,4,IND,Miranda Allen,39,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,U.S. House,4,IND,Miranda Allen,11,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,U.S. House,4,IND,Miranda Allen,17,,,,,,,,,,,
-Kingman,Totals,U.S. House,4,IND,Miranda Allen,295,,,,,,,,,,,
-Kingman,Provisionals,U.S. House,4,IND,Miranda Allen,5,,,,,,,,,,,
-Kingman,Grand Total,U.S. House,4,IND,Miranda Allen,300,,,,,,,,,,,
-Kingman,Allen,State Senate,32,REP,Larry W. Alley,39,,,,,,,,,,,
-Kingman,Belmont,State Senate,32,REP,Larry W. Alley,14,,,,,,,,,,,
-Kingman,Bennett,State Senate,32,REP,Larry W. Alley,191,,,,,,,,,,,
-Kingman,Canton,State Senate,32,REP,Larry W. Alley,38,,,,,,,,,,,
-Kingman,Chikaskia,State Senate,32,REP,Larry W. Alley,33,,,,,,,,,,,
-Kingman,Eagle,State Senate,32,REP,Larry W. Alley,38,,,,,,,,,,,
-Kingman,Kingman,State Senate,32,REP,Larry W. Alley,33,,,,,,,,,,,
-Kingman,Liberty,State Senate,32,REP,Larry W. Alley,36,,,,,,,,,,,
-Kingman,Peters,State Senate,32,REP,Larry W. Alley,40,,,,,,,,,,,
-Kingman,Richland,State Senate,32,REP,Larry W. Alley,41,,,,,,,,,,,
-Kingman,Rochester,State Senate,32,REP,Larry W. Alley,55,,,,,,,,,,,
-Kingman,Valley,State Senate,32,REP,Larry W. Alley,35,,,,,,,,,,,
-Kingman,Totals,State Senate,32,REP,Larry W. Alley,593,,,,,,,,,,,
-Kingman,Provisionals,State Senate,32,REP,Larry W. Alley,2,,,,,,,,,,,
-Kingman,Grand Total,State Senate,32,REP,Larry W. Alley,595,,,,,,,,,,,
-Kingman,Allen,State Senate,32,DEM,Don Shimkus,11,,,,,,,,,,,
-Kingman,Belmont,State Senate,32,DEM,Don Shimkus,9,,,,,,,,,,,
-Kingman,Bennett,State Senate,32,DEM,Don Shimkus,81,,,,,,,,,,,
-Kingman,Canton,State Senate,32,DEM,Don Shimkus,5,,,,,,,,,,,
-Kingman,Chikaskia,State Senate,32,DEM,Don Shimkus,13,,,,,,,,,,,
-Kingman,Eagle,State Senate,32,DEM,Don Shimkus,9,,,,,,,,,,,
-Kingman,Kingman,State Senate,32,DEM,Don Shimkus,10,,,,,,,,,,,
-Kingman,Liberty,State Senate,32,DEM,Don Shimkus,13,,,,,,,,,,,
-Kingman,Peters,State Senate,32,DEM,Don Shimkus,7,,,,,,,,,,,
-Kingman,Richland,State Senate,32,DEM,Don Shimkus,6,,,,,,,,,,,
-Kingman,Rochester,State Senate,32,DEM,Don Shimkus,24,,,,,,,,,,,
-Kingman,Valley,State Senate,32,DEM,Don Shimkus,11,,,,,,,,,,,
-Kingman,Totals,State Senate,32,DEM,Don Shimkus,199,,,,,,,,,,,
-Kingman,Provisionals,State Senate,32,DEM,Don Shimkus,2,,,,,,,,,,,
-Kingman,Grand Total,State Senate,32,DEM,Don Shimkus,201,,,,,,,,,,,
-Kingman,Dale,State Senate,34,REP,Edward E. Berger,60,,,,,,,,,,,
-Kingman,Dresden,State Senate,34,REP,Edward E. Berger,131,,,,,,,,,,,
-Kingman,Eureka,State Senate,34,REP,Edward E. Berger,49,,,,,,,,,,,
-Kingman,Evan,State Senate,34,REP,Edward E. Berger,218,,,,,,,,,,,
-Kingman,Galesburg,State Senate,34,REP,Edward E. Berger,89,,,,,,,,,,,
-Kingman,Hoosier,State Senate,34,REP,Edward E. Berger,63,,,,,,,,,,,
-Kingman,Ninnescah,State Senate,34,REP,Edward E. Berger,128,,,,,,,,,,,
-Kingman,Rural,State Senate,34,REP,Edward E. Berger,101,,,,,,,,,,,
-Kingman,Union,State Senate,34,REP,Edward E. Berger,22,,,,,,,,,,,
-Kingman,Vinita,State Senate,34,REP,Edward E. Berger,92,,,,,,,,,,,
-Kingman,White,State Senate,34,REP,Edward E. Berger,76,,,,,,,,,,,
-Kingman,White #3,State Senate,34,REP,Edward E. Berger,45,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,State Senate,34,REP,Edward E. Berger,248,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,State Senate,34,REP,Edward E. Berger,343,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,State Senate,34,REP,Edward E. Berger,127,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,State Senate,34,REP,Edward E. Berger,161,,,,,,,,,,,
-Kingman,Totals,State Senate,34,REP,Edward E. Berger,1953,,,,,,,,,,,
-Kingman,Provisionals,State Senate,34,REP,Edward E. Berger,18,,,,,,,,,,,
-Kingman,Grand Total,State Senate,34,REP,Edward E. Berger,1971,,,,,,,,,,,
-Kingman,Dale,State Senate,34,DEM,Homer L. Gilson,13,,,,,,,,,,,
-Kingman,Dresden,State Senate,34,DEM,Homer L. Gilson,35,,,,,,,,,,,
-Kingman,Eureka,State Senate,34,DEM,Homer L. Gilson,7,,,,,,,,,,,
-Kingman,Evan,State Senate,34,DEM,Homer L. Gilson,34,,,,,,,,,,,
-Kingman,Galesburg,State Senate,34,DEM,Homer L. Gilson,13,,,,,,,,,,,
-Kingman,Hoosier,State Senate,34,DEM,Homer L. Gilson,6,,,,,,,,,,,
-Kingman,Ninnescah,State Senate,34,DEM,Homer L. Gilson,13,,,,,,,,,,,
-Kingman,Rural,State Senate,34,DEM,Homer L. Gilson,23,,,,,,,,,,,
-Kingman,Union,State Senate,34,DEM,Homer L. Gilson,6,,,,,,,,,,,
-Kingman,Vinita,State Senate,34,DEM,Homer L. Gilson,20,,,,,,,,,,,
-Kingman,White,State Senate,34,DEM,Homer L. Gilson,15,,,,,,,,,,,
-Kingman,White #3,State Senate,34,DEM,Homer L. Gilson,5,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,State Senate,34,DEM,Homer L. Gilson,55,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,State Senate,34,DEM,Homer L. Gilson,86,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,State Senate,34,DEM,Homer L. Gilson,28,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,State Senate,34,DEM,Homer L. Gilson,42,,,,,,,,,,,
-Kingman,Totals,State Senate,34,DEM,Homer L. Gilson,401,,,,,,,,,,,
-Kingman,Provisionals,State Senate,34,DEM,Homer L. Gilson,5,,,,,,,,,,,
-Kingman,Grand Total,State Senate,34,DEM,Homer L. Gilson,406,,,,,,,,,,,
-Kingman,Allen,State House,114,REP,Jack Thimesch,49,,,,,,,,,,,
-Kingman,Belmont,State House,114,REP,Jack Thimesch,21,,,,,,,,,,,
-Kingman,Bennett,State House,114,REP,Jack Thimesch,249,,,,,,,,,,,
-Kingman,Canton,State House,114,REP,Jack Thimesch,43,,,,,,,,,,,
-Kingman,Chikaskia,State House,114,REP,Jack Thimesch,47,,,,,,,,,,,
-Kingman,Dale,State House,114,REP,Jack Thimesch,66,,,,,,,,,,,
-Kingman,Dresden,State House,114,REP,Jack Thimesch,136,,,,,,,,,,,
-Kingman,Eagle,State House,114,REP,Jack Thimesch,48,,,,,,,,,,,
-Kingman,Eureka,State House,114,REP,Jack Thimesch,54,,,,,,,,,,,
-Kingman,Evan,State House,114,REP,Jack Thimesch,239,,,,,,,,,,,
-Kingman,Galesburg,State House,114,REP,Jack Thimesch,105,,,,,,,,,,,
-Kingman,Hoosier,State House,114,REP,Jack Thimesch,57,,,,,,,,,,,
-Kingman,Kingman,State House,114,REP,Jack Thimesch,36,,,,,,,,,,,
-Kingman,Liberty,State House,114,REP,Jack Thimesch,39,,,,,,,,,,,
-Kingman,Ninnescah,State House,114,REP,Jack Thimesch,125,,,,,,,,,,,
-Kingman,Peters,State House,114,REP,Jack Thimesch,46,,,,,,,,,,,
-Kingman,Richland,State House,114,REP,Jack Thimesch,40,,,,,,,,,,,
-Kingman,Rochester,State House,114,REP,Jack Thimesch,69,,,,,,,,,,,
-Kingman,Rural,State House,114,REP,Jack Thimesch,101,,,,,,,,,,,
-Kingman,Union,State House,114,REP,Jack Thimesch,31,,,,,,,,,,,
-Kingman,Valley,State House,114,REP,Jack Thimesch,46,,,,,,,,,,,
-Kingman,Vinita,State House,114,REP,Jack Thimesch,100,,,,,,,,,,,
-Kingman,White,State House,114,REP,Jack Thimesch,89,,,,,,,,,,,
-Kingman,White #3,State House,114,REP,Jack Thimesch,50,,,,,,,,,,,
-Kingman,Kingman City 1st Ward,State House,114,REP,Jack Thimesch,277,,,,,,,,,,,
-Kingman,Kingman City 2nd Ward,State House,114,REP,Jack Thimesch,381,,,,,,,,,,,
-Kingman,Kingman City 3rd Ward,State House,114,REP,Jack Thimesch,145,,,,,,,,,,,
-Kingman,Kingman City 4th Ward,State House,114,REP,Jack Thimesch,198,,,,,,,,,,,
-Kingman,Totals,State House,114,REP,Jack Thimesch,2887,,,,,,,,,,,
-Kingman,Provisionals,State House,114,REP,Jack Thimesch,26,,,,,,,,,,,
-Kingman,Grand Total,State House,114,REP,Jack Thimesch,2913,,,,,,,,,,,
+county,precinct,office,district,party,candidate,votes,vtd
+KINGMAN,Allen Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",49,000010
+KINGMAN,Belmont Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",21,000020
+KINGMAN,Bennett Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",249,000030
+KINGMAN,Canton Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",43,000040
+KINGMAN,Chikaskia Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",47,000050
+KINGMAN,Dale Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",66,000060
+KINGMAN,Dresden Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",136,000070
+KINGMAN,Eagle Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",48,000080
+KINGMAN,Eureka Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",54,000090
+KINGMAN,Evan Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",239,000100
+KINGMAN,Galesburg Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",105,000110
+KINGMAN,Hoosier Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",57,000120
+KINGMAN,Kingman Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",36,000130
+KINGMAN,Kingman Ward 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",277,00014A
+KINGMAN,Kingman Ward 1 Exclave,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00014B
+KINGMAN,Kingman Ward 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",407,000150
+KINGMAN,Kingman Ward 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",145,000160
+KINGMAN,Kingman Ward 4,Kansas House of Representatives,114,Republican,"Thimesch, Jack",198,000170
+KINGMAN,Liberty Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",39,000180
+KINGMAN,Ninnescah Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",125,000190
+KINGMAN,Peters Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",46,000200
+KINGMAN,Richland Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",40,000210
+KINGMAN,Rochester Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",69,000220
+KINGMAN,Rural Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",101,000230
+KINGMAN,Union Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",31,000240
+KINGMAN,Valley Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",46,000250
+KINGMAN,Vinita Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",100,000260
+KINGMAN,White Township Part A,Kansas House of Representatives,114,Republican,"Thimesch, Jack",89,00027A
+KINGMAN,White Township Part A Enclave,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00027B
+KINGMAN,White Township Part B,Kansas House of Representatives,114,Republican,"Thimesch, Jack",50,00027C
+KINGMAN,Allen Township,Kansas Senate,32,Democratic,"Shimkus, Don",11,000010
+KINGMAN,Allen Township,Kansas Senate,32,Republican,"Alley, Larry W.",39,000010
+KINGMAN,Belmont Township,Kansas Senate,32,Democratic,"Shimkus, Don",9,000020
+KINGMAN,Belmont Township,Kansas Senate,32,Republican,"Alley, Larry W.",14,000020
+KINGMAN,Bennett Township,Kansas Senate,32,Democratic,"Shimkus, Don",83,000030
+KINGMAN,Bennett Township,Kansas Senate,32,Republican,"Alley, Larry W.",193,000030
+KINGMAN,Canton Township,Kansas Senate,32,Democratic,"Shimkus, Don",5,000040
+KINGMAN,Canton Township,Kansas Senate,32,Republican,"Alley, Larry W.",38,000040
+KINGMAN,Chikaskia Township,Kansas Senate,32,Democratic,"Shimkus, Don",13,000050
+KINGMAN,Chikaskia Township,Kansas Senate,32,Republican,"Alley, Larry W.",33,000050
+KINGMAN,Dale Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",13,000060
+KINGMAN,Dale Township,Kansas Senate,34,Republican,"Berger, Edward E.",60,000060
+KINGMAN,Dresden Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",35,000070
+KINGMAN,Dresden Township,Kansas Senate,34,Republican,"Berger, Edward E.",131,000070
+KINGMAN,Eagle Township,Kansas Senate,32,Democratic,"Shimkus, Don",9,000080
+KINGMAN,Eagle Township,Kansas Senate,32,Republican,"Alley, Larry W.",38,000080
+KINGMAN,Eureka Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",7,000090
+KINGMAN,Eureka Township,Kansas Senate,34,Republican,"Berger, Edward E.",49,000090
+KINGMAN,Evan Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",34,000100
+KINGMAN,Evan Township,Kansas Senate,34,Republican,"Berger, Edward E.",218,000100
+KINGMAN,Galesburg Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",13,000110
+KINGMAN,Galesburg Township,Kansas Senate,34,Republican,"Berger, Edward E.",89,000110
+KINGMAN,Hoosier Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",6,000120
+KINGMAN,Hoosier Township,Kansas Senate,34,Republican,"Berger, Edward E.",63,000120
+KINGMAN,Kingman Township,Kansas Senate,32,Democratic,"Shimkus, Don",10,000130
+KINGMAN,Kingman Township,Kansas Senate,32,Republican,"Alley, Larry W.",33,000130
+KINGMAN,Kingman Ward 1,Kansas Senate,34,Democratic,"Gilson, Homer L.",55,00014A
+KINGMAN,Kingman Ward 1,Kansas Senate,34,Republican,"Berger, Edward E.",248,00014A
+KINGMAN,Kingman Ward 1 Exclave,Kansas Senate,34,Democratic,"Gilson, Homer L.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,Kansas Senate,34,Republican,"Berger, Edward E.",0,00014B
+KINGMAN,Kingman Ward 2,Kansas Senate,34,Democratic,"Gilson, Homer L.",91,000150
+KINGMAN,Kingman Ward 2,Kansas Senate,34,Republican,"Berger, Edward E.",361,000150
+KINGMAN,Kingman Ward 3,Kansas Senate,34,Democratic,"Gilson, Homer L.",28,000160
+KINGMAN,Kingman Ward 3,Kansas Senate,34,Republican,"Berger, Edward E.",127,000160
+KINGMAN,Kingman Ward 4,Kansas Senate,34,Democratic,"Gilson, Homer L.",42,000170
+KINGMAN,Kingman Ward 4,Kansas Senate,34,Republican,"Berger, Edward E.",161,000170
+KINGMAN,Liberty Township,Kansas Senate,32,Democratic,"Shimkus, Don",13,000180
+KINGMAN,Liberty Township,Kansas Senate,32,Republican,"Alley, Larry W.",36,000180
+KINGMAN,Ninnescah Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",13,000190
+KINGMAN,Ninnescah Township,Kansas Senate,34,Republican,"Berger, Edward E.",128,000190
+KINGMAN,Peters Township,Kansas Senate,32,Democratic,"Shimkus, Don",7,000200
+KINGMAN,Peters Township,Kansas Senate,32,Republican,"Alley, Larry W.",40,000200
+KINGMAN,Richland Township,Kansas Senate,32,Democratic,"Shimkus, Don",6,000210
+KINGMAN,Richland Township,Kansas Senate,32,Republican,"Alley, Larry W.",41,000210
+KINGMAN,Rochester Township,Kansas Senate,32,Democratic,"Shimkus, Don",24,000220
+KINGMAN,Rochester Township,Kansas Senate,32,Republican,"Alley, Larry W.",55,000220
+KINGMAN,Rural Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",23,000230
+KINGMAN,Rural Township,Kansas Senate,34,Republican,"Berger, Edward E.",101,000230
+KINGMAN,Union Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",6,000240
+KINGMAN,Union Township,Kansas Senate,34,Republican,"Berger, Edward E.",22,000240
+KINGMAN,Valley Township,Kansas Senate,32,Democratic,"Shimkus, Don",11,000250
+KINGMAN,Valley Township,Kansas Senate,32,Republican,"Alley, Larry W.",35,000250
+KINGMAN,Vinita Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",20,000260
+KINGMAN,Vinita Township,Kansas Senate,34,Republican,"Berger, Edward E.",92,000260
+KINGMAN,White Township Part A,Kansas Senate,34,Democratic,"Gilson, Homer L.",15,00027A
+KINGMAN,White Township Part A,Kansas Senate,34,Republican,"Berger, Edward E.",76,00027A
+KINGMAN,White Township Part A Enclave,Kansas Senate,34,Democratic,"Gilson, Homer L.",0,00027B
+KINGMAN,White Township Part A Enclave,Kansas Senate,34,Republican,"Berger, Edward E.",0,00027B
+KINGMAN,White Township Part B,Kansas Senate,34,Democratic,"Gilson, Homer L.",5,00027C
+KINGMAN,White Township Part B,Kansas Senate,34,Republican,"Berger, Edward E.",45,00027C
+KINGMAN,Allen Township,President / Vice President,,independent,"Stein, Jill",6,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+KINGMAN,Allen Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+KINGMAN,Allen Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000010
+KINGMAN,Allen Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+KINGMAN,Allen Township,President / Vice President,,Republican,"Trump, Donald J.",38,000010
+KINGMAN,Belmont Township,President / Vice President,,independent,"Stein, Jill",1,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+KINGMAN,Belmont Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+KINGMAN,Belmont Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000020
+KINGMAN,Belmont Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+KINGMAN,Belmont Township,President / Vice President,,Republican,"Trump, Donald J.",19,000020
+KINGMAN,Bennett Township,President / Vice President,,independent,"Stein, Jill",2,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+KINGMAN,Bennett Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+KINGMAN,Bennett Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000030
+KINGMAN,Bennett Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000030
+KINGMAN,Bennett Township,President / Vice President,,Republican,"Trump, Donald J.",207,000030
+KINGMAN,Canton Township,President / Vice President,,independent,"Stein, Jill",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+KINGMAN,Canton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+KINGMAN,Canton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000040
+KINGMAN,Canton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+KINGMAN,Canton Township,President / Vice President,,Republican,"Trump, Donald J.",42,000040
+KINGMAN,Chikaskia Township,President / Vice President,,independent,"Stein, Jill",1,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+KINGMAN,Chikaskia Township,President / Vice President,,Republican,"Trump, Donald J.",35,000050
+KINGMAN,Dale Township,President / Vice President,,independent,"Stein, Jill",1,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+KINGMAN,Dale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+KINGMAN,Dale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000060
+KINGMAN,Dale Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+KINGMAN,Dale Township,President / Vice President,,Republican,"Trump, Donald J.",58,000060
+KINGMAN,Dresden Township,President / Vice President,,independent,"Stein, Jill",8,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+KINGMAN,Dresden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+KINGMAN,Dresden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000070
+KINGMAN,Dresden Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+KINGMAN,Dresden Township,President / Vice President,,Republican,"Trump, Donald J.",122,000070
+KINGMAN,Eagle Township,President / Vice President,,independent,"Stein, Jill",2,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+KINGMAN,Eagle Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+KINGMAN,Eagle Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000080
+KINGMAN,Eagle Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+KINGMAN,Eagle Township,President / Vice President,,Republican,"Trump, Donald J.",38,000080
+KINGMAN,Eureka Township,President / Vice President,,independent,"Stein, Jill",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+KINGMAN,Eureka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+KINGMAN,Eureka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000090
+KINGMAN,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+KINGMAN,Eureka Township,President / Vice President,,Republican,"Trump, Donald J.",48,000090
+KINGMAN,Evan Township,President / Vice President,,independent,"Stein, Jill",2,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+KINGMAN,Evan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+KINGMAN,Evan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000100
+KINGMAN,Evan Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000100
+KINGMAN,Evan Township,President / Vice President,,Republican,"Trump, Donald J.",217,000100
+KINGMAN,Galesburg Township,President / Vice President,,independent,"Stein, Jill",1,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+KINGMAN,Galesburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000110
+KINGMAN,Galesburg Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+KINGMAN,Galesburg Township,President / Vice President,,Republican,"Trump, Donald J.",96,000110
+KINGMAN,Hoosier Township,President / Vice President,,independent,"Stein, Jill",2,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000120
+KINGMAN,Hoosier Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+KINGMAN,Hoosier Township,President / Vice President,,Republican,"Trump, Donald J.",51,000120
+KINGMAN,Kingman Township,President / Vice President,,independent,"Stein, Jill",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+KINGMAN,Kingman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+KINGMAN,Kingman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000130
+KINGMAN,Kingman Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+KINGMAN,Kingman Township,President / Vice President,,Republican,"Trump, Donald J.",45,000130
+KINGMAN,Kingman Ward 1,President / Vice President,,independent,"Stein, Jill",5,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Castle, Darrell L",1,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Maturen, Michael A",1,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"McMullin, Evan",3,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,00014A
+KINGMAN,Kingman Ward 1,President / Vice President,,Republican,"Trump, Donald J.",216,00014A
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00014B
+KINGMAN,Kingman Ward 2,President / Vice President,,independent,"Stein, Jill",13,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"McMullin, Evan",10,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",119,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",24,000150
+KINGMAN,Kingman Ward 2,President / Vice President,,Republican,"Trump, Donald J.",325,000150
+KINGMAN,Kingman Ward 3,President / Vice President,,independent,"Stein, Jill",4,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"McMullin, Evan",5,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000160
+KINGMAN,Kingman Ward 3,President / Vice President,,Republican,"Trump, Donald J.",128,000160
+KINGMAN,Kingman Ward 4,President / Vice President,,independent,"Stein, Jill",8,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",12,000170
+KINGMAN,Kingman Ward 4,President / Vice President,,Republican,"Trump, Donald J.",155,000170
+KINGMAN,Liberty Township,President / Vice President,,independent,"Stein, Jill",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+KINGMAN,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+KINGMAN,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000180
+KINGMAN,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+KINGMAN,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",42,000180
+KINGMAN,Ninnescah Township,President / Vice President,,independent,"Stein, Jill",4,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000190
+KINGMAN,Ninnescah Township,President / Vice President,,Republican,"Trump, Donald J.",123,000190
+KINGMAN,Peters Township,President / Vice President,,independent,"Stein, Jill",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+KINGMAN,Peters Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+KINGMAN,Peters Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000200
+KINGMAN,Peters Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+KINGMAN,Peters Township,President / Vice President,,Republican,"Trump, Donald J.",44,000200
+KINGMAN,Richland Township,President / Vice President,,independent,"Stein, Jill",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+KINGMAN,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+KINGMAN,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000210
+KINGMAN,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+KINGMAN,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",46,000210
+KINGMAN,Rochester Township,President / Vice President,,independent,"Stein, Jill",2,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+KINGMAN,Rochester Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+KINGMAN,Rochester Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000220
+KINGMAN,Rochester Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000220
+KINGMAN,Rochester Township,President / Vice President,,Republican,"Trump, Donald J.",53,000220
+KINGMAN,Rural Township,President / Vice President,,independent,"Stein, Jill",3,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+KINGMAN,Rural Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+KINGMAN,Rural Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000230
+KINGMAN,Rural Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000230
+KINGMAN,Rural Township,President / Vice President,,Republican,"Trump, Donald J.",97,000230
+KINGMAN,Union Township,President / Vice President,,independent,"Stein, Jill",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+KINGMAN,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+KINGMAN,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000240
+KINGMAN,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+KINGMAN,Union Township,President / Vice President,,Republican,"Trump, Donald J.",23,000240
+KINGMAN,Valley Township,President / Vice President,,independent,"Stein, Jill",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+KINGMAN,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+KINGMAN,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000250
+KINGMAN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+KINGMAN,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",41,000250
+KINGMAN,Vinita Township,President / Vice President,,independent,"Stein, Jill",2,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+KINGMAN,Vinita Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+KINGMAN,Vinita Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000260
+KINGMAN,Vinita Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+KINGMAN,Vinita Township,President / Vice President,,Republican,"Trump, Donald J.",95,000260
+KINGMAN,White Township Part A,President / Vice President,,independent,"Stein, Jill",1,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Hedges, James A",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"McMullin, Evan",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Perry, Darryl",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Smith, Mike",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Sood, Ajay",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,00027A
+KINGMAN,White Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00027A
+KINGMAN,White Township Part A,President / Vice President,,Republican,"Trump, Donald J.",85,00027A
+KINGMAN,White Township Part A Enclave,President / Vice President,,independent,"Stein, Jill",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Hedges, James A",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Smith, Mike",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027B
+KINGMAN,White Township Part A Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00027B
+KINGMAN,White Township Part B,President / Vice President,,independent,"Stein, Jill",1,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Hedges, James A",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"McMullin, Evan",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Perry, Darryl",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Smith, Mike",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Sood, Ajay",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027C
+KINGMAN,White Township Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,00027C
+KINGMAN,White Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",2,00027C
+KINGMAN,White Township Part B,President / Vice President,,Republican,"Trump, Donald J.",41,00027C
+KINGMAN,Allen Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000010
+KINGMAN,Allen Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000010
+KINGMAN,Allen Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000010
+KINGMAN,Allen Township,United States House of Representatives,4,Republican,"Pompeo, Michael",32,000010
+KINGMAN,Belmont Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000020
+KINGMAN,Belmont Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000020
+KINGMAN,Belmont Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000020
+KINGMAN,Belmont Township,United States House of Representatives,4,Republican,"Pompeo, Michael",20,000020
+KINGMAN,Bennett Township,United States House of Representatives,4,independent,"Allen, Miranda",31,000030
+KINGMAN,Bennett Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",52,000030
+KINGMAN,Bennett Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000030
+KINGMAN,Bennett Township,United States House of Representatives,4,Republican,"Pompeo, Michael",192,000030
+KINGMAN,Canton Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000040
+KINGMAN,Canton Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000040
+KINGMAN,Canton Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000040
+KINGMAN,Canton Township,United States House of Representatives,4,Republican,"Pompeo, Michael",39,000040
+KINGMAN,Chikaskia Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000050
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000050
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000050
+KINGMAN,Chikaskia Township,United States House of Representatives,4,Republican,"Pompeo, Michael",35,000050
+KINGMAN,Dale Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000060
+KINGMAN,Dale Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000060
+KINGMAN,Dale Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000060
+KINGMAN,Dale Township,United States House of Representatives,4,Republican,"Pompeo, Michael",56,000060
+KINGMAN,Dresden Township,United States House of Representatives,4,independent,"Allen, Miranda",17,000070
+KINGMAN,Dresden Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",37,000070
+KINGMAN,Dresden Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000070
+KINGMAN,Dresden Township,United States House of Representatives,4,Republican,"Pompeo, Michael",112,000070
+KINGMAN,Eagle Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000080
+KINGMAN,Eagle Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000080
+KINGMAN,Eagle Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000080
+KINGMAN,Eagle Township,United States House of Representatives,4,Republican,"Pompeo, Michael",38,000080
+KINGMAN,Eureka Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000090
+KINGMAN,Eureka Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000090
+KINGMAN,Eureka Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000090
+KINGMAN,Eureka Township,United States House of Representatives,4,Republican,"Pompeo, Michael",46,000090
+KINGMAN,Evan Township,United States House of Representatives,4,independent,"Allen, Miranda",19,000100
+KINGMAN,Evan Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",31,000100
+KINGMAN,Evan Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000100
+KINGMAN,Evan Township,United States House of Representatives,4,Republican,"Pompeo, Michael",208,000100
+KINGMAN,Galesburg Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000110
+KINGMAN,Galesburg Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",16,000110
+KINGMAN,Galesburg Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000110
+KINGMAN,Galesburg Township,United States House of Representatives,4,Republican,"Pompeo, Michael",88,000110
+KINGMAN,Hoosier Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000120
+KINGMAN,Hoosier Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000120
+KINGMAN,Hoosier Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000120
+KINGMAN,Hoosier Township,United States House of Representatives,4,Republican,"Pompeo, Michael",55,000120
+KINGMAN,Kingman Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000130
+KINGMAN,Kingman Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000130
+KINGMAN,Kingman Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000130
+KINGMAN,Kingman Township,United States House of Representatives,4,Republican,"Pompeo, Michael",37,000130
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",15,00014A
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",74,00014A
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,00014A
+KINGMAN,Kingman Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",216,00014A
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00014B
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",44,000150
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",104,000150
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000150
+KINGMAN,Kingman Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",319,000150
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,independent,"Allen, Miranda",11,000160
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",33,000160
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000160
+KINGMAN,Kingman Ward 3,United States House of Representatives,4,Republican,"Pompeo, Michael",118,000160
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,independent,"Allen, Miranda",17,000170
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",45,000170
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000170
+KINGMAN,Kingman Ward 4,United States House of Representatives,4,Republican,"Pompeo, Michael",151,000170
+KINGMAN,Liberty Township,United States House of Representatives,4,independent,"Allen, Miranda",9,000180
+KINGMAN,Liberty Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000180
+KINGMAN,Liberty Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000180
+KINGMAN,Liberty Township,United States House of Representatives,4,Republican,"Pompeo, Michael",35,000180
+KINGMAN,Ninnescah Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000190
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000190
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000190
+KINGMAN,Ninnescah Township,United States House of Representatives,4,Republican,"Pompeo, Michael",122,000190
+KINGMAN,Peters Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000200
+KINGMAN,Peters Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000200
+KINGMAN,Peters Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000200
+KINGMAN,Peters Township,United States House of Representatives,4,Republican,"Pompeo, Michael",36,000200
+KINGMAN,Richland Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000210
+KINGMAN,Richland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000210
+KINGMAN,Richland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000210
+KINGMAN,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",43,000210
+KINGMAN,Rochester Township,United States House of Representatives,4,independent,"Allen, Miranda",15,000220
+KINGMAN,Rochester Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000220
+KINGMAN,Rochester Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000220
+KINGMAN,Rochester Township,United States House of Representatives,4,Republican,"Pompeo, Michael",52,000220
+KINGMAN,Rural Township,United States House of Representatives,4,independent,"Allen, Miranda",15,000230
+KINGMAN,Rural Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",32,000230
+KINGMAN,Rural Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000230
+KINGMAN,Rural Township,United States House of Representatives,4,Republican,"Pompeo, Michael",79,000230
+KINGMAN,Union Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000240
+KINGMAN,Union Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000240
+KINGMAN,Union Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000240
+KINGMAN,Union Township,United States House of Representatives,4,Republican,"Pompeo, Michael",24,000240
+KINGMAN,Valley Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000250
+KINGMAN,Valley Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000250
+KINGMAN,Valley Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000250
+KINGMAN,Valley Township,United States House of Representatives,4,Republican,"Pompeo, Michael",35,000250
+KINGMAN,Vinita Township,United States House of Representatives,4,independent,"Allen, Miranda",11,000260
+KINGMAN,Vinita Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,000260
+KINGMAN,Vinita Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000260
+KINGMAN,Vinita Township,United States House of Representatives,4,Republican,"Pompeo, Michael",81,000260
+KINGMAN,White Township Part A,United States House of Representatives,4,independent,"Allen, Miranda",9,00027A
+KINGMAN,White Township Part A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",21,00027A
+KINGMAN,White Township Part A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00027A
+KINGMAN,White Township Part A,United States House of Representatives,4,Republican,"Pompeo, Michael",71,00027A
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00027B
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00027B
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00027B
+KINGMAN,White Township Part A Enclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00027B
+KINGMAN,White Township Part B,United States House of Representatives,4,independent,"Allen, Miranda",5,00027C
+KINGMAN,White Township Part B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",14,00027C
+KINGMAN,White Township Part B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,00027C
+KINGMAN,White Township Part B,United States House of Representatives,4,Republican,"Pompeo, Michael",34,00027C
+KINGMAN,Allen Township,United States Senate,,write - in,"Smith, DJ",0,000010
+KINGMAN,Allen Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000010
+KINGMAN,Allen Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000010
+KINGMAN,Allen Township,United States Senate,,Republican,"Moran, Jerry",37,000010
+KINGMAN,Belmont Township,United States Senate,,write - in,"Smith, DJ",0,000020
+KINGMAN,Belmont Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000020
+KINGMAN,Belmont Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+KINGMAN,Belmont Township,United States Senate,,Republican,"Moran, Jerry",19,000020
+KINGMAN,Bennett Township,United States Senate,,write - in,"Smith, DJ",0,000030
+KINGMAN,Bennett Township,United States Senate,,Democratic,"Wiesner, Patrick",52,000030
+KINGMAN,Bennett Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000030
+KINGMAN,Bennett Township,United States Senate,,Republican,"Moran, Jerry",210,000030
+KINGMAN,Canton Township,United States Senate,,write - in,"Smith, DJ",0,000040
+KINGMAN,Canton Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+KINGMAN,Canton Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+KINGMAN,Canton Township,United States Senate,,Republican,"Moran, Jerry",44,000040
+KINGMAN,Chikaskia Township,United States Senate,,write - in,"Smith, DJ",0,000050
+KINGMAN,Chikaskia Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000050
+KINGMAN,Chikaskia Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+KINGMAN,Chikaskia Township,United States Senate,,Republican,"Moran, Jerry",41,000050
+KINGMAN,Dale Township,United States Senate,,write - in,"Smith, DJ",0,000060
+KINGMAN,Dale Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000060
+KINGMAN,Dale Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000060
+KINGMAN,Dale Township,United States Senate,,Republican,"Moran, Jerry",62,000060
+KINGMAN,Dresden Township,United States Senate,,write - in,"Smith, DJ",0,000070
+KINGMAN,Dresden Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000070
+KINGMAN,Dresden Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000070
+KINGMAN,Dresden Township,United States Senate,,Republican,"Moran, Jerry",127,000070
+KINGMAN,Eagle Township,United States Senate,,write - in,"Smith, DJ",0,000080
+KINGMAN,Eagle Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+KINGMAN,Eagle Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+KINGMAN,Eagle Township,United States Senate,,Republican,"Moran, Jerry",43,000080
+KINGMAN,Eureka Township,United States Senate,,write - in,"Smith, DJ",0,000090
+KINGMAN,Eureka Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000090
+KINGMAN,Eureka Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000090
+KINGMAN,Eureka Township,United States Senate,,Republican,"Moran, Jerry",48,000090
+KINGMAN,Evan Township,United States Senate,,write - in,"Smith, DJ",0,000100
+KINGMAN,Evan Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000100
+KINGMAN,Evan Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000100
+KINGMAN,Evan Township,United States Senate,,Republican,"Moran, Jerry",226,000100
+KINGMAN,Galesburg Township,United States Senate,,write - in,"Smith, DJ",0,000110
+KINGMAN,Galesburg Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000110
+KINGMAN,Galesburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000110
+KINGMAN,Galesburg Township,United States Senate,,Republican,"Moran, Jerry",92,000110
+KINGMAN,Hoosier Township,United States Senate,,write - in,"Smith, DJ",0,000120
+KINGMAN,Hoosier Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000120
+KINGMAN,Hoosier Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000120
+KINGMAN,Hoosier Township,United States Senate,,Republican,"Moran, Jerry",56,000120
+KINGMAN,Kingman Township,United States Senate,,write - in,"Smith, DJ",0,000130
+KINGMAN,Kingman Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000130
+KINGMAN,Kingman Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+KINGMAN,Kingman Township,United States Senate,,Republican,"Moran, Jerry",42,000130
+KINGMAN,Kingman Ward 1,United States Senate,,write - in,"Smith, DJ",0,00014A
+KINGMAN,Kingman Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",51,00014A
+KINGMAN,Kingman Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",12,00014A
+KINGMAN,Kingman Ward 1,United States Senate,,Republican,"Moran, Jerry",248,00014A
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00014B
+KINGMAN,Kingman Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00014B
+KINGMAN,Kingman Ward 2,United States Senate,,write - in,"Smith, DJ",0,000150
+KINGMAN,Kingman Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",94,000150
+KINGMAN,Kingman Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",28,000150
+KINGMAN,Kingman Ward 2,United States Senate,,Republican,"Moran, Jerry",353,000150
+KINGMAN,Kingman Ward 3,United States Senate,,write - in,"Smith, DJ",0,000160
+KINGMAN,Kingman Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",23,000160
+KINGMAN,Kingman Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",7,000160
+KINGMAN,Kingman Ward 3,United States Senate,,Republican,"Moran, Jerry",132,000160
+KINGMAN,Kingman Ward 4,United States Senate,,write - in,"Smith, DJ",0,000170
+KINGMAN,Kingman Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",36,000170
+KINGMAN,Kingman Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",19,000170
+KINGMAN,Kingman Ward 4,United States Senate,,Republican,"Moran, Jerry",162,000170
+KINGMAN,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000180
+KINGMAN,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000180
+KINGMAN,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000180
+KINGMAN,Liberty Township,United States Senate,,Republican,"Moran, Jerry",40,000180
+KINGMAN,Ninnescah Township,United States Senate,,write - in,"Smith, DJ",0,000190
+KINGMAN,Ninnescah Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000190
+KINGMAN,Ninnescah Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000190
+KINGMAN,Ninnescah Township,United States Senate,,Republican,"Moran, Jerry",134,000190
+KINGMAN,Peters Township,United States Senate,,write - in,"Smith, DJ",0,000200
+KINGMAN,Peters Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000200
+KINGMAN,Peters Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000200
+KINGMAN,Peters Township,United States Senate,,Republican,"Moran, Jerry",43,000200
+KINGMAN,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000210
+KINGMAN,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000210
+KINGMAN,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000210
+KINGMAN,Richland Township,United States Senate,,Republican,"Moran, Jerry",46,000210
+KINGMAN,Rochester Township,United States Senate,,write - in,"Smith, DJ",0,000220
+KINGMAN,Rochester Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000220
+KINGMAN,Rochester Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000220
+KINGMAN,Rochester Township,United States Senate,,Republican,"Moran, Jerry",59,000220
+KINGMAN,Rural Township,United States Senate,,write - in,"Smith, DJ",0,000230
+KINGMAN,Rural Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000230
+KINGMAN,Rural Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000230
+KINGMAN,Rural Township,United States Senate,,Republican,"Moran, Jerry",96,000230
+KINGMAN,Union Township,United States Senate,,write - in,"Smith, DJ",0,000240
+KINGMAN,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000240
+KINGMAN,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+KINGMAN,Union Township,United States Senate,,Republican,"Moran, Jerry",27,000240
+KINGMAN,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000250
+KINGMAN,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000250
+KINGMAN,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000250
+KINGMAN,Valley Township,United States Senate,,Republican,"Moran, Jerry",42,000250
+KINGMAN,Vinita Township,United States Senate,,write - in,"Smith, DJ",0,000260
+KINGMAN,Vinita Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000260
+KINGMAN,Vinita Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000260
+KINGMAN,Vinita Township,United States Senate,,Republican,"Moran, Jerry",98,000260
+KINGMAN,White Township Part A,United States Senate,,write - in,"Smith, DJ",0,00027A
+KINGMAN,White Township Part A,United States Senate,,Democratic,"Wiesner, Patrick",9,00027A
+KINGMAN,White Township Part A,United States Senate,,Libertarian,"Garrard, Robert D.",2,00027A
+KINGMAN,White Township Part A,United States Senate,,Republican,"Moran, Jerry",87,00027A
+KINGMAN,White Township Part A Enclave,United States Senate,,write - in,"Smith, DJ",0,00027B
+KINGMAN,White Township Part A Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00027B
+KINGMAN,White Township Part A Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00027B
+KINGMAN,White Township Part A Enclave,United States Senate,,Republican,"Moran, Jerry",0,00027B
+KINGMAN,White Township Part B,United States Senate,,write - in,"Smith, DJ",0,00027C
+KINGMAN,White Township Part B,United States Senate,,Democratic,"Wiesner, Patrick",6,00027C
+KINGMAN,White Township Part B,United States Senate,,Libertarian,"Garrard, Robert D.",1,00027C
+KINGMAN,White Township Part B,United States Senate,,Republican,"Moran, Jerry",47,00027C

--- a/2016/20161108__ks__general__kiowa__precinct.csv
+++ b/2016/20161108__ks__general__kiowa__precinct.csv
@@ -1,189 +1,181 @@
-county,precinct,office,district,party,candidate,votes
-Kiowa,Center I City,President,,IND,Jill Stein,2
-Kiowa,Center I City,President,,REP,Donald J Trump,128
-Kiowa,Center I City,President,,DEM,Hillary Clinton,23
-Kiowa,Center I City,President,,LIB,Gary Johnson,8
-Kiowa,Center I City,President,,,Bernie Sanders,1
-Kiowa,Center I Twp,President,,IND,Jill Stein,1
-Kiowa,Center I Twp,President,,REP,Donald J Trump,96
-Kiowa,Center I Twp,President,,DEM,Hillary Clinton,7
-Kiowa,Center I Twp,President,,LIB,Gary Johnson,4
-Kiowa,Center I Twp,President,,,John McCain,1
-Kiowa,Center IA Twp,President,,IND,Jill Stein,0
-Kiowa,Center IA Twp,President,,REP,Donald J Trump,20
-Kiowa,Center IA Twp,President,,DEM,Hillary Clinton,3
-Kiowa,Center IA Twp,President,,LIB,Gary Johnson,1
-Kiowa,Center II City,President,,IND,Jill Stein,1
-Kiowa,Center II City,President,,REP,Donald J Trump,56
-Kiowa,Center II City,President,,DEM,Hillary Clinton,12
-Kiowa,Center II City,President,,LIB,Gary Johnson,4
-Kiowa,Center II City,President,,,Sarah Palin,1
-Kiowa,Center IIA City,President,,IND,Jill Stein,4
-Kiowa,Center IIA City,President,,REP,Donald J Trump,85
-Kiowa,Center IIA City,President,,DEM,Hillary Clinton,15
-Kiowa,Center IIA City,President,,LIB,Gary Johnson,6
-Kiowa,Center IIA City,President,,,Evan McMullin,1
-Kiowa,Center IIA Twp,President,,IND,Jill Stein,0
-Kiowa,Center IIA Twp,President,,REP,Donald J Trump,2
-Kiowa,Center IIA Twp,President,,DEM,Hillary Clinton,0
-Kiowa,Center IIA Twp,President,,LIB,Gary Johnson,0
-Kiowa,Haviland City,President,,IND,Jill Stein,3
-Kiowa,Haviland City,President,,REP,Donald J Trump,187
-Kiowa,Haviland City,President,,DEM,Hillary Clinton,23
-Kiowa,Haviland City,President,,LIB,Gary Johnson,9
-Kiowa,Haviland City,President,,,Ted Cruz,2
-Kiowa,Haviland City,President,,,Maturen/Munoz,2
-Kiowa,Haviland City,President,,,Michael Maturen/Auan Munoz,2
-Kiowa,Haviland City,President,,,McMallin/Johnson,1
-Kiowa,Haviland City,President,,,John Kasack,2
-Kiowa,Haviland City,President,,,Ben Carson,2
-Kiowa,Haviland Twp,President,,IND,Jill Stein,2
-Kiowa,Haviland Twp,President,,REP,Donald J Trump,66
-Kiowa,Haviland Twp,President,,DEM,Hillary Clinton,7
-Kiowa,Haviland Twp,President,,LIB,Gary Johnson,3
-Kiowa,Haviland A Twp,President,,IND,Jill Stein,0
-Kiowa,Haviland A Twp,President,,REP,Donald J Trump,26
-Kiowa,Haviland A Twp,President,,DEM,Hillary Clinton,3
-Kiowa,Haviland A Twp,President,,LIB,Gary Johnson,1
-Kiowa,Belvidere Twp,President,,IND,Jill Stein,0
-Kiowa,Belvidere Twp,President,,REP,Donald J Trump,18
-Kiowa,Belvidere Twp,President,,DEM,Hillary Clinton,2
-Kiowa,Belvidere Twp,President,,LIB,Gary Johnson,1
-Kiowa,Mullinville City,President,,IND,Jill Stein,1
-Kiowa,Mullinville City,President,,REP,Donald J Trump,87
-Kiowa,Mullinville City,President,,DEM,Hillary Clinton,6
-Kiowa,Mullinville City,President,,LIB,Gary Johnson,3
-Kiowa,Mullinville City,President,,,Rand Paul,1
-Kiowa,Mullinville Twp,President,,IND,Jill Stein,1
-Kiowa,Mullinville Twp,President,,REP,Donald J Trump,84
-Kiowa,Mullinville Twp,President,,DEM,Hillary Clinton,10
-Kiowa,Mullinville Twp,President,,LIB,Gary Johnson,2
-Kiowa,Mullinville Twp,President,,,Mike Pence,2
-Kiowa,Center I City,U.S. Senate,,LIB,Robert Garrard ,10
-Kiowa,Center I City,U.S. Senate,,DEM,Patrick Wiesner ,15
-Kiowa,Center I City,U.S. Senate,,REP,Jerry Moran ,135
-Kiowa,Center I Twp,U.S. Senate,,LIB,Robert Garrard ,2
-Kiowa,Center I Twp,U.S. Senate,,DEM,Patrick Wiesner ,5
-Kiowa,Center I Twp,U.S. Senate,,REP,Jerry Moran ,101
-Kiowa,Center IA Twp,U.S. Senate,,LIB,Robert Garrard ,1
-Kiowa,Center IA Twp,U.S. Senate,,DEM,Patrick Wiesner ,2
-Kiowa,Center IA Twp,U.S. Senate,,REP,Jerry Moran ,20
-Kiowa,Center II City,U.S. Senate,,LIB,Robert Garrard ,3
-Kiowa,Center II City,U.S. Senate,,DEM,Patrick Wiesner ,10
-Kiowa,Center II City,U.S. Senate,,REP,Jerry Moran ,61
-Kiowa,Center IIA City,U.S. Senate,,LIB,Robert Garrard ,1
-Kiowa,Center IIA City,U.S. Senate,,DEM,Patrick Wiesner ,10
-Kiowa,Center IIA City,U.S. Senate,,REP,Jerry Moran ,99
-Kiowa,Center IIA Twp,U.S. Senate,,LIB,Robert Garrard ,0
-Kiowa,Center IIA Twp,U.S. Senate,,DEM,Patrick Wiesner ,0
-Kiowa,Center IIA Twp,U.S. Senate,,REP,Jerry Moran ,2
-Kiowa,Haviland City,U.S. Senate,,LIB,Robert Garrard ,12
-Kiowa,Haviland City,U.S. Senate,,DEM,Patrick Wiesner ,17
-Kiowa,Haviland City,U.S. Senate,,REP,Jerry Moran ,198
-Kiowa,Haviland Twp,U.S. Senate,,LIB,Robert Garrard ,3
-Kiowa,Haviland Twp,U.S. Senate,,DEM,Patrick Wiesner ,6
-Kiowa,Haviland Twp,U.S. Senate,,REP,Jerry Moran ,67
-Kiowa,Haviland A Twp,U.S. Senate,,LIB,Robert Garrard ,2
-Kiowa,Haviland A Twp,U.S. Senate,,DEM,Patrick Wiesner ,2
-Kiowa,Haviland A Twp,U.S. Senate,,REP,Jerry Moran ,24
-Kiowa,Belvidere Twp,U.S. Senate,,LIB,Robert Garrard ,0
-Kiowa,Belvidere Twp,U.S. Senate,,DEM,Patrick Wiesner ,1
-Kiowa,Belvidere Twp,U.S. Senate,,REP,Jerry Moran ,20
-Kiowa,Mullinville City,U.S. Senate,,LIB,Robert Garrard ,10
-Kiowa,Mullinville City,U.S. Senate,,DEM,Patrick Wiesner ,9
-Kiowa,Mullinville City,U.S. Senate,,REP,Jerry Moran ,81
-Kiowa,Mullinville Twp,U.S. Senate,,LIB,Robert Garrard ,2
-Kiowa,Mullinville Twp,U.S. Senate,,DEM,Patrick Wiesner ,4
-Kiowa,Mullinville Twp,U.S. Senate,,REP,Jerry Moran ,93
-Kiowa,Center I City,U.S. House,4,REP,Mike Pompeo ,128
-Kiowa,Center I City,U.S. House,4,DEM,Daniel B Giroux ,14
-Kiowa,Center I City,U.S. House,4,LIB,Gorden J. Bakken ,3
-Kiowa,Center I City,U.S. House,4,IND,Miranda Allen ,14
-Kiowa,Center I Twp,U.S. House,4,REP,Mike Pompeo ,86
-Kiowa,Center I Twp,U.S. House,4,DEM,Daniel B Giroux ,9
-Kiowa,Center I Twp,U.S. House,4,LIB,Gorden J. Bakken ,0
-Kiowa,Center I Twp,U.S. House,4,IND,Miranda Allen ,6
-Kiowa,Center IA Twp,U.S. House,4,REP,Mike Pompeo ,15
-Kiowa,Center IA Twp,U.S. House,4,DEM,Daniel B Giroux ,2
-Kiowa,Center IA Twp,U.S. House,4,LIB,Gorden J. Bakken ,0
-Kiowa,Center IA Twp,U.S. House,4,IND,Miranda Allen ,5
-Kiowa,Center II City,U.S. House,4,REP,Mike Pompeo ,52
-Kiowa,Center II City,U.S. House,4,DEM,Daniel B Giroux ,9
-Kiowa,Center II City,U.S. House,4,LIB,Gorden J. Bakken ,4
-Kiowa,Center II City,U.S. House,4,IND,Miranda Allen ,8
-Kiowa,Center IIA City,U.S. House,4,REP,Mike Pompeo ,87
-Kiowa,Center IIA City,U.S. House,4,DEM,Daniel B Giroux ,11
-Kiowa,Center IIA City,U.S. House,4,LIB,Gorden J. Bakken ,1
-Kiowa,Center IIA City,U.S. House,4,IND,Miranda Allen ,8
-Kiowa,Center IIA Twp,U.S. House,4,REP,Mike Pompeo ,2
-Kiowa,Center IIA Twp,U.S. House,4,DEM,Daniel B Giroux ,0
-Kiowa,Center IIA Twp,U.S. House,4,LIB,Gorden J. Bakken ,0
-Kiowa,Center IIA Twp,U.S. House,4,IND,Miranda Allen ,0
-Kiowa,Haviland City,U.S. House,4,REP,Mike Pompeo ,186
-Kiowa,Haviland City,U.S. House,4,DEM,Daniel B Giroux ,16
-Kiowa,Haviland City,U.S. House,4,LIB,Gorden J. Bakken ,7
-Kiowa,Haviland City,U.S. House,4,IND,Miranda Allen ,21
-Kiowa,Haviland Twp,U.S. House,4,REP,Mike Pompeo ,61
-Kiowa,Haviland Twp,U.S. House,4,DEM,Daniel B Giroux ,7
-Kiowa,Haviland Twp,U.S. House,4,LIB,Gorden J. Bakken ,1
-Kiowa,Haviland Twp,U.S. House,4,IND,Miranda Allen ,7
-Kiowa,Haviland A Twp,U.S. House,4,REP,Mike Pompeo ,21
-Kiowa,Haviland A Twp,U.S. House,4,DEM,Daniel B Giroux ,1
-Kiowa,Haviland A Twp,U.S. House,4,LIB,Gorden J. Bakken ,2
-Kiowa,Haviland A Twp,U.S. House,4,IND,Miranda Allen ,4
-Kiowa,Belvidere Twp,U.S. House,4,REP,Mike Pompeo ,14
-Kiowa,Belvidere Twp,U.S. House,4,DEM,Daniel B Giroux ,2
-Kiowa,Belvidere Twp,U.S. House,4,LIB,Gorden J. Bakken ,0
-Kiowa,Belvidere Twp,U.S. House,4,IND,Miranda Allen ,5
-Kiowa,Mullinville City,U.S. House,4,REP,Mike Pompeo ,87
-Kiowa,Mullinville City,U.S. House,4,DEM,Daniel B Giroux ,3
-Kiowa,Mullinville City,U.S. House,4,LIB,Gorden J. Bakken ,4
-Kiowa,Mullinville City,U.S. House,4,IND,Miranda Allen ,7
-Kiowa,Mullinville Twp,U.S. House,4,REP,Mike Pompeo ,85
-Kiowa,Mullinville Twp,U.S. House,4,DEM,Daniel B Giroux ,6
-Kiowa,Mullinville Twp,U.S. House,4,LIB,Gorden J. Bakken ,2
-Kiowa,Mullinville Twp,U.S. House,4,IND,Miranda Allen ,6
-Kiowa,Center I City,State Senate,,DEM,Matt Bristow ,16
-Kiowa,Center I City,State Senate,,REP,Mary Jo Taylor ,134
-Kiowa,Center I Twp,State Senate,,DEM,Matt Bristow ,13
-Kiowa,Center I Twp,State Senate,,REP,Mary Jo Taylor ,89
-Kiowa,Center I Twp,State Senate,,,Dennis McKinney ,1
-Kiowa,Center IA Twp,State Senate,,DEM,Matt Bristow ,2
-Kiowa,Center IA Twp,State Senate,,REP,Mary Jo Taylor ,19
-Kiowa,Center II City,State Senate,,DEM,Matt Bristow ,12
-Kiowa,Center II City,State Senate,,REP,Mary Jo Taylor ,61
-Kiowa,Center IIA City,State Senate,,DEM,Matt Bristow ,12
-Kiowa,Center IIA City,State Senate,,REP,Mary Jo Taylor ,94
-Kiowa,Center IIA Twp,State Senate,,DEM,Matt Bristow ,0
-Kiowa,Center IIA Twp,State Senate,,REP,Mary Jo Taylor ,2
-Kiowa,Haviland City,State Senate,,DEM,Matt Bristow ,26
-Kiowa,Haviland City,State Senate,,REP,Mary Jo Taylor ,190
-Kiowa,Haviland City,State Senate,,,Mitch Holmes ,1
-Kiowa,Haviland Twp,State Senate,,DEM,Matt Bristow ,8
-Kiowa,Haviland Twp,State Senate,,REP,Mary Jo Taylor ,65
-Kiowa,Haviland A Twp,State Senate,,DEM,Matt Bristow ,1
-Kiowa,Haviland A Twp,State Senate,,REP,Mary Jo Taylor ,25
-Kiowa,Belvidere Twp,State Senate,,DEM,Matt Bristow ,1
-Kiowa,Belvidere Twp,State Senate,,REP,Mary Jo Taylor ,20
-Kiowa,Mullinville City,State Senate,,DEM,Matt Bristow ,8
-Kiowa,Mullinville City,State Senate,,REP,Mary Jo Taylor ,90
-Kiowa,Mullinville Twp,State Senate,,DEM,Matt Bristow ,7
-Kiowa,Mullinville Twp,State Senate,,REP,Mary Jo Taylor ,88
-Kiowa,Center I City,State House,,REP,Leonard A Mastroni ,141
-Kiowa,Center I Twp,State House,,REP,Leonard A Mastroni ,89
-Kiowa,Center IA Twp,State House,,REP,Leonard A Mastroni ,15
-Kiowa,Center IA Twp,State House,,,Dennis McKinney ,1
-Kiowa,Center II City,State House,,REP,Leonard A Mastroni ,64
-Kiowa,Center II City,State House,,,Dennis McKinney ,1
-Kiowa,Center IIA City,State House,,REP,Leonard A Mastroni ,84
-Kiowa,Center IIA Twp,State House,,REP,Leonard A Mastroni ,2
-Kiowa,Haviland City,State House,,REP,Leonard A Mastroni ,194
-Kiowa,Haviland City,State House,,,Arlen Harris ,1
-Kiowa,Haviland City,State House,,,Chris Reed ,1
-Kiowa,Haviland City,State House,,,Genie Ross ,1
-Kiowa,Haviland Twp,State House,,REP,Leonard A Mastroni ,64
-Kiowa,Haviland Twp,State House,,,Dennis McKinney ,1
-Kiowa,Haviland A Twp,State House,,REP,Leonard A Mastroni ,21
-Kiowa,Belvidere Twp,State House,,REP,Leonard A Mastroni ,21
-Kiowa,Mullinville City,State House,,REP,Leonard A Mastroni ,84
-Kiowa,Mullinville Twp,State House,,REP,Leonard A Mastroni ,86
+county,precinct,office,district,party,candidate,votes,vtd
+KIOWA,Belvidere,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",22,000010
+KIOWA,Center I,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",257,000020
+KIOWA,Center I I,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",154,000030
+KIOWA,Haviland,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",303,000040
+KIOWA,Mullinville,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",174,000050
+KIOWA,Belvidere,Kansas Senate,33,Democratic,"Bristow, Matt",1,000010
+KIOWA,Belvidere,Kansas Senate,33,Republican,"Taylor, Mary Jo",22,000010
+KIOWA,Center I,Kansas Senate,33,Democratic,"Bristow, Matt",32,000020
+KIOWA,Center I,Kansas Senate,33,Republican,"Taylor, Mary Jo",257,000020
+KIOWA,Center I I,Kansas Senate,33,Democratic,"Bristow, Matt",24,000030
+KIOWA,Center I I,Kansas Senate,33,Republican,"Taylor, Mary Jo",161,000030
+KIOWA,Haviland,Kansas Senate,33,Democratic,"Bristow, Matt",36,000040
+KIOWA,Haviland,Kansas Senate,33,Republican,"Taylor, Mary Jo",300,000040
+KIOWA,Mullinville,Kansas Senate,33,Democratic,"Bristow, Matt",15,000050
+KIOWA,Mullinville,Kansas Senate,33,Republican,"Taylor, Mary Jo",182,000050
+KIOWA,Belvidere,President / Vice President,,independent,"Stein, Jill",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Hedges, James A",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"McMullin, Evan",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Perry, Darryl",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Smith, Mike",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Sood, Ajay",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+KIOWA,Belvidere,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+KIOWA,Belvidere,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+KIOWA,Belvidere,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+KIOWA,Belvidere,President / Vice President,,Republican,"Trump, Donald J.",21,000010
+KIOWA,Center I,President / Vice President,,independent,"Stein, Jill",4,000020
+KIOWA,Center I,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Hedges, James A",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"McMullin, Evan",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Perry, Darryl",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Smith, Mike",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Sood, Ajay",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+KIOWA,Center I,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+KIOWA,Center I,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000020
+KIOWA,Center I,President / Vice President,,Libertarian,"Johnson, Gary",14,000020
+KIOWA,Center I,President / Vice President,,Republican,"Trump, Donald J.",254,000020
+KIOWA,Center I I,President / Vice President,,independent,"Stein, Jill",5,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Hedges, James A",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"McMullin, Evan",1,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Perry, Darryl",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Smith, Mike",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Sood, Ajay",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+KIOWA,Center I I,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+KIOWA,Center I I,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000030
+KIOWA,Center I I,President / Vice President,,Libertarian,"Johnson, Gary",10,000030
+KIOWA,Center I I,President / Vice President,,Republican,"Trump, Donald J.",147,000030
+KIOWA,Haviland,President / Vice President,,independent,"Stein, Jill",5,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Hedges, James A",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Maturen, Michael A",4,000040
+KIOWA,Haviland,President / Vice President,,write - in,"McMullin, Evan",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Perry, Darryl",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Smith, Mike",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Sood, Ajay",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+KIOWA,Haviland,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+KIOWA,Haviland,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000040
+KIOWA,Haviland,President / Vice President,,Libertarian,"Johnson, Gary",14,000040
+KIOWA,Haviland,President / Vice President,,Republican,"Trump, Donald J.",303,000040
+KIOWA,Mullinville,President / Vice President,,independent,"Stein, Jill",2,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Hedges, James A",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"McMullin, Evan",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Perry, Darryl",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Smith, Mike",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Sood, Ajay",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+KIOWA,Mullinville,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+KIOWA,Mullinville,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000050
+KIOWA,Mullinville,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+KIOWA,Mullinville,President / Vice President,,Republican,"Trump, Donald J.",175,000050
+KIOWA,Belvidere,United States House of Representatives,4,independent,"Allen, Miranda",5,000010
+KIOWA,Belvidere,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,000010
+KIOWA,Belvidere,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000010
+KIOWA,Belvidere,United States House of Representatives,4,Republican,"Pompeo, Michael",17,000010
+KIOWA,Center I,United States House of Representatives,4,independent,"Allen, Miranda",29,000020
+KIOWA,Center I,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",25,000020
+KIOWA,Center I,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000020
+KIOWA,Center I,United States House of Representatives,4,Republican,"Pompeo, Michael",238,000020
+KIOWA,Center I I,United States House of Representatives,4,independent,"Allen, Miranda",16,000030
+KIOWA,Center I I,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",20,000030
+KIOWA,Center I I,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000030
+KIOWA,Center I I,United States House of Representatives,4,Republican,"Pompeo, Michael",145,000030
+KIOWA,Haviland,United States House of Representatives,4,independent,"Allen, Miranda",35,000040
+KIOWA,Haviland,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",24,000040
+KIOWA,Haviland,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000040
+KIOWA,Haviland,United States House of Representatives,4,Republican,"Pompeo, Michael",290,000040
+KIOWA,Mullinville,United States House of Representatives,4,independent,"Allen, Miranda",14,000050
+KIOWA,Mullinville,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",9,000050
+KIOWA,Mullinville,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000050
+KIOWA,Mullinville,United States House of Representatives,4,Republican,"Pompeo, Michael",175,000050
+KIOWA,Belvidere,United States Senate,,write - in,"Smith, DJ",0,000010
+KIOWA,Belvidere,United States Senate,,Democratic,"Wiesner, Patrick",1,000010
+KIOWA,Belvidere,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+KIOWA,Belvidere,United States Senate,,Republican,"Moran, Jerry",23,000010
+KIOWA,Center I,United States Senate,,write - in,"Smith, DJ",0,000020
+KIOWA,Center I,United States Senate,,Democratic,"Wiesner, Patrick",23,000020
+KIOWA,Center I,United States Senate,,Libertarian,"Garrard, Robert D.",13,000020
+KIOWA,Center I,United States Senate,,Republican,"Moran, Jerry",270,000020
+KIOWA,Center I I,United States Senate,,write - in,"Smith, DJ",0,000030
+KIOWA,Center I I,United States Senate,,Democratic,"Wiesner, Patrick",20,000030
+KIOWA,Center I I,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+KIOWA,Center I I,United States Senate,,Republican,"Moran, Jerry",166,000030
+KIOWA,Haviland,United States Senate,,write - in,"Smith, DJ",0,000040
+KIOWA,Haviland,United States Senate,,Democratic,"Wiesner, Patrick",26,000040
+KIOWA,Haviland,United States Senate,,Libertarian,"Garrard, Robert D.",18,000040
+KIOWA,Haviland,United States Senate,,Republican,"Moran, Jerry",313,000040
+KIOWA,Mullinville,United States Senate,,write - in,"Smith, DJ",0,000050
+KIOWA,Mullinville,United States Senate,,Democratic,"Wiesner, Patrick",13,000050
+KIOWA,Mullinville,United States Senate,,Libertarian,"Garrard, Robert D.",12,000050
+KIOWA,Mullinville,United States Senate,,Republican,"Moran, Jerry",178,000050

--- a/2016/20161108__ks__general__labette__precinct.csv
+++ b/2016/20161108__ks__general__labette__precinct.csv
@@ -1,702 +1,1611 @@
-county,precinct,office,district,candidate,party,votes
-Labette,Parsons W1D1,President,,Stein/Baraka,I,19
-Labette,Parsons W1D1,President,,Trump/Pence,R,169
-Labette,Parsons W1D1,President,,Clinton/Kaine,D,103
-Labette,Parsons W1D1,President,,Johnson/Weld,L,15
-Labette,Parsons W1D1,President,,Castle/Bradley,,1
-Labette,Parsons W1D1,President,,Write-ins,,5
-Labette,Parsons W1D1,U.S. Senate,,Jerry  Moran,R,191
-Labette,Parsons W1D1,U.S. Senate,,Patrick  Wiesner,D,102
-Labette,Parsons W1D1,U.S. Senate,,Robert  D  Garrard,L,12
-Labette,Parsons W1D1,U.S. Senate,,Write-ins,,1
-Labette,Parsons W1D1,U.S. House,2,Lynn  Jenkins,R,207
-Labette,Parsons W1D1,U.S. House,2,Britani  Potter,D,88
-Labette,Parsons W1D1,U.S. House,2,James Bales,L,12
-Labette,Parsons W1D1,U.S. House,2,Write-ins,,1
-Labette,Parsons W1D1,State Senate,15,Chuck  Schmidt,D,124
-Labette,Parsons W1D1,State Senate,15,Dan  Goddard,R,181
-Labette,Parsons W1D1,State Senate,15,Write-ins,,1
-Labette,Parsons W1D1,State House,7,Richard Proehl,R,277
-Labette,Parsons W1D1,State House,7,Write-ins,,3
-Labette,Parsons W1D2,President,,Stein/Baraka,I,2
-Labette,Parsons W1D2,President,,Trump/Pence,R,88
-Labette,Parsons W1D2,President,,Clinton/Kaine,D,56
-Labette,Parsons W1D2,President,,Johnson/Weld,L,6
-Labette,Parsons W1D2,President,,Write-ins,,2
-Labette,Parsons W1D2,U.S. Senate,,Jerry  Moran,R,80
-Labette,Parsons W1D2,U.S. Senate,,Patrick  Wiesner,D,57
-Labette,Parsons W1D2,U.S. Senate,,Robert  D  Garrard,L,12
-Labette,Parsons W1D2,U.S. Senate,,Write-ins,,1
-Labette,Parsons W1D2,U.S. House,2,Lynn  Jenkins,R,95
-Labette,Parsons W1D2,U.S. House,2,Britani  Potter,D,48
-Labette,Parsons W1D2,U.S. House,2,James Bales,L,10
-Labette,Parsons W1D2,U.S. House,2,Write-ins,,1
-Labette,Parsons W1D2,State Senate,15,Chuck  Schmidt,D,66
-Labette,Parsons W1D2,State Senate,15,Dan  Goddard,R,86
-Labette,Parsons W1D2,State Senate,15,Write-ins,,1
-Labette,Parsons W1D2,State House,7,Richard Proehl,R,129
-Labette,Parsons W1D2,State House,7,Write-ins,,9
-Labette,Parsons W1D3,President,,Stein/Baraka,I,2
-Labette,Parsons W1D3,President,,Trump/Pence,R,66
-Labette,Parsons W1D3,President,,Clinton/Kaine,D,52
-Labette,Parsons W1D3,President,,Johnson/Weld,L,4
-Labette,Parsons W1D3,President,,Write-ins,,1
-Labette,Parsons W1D3,U.S. Senate,,Jerry  Moran,R,51
-Labette,Parsons W1D3,U.S. Senate,,Patrick  Wiesner,D,60
-Labette,Parsons W1D3,U.S. Senate,,Robert  D  Garrard,L,7
-Labette,Parsons W1D3,U.S. House,2,Lynn  Jenkins,R,66
-Labette,Parsons W1D3,U.S. House,2,Britani  Potter,D,48
-Labette,Parsons W1D3,U.S. House,2,James Bales,L,7
-Labette,Parsons W1D3,State Senate,15,Chuck  Schmidt,D,58
-Labette,Parsons W1D3,State Senate,15,Dan  Goddard,R,63
-Labette,Parsons W1D3,State House,7,Richard Proehl,R,100
-Labette,Parsons W1D3,State House,7,Write-ins,,5
-Labette,Parsons W2D1,President,,Stein/Baraka,I,2
-Labette,Parsons W2D1,President,,Trump/Pence,R,55
-Labette,Parsons W2D1,President,,Clinton/Kaine,D,34
-Labette,Parsons W2D1,President,,Johnson/Weld,L,4
-Labette,Parsons W2D1,President,,Write-ins,,1
-Labette,Parsons W2D1,U.S. Senate,,Jerry  Moran,R,55
-Labette,Parsons W2D1,U.S. Senate,,Patrick  Wiesner,D,37
-Labette,Parsons W2D1,U.S. Senate,,Robert  D  Garrard,L,6
-Labette,Parsons W2D1,U.S. House,2,Lynn  Jenkins,R,61
-Labette,Parsons W2D1,U.S. House,2,Britani  Potter,D,29
-Labette,Parsons W2D1,U.S. House,2,James Bales,L,7
-Labette,Parsons W2D1,State Senate,15,Chuck  Schmidt,D,42
-Labette,Parsons W2D1,State Senate,15,Dan  Goddard,R,54
-Labette,Parsons W2D1,State House,7,Richard Proehl,R,86
-Labette,Parsons W2D1,State House,7,Write-ins,,3
-Labette,Parsons W2D2,President,,Stein/Baraka,I,7
-Labette,Parsons W2D2,President,,Trump/Pence,R,108
-Labette,Parsons W2D2,President,,Clinton/Kaine,D,124
-Labette,Parsons W2D2,President,,Johnson/Weld,L,21
-Labette,Parsons W2D2,President,,Write-ins,,6
-Labette,Parsons W2D2,US  Senate,,Jerry  Moran,R,123
-Labette,Parsons W2D2,US  Senate,,Patrick  Wiesner,D,121
-Labette,Parsons W2D2,US  Senate,,Robert  D  Garrard,L,23
-Labette,Parsons W2D2,US  Senate,,Write-ins,,0
-Labette,Parsons W2D2,U.S. House,2,Lynn  Jenkins,R,129
-Labette,Parsons W2D2,U.S. House,2,Britani  Potter,D,129
-Labette,Parsons W2D2,U.S. House,2,James Bales,L,13
-Labette,Parsons W2D2,U.S. House,2,Write-ins,,0
-Labette,Parsons W2D2,State Senate,15,Chuck  Schmidt,D,132
-Labette,Parsons W2D2,State Senate,15,Dan  Goddard,R,135
-Labette,Parsons W2D2,State Senate,15,Write-ins,,0
-Labette,Parsons W2D2,State House,7,Richard Proehl,R,237
-Labette,Parsons W2D2,State House,7,Write-ins,,6
-Labette,Parsons W2D3,President,,Stein/Baraka,I,5
-Labette,Parsons W2D3,President,,Trump/Pence,R,125
-Labette,Parsons W2D3,President,,Clinton/Kaine,D,137
-Labette,Parsons W2D3,President,,Johnson/Weld,L,17
-Labette,Parsons W2D3,President,,Write-ins,,9
-Labette,Parsons W2D3,U.S. Senate,,Jerry  Moran,R,152
-Labette,Parsons W2D3,U.S. Senate,,Patrick  Wiesner,D,117
-Labette,Parsons W2D3,U.S. Senate,,Robert  D  Garrard,L,22
-Labette,Parsons W2D3,U.S. Senate,,Write-ins,,2
-Labette,Parsons W2D3,U.S. House,2,Lynn  Jenkins,R,181
-Labette,Parsons W2D3,U.S. House,2,Britani  Potter,D,103
-Labette,Parsons W2D3,U.S. House,2,James Bales,L,9
-Labette,Parsons W2D3,U.S. House,2,Write-ins,,0
-Labette,Parsons W2D3,State Senate,15,Chuck  Schmidt,D,132
-Labette,Parsons W2D3,State Senate,15,Dan  Goddard,R,163
-Labette,Parsons W2D3,State Senate,15,Write-ins,,1
-Labette,Parsons W2D3,State House,7,Richard Proehl,R,252
-Labette,Parsons W2D3,State House,7,Write-ins,,5
-Labette,Parsons W3D1,President,,Stein/Baraka,I,1
-Labette,Parsons W3D1,President,,Trump/Pence,R,79
-Labette,Parsons W3D1,President,,Clinton/Kaine,D,43
-Labette,Parsons W3D1,President,,Johnson/Weld,L,4
-Labette,Parsons W3D1,President,,Write-ins,,3
-Labette,Parsons W3D1,U.S. Senate,,Jerry  Moran,R,75
-Labette,Parsons W3D1,U.S. Senate,,Patrick  Wiesner,D,41
-Labette,Parsons W3D1,U.S. Senate,,Robert  D  Garrard,L,10
-Labette,Parsons W3D1,U.S. Senate,,Write-ins,,1
-Labette,Parsons W3D1,U.S. House,2,Lynn  Jenkins,R,78
-Labette,Parsons W3D1,U.S. House,2,Britani  Potter,D,39
-Labette,Parsons W3D1,U.S. House,2,James Bales,L,6
-Labette,Parsons W3D1,U.S. House,2,Write-ins,,2
-Labette,Parsons W3D1,State Senate,15,Chuck  Schmidt,D,44
-Labette,Parsons W3D1,State Senate,15,Dan  Goddard,R,80
-Labette,Parsons W3D1,State Senate,15,Write-ins,,1
-Labette,Parsons W3D1,State House,7,Richard Proehl,R,112
-Labette,Parsons W3D1,State House,7,Write-ins,,5
-Labette,Parsons W3D2,President,,Stein/Baraka,I,6
-Labette,Parsons W3D2,President,,Trump/Pence,R,176
-Labette,Parsons W3D2,President,,Clinton/Kaine,D,136
-Labette,Parsons W3D2,President,,Johnson/Weld,L,19
-Labette,Parsons W3D2,President,,Castle/Bradley,,1
-Labette,Parsons W3D2,President,,Write-ins,,10
-Labette,Parsons W3D2,U.S. Senate,,Jerry  Moran,R,185
-Labette,Parsons W3D2,U.S. Senate,,Patrick  Wiesner,D,147
-Labette,Parsons W3D2,U.S. Senate,,Robert  D  Garrard,L,16
-Labette,Parsons W3D2,U.S. Senate,,Write-ins,,1
-Labette,Parsons W3D2,U.S. House,2,Lynn  Jenkins,R,201
-Labette,Parsons W3D2,U.S. House,2,Britani  Potter,D,135
-Labette,Parsons W3D2,U.S. House,2,James Bales,L,14
-Labette,Parsons W3D2,U.S. House,2,Write-ins,,0
-Labette,Parsons W3D2,State Senate,15,Chuck  Schmidt,D,177
-Labette,Parsons W3D2,State Senate,15,Dan  Goddard,R,169
-Labette,Parsons W3D2,State Senate,15,Write-ins,,0
-Labette,Parsons W3D2,State House,7,Richard Proehl,R,281
-Labette,Parsons W3D2,State House,7,Write-ins,,17
-Labette,Parsons W3D3,President,,Stein/Baraka,I,6
-Labette,Parsons W3D3,President,,Trump/Pence,R,146
-Labette,Parsons W3D3,President,,Clinton/Kaine,D,119
-Labette,Parsons W3D3,President,,Johnson/Weld,L,9
-Labette,Parsons W3D3,President,,Write-ins,,6
-Labette,Parsons W3D3,U.S. Senate,,Jerry  Moran,R,155
-Labette,Parsons W3D3,U.S. Senate,,Patrick  Wiesner,D,105
-Labette,Parsons W3D3,U.S. Senate,,Robert  D  Garrard,L,19
-Labette,Parsons W3D3,U.S. Senate,,Write-ins,,1
-Labette,Parsons W3D3,U.S. House,2,Lynn  Jenkins,R,159
-Labette,Parsons W3D3,U.S. House,2,Britani  Potter,D,107
-Labette,Parsons W3D3,U.S. House,2,James Bales,L,19
-Labette,Parsons W3D3,U.S. House,2,Write-ins,,0
-Labette,Parsons W3D3,State Senate,15,Chuck  Schmidt,D,127
-Labette,Parsons W3D3,State Senate,15,Dan  Goddard,R,155
-Labette,Parsons W3D3,State Senate,15,Write-ins,,2
-Labette,Parsons W3D3,State House,7,Richard Proehl,R,233
-Labette,Parsons W3D3,State House,7,Write-ins,,8
-Labette,Parsons W3D4,President,,Stein/Baraka,I,5
-Labette,Parsons W3D4,President,,Trump/Pence,R,235
-Labette,Parsons W3D4,President,,Clinton/Kaine,D,154
-Labette,Parsons W3D4,President,,Johnson/Weld,L,9
-Labette,Parsons W3D4,President,,McMullin/Johnson,,3
-Labette,Parsons W3D4,President,,Write-ins,,3
-Labette,Parsons W3D4,U.S. Senate,,Jerry  Moran,R,228
-Labette,Parsons W3D4,U.S. Senate,,Patrick  Wiesner,D,157
-Labette,Parsons W3D4,U.S. Senate,,Robert  D  Garrard,L,17
-Labette,Parsons W3D4,U.S. Senate,,Write-ins,,0
-Labette,Parsons W3D4,U.S. House,2,Lynn  Jenkins,R,242
-Labette,Parsons W3D4,U.S. House,2,Britani  Potter,D,145
-Labette,Parsons W3D4,U.S. House,2,James Bales,L,17
-Labette,Parsons W3D4,U.S. House,2,Write-ins,,0
-Labette,Parsons W3D4,State Senate,15,Chuck  Schmidt,D,191
-Labette,Parsons W3D4,State Senate,15,Dan  Goddard,R,207
-Labette,Parsons W3D4,State Senate,15,Write-ins,,2
-Labette,Parsons W3D4,State House,7,Richard Proehl,R,334
-Labette,Parsons W3D4,State House,7,Write-ins,,11
-Labette,Parsons W4D1,President,,Stein/Baraka,I,1
-Labette,Parsons W4D1,President,,Trump/Pence,R,101
-Labette,Parsons W4D1,President,,Clinton/Kaine,D,60
-Labette,Parsons W4D1,President,,Johnson/Weld,L,6
-Labette,Parsons W4D1,President,,Write-ins,,2
-Labette,Parsons W4D1,U.S. Senate,,Jerry  Moran,R,100
-Labette,Parsons W4D1,U.S. Senate,,Patrick  Wiesner,D,60
-Labette,Parsons W4D1,U.S. Senate,,Robert  D  Garrard,L,8
-Labette,Parsons W4D1,U.S. Senate,,Write-ins,,1
-Labette,Parsons W4D1,U.S. House,2,Lynn  Jenkins,R,102
-Labette,Parsons W4D1,U.S. House,2,Britani  Potter,D,60
-Labette,Parsons W4D1,U.S. House,2,James Bales,L,10
-Labette,Parsons W4D1,U.S. House,2,Write-ins,,0
-Labette,Parsons W4D1,State Senate,15,Chuck  Schmidt,D,63
-Labette,Parsons W4D1,State Senate,15,Dan  Goddard,R,107
-Labette,Parsons W4D1,State Senate,15,Write-ins,,1
-Labette,Parsons W4D1,State House,7,Richard Proehl,R,147
-Labette,Parsons W4D1,State House,7,Write-ins,,6
-Labette,Parsons W4D2,President,,Stein/Baraka,I,8
-Labette,Parsons W4D2,President,,Trump/Pence,R,126
-Labette,Parsons W4D2,President,,Clinton/Kaine,D,76
-Labette,Parsons W4D2,President,,Johnson/Weld,L,16
-Labette,Parsons W4D2,President,,McMullin/Johnson,,2
-Labette,Parsons W4D2,President,,Write-ins,,1
-Labette,Parsons W4D2,U.S. Senate,,Jerry  Moran,R,112
-Labette,Parsons W4D2,U.S. Senate,,Patrick  Wiesner,D,90
-Labette,Parsons W4D2,U.S. Senate,,Robert  D  Garrard,L,19
-Labette,Parsons W4D2,U.S. Senate,,Write-ins,,1
-Labette,Parsons W4D2,U.S. House,2,Lynn  Jenkins,R,123
-Labette,Parsons W4D2,U.S. House,2,Britani  Potter,D,80
-Labette,Parsons W4D2,U.S. House,2,James Bales,L,17
-Labette,Parsons W4D2,U.S. House,2,Write-ins,,1
-Labette,Parsons W4D2,State Senate,15,Chuck  Schmidt,D,99
-Labette,Parsons W4D2,State Senate,15,Dan  Goddard,R,124
-Labette,Parsons W4D2,State Senate,15,Write-ins,,1
-Labette,Parsons W4D2,State House,7,Richard Proehl,R,191
-Labette,Parsons W4D2,State House,7,Write-ins,,9
-Labette,Parsons W4D3,President,,Stein/Baraka,I,3
-Labette,Parsons W4D3,President,,Trump/Pence,R,101
-Labette,Parsons W4D3,President,,Clinton/Kaine,D,82
-Labette,Parsons W4D3,President,,Johnson/Weld,L,5
-Labette,Parsons W4D3,President,,Write-ins,,2
-Labette,Parsons W4D3,U.S. Senate,,Jerry  Moran,R,102
-Labette,Parsons W4D3,U.S. Senate,,Patrick  Wiesner,D,70
-Labette,Parsons W4D3,U.S. Senate,,Robert  D  Garrard,L,15
-Labette,Parsons W4D3,U.S. Senate,,Write-ins,,0
-Labette,Parsons W4D3,U.S. House,2,Lynn  Jenkins,R,108
-Labette,Parsons W4D3,U.S. House,2,Britani  Potter,D,69
-Labette,Parsons W4D3,U.S. House,2,James Bales,L,11
-Labette,Parsons W4D3,U.S. House,2,Write-ins,,0
-Labette,Parsons W4D3,State Senate,15,Chuck  Schmidt,D,81
-Labette,Parsons W4D3,State Senate,15,Dan  Goddard,R,106
-Labette,Parsons W4D3,State Senate,15,Write-ins,,0
-Labette,Parsons W4D3,State House,7,Richard Proehl,R,159
-Labette,Parsons W4D3,State House,7,Write-ins,,7
-Labette,Parsons W4D4,President,,Stein/Baraka,I,6
-Labette,Parsons W4D4,President,,Trump/Pence,R,170
-Labette,Parsons W4D4,President,,Clinton/Kaine,D,91
-Labette,Parsons W4D4,President,,Johnson/Weld,L,10
-Labette,Parsons W4D4,President,,Write-ins,,4
-Labette,Parsons W4D4,U.S. Senate,,Jerry  Moran,R,182
-Labette,Parsons W4D4,U.S. Senate,,Patrick  Wiesner,D,88
-Labette,Parsons W4D4,U.S. Senate,,Robert  D  Garrard,L,13
-Labette,Parsons W4D4,U.S. Senate,,Write-ins,,0
-Labette,Parsons W4D4,U.S. House,2,Lynn  Jenkins,R,198
-Labette,Parsons W4D4,U.S. House,2,Britani  Potter,D,76
-Labette,Parsons W4D4,U.S. House,2,James Bales,L,7
-Labette,Parsons W4D4,U.S. House,2,Write-ins,,0
-Labette,Parsons W4D4,State Senate,15,Chuck  Schmidt,D,116
-Labette,Parsons W4D4,State Senate,15,Dan  Goddard,R,169
-Labette,Parsons W4D4,State Senate,15,Write-ins,,1
-Labette,Parsons W4D4,State House,7,Richard Proehl,R,250
-Labette,Parsons W4D4,State House,7,Write-ins,,3
-Labette,Chetopa W1,President,,Stein/Baraka,I,2
-Labette,Chetopa W1,President,,Trump/Pence,R,63
-Labette,Chetopa W1,President,,Clinton/Kaine,D,38
-Labette,Chetopa W1,President,,Johnson/Weld,L,5
-Labette,Chetopa W1,President,,Write-ins,,2
-Labette,Chetopa W1,U.S. Senate,,Jerry  Moran,R,58
-Labette,Chetopa W1,U.S. Senate,,Patrick  Wiesner,D,44
-Labette,Chetopa W1,U.S. Senate,,Robert  D  Garrard,L,1
-Labette,Chetopa W1,U.S. Senate,,Write-ins,,0
-Labette,Chetopa W1,U.S. House,2,Lynn  Jenkins,R,72
-Labette,Chetopa W1,U.S. House,2,Britani  Potter,D,32
-Labette,Chetopa W1,U.S. House,2,James Bales,L,3
-Labette,Chetopa W1,U.S. House,2,Write-ins,,0
-Labette,Chetopa W1,State Senate,13,Jake  LaTumer,R,59
-Labette,Chetopa W1,State Senate,13,Lynn  D  Grant,D,46
-Labette,Chetopa W1,State Senate,13,Write-ins,,1
-Labette,Chetopa W1,State House,1,Michael Houser,R,99
-Labette,Chetopa W1,State House,1,Write-ins,,0
-Labette,Chetopa W2,President,,Stein/Baraka,I,2
-Labette,Chetopa W2,President,,Trump/Pence,R,80
-Labette,Chetopa W2,President,,Clinton/Kaine,D,28
-Labette,Chetopa W2,President,,Johnson/Weld,L,7
-Labette,Chetopa W2,President,,Write-ins,,2
-Labette,Chetopa W2,U.S. Senate,,Jerry  Moran,R,73
-Labette,Chetopa W2,U.S. Senate,,Patrick  Wiesner,D,33
-Labette,Chetopa W2,U.S. Senate,,Robert  D  Garrard,L,6
-Labette,Chetopa W2,U.S. House,2,Lynn  Jenkins,R,82
-Labette,Chetopa W2,U.S. House,2,Britani  Potter,D,23
-Labette,Chetopa W2,U.S. House,2,James Bales,L,9
-Labette,Chetopa W2,State Senate,13,Jake  LaTumer,R,60
-Labette,Chetopa W2,State Senate,13,Lynn  D  Grant,D,55
-Labette,Chetopa W2,State Senate,13,Write-ins,,1
-Labette,Chetopa W2,State House,1,Michael Houser,R,90
-Labette,Chetopa W2,State House,1,Write-ins,,4
-Labette,Chetopa W3,President,,Stein/Baraka,I,3
-Labette,Chetopa W3,President,,Trump/Pence,R,111
-Labette,Chetopa W3,President,,Clinton/Kaine,D,29
-Labette,Chetopa W3,President,,Johnson/Weld,L,5
-Labette,Chetopa W3,U.S. Senate,,Jerry  Moran,R,95
-Labette,Chetopa W3,U.S. Senate,,Patrick  Wiesner,D,35
-Labette,Chetopa W3,U.S. Senate,,Robert  D  Garrard,L,9
-Labette,Chetopa W3,U.S. House,2,Lynn  Jenkins,R,101
-Labette,Chetopa W3,U.S. House,2,Britani  Potter,D,30
-Labette,Chetopa W3,U.S. House,2,James Bales,L,9
-Labette,Chetopa W3,State Senate,13,Jake  LaTumer,R,85
-Labette,Chetopa W3,State Senate,13,Lynn  D  Grant,D,58
-Labette,Chetopa W3,State House,1,Michael Houser,R,114
-Labette,Chetopa W3,State House,1,Write-ins,,5
-Labette,Oswego 1,President,,Stein/Baraka,I,4
-Labette,Oswego 1,President,,Trump/Pence,R,179
-Labette,Oswego 1,President,,Clinton/Kaine,D,56
-Labette,Oswego 1,President,,Johnson/Weld,L,9
-Labette,Oswego 1,President,,Write-ins,,1
-Labette,Oswego 1,U.S. Senate,,Jerry  Moran,R,164
-Labette,Oswego 1,U.S. Senate,,Patrick  Wiesner,D,56
-Labette,Oswego 1,U.S. Senate,,Robert  D  Garrard,L,24
-Labette,Oswego 1,U.S. House,2,Lynn  Jenkins,R,186
-Labette,Oswego 1,U.S. House,2,Britani  Potter,D,52
-Labette,Oswego 1,U.S. House,2,James Bales,L,12
-Labette,Oswego 1,State Senate,15,Chuck  Schmidt,D,78
-Labette,Oswego 1,State Senate,15,Dan  Goddard,R,169
-Labette,Oswego 1,State House,7,Richard Proehl,R,205
-Labette,Oswego 1,State House,7,Write-ins,,9
-Labette,Oswego W2,President,,Stein/Baraka,I,3
-Labette,Oswego W2,President,,Trump/Pence,R,177
-Labette,Oswego W2,President,,Clinton/Kaine,D,53
-Labette,Oswego W2,President,,Johnson/Weld,L,7
-Labette,Oswego W2,President,,McMullin/Johnson,,1
-Labette,Oswego W2,President,,Write-ins,,4
-Labette,Oswego W2,U.S. Senate,,Jerry  Moran,R,158
-Labette,Oswego W2,U.S. Senate,,Patrick  Wiesner,D,51
-Labette,Oswego W2,U.S. Senate,,Robert  D  Garrard,L,21
-Labette,Oswego W2,U.S. House,2,Lynn  Jenkins,R,176
-Labette,Oswego W2,U.S. House,2,Britani  Potter,D,47
-Labette,Oswego W2,U.S. House,2,James Bales,L,15
-Labette,Oswego W2,State Senate,15,Chuck  Schmidt,D,104
-Labette,Oswego W2,State Senate,15,Dan  Goddard,R,137
-Labette,Oswego W2,State House,7,Richard Proehl,R,210
-Labette,Oswego W2,State House,7,Write-ins,,4
-Labette,Oswego W3,President,,Stein/Baraka,I,3
-Labette,Oswego W3,President,,Trump/Pence,R,127
-Labette,Oswego W3,President,,Clinton/Kaine,D,47
-Labette,Oswego W3,President,,Johnson/Weld,L,10
-Labette,Oswego W3,President,,Write-ins,,3
-Labette,Oswego W3,U.S. Senate,,Jerry  Moran,R,125
-Labette,Oswego W3,U.S. Senate,,Patrick  Wiesner,D,39
-Labette,Oswego W3,U.S. Senate,,Robert  D  Garrard,L,17
-Labette,Oswego W3,U.S. House,2,Lynn  Jenkins,R,131
-Labette,Oswego W3,U.S. House,2,Britani  Potter,D,44
-Labette,Oswego W3,U.S. House,2,James Bales,L,8
-Labette,Oswego W3,State Senate,15,Chuck  Schmidt,D,72
-Labette,Oswego W3,State Senate,15,Dan  Goddard,R,106
-Labette,Oswego W3,State Senate,15,Write-ins,,1
-Labette,Oswego W3,State House,7,Richard Proehl,R,159
-Labette,Oswego W3,State House,7,Write-ins,,4
-Labette,Canada,President,,Stein/Baraka,I,2
-Labette,Canada,President,,Trump/Pence,R,99
-Labette,Canada,President,,Clinton/Kaine,D,15
-Labette,Canada,President,,Johnson/Weld,L,1
-Labette,Canada,U.S. Senate,,Jerry  Moran,R,90
-Labette,Canada,U.S. Senate,,Patrick  Wiesner,D,19
-Labette,Canada,U.S. Senate,,Robert  D  Garrard,L,7
-Labette,Canada,U.S. Senate,,Write-ins,,1
-Labette,Canada,U.S. House,2,Lynn  Jenkins,R,90
-Labette,Canada,U.S. House,2,Britani  Potter,D,22
-Labette,Canada,U.S. House,2,James Bales,L,3
-Labette,Canada,U.S. House,2,Write-ins,,1
-Labette,Canada,State Senate,15,Chuck  Schmidt,D,31
-Labette,Canada,State Senate,15,Dan  Goddard,R,85
-Labette,Canada,State Senate,15,Write-ins,,1
-Labette,Canada,State House,7,Richard Proehl,R,109
-Labette,Canada,State House,7,Write-ins,,3
-Labette,Elm Grove,President,,Stein/Baraka,I,10
-Labette,Elm Grove,President,,Trump/Pence,R,311
-Labette,Elm Grove,President,,Clinton/Kaine,D,54
-Labette,Elm Grove,President,,Johnson/Weld,L,9
-Labette,Elm Grove,President,,Write-ins,,6
-Labette,Elm Grove,U.S. Senate,,Jerry  Moran,R,304
-Labette,Elm Grove,U.S. Senate,,Patrick  Wiesner,D,59
-Labette,Elm Grove,U.S. Senate,,Robert  D  Garrard,L,22
-Labette,Elm Grove,U.S. House,2,Lynn  Jenkins,R,323
-Labette,Elm Grove,U.S. House,2,Britani  Potter,D,48
-Labette,Elm Grove,U.S. House,2,James Bales,L,14
-Labette,Elm Grove,U.S. House,2,Write-ins,,1
-Labette,Elm Grove,State Senate,15,Chuck  Schmidt,D,102
-Labette,Elm Grove,State Senate,15,Dan  Goddard,R,282
-Labette,Elm Grove,State Senate,15,Write-ins,,1
-Labette,Elm Grove,State House,7,Richard Proehl,R,326
-Labette,Elm Grove,State House,7,Write-ins,,9
-Labette,Fairview,President,,Stein/Baraka,I,2
-Labette,Fairview,President,,Trump/Pence,R,84
-Labette,Fairview,President,,Clinton/Kaine,D,12
-Labette,Fairview,President,,Johnson/Weld,L,4
-Labette,Fairview,U.S. Senate,,Jerry  Moran,R,81
-Labette,Fairview,U.S. Senate,,Patrick  Wiesner,D,15
-Labette,Fairview,U.S. Senate,,Robert  D  Garrard,L,2
-Labette,Fairview,U.S. House,2,Lynn  Jenkins,R,80
-Labette,Fairview,U.S. House,2,Britani  Potter,D,18
-Labette,Fairview,U.S. House,2,James Bales,L,2
-Labette,Fairview,State Senate,15,Chuck  Schmidt,D,29
-Labette,Fairview,State Senate,15,Dan  Goddard,R,68
-Labette,Fairview,State House,7,Richard Proehl,R,83
-Labette,Hackberry,President,,Stein/Baraka,I,3
-Labette,Hackberry,President,,Trump/Pence,R,122
-Labette,Hackberry,President,,Clinton/Kaine,D,24
-Labette,Hackberry,President,,Johnson/Weld,L,5
-Labette,Hackberry,President,,Write-ins,,3
-Labette,Hackberry,U.S. Senate,,Jerry  Moran,R,126
-Labette,Hackberry,U.S. Senate,,Patrick  Wiesner,D,22
-Labette,Hackberry,U.S. Senate,,Robert  D  Garrard,L,8
-Labette,Hackberry,U.S. House,2,Lynn  Jenkins,R,126
-Labette,Hackberry,U.S. House,2,Britani  Potter,D,23
-Labette,Hackberry,U.S. House,2,James Bales,L,8
-Labette,Hackberry,State Senate,15,Chuck  Schmidt,D,32
-Labette,Hackberry,State Senate,15,Dan  Goddard,R,117
-Labette,Hackberry,State House,7,Richard Proehl,R,119
-Labette,Hackberry,State House,7,Write-ins,,4
-Labette,Howard,President,,Stein/Baraka,I,2
-Labette,Howard,President,,Trump/Pence,R,133
-Labette,Howard,President,,Clinton/Kaine,D,29
-Labette,Howard,President,,Johnson/Weld,L,4
-Labette,Howard,President,,Write-ins,,3
-Labette,Howard,U.S. Senate,,Jerry  Moran,R,125
-Labette,Howard,U.S. Senate,,Patrick  Wiesner,D,33
-Labette,Howard,U.S. Senate,,Robert  D  Garrard,L,11
-Labette,Howard,U.S. House,2,Lynn  Jenkins,R,135
-Labette,Howard,U.S. House,2,Britani  Potter,D,29
-Labette,Howard,U.S. House,2,James Bales,L,6
-Labette,Howard,State Senate,15,Chuck  Schmidt,D,52
-Labette,Howard,State Senate,15,Dan  Goddard,R,116
-Labette,Howard,State House,7,Richard Proehl,R,139
-Labette,Howard,State House,7,Write-ins,,1
-Labette,Labette,President,,Stein/Baraka,I,5
-Labette,Labette,President,,Trump/Pence,R,157
-Labette,Labette,President,,Clinton/Kaine,D,26
-Labette,Labette,President,,Johnson/Weld,L,3
-Labette,Labette,President,,Castle/Bradley,,4
-Labette,Labette,President,,Write-ins,,4
-Labette,Labette,U.S. Senate,,Jerry  Moran,R,155
-Labette,Labette,U.S. Senate,,Patrick  Wiesner,D,34
-Labette,Labette,U.S. Senate,,Robert  D  Garrard,L,11
-Labette,Labette,U.S. Senate,,Write-ins,,1
-Labette,Labette,U.S. House,2,Lynn  Jenkins,R,165
-Labette,Labette,U.S. House,2,Britani  Potter,D,25
-Labette,Labette,U.S. House,2,James Bales,L,6
-Labette,Labette,State Senate,15,Chuck  Schmidt,D,50
-Labette,Labette,State Senate,15,Dan  Goddard,R,146
-Labette,Labette,State Senate,15,Write-ins,,1
-Labette,Labette,State House,7,Richard Proehl,R,173
-Labette,Labette,State House,7,Write-ins,,5
-Labette,Liberty,President,,Stein/Baraka,I,4
-Labette,Liberty,President,,Trump/Pence,R,141
-Labette,Liberty,President,,Clinton/Kaine,D,38
-Labette,Liberty,President,,Johnson/Weld,L,7
-Labette,Liberty,President,,McMullin/Johnson,,1
-Labette,Liberty,President,,Write-ins,,4
-Labette,Liberty,U.S. Senate,,Jerry  Moran,R,136
-Labette,Liberty,U.S. Senate,,Patrick  Wiesner,D,39
-Labette,Liberty,U.S. Senate,,Robert  D  Garrard,L,15
-Labette,Liberty,U.S. House,2,Lynn  Jenkins,R,140
-Labette,Liberty,U.S. House,2,Britani  Potter,D,39
-Labette,Liberty,U.S. House,2,James Bales,L,12
-Labette,Liberty,State Senate,15,Chuck  Schmidt,D,59
-Labette,Liberty,State Senate,15,Dan  Goddard,R,131
-Labette,Liberty,State House,7,Richard Proehl,R,172
-Labette,Liberty,State House,7,Write-ins,,1
-Labette,Montana,President,,Stein/Baraka,I,1
-Labette,Montana,President,,Trump/Pence,R,69
-Labette,Montana,President,,Clinton/Kaine,D,10
-Labette,Montana,U.S. Senate,,Jerry  Moran,R,64
-Labette,Montana,U.S. Senate,,Patrick  Wiesner,D,12
-Labette,Montana,U.S. Senate,,Robert  D  Garrard,L,2
-Labette,Montana,U.S. House,2,Lynn  Jenkins,R,66
-Labette,Montana,U.S. House,2,Britani  Potter,D,11
-Labette,Montana,U.S. House,2,James Bales,L,1
-Labette,Montana,State Senate,15,Chuck  Schmidt,D,20
-Labette,Montana,State Senate,15,Dan  Goddard,R,58
-Labette,Montana,State House,7,Richard Proehl,R,62
-Labette,Montana,State House,7,Write-ins,,2
-Labette,Mound Valley,President,,Stein/Baraka,I,10
-Labette,Mound Valley,President,,Trump/Pence,R,271
-Labette,Mound Valley,President,,Clinton/Kaine,D,43
-Labette,Mound Valley,President,,Johnson/Weld,L,10
-Labette,Mound Valley,President,,Write-ins,,4
-Labette,Mound Valley,U.S. Senate,,Jerry  Moran,R,254
-Labette,Mound Valley,U.S. Senate,,Patrick  Wiesner,D,55
-Labette,Mound Valley,U.S. Senate,,Robert  D  Garrard,L,29
-Labette,Mound Valley,U.S. House,2,Lynn  Jenkins,R,253
-Labette,Mound Valley,U.S. House,2,Britani  Potter,D,66
-Labette,Mound Valley,U.S. House,2,James Bales,L,18
-Labette,Mound Valley,State Senate,15,Chuck  Schmidt,D,110
-Labette,Mound Valley,State Senate,15,Dan  Goddard,R,225
-Labette,Mound Valley,State Senate,15,Write-ins,,1
-Labette,Mound Valley,State House,7,Richard Proehl,R,295
-Labette,Mound Valley,State House,7,Write-ins,,6
-Labette,Mt Pleasant,President,,Stein/Baraka,I,14
-Labette,Mt Pleasant,President,,Trump/Pence,R,414
-Labette,Mt Pleasant,President,,Clinton/Kaine,D,117
-Labette,Mt Pleasant,President,,Johnson/Weld,L,29
-Labette,Mt Pleasant,President,,Write-ins,,5
-Labette,Mt Pleasant,U.S. Senate,,Jerry  Moran,R,410
-Labette,Mt Pleasant,U.S. Senate,,Patrick  Wiesner,D,124
-Labette,Mt Pleasant,U.S. Senate,,Robert  D  Garrard,L,32
-Labette,Mt Pleasant,U.S. Senate,,Write-ins,,1
-Labette,Mt Pleasant,U.S. House,2,Lynn  Jenkins,R,445
-Labette,Mt Pleasant,U.S. House,2,Britani  Potter,D,105
-Labette,Mt Pleasant,U.S. House,2,James Bales,L,22
-Labette,Mt Pleasant,U.S. House,2,Write-ins,,2
-Labette,Mt Pleasant,State Senate,15,Chuck  Schmidt,D,229
-Labette,Mt Pleasant,State Senate,15,Dan  Goddard,R,335
-Labette,Mt Pleasant,State Senate,15,Write-ins,,1
-Labette,Mt Pleasant,State House,7,Richard Proehl,R,484
-Labette,Mt Pleasant,State House,7,Write-ins,,21
-Labette,Neosho,President,,Stein/Baraka,I,0
-Labette,Neosho,President,,Trump/Pence,R,57
-Labette,Neosho,President,,Clinton/Kaine,D,28
-Labette,Neosho,President,,Johnson/Weld,L,1
-Labette,Neosho,President,,Write-ins,,1
-Labette,Neosho,U.S. Senate,,Jerry  Moran,R,44
-Labette,Neosho,U.S. Senate,,Patrick  Wiesner,D,34
-Labette,Neosho,U.S. Senate,,Robert  D  Garrard,L,3
-Labette,Neosho,U.S. House,2,Lynn  Jenkins,R,53
-Labette,Neosho,U.S. House,2,Britani  Potter,D,24
-Labette,Neosho,U.S. House,2,James Bales,L,6
-Labette,Neosho,State Senate,15,Chuck  Schmidt,D,41
-Labette,Neosho,State Senate,15,Dan  Goddard,R,39
-Labette,Neosho,State Senate,15,Write-ins,,1
-Labette,Neosho,State House,7,Richard Proehl,R,69
-Labette,Neosho,State House,7,Write-ins,,2
-Labette,North,President,,Stein/Baraka,I,8
-Labette,North,President,,Trump/Pence,R,212
-Labette,North,President,,Clinton/Kaine,D,89
-Labette,North,President,,Johnson/Weld,L,10
-Labette,North,President,,Write-ins,,9
-Labette,North,U.S. Senate,,Jerry  Moran,R,207
-Labette,North,U.S. Senate,,Patrick  Wiesner,D,82
-Labette,North,U.S. Senate,,Robert  D  Garrard,L,21
-Labette,North,U.S. House,2,Lynn  Jenkins,R,226
-Labette,North,U.S. House,2,Britani  Potter,D,73
-Labette,North,U.S. House,2,James Bales,L,12
-Labette,North,State Senate,15,Chuck  Schmidt,D,110
-Labette,North,State Senate,15,Dan  Goddard,R,200
-Labette,North,State Senate,15,Write-ins,,1
-Labette,North,State House,7,Richard Proehl,R,258
-Labette,North,State House,7,Write-ins,,8
-Labette,Osage,President,,Stein/Baraka,I,8
-Labette,Osage,President,,Trump/Pence,R,234
-Labette,Osage,President,,Clinton/Kaine,D,70
-Labette,Osage,President,,Johnson/Weld,L,7
-Labette,Osage,President,,Write-ins,,5
-Labette,Osage,U.S. Senate,,Jerry  Moran,R,220
-Labette,Osage,U.S. Senate,,Patrick  Wiesner,D,70
-Labette,Osage,U.S. Senate,,Robert  D  Garrard,L,22
-Labette,Osage,U.S. House,2,Lynn  Jenkins,R,242
-Labette,Osage,U.S. House,2,Britani  Potter,D,60
-Labette,Osage,U.S. House,2,James Bales,L,14
-Labette,Osage,State Senate,13,Jake  LaTumer,R,15
-Labette,Osage,State Senate,13,Lynn  D  Grant,D,12
-Labette,Osage,State Senate,15,Chuck  Schmidt,D,96
-Labette,Osage,State Senate,15,Dan  Goddard,R,217
-Labette,Osage,State Senate,15,Write-ins,,2
-Labette,Osage,State House,7,Richard Proehl,R,113
-Labette,Osage,State House,7,Write-ins,,5
-Labette,Oswego,President,,Stein/Baraka,I,1
-Labette,Oswego,President,,Trump/Pence,R,97
-Labette,Oswego,President,,Clinton/Kaine,D,22
-Labette,Oswego,President,,Johnson/Weld,L,3
-Labette,Oswego,President,,McMullin/Johnson,,3
-Labette,Oswego,President,,Hoefing/Schulin,,1
-Labette,Oswego,President,,Write-ins,,1
-Labette,Oswego,U.S. Senate,,Jerry  Moran,R,98
-Labette,Oswego,U.S. Senate,,Patrick  Wiesner,D,20
-Labette,Oswego,U.S. Senate,,Robert  D  Garrard,L,6
-Labette,Oswego,U.S. House,2,Lynn  Jenkins,R,100
-Labette,Oswego,U.S. House,2,Britani  Potter,D,20
-Labette,Oswego,U.S. House,2,James Bales,L,6
-Labette,Oswego,State Senate,13,Jake  LaTumer,R,46
-Labette,Oswego,State Senate,13,Lynn  D  Grant,D,35
-Labette,Oswego,State Senate,15,Chuck  Schmidt,D,26
-Labette,Oswego,State Senate,15,Dan  Goddard,R,98
-Labette,Richland 1A,President,,Stein/Baraka,I,1
-Labette,Richland 1A,President,,Trump/Pence,R,20
-Labette,Richland 1A,President,,Clinton/Kaine,D,5
-Labette,Richland 1A,President,,Johnson/Weld,L,1
-Labette,Richland 1A,U.S. Senate,,Jerry  Moran,R,19
-Labette,Richland 1A,U.S. Senate,,Patrick  Wiesner,D,7
-Labette,Richland 1A,U.S. Senate,,Robert  D  Garrard,L,2
-Labette,Richland 1A,U.S. House,2,Lynn  Jenkins,R,25
-Labette,Richland 1A,U.S. House,2,Britani  Potter,D,3
-Labette,Richland 1A,U.S. House,2,James Bales,L,1
-Labette,Richland 1A,State Senate,13,Jake  LaTumer,R,15
-Labette,Richland 1A,State Senate,13,Lynn  D  Grant,D,12
-Labette,Richland 1A,State House,1,Michael Houser,R,24
-Labette,Richland 1A,State House,1,Write-ins,,0
-Labette,Richland H007,President,,Stein/Baraka,I,2
-Labette,Richland H007,President,,Trump/Pence,R,54
-Labette,Richland H007,President,,Clinton/Kaine,D,23
-Labette,Richland H007,President,,Johnson/Weld,L,2
-Labette,Richland H007,U.S. Senate,,Jerry  Moran,R,53
-Labette,Richland H007,U.S. Senate,,Patrick  Wiesner,D,22
-Labette,Richland H007,U.S. Senate,,Robert  D  Garrard,L,5
-Labette,Richland H007,U.S. House,2,Lynn  Jenkins,R,60
-Labette,Richland H007,U.S. House,2,Britani  Potter,D,18
-Labette,Richland H007,U.S. House,2,James Bales,L,2
-Labette,Richland H007,State Senate,13,Jake  LaTumer,R,46
-Labette,Richland H007,State Senate,13,Lynn  D  Grant,D,35
-Labette,Richland H007,State Senate,13,Write-ins,,0
-Labette,Richland H007,State House,7,Richard Proehl,R,70
-Labette,Richland H007,State House,7,Write-ins,,1
-Labette,Richland 1B,President,,Stein/Baraka,I,1
-Labette,Richland 1B,President,,Trump/Pence,R,16
-Labette,Richland 1B,President,,Clinton/Kaine,D,4
-Labette,Richland 1B,U.S. Senate,,Jerry  Moran,R,16
-Labette,Richland 1B,U.S. Senate,,Patrick  Wiesner,D,2
-Labette,Richland 1B,U.S. Senate,,Robert  D  Garrard,L,1
-Labette,Richland 1B,U.S. House,2,Lynn  Jenkins,R,17
-Labette,Richland 1B,U.S. House,2,Britani  Potter,D,1
-Labette,Richland 1B,U.S. House,2,James Bales,L,1
-Labette,Richland 1B,State Senate,13,Jake  LaTumer,R,11
-Labette,Richland 1B,State Senate,13,Lynn  D  Grant,D,7
-Labette,Richland 1B,State House,1,Michael Houser,R,17
-Labette,Richland 1B,State House,1,Write-ins,,1
-Labette,Walton,President,,Stein/Baraka,I,3
-Labette,Walton,President,,Trump/Pence,R,264
-Labette,Walton,President,,Clinton/Kaine,D,110
-Labette,Walton,President,,Johnson/Weld,L,7
-Labette,Walton,President,,Write-ins,,2
-Labette,Walton,U.S. Senate,,Jerry  Moran,R,251
-Labette,Walton,U.S. Senate,,Patrick  Wiesner,D,104
-Labette,Walton,U.S. Senate,,Robert  D  Garrard,L,20
-Labette,Walton,U.S. Senate,,Write-ins,,2
-Labette,Walton,U.S. House,2,Lynn  Jenkins,R,274
-Labette,Walton,U.S. House,2,Britani  Potter,D,92
-Labette,Walton,U.S. House,2,James Bales,L,14
-Labette,Walton,U.S. House,2,Write-ins,,1
-Labette,Walton,State Senate,15,Chuck  Schmidt,D,122
-Labette,Walton,State Senate,15,Dan  Goddard,R,257
-Labette,Walton,State Senate,15,Write-ins,,1
-Labette,Walton,State House,7,Richard Proehl,R,326
-Labette,Walton,State House,7,Write-ins,,14
-Labette,Hand Count,President,,Stein/Baraka,I,3
-Labette,Hand Count,President,,Trump/Pence,R,19
-Labette,Hand Count,President,,Clinton/Kaine,D,14
-Labette,Hand Count,President,,Johnson/Weld,L,3
-Labette,Hand Count,President,,Write-ins,,0
-Labette,Hand Count,U.S. Senate,,Jerry  Moran,R,21
-Labette,Hand Count,U.S. Senate,,Patrick  Wiesner,D,12
-Labette,Hand Count,U.S. Senate,,Robert  D  Garrard,L,3
-Labette,Hand Count,U.S. Senate,,Write-ins,,0
-Labette,Hand Count,U.S. House,2,Lynn  Jenkins,R,26
-Labette,Hand Count,U.S. House,2,Britani  Potter,D,9
-Labette,Hand Count,U.S. House,2,James Bales,L,2
-Labette,Hand Count,U.S. House,2,Write-ins,,0
-Labette,Hand Count,State Senate,13,Jake  LaTumer,R,2
-Labette,Hand Count,State Senate,13,Lynn  D  Grant,D,1
-Labette,Hand Count,State Senate,13,Write-ins,,0
-Labette,Hand Count,State Senate,15,Chuck  Schmidt,D,12
-Labette,Hand Count,State Senate,15,Dan  Goddard,R,20
-Labette,Hand Count,State Senate,15,Write-ins,,0
-Labette,Hand Count,State House,1,Michael Houser,R,3
-Labette,Hand Count,State House,1,Write-ins,,0
-Labette,Hand Count,State House,7,Richard Proehl,R,22
-Labette,Hand Count,State House,7,Write-ins,,1
-Labette,Provisional,President,,Stein/Baraka,I,1
-Labette,Provisional,President,,Trump/Pence,R,84
-Labette,Provisional,President,,Clinton/Kaine,D,43
-Labette,Provisional,President,,Johnson/Weld,L,4
-Labette,Provisional,President,,Write-ins,,2
-Labette,Provisional,U.S. Senate,,Jerry  Moran,R,74
-Labette,Provisional,U.S. Senate,,Patrick  Wiesner,D,44
-Labette,Provisional,U.S. Senate,,Robert  D  Garrard,L,9
-Labette,Provisional,U.S. Senate,,Write-ins,,1
-Labette,Provisional,U.S. House,2,Lynn  Jenkins,R,78
-Labette,Provisional,U.S. House,2,Britani  Potter,D,38
-Labette,Provisional,U.S. House,2,James Bales,L,8
-Labette,Provisional,U.S. House,2,Write-ins,,1
-Labette,Provisional,State Senate,13,Jake  LaTumer,R,1
-Labette,Provisional,State Senate,13,Lynn  D  Grant,D,1
-Labette,Provisional,State Senate,15,Chuck  Schmidt,D,46
-Labette,Provisional,State Senate,15,Dan  Goddard,R,79
-Labette,Provisional,State Senate,15,Write-ins,,1
-Labette,Provisional,State House,1,Michael Houser,R,1
-Labette,Provisional,State House,1,Write-ins,,1
-Labette,Provisional,State House,7,Richard Proehl,R,115
-Labette,Provisional,State House,7,Write-ins,,1
-Labette,LABETTE KS,President,,Stein/Baraka,I,166
-Labette,LABETTE KS,President,,Trump/Pence,R,5335
-Labette,LABETTE KS,President,,Clinton/Kaine,D,2291
-Labette,LABETTE KS,President,,Johnson/Weld,L,298
-Labette,LABETTE KS,President,,Darrell Castle,,6
-Labette,LABETTE KS,President,,Evan McMullin,,10
-Labette,LABETTE KS,President,,Tom Hoefling,,1
-Labette,LABETTE KS,President,,Write-ins,,111
-Labette,LABETTE KS,U.S. Senate,,Jerry  Moran,R,5212
-Labette,LABETTE KS,U.S. Senate,,Patrick  Wiesner,D,2319
-Labette,LABETTE KS,U.S. Senate,,Robert  D  Garrard,L,508
-Labette,LABETTE KS,U.S. Senate,,Write-ins,,15
-Labette,LABETTE KS,U.S. House,2,Lynn  Jenkins,R,5622
-Labette,LABETTE KS,U.S. House,2,Britani  Potter,D,2103
-Labette,LABETTE KS,U.S. House,2,James Bales,L,373
-Labette,LABETTE KS,U.S. House,2,Write-ins,,11
-Labette,LABETTE KS,State Senate,13,Jake  LaTumer,R,279
-Labette,LABETTE KS,State Senate,13,Lynn  D  Grant,D,215
-Labette,LABETTE KS,State Senate,13,Write-ins,,2
-Labette,LABETTE KS,State Senate,15,Chuck  Schmidt,D,2873
-Labette,LABETTE KS,State Senate,15,Dan  Goddard,R,4679
-Labette,LABETTE KS,State Senate,15,Write-ins,,23
-Labette,LABETTE KS,State House,1,Michael Houser,R,348
-Labette,LABETTE KS,State House,1,Write-ins,,11
-Labette,LABETTE KS,State House,7,Richard Proehl,R,6573
-Labette,LABETTE KS,State House,7,Write-ins,,198
+county,precinct,office,district,party,candidate,votes,vtd
+LABETTE,Altamont City Part A,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00001A
+LABETTE,Canada Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",109,000020
+LABETTE,Chetopa Ward 1,Kansas House of Representatives,1,Republican,"Houser, Michael",100,000030
+LABETTE,Chetopa Ward 2,Kansas House of Representatives,1,Republican,"Houser, Michael",91,000040
+LABETTE,Chetopa Ward 3,Kansas House of Representatives,1,Republican,"Houser, Michael",115,000050
+LABETTE,Elm Grove Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",332,000060
+LABETTE,Fairview Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",83,000070
+LABETTE,Hackberry Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",120,000080
+LABETTE,Howard Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",141,000090
+LABETTE,Labette Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",173,000100
+LABETTE,Liberty Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",174,000110
+LABETTE,Montana Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",62,000120
+LABETTE,Mound Valley Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",299,000130
+LABETTE,Mount Pleasant Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",494,000140
+LABETTE,Neosho Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",69,000150
+LABETTE,North Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",262,00016A
+LABETTE,North Township Enclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00016B
+LABETTE,Oswego City Ward 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",212,000180
+LABETTE,Oswego City Ward 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",213,00019A
+LABETTE,Oswego City Ward 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",161,000200
+LABETTE,Oswego Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",115,000210
+LABETTE,Parsons Ward 1 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",294,000220
+LABETTE,Parsons Ward 1 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",130,000230
+LABETTE,Parsons Ward 1 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",103,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",93,000250
+LABETTE,Parsons Ward 2 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",239,000260
+LABETTE,Parsons Ward 2 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",261,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",114,000280
+LABETTE,Parsons Ward 3 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",285,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",238,000300
+LABETTE,Parsons Ward 3 Precinct 4,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",341,000310
+LABETTE,Parsons Ward 4 Precinct 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",149,000320
+LABETTE,Parsons Ward 4 Precinct 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",197,000330
+LABETTE,Parsons Ward 4 Precinct 3,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",171,000340
+LABETTE,Parsons Ward 4 Precinct 4,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",255,000350
+LABETTE,Walton Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",330,000370
+LABETTE,Osage Township S14,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,120020
+LABETTE,Osage Township S15,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",284,120030
+LABETTE,Richland Township H1 A,Kansas House of Representatives,1,Republican,"Houser, Michael",25,12004A
+LABETTE,Richland Township H1 B,Kansas House of Representatives,1,Republican,"Houser, Michael",17,12004B
+LABETTE,Richland Township H1,Kansas House of Representatives,1,Republican,"Houser, Michael",0,120040
+LABETTE,Richland Township H7,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",70,120050
+LABETTE,Oswego City Ward 1 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900010
+LABETTE,Altamont City Part A,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00001A
+LABETTE,Altamont City Part A,Kansas Senate,15,Republican,"Goddard, Dan",0,00001A
+LABETTE,Canada Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",31,000020
+LABETTE,Canada Township,Kansas Senate,15,Republican,"Goddard, Dan",85,000020
+LABETTE,Chetopa Ward 1,Kansas Senate,13,Democratic,"Grant, Lynn D.",46,000030
+LABETTE,Chetopa Ward 1,Kansas Senate,13,Republican,"LaTurner, Jake",60,000030
+LABETTE,Chetopa Ward 2,Kansas Senate,13,Democratic,"Grant, Lynn D.",55,000040
+LABETTE,Chetopa Ward 2,Kansas Senate,13,Republican,"LaTurner, Jake",61,000040
+LABETTE,Chetopa Ward 3,Kansas Senate,13,Democratic,"Grant, Lynn D.",60,000050
+LABETTE,Chetopa Ward 3,Kansas Senate,13,Republican,"LaTurner, Jake",85,000050
+LABETTE,Elm Grove Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",105,000060
+LABETTE,Elm Grove Township,Kansas Senate,15,Republican,"Goddard, Dan",285,000060
+LABETTE,Fairview Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",29,000070
+LABETTE,Fairview Township,Kansas Senate,15,Republican,"Goddard, Dan",68,000070
+LABETTE,Hackberry Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",32,000080
+LABETTE,Hackberry Township,Kansas Senate,15,Republican,"Goddard, Dan",118,000080
+LABETTE,Howard Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",52,000090
+LABETTE,Howard Township,Kansas Senate,15,Republican,"Goddard, Dan",118,000090
+LABETTE,Labette Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",50,000100
+LABETTE,Labette Township,Kansas Senate,15,Republican,"Goddard, Dan",147,000100
+LABETTE,Liberty Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",59,000110
+LABETTE,Liberty Township,Kansas Senate,15,Republican,"Goddard, Dan",133,000110
+LABETTE,Montana Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",20,000120
+LABETTE,Montana Township,Kansas Senate,15,Republican,"Goddard, Dan",58,000120
+LABETTE,Mound Valley Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",114,000130
+LABETTE,Mound Valley Township,Kansas Senate,15,Republican,"Goddard, Dan",226,000130
+LABETTE,Mount Pleasant Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",232,000140
+LABETTE,Mount Pleasant Township,Kansas Senate,15,Republican,"Goddard, Dan",342,000140
+LABETTE,Neosho Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",41,000150
+LABETTE,Neosho Township,Kansas Senate,15,Republican,"Goddard, Dan",39,000150
+LABETTE,North Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",112,00016A
+LABETTE,North Township,Kansas Senate,15,Republican,"Goddard, Dan",203,00016A
+LABETTE,North Township Enclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00016B
+LABETTE,North Township Enclave,Kansas Senate,15,Republican,"Goddard, Dan",0,00016B
+LABETTE,Oswego City Ward 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",81,000180
+LABETTE,Oswego City Ward 1,Kansas Senate,15,Republican,"Goddard, Dan",175,000180
+LABETTE,Oswego City Ward 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",106,00019A
+LABETTE,Oswego City Ward 2,Kansas Senate,15,Republican,"Goddard, Dan",139,00019A
+LABETTE,Oswego City Ward 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",73,000200
+LABETTE,Oswego City Ward 3,Kansas Senate,15,Republican,"Goddard, Dan",107,000200
+LABETTE,Oswego Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",27,000210
+LABETTE,Oswego Township,Kansas Senate,15,Republican,"Goddard, Dan",100,000210
+LABETTE,Parsons Ward 1 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",129,000220
+LABETTE,Parsons Ward 1 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",196,000220
+LABETTE,Parsons Ward 1 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",69,000230
+LABETTE,Parsons Ward 1 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",89,000230
+LABETTE,Parsons Ward 1 Precinct 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",59,00024A
+LABETTE,Parsons Ward 1 Precinct 3,Kansas Senate,15,Republican,"Goddard, Dan",65,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",45,000250
+LABETTE,Parsons Ward 2 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",58,000250
+LABETTE,Parsons Ward 2 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",134,000260
+LABETTE,Parsons Ward 2 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",136,000260
+LABETTE,Parsons Ward 2 Precinct 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",137,00027A
+LABETTE,Parsons Ward 2 Precinct 3,Kansas Senate,15,Republican,"Goddard, Dan",167,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",45,000280
+LABETTE,Parsons Ward 3 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",83,000280
+LABETTE,Parsons Ward 3 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",179,00029A
+LABETTE,Parsons Ward 3 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",172,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",128,000300
+LABETTE,Parsons Ward 3 Precinct 3,Kansas Senate,15,Republican,"Goddard, Dan",159,000300
+LABETTE,Parsons Ward 3 Precinct 4,Kansas Senate,15,Democratic,"Schmidt, Chuck",193,000310
+LABETTE,Parsons Ward 3 Precinct 4,Kansas Senate,15,Republican,"Goddard, Dan",213,000310
+LABETTE,Parsons Ward 4 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",64,000320
+LABETTE,Parsons Ward 4 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",109,000320
+LABETTE,Parsons Ward 4 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",101,000330
+LABETTE,Parsons Ward 4 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",128,000330
+LABETTE,Parsons Ward 4 Precinct 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",88,000340
+LABETTE,Parsons Ward 4 Precinct 3,Kansas Senate,15,Republican,"Goddard, Dan",113,000340
+LABETTE,Parsons Ward 4 Precinct 4,Kansas Senate,15,Democratic,"Schmidt, Chuck",118,000350
+LABETTE,Parsons Ward 4 Precinct 4,Kansas Senate,15,Republican,"Goddard, Dan",169,000350
+LABETTE,Walton Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",123,000370
+LABETTE,Walton Township,Kansas Senate,15,Republican,"Goddard, Dan",260,000370
+LABETTE,Osage Township S14,Kansas Senate,14,Democratic,"Pringle, Mark",0,120020
+LABETTE,Osage Township S14,Kansas Senate,14,Republican,"Givens, Bruce",0,120020
+LABETTE,Osage Township S15,Kansas Senate,15,Democratic,"Schmidt, Chuck",97,120030
+LABETTE,Osage Township S15,Kansas Senate,15,Republican,"Goddard, Dan",219,120030
+LABETTE,Richland Township H1 A,Kansas Senate,13,Democratic,"Grant, Lynn D.",12,12004A
+LABETTE,Richland Township H1 A,Kansas Senate,13,Republican,"LaTurner, Jake",16,12004A
+LABETTE,Richland Township H1 B,Kansas Senate,13,Democratic,"Grant, Lynn D.",7,12004B
+LABETTE,Richland Township H1 B,Kansas Senate,13,Republican,"LaTurner, Jake",11,12004B
+LABETTE,Richland Township H1,Kansas Senate,13,Democratic,"Grant, Lynn D.",0,120040
+LABETTE,Richland Township H1,Kansas Senate,13,Republican,"LaTurner, Jake",0,120040
+LABETTE,Richland Township H7,Kansas Senate,13,Democratic,"Grant, Lynn D.",35,120050
+LABETTE,Richland Township H7,Kansas Senate,13,Republican,"LaTurner, Jake",46,120050
+LABETTE,Oswego City Ward 1 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900010
+LABETTE,Oswego City Ward 1 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,900010
+LABETTE,Altamont City Part A,President / Vice President,,independent,"Stein, Jill",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Hedges, James A",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"McMullin, Evan",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Perry, Darryl",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Smith, Mike",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Sood, Ajay",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001A
+LABETTE,Altamont City Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00001A
+LABETTE,Canada Township,President / Vice President,,independent,"Stein, Jill",2,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+LABETTE,Canada Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+LABETTE,Canada Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000020
+LABETTE,Canada Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+LABETTE,Canada Township,President / Vice President,,Republican,"Trump, Donald J.",99,000020
+LABETTE,Chetopa Ward 1,President / Vice President,,independent,"Stein, Jill",2,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000030
+LABETTE,Chetopa Ward 1,President / Vice President,,Republican,"Trump, Donald J.",64,000030
+LABETTE,Chetopa Ward 2,President / Vice President,,independent,"Stein, Jill",2,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000040
+LABETTE,Chetopa Ward 2,President / Vice President,,Republican,"Trump, Donald J.",80,000040
+LABETTE,Chetopa Ward 3,President / Vice President,,independent,"Stein, Jill",3,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+LABETTE,Chetopa Ward 3,President / Vice President,,Republican,"Trump, Donald J.",112,000050
+LABETTE,Elm Grove Township,President / Vice President,,independent,"Stein, Jill",10,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+LABETTE,Elm Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000060
+LABETTE,Elm Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000060
+LABETTE,Elm Grove Township,President / Vice President,,Republican,"Trump, Donald J.",315,000060
+LABETTE,Fairview Township,President / Vice President,,independent,"Stein, Jill",2,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LABETTE,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LABETTE,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000070
+LABETTE,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+LABETTE,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",84,000070
+LABETTE,Hackberry Township,President / Vice President,,independent,"Stein, Jill",3,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LABETTE,Hackberry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LABETTE,Hackberry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000080
+LABETTE,Hackberry Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+LABETTE,Hackberry Township,President / Vice President,,Republican,"Trump, Donald J.",124,000080
+LABETTE,Howard Township,President / Vice President,,independent,"Stein, Jill",2,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+LABETTE,Howard Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+LABETTE,Howard Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000090
+LABETTE,Howard Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+LABETTE,Howard Township,President / Vice President,,Republican,"Trump, Donald J.",135,000090
+LABETTE,Labette Township,President / Vice President,,independent,"Stein, Jill",5,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Castle, Darrell L",4,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LABETTE,Labette Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LABETTE,Labette Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000100
+LABETTE,Labette Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000100
+LABETTE,Labette Township,President / Vice President,,Republican,"Trump, Donald J.",158,000100
+LABETTE,Liberty Township,President / Vice President,,independent,"Stein, Jill",4,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",1,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LABETTE,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LABETTE,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000110
+LABETTE,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+LABETTE,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",143,000110
+LABETTE,Montana Township,President / Vice President,,independent,"Stein, Jill",1,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+LABETTE,Montana Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+LABETTE,Montana Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000120
+LABETTE,Montana Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+LABETTE,Montana Township,President / Vice President,,Republican,"Trump, Donald J.",69,000120
+LABETTE,Mound Valley Township,President / Vice President,,independent,"Stein, Jill",10,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+LABETTE,Mound Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",46,000130
+LABETTE,Mound Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000130
+LABETTE,Mound Valley Township,President / Vice President,,Republican,"Trump, Donald J.",273,000130
+LABETTE,Mount Pleasant Township,President / Vice President,,independent,"Stein, Jill",14,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000140
+LABETTE,Mount Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",420,000140
+LABETTE,Neosho Township,President / Vice President,,independent,"Stein, Jill",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+LABETTE,Neosho Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+LABETTE,Neosho Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000150
+LABETTE,Neosho Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+LABETTE,Neosho Township,President / Vice President,,Republican,"Trump, Donald J.",57,000150
+LABETTE,North Township,President / Vice President,,independent,"Stein, Jill",9,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Hedges, James A",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"McMullin, Evan",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Smith, Mike",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+LABETTE,North Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+LABETTE,North Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,00016A
+LABETTE,North Township,President / Vice President,,Libertarian,"Johnson, Gary",10,00016A
+LABETTE,North Township,President / Vice President,,Republican,"Trump, Donald J.",215,00016A
+LABETTE,North Township Enclave,President / Vice President,,independent,"Stein, Jill",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+LABETTE,North Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00016B
+LABETTE,Oswego City Ward 1,President / Vice President,,independent,"Stein, Jill",4,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000180
+LABETTE,Oswego City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",186,000180
+LABETTE,Oswego City Ward 2,President / Vice President,,independent,"Stein, Jill",3,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,00019A
+LABETTE,Oswego City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",179,00019A
+LABETTE,Oswego City Ward 3,President / Vice President,,independent,"Stein, Jill",3,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"McMullin, Evan",3,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",11,000200
+LABETTE,Oswego City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",128,000200
+LABETTE,Oswego Township,President / Vice President,,independent,"Stein, Jill",1,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Hoefling, Tom",1,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+LABETTE,Oswego Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+LABETTE,Oswego Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000210
+LABETTE,Oswego Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000210
+LABETTE,Oswego Township,President / Vice President,,Republican,"Trump, Donald J.",101,000210
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",14,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000220
+LABETTE,Parsons Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",177,000220
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000230
+LABETTE,Parsons Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",93,000230
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,independent,"Stein, Jill",2,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",4,00024A
+LABETTE,Parsons Ward 1 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",67,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",4,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000250
+LABETTE,Parsons Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",58,000250
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",7,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",125,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",21,000260
+LABETTE,Parsons Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",110,000260
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",5,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",144,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",17,00027A
+LABETTE,Parsons Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",128,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",1,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000280
+LABETTE,Parsons Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",81,000280
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",6,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",1,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",139,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",20,00029A
+LABETTE,Parsons Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",177,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,independent,"Stein, Jill",6,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000300
+LABETTE,Parsons Ward 3 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",150,000300
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,independent,"Stein, Jill",5,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",3,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",155,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",10,000310
+LABETTE,Parsons Ward 3 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",242,000310
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",1,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000320
+LABETTE,Parsons Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",103,000320
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",78,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",16,000330
+LABETTE,Parsons Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",130,000330
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",4,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",6,000340
+LABETTE,Parsons Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",108,000340
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,independent,"Stein, Jill",6,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",96,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",10,000350
+LABETTE,Parsons Ward 4 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",173,000350
+LABETTE,Walton Township,President / Vice President,,independent,"Stein, Jill",3,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Hedges, James A",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"McMullin, Evan",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Perry, Darryl",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Smith, Mike",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Sood, Ajay",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+LABETTE,Walton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+LABETTE,Walton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",112,000370
+LABETTE,Walton Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000370
+LABETTE,Walton Township,President / Vice President,,Republican,"Trump, Donald J.",268,000370
+LABETTE,Osage Township S14,President / Vice President,,independent,"Stein, Jill",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Hedges, James A",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"McMullin, Evan",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Perry, Darryl",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Smith, Mike",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Sood, Ajay",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+LABETTE,Osage Township S14,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+LABETTE,Osage Township S14,President / Vice President,,Republican,"Trump, Donald J.",0,120020
+LABETTE,Osage Township S15,President / Vice President,,independent,"Stein, Jill",8,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Hedges, James A",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"McMullin, Evan",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Perry, Darryl",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Smith, Mike",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Sood, Ajay",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+LABETTE,Osage Township S15,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+LABETTE,Osage Township S15,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,120030
+LABETTE,Osage Township S15,President / Vice President,,Libertarian,"Johnson, Gary",7,120030
+LABETTE,Osage Township S15,President / Vice President,,Republican,"Trump, Donald J.",237,120030
+LABETTE,Richland Township H1 A,President / Vice President,,independent,"Stein, Jill",1,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Castle, Darrell L",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Giordani, Rocky",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Hedges, James A",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Hoefling, Tom",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Kahn, Lynn",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"La Riva, Gloria",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Maturen, Michael A",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"McMullin, Evan",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Perry, Darryl",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Schriner, Joe C",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Smith, Mike",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Sood, Ajay",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Sterling, Shawna",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Libertarian,"Johnson, Gary",1,12004A
+LABETTE,Richland Township H1 A,President / Vice President,,Republican,"Trump, Donald J.",21,12004A
+LABETTE,Richland Township H1 B,President / Vice President,,independent,"Stein, Jill",1,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Basiago, Andrew D.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Castle, Darrell L",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Giordani, Rocky",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Hedges, James A",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Hoefling, Tom",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Kahn, Lynn",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"La Riva, Gloria",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Levinson, Michael S.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Maturen, Michael A",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"McMullin, Evan",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Moorehead, Monica G.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Perry, Darryl",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Schriner, Joe C",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Smith, Mike",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Sood, Ajay",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Sterling, Shawna",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Valdivia, Anthony J",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Libertarian,"Johnson, Gary",0,12004B
+LABETTE,Richland Township H1 B,President / Vice President,,Republican,"Trump, Donald J.",16,12004B
+LABETTE,Richland Township H1,President / Vice President,,independent,"Stein, Jill",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Hedges, James A",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"McMullin, Evan",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Perry, Darryl",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Smith, Mike",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Sood, Ajay",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+LABETTE,Richland Township H1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+LABETTE,Richland Township H1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120040
+LABETTE,Richland Township H1,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+LABETTE,Richland Township H1,President / Vice President,,Republican,"Trump, Donald J.",0,120040
+LABETTE,Richland Township H7,President / Vice President,,independent,"Stein, Jill",2,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Hedges, James A",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"McMullin, Evan",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Perry, Darryl",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Smith, Mike",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Sood, Ajay",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+LABETTE,Richland Township H7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+LABETTE,Richland Township H7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,120050
+LABETTE,Richland Township H7,President / Vice President,,Libertarian,"Johnson, Gary",2,120050
+LABETTE,Richland Township H7,President / Vice President,,Republican,"Trump, Donald J.",54,120050
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LABETTE,Oswego City Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+LABETTE,Altamont City Part A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00001A
+LABETTE,Altamont City Part A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00001A
+LABETTE,Altamont City Part A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001A
+LABETTE,Canada Township,United States House of Representatives,2,Democratic,"Potter, Britani",22,000020
+LABETTE,Canada Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000020
+LABETTE,Canada Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",90,000020
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",32,000030
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000030
+LABETTE,Chetopa Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000030
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",24,000040
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000040
+LABETTE,Chetopa Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000040
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",31,000050
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000050
+LABETTE,Chetopa Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000050
+LABETTE,Elm Grove Township,United States House of Representatives,2,Democratic,"Potter, Britani",49,000060
+LABETTE,Elm Grove Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000060
+LABETTE,Elm Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",327,000060
+LABETTE,Fairview Township,United States House of Representatives,2,Democratic,"Potter, Britani",18,000070
+LABETTE,Fairview Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000070
+LABETTE,Fairview Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",80,000070
+LABETTE,Hackberry Township,United States House of Representatives,2,Democratic,"Potter, Britani",23,000080
+LABETTE,Hackberry Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000080
+LABETTE,Hackberry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000080
+LABETTE,Howard Township,United States House of Representatives,2,Democratic,"Potter, Britani",29,000090
+LABETTE,Howard Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000090
+LABETTE,Howard Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,000090
+LABETTE,Labette Township,United States House of Representatives,2,Democratic,"Potter, Britani",25,000100
+LABETTE,Labette Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000100
+LABETTE,Labette Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000100
+LABETTE,Liberty Township,United States House of Representatives,2,Democratic,"Potter, Britani",39,000110
+LABETTE,Liberty Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000110
+LABETTE,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",142,000110
+LABETTE,Montana Township,United States House of Representatives,2,Democratic,"Potter, Britani",11,000120
+LABETTE,Montana Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000120
+LABETTE,Montana Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000120
+LABETTE,Mound Valley Township,United States House of Representatives,2,Democratic,"Potter, Britani",67,000130
+LABETTE,Mound Valley Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000130
+LABETTE,Mound Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",256,000130
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Democratic,"Potter, Britani",108,000140
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000140
+LABETTE,Mount Pleasant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",450,000140
+LABETTE,Neosho Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000150
+LABETTE,Neosho Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000150
+LABETTE,Neosho Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000150
+LABETTE,North Township,United States House of Representatives,2,Democratic,"Potter, Britani",75,00016A
+LABETTE,North Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,00016A
+LABETTE,North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,00016A
+LABETTE,North Township Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00016B
+LABETTE,North Township Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00016B
+LABETTE,North Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00016B
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",54,000180
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000180
+LABETTE,Oswego City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,000180
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",48,00019A
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,00019A
+LABETTE,Oswego City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,00019A
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",44,000200
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000200
+LABETTE,Oswego City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000200
+LABETTE,Oswego Township,United States House of Representatives,2,Democratic,"Potter, Britani",21,000210
+LABETTE,Oswego Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000210
+LABETTE,Oswego Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000210
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",92,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",221,000220
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",50,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000230
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",48,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",30,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,000250
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",125,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,000260
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",110,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",184,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",42,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,000280
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",136,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",204,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",108,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",163,000300
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",146,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",249,000310
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",61,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,000320
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",81,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",127,000330
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",74,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",116,000340
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",80,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,000350
+LABETTE,Walton Township,United States House of Representatives,2,Democratic,"Potter, Britani",93,000370
+LABETTE,Walton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000370
+LABETTE,Walton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",278,000370
+LABETTE,Osage Township S14,United States House of Representatives,2,Democratic,"Potter, Britani",0,120020
+LABETTE,Osage Township S14,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120020
+LABETTE,Osage Township S14,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120020
+LABETTE,Osage Township S15,United States House of Representatives,2,Democratic,"Potter, Britani",61,120030
+LABETTE,Osage Township S15,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,120030
+LABETTE,Osage Township S15,United States House of Representatives,2,Republican,"Jenkins, Lynn",243,120030
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Democratic,"Potter, Britani",3,12004A
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,12004A
+LABETTE,Richland Township H1 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",26,12004A
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Democratic,"Potter, Britani",1,12004B
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,12004B
+LABETTE,Richland Township H1 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",17,12004B
+LABETTE,Richland Township H1,United States House of Representatives,2,Democratic,"Potter, Britani",0,120040
+LABETTE,Richland Township H1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120040
+LABETTE,Richland Township H1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120040
+LABETTE,Richland Township H7,United States House of Representatives,2,Democratic,"Potter, Britani",18,120050
+LABETTE,Richland Township H7,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,120050
+LABETTE,Richland Township H7,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,120050
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+LABETTE,Altamont City Part A,United States Senate,,write - in,"Smith, DJ",0,00001A
+LABETTE,Altamont City Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00001A
+LABETTE,Altamont City Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00001A
+LABETTE,Altamont City Part A,United States Senate,,Republican,"Moran, Jerry",0,00001A
+LABETTE,Canada Township,United States Senate,,write - in,"Smith, DJ",0,000020
+LABETTE,Canada Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000020
+LABETTE,Canada Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000020
+LABETTE,Canada Township,United States Senate,,Republican,"Moran, Jerry",90,000020
+LABETTE,Chetopa Ward 1,United States Senate,,write - in,"Smith, DJ",0,000030
+LABETTE,Chetopa Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",44,000030
+LABETTE,Chetopa Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+LABETTE,Chetopa Ward 1,United States Senate,,Republican,"Moran, Jerry",59,000030
+LABETTE,Chetopa Ward 2,United States Senate,,write - in,"Smith, DJ",0,000040
+LABETTE,Chetopa Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",33,000040
+LABETTE,Chetopa Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",6,000040
+LABETTE,Chetopa Ward 2,United States Senate,,Republican,"Moran, Jerry",74,000040
+LABETTE,Chetopa Ward 3,United States Senate,,write - in,"Smith, DJ",0,000050
+LABETTE,Chetopa Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",36,000050
+LABETTE,Chetopa Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",9,000050
+LABETTE,Chetopa Ward 3,United States Senate,,Republican,"Moran, Jerry",96,000050
+LABETTE,Elm Grove Township,United States Senate,,write - in,"Smith, DJ",0,000060
+LABETTE,Elm Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",60,000060
+LABETTE,Elm Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,000060
+LABETTE,Elm Grove Township,United States Senate,,Republican,"Moran, Jerry",308,000060
+LABETTE,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000070
+LABETTE,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000070
+LABETTE,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+LABETTE,Fairview Township,United States Senate,,Republican,"Moran, Jerry",81,000070
+LABETTE,Hackberry Township,United States Senate,,write - in,"Smith, DJ",0,000080
+LABETTE,Hackberry Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000080
+LABETTE,Hackberry Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+LABETTE,Hackberry Township,United States Senate,,Republican,"Moran, Jerry",128,000080
+LABETTE,Howard Township,United States Senate,,write - in,"Smith, DJ",0,000090
+LABETTE,Howard Township,United States Senate,,Democratic,"Wiesner, Patrick",33,000090
+LABETTE,Howard Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000090
+LABETTE,Howard Township,United States Senate,,Republican,"Moran, Jerry",127,000090
+LABETTE,Labette Township,United States Senate,,write - in,"Smith, DJ",0,000100
+LABETTE,Labette Township,United States Senate,,Democratic,"Wiesner, Patrick",34,000100
+LABETTE,Labette Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000100
+LABETTE,Labette Township,United States Senate,,Republican,"Moran, Jerry",155,000100
+LABETTE,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000110
+LABETTE,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000110
+LABETTE,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000110
+LABETTE,Liberty Township,United States Senate,,Republican,"Moran, Jerry",138,000110
+LABETTE,Montana Township,United States Senate,,write - in,"Smith, DJ",0,000120
+LABETTE,Montana Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000120
+LABETTE,Montana Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000120
+LABETTE,Montana Township,United States Senate,,Republican,"Moran, Jerry",64,000120
+LABETTE,Mound Valley Township,United States Senate,,write - in,"Smith, DJ",0,000130
+LABETTE,Mound Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",56,000130
+LABETTE,Mound Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",30,000130
+LABETTE,Mound Valley Township,United States Senate,,Republican,"Moran, Jerry",256,000130
+LABETTE,Mount Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,000140
+LABETTE,Mount Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",128,000140
+LABETTE,Mount Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",32,000140
+LABETTE,Mount Pleasant Township,United States Senate,,Republican,"Moran, Jerry",416,000140
+LABETTE,Neosho Township,United States Senate,,write - in,"Smith, DJ",0,000150
+LABETTE,Neosho Township,United States Senate,,Democratic,"Wiesner, Patrick",34,000150
+LABETTE,Neosho Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000150
+LABETTE,Neosho Township,United States Senate,,Republican,"Moran, Jerry",44,000150
+LABETTE,North Township,United States Senate,,write - in,"Smith, DJ",0,00016A
+LABETTE,North Township,United States Senate,,Democratic,"Wiesner, Patrick",85,00016A
+LABETTE,North Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,00016A
+LABETTE,North Township,United States Senate,,Republican,"Moran, Jerry",210,00016A
+LABETTE,North Township Enclave,United States Senate,,write - in,"Smith, DJ",0,00016B
+LABETTE,North Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00016B
+LABETTE,North Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016B
+LABETTE,North Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,00016B
+LABETTE,Oswego City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000180
+LABETTE,Oswego City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",58,000180
+LABETTE,Oswego City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,000180
+LABETTE,Oswego City Ward 1,United States Senate,,Republican,"Moran, Jerry",171,000180
+LABETTE,Oswego City Ward 2,United States Senate,,write - in,"Smith, DJ",0,00019A
+LABETTE,Oswego City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",52,00019A
+LABETTE,Oswego City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,00019A
+LABETTE,Oswego City Ward 2,United States Senate,,Republican,"Moran, Jerry",160,00019A
+LABETTE,Oswego City Ward 3,United States Senate,,write - in,"Smith, DJ",0,000200
+LABETTE,Oswego City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",39,000200
+LABETTE,Oswego City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",18,000200
+LABETTE,Oswego City Ward 3,United States Senate,,Republican,"Moran, Jerry",126,000200
+LABETTE,Oswego Township,United States Senate,,write - in,"Smith, DJ",0,000210
+LABETTE,Oswego Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000210
+LABETTE,Oswego Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000210
+LABETTE,Oswego Township,United States Senate,,Republican,"Moran, Jerry",101,000210
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",107,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",13,000220
+LABETTE,Parsons Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",204,000220
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",59,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",12,000230
+LABETTE,Parsons Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",84,000230
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",61,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",7,00024A
+LABETTE,Parsons Ward 1 Precinct 3,United States Senate,,Republican,"Moran, Jerry",53,00024A
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00024B
+LABETTE,Parsons Ward 1 Precinct 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00024B
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",40,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",6,000250
+LABETTE,Parsons Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",59,000250
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",122,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",23,000260
+LABETTE,Parsons Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",125,000260
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",123,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",23,00027A
+LABETTE,Parsons Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",155,00027A
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00027B
+LABETTE,Parsons Ward 2 Precinct 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00027B
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",45,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",10,000280
+LABETTE,Parsons Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",75,000280
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",149,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,00029A
+LABETTE,Parsons Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",188,00029A
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00029B
+LABETTE,Parsons Ward 3 Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00029B
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",106,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",20,000300
+LABETTE,Parsons Ward 3 Precinct 3,United States Senate,,Republican,"Moran, Jerry",158,000300
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",159,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",18,000310
+LABETTE,Parsons Ward 3 Precinct 4,United States Senate,,Republican,"Moran, Jerry",234,000310
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",61,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",8,000320
+LABETTE,Parsons Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",102,000320
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",92,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,000330
+LABETTE,Parsons Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",116,000330
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",76,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",18,000340
+LABETTE,Parsons Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",106,000340
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",91,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",14,000350
+LABETTE,Parsons Ward 4 Precinct 4,United States Senate,,Republican,"Moran, Jerry",185,000350
+LABETTE,Walton Township,United States Senate,,write - in,"Smith, DJ",0,000370
+LABETTE,Walton Township,United States Senate,,Democratic,"Wiesner, Patrick",107,000370
+LABETTE,Walton Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000370
+LABETTE,Walton Township,United States Senate,,Republican,"Moran, Jerry",253,000370
+LABETTE,Osage Township S14,United States Senate,,write - in,"Smith, DJ",0,120020
+LABETTE,Osage Township S14,United States Senate,,Democratic,"Wiesner, Patrick",0,120020
+LABETTE,Osage Township S14,United States Senate,,Libertarian,"Garrard, Robert D.",0,120020
+LABETTE,Osage Township S14,United States Senate,,Republican,"Moran, Jerry",0,120020
+LABETTE,Osage Township S15,United States Senate,,write - in,"Smith, DJ",0,120030
+LABETTE,Osage Township S15,United States Senate,,Democratic,"Wiesner, Patrick",71,120030
+LABETTE,Osage Township S15,United States Senate,,Libertarian,"Garrard, Robert D.",22,120030
+LABETTE,Osage Township S15,United States Senate,,Republican,"Moran, Jerry",222,120030
+LABETTE,Richland Township H1 A,United States Senate,,write - in,"Smith, DJ",0,12004A
+LABETTE,Richland Township H1 A,United States Senate,,Democratic,"Wiesner, Patrick",7,12004A
+LABETTE,Richland Township H1 A,United States Senate,,Libertarian,"Garrard, Robert D.",2,12004A
+LABETTE,Richland Township H1 A,United States Senate,,Republican,"Moran, Jerry",20,12004A
+LABETTE,Richland Township H1 B,United States Senate,,write - in,"Smith, DJ",0,12004B
+LABETTE,Richland Township H1 B,United States Senate,,Democratic,"Wiesner, Patrick",2,12004B
+LABETTE,Richland Township H1 B,United States Senate,,Libertarian,"Garrard, Robert D.",1,12004B
+LABETTE,Richland Township H1 B,United States Senate,,Republican,"Moran, Jerry",16,12004B
+LABETTE,Richland Township H1,United States Senate,,write - in,"Smith, DJ",0,120040
+LABETTE,Richland Township H1,United States Senate,,Democratic,"Wiesner, Patrick",0,120040
+LABETTE,Richland Township H1,United States Senate,,Libertarian,"Garrard, Robert D.",0,120040
+LABETTE,Richland Township H1,United States Senate,,Republican,"Moran, Jerry",0,120040
+LABETTE,Richland Township H7,United States Senate,,write - in,"Smith, DJ",0,120050
+LABETTE,Richland Township H7,United States Senate,,Democratic,"Wiesner, Patrick",22,120050
+LABETTE,Richland Township H7,United States Senate,,Libertarian,"Garrard, Robert D.",5,120050
+LABETTE,Richland Township H7,United States Senate,,Republican,"Moran, Jerry",53,120050
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+LABETTE,Oswego City Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__lane__precinct.csv
+++ b/2016/20161108__ks__general__lane__precinct.csv
@@ -1,141 +1,361 @@
-county,precinct,office,district,party,candidate,votes
-Lane,Alamota Twp,President,,DEM,Hillary Clinton,3
-Lane,Alamota Twp,President,,REP,Donald J Trump,41
-Lane,Alamota Twp,President,,LIB,Gary Johnson,2
-Lane,Alamota Twp,President,,IND,Jill Stein,0
-Lane,Cheyenne Twp,President,,DEM,Hillary Clinton,13
-Lane,Cheyenne Twp,President,,REP,Donald J Trump,101
-Lane,Cheyenne Twp,President,,LIB,Gary Johnson,5
-Lane,Cheyenne Twp,President,,IND,Jill Stein,1
-Lane,Dighton C 1,President,,DEM,Hillary Clinton,22
-Lane,Dighton C 1,President,,REP,Donald J Trump,158
-Lane,Dighton C 1,President,,LIB,Gary Johnson,5
-Lane,Dighton C 1,President,,IND,Jill Stein,2
-Lane,Dighton C 2,President,,DEM,Hillary Clinton,40
-Lane,Dighton C 2,President,,REP,Donald J Trump,199
-Lane,Dighton C 2,President,,LIB,Gary Johnson,12
-Lane,Dighton C 2,President,,IND,Jill Stein,10
-Lane,Dighton C 3,President,,DEM,Hillary Clinton,5
-Lane,Dighton C 3,President,,REP,Donald J Trump,76
-Lane,Dighton C 3,President,,LIB,Gary Johnson,2
-Lane,Dighton C 3,President,,IND,Jill Stein,0
-Lane,Dighton Twp 1,President,,DEM,Hillary Clinton,6
-Lane,Dighton Twp 1,President,,REP,Donald J Trump,37
-Lane,Dighton Twp 1,President,,LIB,Gary Johnson,1
-Lane,Dighton Twp 1,President,,IND,Jill Stein,1
-Lane,Dighton Twp2,President,,DEM,Hillary Clinton,8
-Lane,Dighton Twp2,President,,REP,Donald J Trump,46
-Lane,Dighton Twp2,President,,LIB,Gary Johnson,2
-Lane,Dighton Twp2,President,,IND,Jill Stein,0
-Lane,Dighton Twp 3,President,,DEM,Hillary Clinton,5
-Lane,Dighton Twp 3,President,,REP,Donald J Trump,23
-Lane,Dighton Twp 3,President,,LIB,Gary Johnson,3
-Lane,Dighton Twp 3,President,,IND,Jill Stein,0
-Lane,White Rock Twp,President,,DEM,Hillary Clinton,4
-Lane,White Rock Twp,President,,REP,Donald J Trump,7
-Lane,White Rock Twp,President,,LIB,Gary Johnson,0
-Lane,White Rock Twp,President,,IND,Jill Stein,0
-Lane,Wilson Twp,President,,DEM,Hillary Clinton,0
-Lane,Wilson Twp,President,,REP,Donald J Trump,30
-Lane,Wilson Twp,President,,LIB,Gary Johnson,1
-Lane,Wilson Twp,President,,IND,Jill Stein,0
-Lane,Alamota Twp,U.S. Senate,,DEM,Patrick Wiesner,7
-Lane,Alamota Twp,U.S. Senate,,LIB,Robert D. Garrard,2
-Lane,Alamota Twp,U.S. Senate,,REP,Jerry Moran,39
-Lane,Cheyenne Twp,U.S. Senate,,DEM,Patrick Wiesner,15
-Lane,Cheyenne Twp,U.S. Senate,,LIB,Robert D. Garrard,4
-Lane,Cheyenne Twp,U.S. Senate,,REP,Jerry Moran,100
-Lane,Dighton C 1,U.S. Senate,,DEM,Patrick Wiesner,18
-Lane,Dighton C 1,U.S. Senate,,LIB,Robert D. Garrard,11
-Lane,Dighton C 1,U.S. Senate,,REP,Jerry Moran,164
-Lane,Dighton C 2,U.S. Senate,,DEM,Patrick Wiesner,27
-Lane,Dighton C 2,U.S. Senate,,LIB,Robert D. Garrard,9
-Lane,Dighton C 2,U.S. Senate,,REP,Jerry Moran,221
-Lane,Dighton C 3,U.S. Senate,,DEM,Patrick Wiesner,4
-Lane,Dighton C 3,U.S. Senate,,LIB,Robert D. Garrard,4
-Lane,Dighton C 3,U.S. Senate,,REP,Jerry Moran,77
-Lane,Dighton Twp 1,U.S. Senate,,DEM,Patrick Wiesner,5
-Lane,Dighton Twp 1,U.S. Senate,,LIB,Robert D. Garrard,1
-Lane,Dighton Twp 1,U.S. Senate,,REP,Jerry Moran,41
-Lane,Dighton Twp2,U.S. Senate,,DEM,Patrick Wiesner,1
-Lane,Dighton Twp2,U.S. Senate,,LIB,Robert D. Garrard,2
-Lane,Dighton Twp2,U.S. Senate,,REP,Jerry Moran,53
-Lane,Dighton Twp 3,U.S. Senate,,DEM,Patrick Wiesner,1
-Lane,Dighton Twp 3,U.S. Senate,,LIB,Robert D. Garrard,4
-Lane,Dighton Twp 3,U.S. Senate,,REP,Jerry Moran,27
-Lane,White Rock Twp,U.S. Senate,,DEM,Patrick Wiesner,1
-Lane,White Rock Twp,U.S. Senate,,LIB,Robert D. Garrard,2
-Lane,White Rock Twp,U.S. Senate,,REP,Jerry Moran,9
-Lane,Wilson Twp,U.S. Senate,,DEM,Patrick Wiesner,0
-Lane,Wilson Twp,U.S. Senate,,LIB,Robert D. Garrard,0
-Lane,Wilson Twp,U.S. Senate,,REP,Jerry Moran,32
-Lane,Alamota Twp,U.S. House,1,LIB,Kerry Burt,1
-Lane,Alamota Twp,U.S. House,1,IND,Alan LaPolice,12
-Lane,Alamota Twp,U.S. House,1,REP,Roger Marshall,32
-Lane,Cheyenne Twp,U.S. House,1,LIB,Kerry Burt,9
-Lane,Cheyenne Twp,U.S. House,1,IND,Alan LaPolice,24
-Lane,Cheyenne Twp,U.S. House,1,REP,Roger Marshall,86
-Lane,Dighton C 1,U.S. House,1,LIB,Kerry Burt,8
-Lane,Dighton C 1,U.S. House,1,IND,Alan LaPolice,42
-Lane,Dighton C 1,U.S. House,1,REP,Roger Marshall,144
-Lane,Dighton C 2,U.S. House,1,LIB,Kerry Burt,7
-Lane,Dighton C 2,U.S. House,1,IND,Alan LaPolice,65
-Lane,Dighton C 2,U.S. House,1,REP,Roger Marshall,182
-Lane,Dighton C 3,U.S. House,1,LIB,Kerry Burt,1
-Lane,Dighton C 3,U.S. House,1,IND,Alan LaPolice,8
-Lane,Dighton C 3,U.S. House,1,REP,Roger Marshall,77
-Lane,Dighton Twp 1,U.S. House,1,LIB,Kerry Burt,2
-Lane,Dighton Twp 1,U.S. House,1,IND,Alan LaPolice,12
-Lane,Dighton Twp 1,U.S. House,1,REP,Roger Marshall,32
-Lane,Dighton Twp2,U.S. House,1,LIB,Kerry Burt,1
-Lane,Dighton Twp2,U.S. House,1,IND,Alan LaPolice,12
-Lane,Dighton Twp2,U.S. House,1,REP,Roger Marshall,41
-Lane,Dighton Twp 3,U.S. House,1,LIB,Kerry Burt,1
-Lane,Dighton Twp 3,U.S. House,1,IND,Alan LaPolice,2
-Lane,Dighton Twp 3,U.S. House,1,REP,Roger Marshall,29
-Lane,White Rock Twp,U.S. House,1,LIB,Kerry Burt,0
-Lane,White Rock Twp,U.S. House,1,IND,Alan LaPolice,1
-Lane,White Rock Twp,U.S. House,1,REP,Roger Marshall,10
-Lane,Wilson Twp,U.S. House,1,LIB,Kerry Burt,0
-Lane,Wilson Twp,U.S. House,1,IND,Alan LaPolice,7
-Lane,Wilson Twp,U.S. House,1,REP,Roger Marshall,24
-Lane,Alamota Twp,State Senate,33,DEM,Matt Bristow,7
-Lane,Alamota Twp,State Senate,33,REP,Mary Jo Taylor,37
-Lane,Cheyenne Twp,State Senate,33,DEM,Matt Bristow,21
-Lane,Cheyenne Twp,State Senate,33,REP,Mary Jo Taylor,87
-Lane,Dighton C 1,State Senate,33,DEM,Matt Bristow,31
-Lane,Dighton C 1,State Senate,33,REP,Mary Jo Taylor,155
-Lane,Dighton C 2,State Senate,33,DEM,Matt Bristow,45
-Lane,Dighton C 2,State Senate,33,REP,Mary Jo Taylor,205
-Lane,Dighton C 3,State Senate,33,DEM,Matt Bristow,4
-Lane,Dighton C 3,State Senate,33,REP,Mary Jo Taylor,75
-Lane,Dighton Twp 1,State Senate,33,DEM,Matt Bristow,10
-Lane,Dighton Twp 1,State Senate,33,REP,Mary Jo Taylor,35
-Lane,Dighton Twp2,State Senate,33,DEM,Matt Bristow,3
-Lane,Dighton Twp2,State Senate,33,REP,Mary Jo Taylor,53
-Lane,Dighton Twp 3,State Senate,33,DEM,Matt Bristow,4
-Lane,Dighton Twp 3,State Senate,33,REP,Mary Jo Taylor,27
-Lane,White Rock Twp,State Senate,33,DEM,Matt Bristow,0
-Lane,White Rock Twp,State Senate,33,REP,Mary Jo Taylor,12
-Lane,Wilson Twp,State Senate,33,DEM,Matt Bristow,2
-Lane,Wilson Twp,State Senate,33,REP,Mary Jo Taylor,25
-Lane,Alamota Twp,State House,118,REP,Don Hineman,40
-Lane,Alamota Twp,State House,118,,Cameron Shay,1
-Lane,Cheyenne Twp,State House,118,REP,Don Hineman,101
-Lane,Cheyenne Twp,State House,118,,Cameron Shay,8
-Lane,Dighton C 1,State House,118,REP,Don Hineman,181
-Lane,Dighton C 1,State House,118,,Cameron Shay,2
-Lane,Dighton C 2,State House,118,REP,Don Hineman,247
-Lane,Dighton C 2,State House,118,,Cameron Shay,0
-Lane,Dighton C 3,State House,118,REP,Don Hineman,78
-Lane,Dighton C 3,State House,118,,Cameron Shay,0
-Lane,Dighton Twp 1,State House,118,REP,Don Hineman,41
-Lane,Dighton Twp 1,State House,118,,Cameron Shay,0
-Lane,Dighton Twp2,State House,118,REP,Don Hineman,54
-Lane,Dighton Twp2,State House,118,,Cameron Shay,1
-Lane,Dighton Twp 3,State House,118,REP,Don Hineman,30
-Lane,Dighton Twp 3,State House,118,,Cameron Shay,0
-Lane,White Rock Twp,State House,118,REP,Don Hineman,11
-Lane,White Rock Twp,State House,118,,Cameron Shay,0
-Lane,Wilson Twp,State House,118,REP,Don Hineman,30
-Lane,Wilson Twp,State House,118,,Cameron Shay,0
+county,precinct,office,district,party,candidate,votes,vtd
+LANE,Alamota Township,Kansas House of Representatives,118,Republican,"Hineman, Don",40,000010
+LANE,Dighton Township 2,Kansas House of Representatives,118,Republican,"Hineman, Don",54,000020
+LANE,Dighton Township 3,Kansas House of Representatives,118,Republican,"Hineman, Don",30,000030
+LANE,Cheyenne Township,Kansas House of Representatives,118,Republican,"Hineman, Don",101,000040
+LANE,Dighton Township 1,Kansas House of Representatives,118,Republican,"Hineman, Don",41,000050
+LANE,Dighton City Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",181,000060
+LANE,Dighton City Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",247,000070
+LANE,Dighton City Precinct 3,Kansas House of Representatives,118,Republican,"Hineman, Don",78,000080
+LANE,White Rock Township,Kansas House of Representatives,118,Republican,"Hineman, Don",11,000100
+LANE,Wilson Township,Kansas House of Representatives,118,Republican,"Hineman, Don",30,000110
+LANE,Alamota Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000010
+LANE,Alamota Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",37,000010
+LANE,Dighton Township 2,Kansas Senate,33,Democratic,"Bristow, Matt",3,000020
+LANE,Dighton Township 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",53,000020
+LANE,Dighton Township 3,Kansas Senate,33,Democratic,"Bristow, Matt",4,000030
+LANE,Dighton Township 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",27,000030
+LANE,Cheyenne Township,Kansas Senate,33,Democratic,"Bristow, Matt",21,000040
+LANE,Cheyenne Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",87,000040
+LANE,Dighton Township 1,Kansas Senate,33,Democratic,"Bristow, Matt",10,000050
+LANE,Dighton Township 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",35,000050
+LANE,Dighton City Precinct 1,Kansas Senate,33,Democratic,"Bristow, Matt",31,000060
+LANE,Dighton City Precinct 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",155,000060
+LANE,Dighton City Precinct 2,Kansas Senate,33,Democratic,"Bristow, Matt",45,000070
+LANE,Dighton City Precinct 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",205,000070
+LANE,Dighton City Precinct 3,Kansas Senate,33,Democratic,"Bristow, Matt",4,000080
+LANE,Dighton City Precinct 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",75,000080
+LANE,White Rock Township,Kansas Senate,33,Democratic,"Bristow, Matt",0,000100
+LANE,White Rock Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",12,000100
+LANE,Wilson Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000110
+LANE,Wilson Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",25,000110
+LANE,Alamota Township,President / Vice President,,independent,"Stein, Jill",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+LANE,Alamota Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+LANE,Alamota Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000010
+LANE,Alamota Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+LANE,Alamota Township,President / Vice President,,Republican,"Trump, Donald J.",41,000010
+LANE,Dighton Township 2,President / Vice President,,independent,"Stein, Jill",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"McMullin, Evan",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+LANE,Dighton Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+LANE,Dighton Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000020
+LANE,Dighton Township 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+LANE,Dighton Township 2,President / Vice President,,Republican,"Trump, Donald J.",46,000020
+LANE,Dighton Township 3,President / Vice President,,independent,"Stein, Jill",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"McMullin, Evan",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LANE,Dighton Township 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LANE,Dighton Township 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+LANE,Dighton Township 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+LANE,Dighton Township 3,President / Vice President,,Republican,"Trump, Donald J.",23,000030
+LANE,Cheyenne Township,President / Vice President,,independent,"Stein, Jill",1,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LANE,Cheyenne Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LANE,Cheyenne Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000040
+LANE,Cheyenne Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+LANE,Cheyenne Township,President / Vice President,,Republican,"Trump, Donald J.",101,000040
+LANE,Dighton Township 1,President / Vice President,,independent,"Stein, Jill",1,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+LANE,Dighton Township 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+LANE,Dighton Township 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000050
+LANE,Dighton Township 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+LANE,Dighton Township 1,President / Vice President,,Republican,"Trump, Donald J.",37,000050
+LANE,Dighton City Precinct 1,President / Vice President,,independent,"Stein, Jill",2,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+LANE,Dighton City Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",158,000060
+LANE,Dighton City Precinct 2,President / Vice President,,independent,"Stein, Jill",10,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000070
+LANE,Dighton City Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",199,000070
+LANE,Dighton City Precinct 3,President / Vice President,,independent,"Stein, Jill",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+LANE,Dighton City Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",76,000080
+LANE,White Rock Township,President / Vice President,,independent,"Stein, Jill",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LANE,White Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LANE,White Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000100
+LANE,White Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+LANE,White Rock Township,President / Vice President,,Republican,"Trump, Donald J.",7,000100
+LANE,Wilson Township,President / Vice President,,independent,"Stein, Jill",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LANE,Wilson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LANE,Wilson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000110
+LANE,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+LANE,Wilson Township,President / Vice President,,Republican,"Trump, Donald J.",30,000110
+LANE,Alamota Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000010
+LANE,Alamota Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+LANE,Alamota Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+LANE,Alamota Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000010
+LANE,Dighton Township 2,United States House of Representatives,1,independent,"LaPolice, Alan",12,000020
+LANE,Dighton Township 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+LANE,Dighton Township 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000020
+LANE,Dighton Township 2,United States House of Representatives,1,Republican,"Marshall, Roger",41,000020
+LANE,Dighton Township 3,United States House of Representatives,1,independent,"LaPolice, Alan",2,000030
+LANE,Dighton Township 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+LANE,Dighton Township 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+LANE,Dighton Township 3,United States House of Representatives,1,Republican,"Marshall, Roger",29,000030
+LANE,Cheyenne Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000040
+LANE,Cheyenne Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+LANE,Cheyenne Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000040
+LANE,Cheyenne Township,United States House of Representatives,1,Republican,"Marshall, Roger",86,000040
+LANE,Dighton Township 1,United States House of Representatives,1,independent,"LaPolice, Alan",12,000050
+LANE,Dighton Township 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+LANE,Dighton Township 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000050
+LANE,Dighton Township 1,United States House of Representatives,1,Republican,"Marshall, Roger",32,000050
+LANE,Dighton City Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",42,000060
+LANE,Dighton City Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+LANE,Dighton City Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000060
+LANE,Dighton City Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",144,000060
+LANE,Dighton City Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",65,000070
+LANE,Dighton City Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+LANE,Dighton City Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000070
+LANE,Dighton City Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",182,000070
+LANE,Dighton City Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",8,000080
+LANE,Dighton City Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+LANE,Dighton City Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+LANE,Dighton City Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",77,000080
+LANE,White Rock Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000100
+LANE,White Rock Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+LANE,White Rock Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+LANE,White Rock Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000100
+LANE,Wilson Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000110
+LANE,Wilson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+LANE,Wilson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+LANE,Wilson Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000110
+LANE,Alamota Township,United States Senate,,write - in,"Smith, DJ",0,000010
+LANE,Alamota Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000010
+LANE,Alamota Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+LANE,Alamota Township,United States Senate,,Republican,"Moran, Jerry",39,000010
+LANE,Dighton Township 2,United States Senate,,write - in,"Smith, DJ",0,000020
+LANE,Dighton Township 2,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+LANE,Dighton Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+LANE,Dighton Township 2,United States Senate,,Republican,"Moran, Jerry",53,000020
+LANE,Dighton Township 3,United States Senate,,write - in,"Smith, DJ",0,000030
+LANE,Dighton Township 3,United States Senate,,Democratic,"Wiesner, Patrick",1,000030
+LANE,Dighton Township 3,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+LANE,Dighton Township 3,United States Senate,,Republican,"Moran, Jerry",27,000030
+LANE,Cheyenne Township,United States Senate,,write - in,"Smith, DJ",0,000040
+LANE,Cheyenne Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000040
+LANE,Cheyenne Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000040
+LANE,Cheyenne Township,United States Senate,,Republican,"Moran, Jerry",100,000040
+LANE,Dighton Township 1,United States Senate,,write - in,"Smith, DJ",0,000050
+LANE,Dighton Township 1,United States Senate,,Democratic,"Wiesner, Patrick",5,000050
+LANE,Dighton Township 1,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+LANE,Dighton Township 1,United States Senate,,Republican,"Moran, Jerry",41,000050
+LANE,Dighton City Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000060
+LANE,Dighton City Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",18,000060
+LANE,Dighton City Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000060
+LANE,Dighton City Precinct 1,United States Senate,,Republican,"Moran, Jerry",164,000060
+LANE,Dighton City Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000070
+LANE,Dighton City Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",27,000070
+LANE,Dighton City Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",9,000070
+LANE,Dighton City Precinct 2,United States Senate,,Republican,"Moran, Jerry",221,000070
+LANE,Dighton City Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000080
+LANE,Dighton City Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+LANE,Dighton City Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+LANE,Dighton City Precinct 3,United States Senate,,Republican,"Moran, Jerry",77,000080
+LANE,White Rock Township,United States Senate,,write - in,"Smith, DJ",0,000100
+LANE,White Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000100
+LANE,White Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000100
+LANE,White Rock Township,United States Senate,,Republican,"Moran, Jerry",9,000100
+LANE,Wilson Township,United States Senate,,write - in,"Smith, DJ",0,000110
+LANE,Wilson Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000110
+LANE,Wilson Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+LANE,Wilson Township,United States Senate,,Republican,"Moran, Jerry",32,000110

--- a/2016/20161108__ks__general__leavenworth__precinct.csv
+++ b/2016/20161108__ks__general__leavenworth__precinct.csv
@@ -1,831 +1,1813 @@
-county,precinct,office,district,candidate,party,votes
-Leavenworth,W1P1,President,,Hillary Clinton,D,187
-Leavenworth,W1P1,President,,Gary Johnson,LBT,13
-Leavenworth,W1P1,President,,Jill Stein,IND,15
-Leavenworth,W1P1,President,,Donald Trump,R,110
-Leavenworth,W1P1,President,,write-in,,4
-Leavenworth,W1P1,U.S. Senate,,Robert Garrard,LBT,19
-Leavenworth,W1P1,U.S. Senate,,Jerry Moran,R,120
-Leavenworth,W1P1,U.S. Senate,,Patrick Wiesner,D,185
-Leavenworth,W1P1,U.S. Senate,,write-in,,1
-Leavenworth,W1P1,U.S. House 2,CD2,James Bales,LBT,28
-Leavenworth,W1P1,U.S. House 2,CD2,Lynn Jenkins,R,134
-Leavenworth,W1P1,U.S. House 2,CD2,Britani Potter,D,161
-Leavenworth,W1P1,State Senate,SD05,Steve Fitzgerald,R,136
-Leavenworth,W1P1,State Senate,SD05,Bill Hutton,D,184
-Leavenworth,W1P1,State Senate ,SD05,write-in,,1
-Leavenworth,W1P1,State House ,HD041,Tony Barton,R,119
-Leavenworth,W1P1,State House ,HD041,Jeff Pittman,D,204
-Leavenworth,W1P1,State House ,HD041,write-in,,3
-Leavenworth,W1P1,Voters,,Voter Registration,,0
-Leavenworth,W1P1,Voters,,Total Voted,,332
-Leavenworth,W2P1,President,,Hillary Clinton,D,118
-Leavenworth,W2P1,President,,Gary Johnson,LBT,13
-Leavenworth,W2P1,President,,Jill Stein,IND,7
-Leavenworth,W2P1,President,,Donald Trump,R,160
-Leavenworth,W2P1,President,,write-in,,7
-Leavenworth,W2P1,U.S. Senate,,Robert Garrard,LBT,24
-Leavenworth,W2P1,U.S. Senate,,Jerry Moran,R,161
-Leavenworth,W2P1,U.S. Senate,,Patrick Wiesner,D,115
-Leavenworth,W2P1,U.S. House 2,CD2,James Bales,LBT,30
-Leavenworth,W2P1,U.S. House 2,CD2,Lynn Jenkins,R,162
-Leavenworth,W2P1,U.S. House 2,CD2,Britani Potter,D,107
-Leavenworth,W2P1,State Senate,SD05,Steve Fitzgerald,R,160
-Leavenworth,W2P1,State Senate,SD05,Bill Hutton,D,139
-Leavenworth,W2P1,State House ,HD041,Tony Barton,R,129
-Leavenworth,W2P1,State House ,HD041,Jeff Pittman,D,170
-Leavenworth,W2P1,Voters,,Voter Registration,,637
-Leavenworth,W2P1,Voters,,Total Voted,,307
-Leavenworth,W2P2,President,,Hillary Clinton,D,123
-Leavenworth,W2P2,President,,Gary Johnson,LBT,22
-Leavenworth,W2P2,President,,Jill Stein,IND,11
-Leavenworth,W2P2,President,,Donald Trump,R,136
-Leavenworth,W2P2,President,,write-in,,6
-Leavenworth,W2P2,U.S. Senate,,Robert Garrard,LBT,23
-Leavenworth,W2P2,U.S. Senate,,Jerry Moran,R,147
-Leavenworth,W2P2,U.S. Senate,,Patrick Wiesner,D,123
-Leavenworth,W2P2,U.S. House 2,CD2,James Bales,LBT,23
-Leavenworth,W2P2,U.S. House 2,CD2,Lynn Jenkins,R,165
-Leavenworth,W2P2,U.S. House 2,CD2,Britani Potter,D,106
-Leavenworth,W2P2,State Senate ,SD05,Steve Fitzgerald,R,143
-Leavenworth,W2P2,State Senate ,SD05,Bill Hutton,D,149
-Leavenworth,W2P2,State House ,HD041,Tony Barton,R,123
-Leavenworth,W2P2,State House ,HD041,Jeff Pittman,D,172
-Leavenworth,W2P2,Voters,,Voter Registration,,610
-Leavenworth,W2P2,Voters,,Total Voted,,301
-Leavenworth,W2P3,President,,Hillary Clinton,D,215
-Leavenworth,W2P3,President,,Gary Johnson,LBT,21
-Leavenworth,W2P3,President,,Jill Stein,IND,10
-Leavenworth,W2P3,President,,Donald Trump,R,204
-Leavenworth,W2P3,President,,write-in,,8
-Leavenworth,W2P3,U.S. Senate,,Robert Garrard,LBT,33
-Leavenworth,W2P3,U.S. Senate,,Jerry Moran,R,207
-Leavenworth,W2P3,U.S. Senate,,Patrick Wiesner,D,208
-Leavenworth,W2P3,U.S. House 2,CD2,James Bales,LBT,30
-Leavenworth,W2P3,U.S. House 2,CD2,Lynn Jenkins,R,230
-Leavenworth,W2P3,U.S. House 2,CD2,Britani Potter,D,181
-Leavenworth,W2P3,State Senate,SD05,Steve Fitzgerald,R,232
-Leavenworth,W2P3,State Senate,SD05,Bill Hutton,D,213
-Leavenworth,W2P3,State Senate,SD05,write-in,,1
-Leavenworth,W2P3,State House ,,JOHN BRADFORD,R,189
-Leavenworth,W2P3,State House ,,DEBBIE DEERE,D,254
-Leavenworth,W2P3,Voters,,Voter Registration,,961
-Leavenworth,W2P3,Voters,,Total Voted,,459
-Leavenworth,W3P1,President,,Hillary Clinton,D,187
-Leavenworth,W3P1,President,,Gary Johnson,LBT,42
-Leavenworth,W3P1,President,,Jill Stein,IND,14
-Leavenworth,W3P1,President,,Donald Trump,R,242
-Leavenworth,W3P1,President,,write-in,,6
-Leavenworth,W3P1,U.S. Senate,,Robert Garrard,LBT,60
-Leavenworth,W3P1,U.S. Senate,,Jerry Moran,R,233
-Leavenworth,W3P1,U.S. Senate,,Patrick Wiesner,D,194
-Leavenworth,W3P1,U.S. House 2,CD2,James Bales,LBT,58
-Leavenworth,W3P1,U.S. House 2,CD2,Lynn Jenkins,R,262
-Leavenworth,W3P1,U.S. House 2,CD2,Britani Potter,D,165
-Leavenworth,W3P1,U.S. House 2,CD2,write-in,,1
-Leavenworth,W3P1,State Senate,SD05,Steve Fitzgerald,R,259
-Leavenworth,W3P1,State Senate,SD05,Bill Hutton,D,220
-Leavenworth,W3P1,State Senate,SD05,write-in,,4
-Leavenworth,W3P1,State House ,HD041,Tony Barton,R,198
-Leavenworth,W3P1,State House ,HD041,Jeff Pittman,D,282
-Leavenworth,W3P1,State House,HD041,write-in,,3
-Leavenworth,W3P1,Voters,,Voter Registration,,1013
-Leavenworth,W3P1,Voters,,Total Voted,,497
-Leavenworth,W4P1,President,,Hillary Clinton,D,119
-Leavenworth,W4P1,President,,Gary Johnson,LBT,16
-Leavenworth,W4P1,President,,Jill Stein,IND,10
-Leavenworth,W4P1,President,,Donald Trump,R,114
-Leavenworth,W4P1,President,,write-in,,3
-Leavenworth,W4P1,U.S. Senate,,Robert Garrard,LBT,22
-Leavenworth,W4P1,U.S. Senate,,Jerry Moran,R,108
-Leavenworth,W4P1,U.S. Senate,,Patrick Wiesner,D,127
-Leavenworth,W4P1,U.S. Senate,,write-in,,3
-Leavenworth,W4P1,U.S. House 2,CD2,James Bales,LBT,23
-Leavenworth,W4P1,U.S. House 2,CD2,Lynn Jenkins,R,128
-Leavenworth,W4P1,U.S. House 2,CD2,Britani Potter,D,108
-Leavenworth,W4P1,State Senate,SD05,Steve Fitzgerald,R,143
-Leavenworth,W4P1,State Senate,SD05,Bill Hutton,D,115
-Leavenworth,W4P1,State House ,HD041,Tony Barton,R,95
-Leavenworth,W4P1,State House ,HD041,Jeff Pittman,D,165
-Leavenworth,W4P1,State House,HD041,write-in,,1
-Leavenworth,W4P1,Voters,,Voter Registration,,692
-Leavenworth,W4P1,Voters,,Total Voted,,265
-Leavenworth,W5P1,President,,Hillary Clinton,D,170
-Leavenworth,W5P1,President,,Gary Johnson,LBT,24
-Leavenworth,W5P1,President,,Jill Stein,IND,14
-Leavenworth,W5P1,President,,Donald Trump,R,172
-Leavenworth,W5P1,President,,write-in,,7
-Leavenworth,W5P1,U.S. Senate,,Robert Garrard,LBT,26
-Leavenworth,W5P1,U.S. Senate,,Jerry Moran,R,181
-Leavenworth,W5P1,U.S. Senate,,Patrick Wiesner,D,174
-Leavenworth,W5P1,U.S. House 2,CD2,James Bales,LBT,41
-Leavenworth,W5P1,U.S. House 2,CD2,Lynn Jenkins,R,186
-Leavenworth,W5P1,U.S. House 2,CD2,Britani Potter,D,156
-Leavenworth,W5P1,State Senate,SD05,Steve Fitzgerald,R,196
-Leavenworth,W5P1,State Senate,SD05,Bill Hutton,D,183
-Leavenworth,W5P1,State Senate,SD05,write-in,,2
-Leavenworth,W5P1,State House ,HD041,Tony Barton,R,149
-Leavenworth,W5P1,State House ,HD041,Jeff Pittman,D,233
-Leavenworth,W5P1,State House,HD041,write-in,,1
-Leavenworth,W5P1,Voters,,Voter Registration,,841
-Leavenworth,W5P1,Voters,,Total Voted,,389
-Leavenworth,W5P2,President,,Hillary Clinton,D,123
-Leavenworth,W5P2,President,,Gary Johnson,LBT,31
-Leavenworth,W5P2,President,,Jill Stein,IND,11
-Leavenworth,W5P2,President,,Donald Trump,R,172
-Leavenworth,W5P2,President,,write-in,,2
-Leavenworth,W5P2,U.S. Senate,,Robert Garrard,LBT,35
-Leavenworth,W5P2,U.S. Senate,,Jerry Moran,R,175
-Leavenworth,W5P2,U.S. Senate,,Patrick Wiesner,D,128
-Leavenworth,W5P2,U.S. House 2,CD2,James Bales,LBT,42
-Leavenworth,W5P2,U.S. House 2,CD2,Lynn Jenkins,R,183
-Leavenworth,W5P2,U.S. House 2,CD2,Britani Potter,D,113
-Leavenworth,W5P2,U.S. House 2,CD2,write-in,,1
-Leavenworth,W5P2,State Senate,SD05,Steve Fitzgerald,R,180
-Leavenworth,W5P2,State Senate,SD05,Bill Hutton,D,157
-Leavenworth,W5P2,State House ,HD041,Tony Barton,R,148
-Leavenworth,W5P2,State House ,HD041,Jeff Pittman,D,188
-Leavenworth,W5P2,Voters,,Voter Registration,,702
-Leavenworth,W5P2,Voters,,Total Voted,,342
-Leavenworth,W5P3,President,,Hillary Clinton,D,230
-Leavenworth,W5P3,President,,Gary Johnson,LBT,47
-Leavenworth,W5P3,President,,Jill Stein,IND,16
-Leavenworth,W5P3,President,,Donald Trump,R,370
-Leavenworth,W5P3,President,,write-in,,8
-Leavenworth,W5P3,U.S. Senate,,Robert Garrard,LBT,56
-Leavenworth,W5P3,U.S. Senate,,Jerry Moran,R,376
-Leavenworth,W5P3,U.S. Senate,,Patrick Wiesner,D,228
-Leavenworth,W5P3,U.S. House 2,CD2,James Bales,LBT,53
-Leavenworth,W5P3,U.S. House 2,CD2,Lynn Jenkins,R,407
-Leavenworth,W5P3,U.S. House 2,CD2,Britani Potter,D,199
-Leavenworth,W5P3,State Senate,SD05,Steve Fitzgerald,R,389
-Leavenworth,W5P3,State Senate,SD05,Bill Hutton,D,270
-Leavenworth,W5P3,State House ,HD041,Tony Barton,R,283
-Leavenworth,W5P3,State House ,HD041,Jeff Pittman,D,377
-Leavenworth,W5P3,State House,HD041,write-in,,1
-Leavenworth,W5P3,Voters,,Voter Registration,,1205
-Leavenworth,W5P3,Voters,,Total Voted,,675
-Leavenworth,W5P4,President,,Hillary Clinton,D,125
-Leavenworth,W5P4,President,,Gary Johnson,LBT,31
-Leavenworth,W5P4,President,,Jill Stein,IND,10
-Leavenworth,W5P4,President,,Donald Trump,R,242
-Leavenworth,W5P4,President,,write-in,,11
-Leavenworth,W5P4,U.S. Senate,,Robert Garrard,LBT,25
-Leavenworth,W5P4,U.S. Senate,,Jerry Moran,R,255
-Leavenworth,W5P4,U.S. Senate,,Patrick Wiesner,D,132
-Leavenworth,W5P4,U.S. House 2,CD2,James Bales,LBT,29
-Leavenworth,W5P4,U.S. House 2,CD2,Lynn Jenkins,R,268
-Leavenworth,W5P4,U.S. House 2,CD2,Britani Potter,D,113
-Leavenworth,W5P4,U.S. House 2,CD2,write-in,,1
-Leavenworth,W5P4,State Senate,SD05,Steve Fitzgerald,R,260
-Leavenworth,W5P4,State Senate,SD05,Bill Hutton,D,152
-Leavenworth,W5P4,State House ,HD041,Tony Barton,R,216
-Leavenworth,W5P4,State House ,HD041,Jeff Pittman,D,197
-Leavenworth,W5P4,State House,HD041,write-in,,1
-Leavenworth,W5P4,Voters,,Voter Registration,,728
-Leavenworth,W5P4,Voters,,Total Voted,,422
-Leavenworth,W6P1,President,,Hillary Clinton,D,218
-Leavenworth,W6P1,President,,Gary Johnson,LBT,31
-Leavenworth,W6P1,President,,Jill Stein,IND,16
-Leavenworth,W6P1,President,,Donald Trump,R,267
-Leavenworth,W6P1,President,,write-in,,10
-Leavenworth,W6P1,U.S. Senate,,Robert Garrard,LBT,39
-Leavenworth,W6P1,U.S. Senate,,Jerry Moran,R,293
-Leavenworth,W6P1,U.S. Senate,,Patrick Wiesner,D,201
-Leavenworth,W6P1,U.S. Senate,,write-in,,2
-Leavenworth,W6P1,U.S. House 2,CD2,James Bales,LBT,44
-Leavenworth,W6P1,U.S. House 2,CD2,Lynn Jenkins,R,299
-Leavenworth,W6P1,U.S. House 2,CD2,Britani Potter,D,193
-Leavenworth,W6P1,U.S. House 2,CD2,write-in,,1
-Leavenworth,W6P1,State Senate,SD05,Steve Fitzgerald,R,303
-Leavenworth,W6P1,State Senate,SD05,Bill Hutton,D,228
-Leavenworth,W6P1,State Senate,SD05,write-in,,2
-Leavenworth,W6P1,State House ,HD041,Tony Barton,R,227
-Leavenworth,W6P1,State House ,HD041,Jeff Pittman,D,308
-Leavenworth,W6P1,State House,HD041,write-in,,2
-Leavenworth,W6P1,Voters,,Voter Registration,,977
-Leavenworth,W6P1,Voters,,Total Voted,,546
-Leavenworth,W6P2,President,,Hillary Clinton,D,213
-Leavenworth,W6P2,President,,Gary Johnson,LBT,23
-Leavenworth,W6P2,President,,Jill Stein,IND,12
-Leavenworth,W6P2,President,,Donald Trump,R,178
-Leavenworth,W6P2,President,,write-in,,11
-Leavenworth,W6P2,U.S. Senate,,Robert Garrard,LBT,25
-Leavenworth,W6P2,U.S. Senate,,Jerry Moran,R,200
-Leavenworth,W6P2,U.S. Senate,,Patrick Wiesner,D,207
-Leavenworth,W6P2,U.S. House 2,CD2,James Bales,LBT,31
-Leavenworth,W6P2,U.S. House 2,CD2,Lynn Jenkins,R,216
-Leavenworth,W6P2,U.S. House 2,CD2,Britani Potter,D,180
-Leavenworth,W6P2,State Senate,SD05,Steve Fitzgerald,R,220
-Leavenworth,W6P2,State Senate,SD05,Bill Hutton,D,210
-Leavenworth,W6P2,State House ,HD041,Tony Barton,R,165
-Leavenworth,W6P2,State House ,HD041,Jeff Pittman,D,260
-Leavenworth,W6P2,Voters,,Voter Registration,,841
-Leavenworth,W6P2,Voters,,Total Voted,,438
-Leavenworth,W6P3,President,,Hillary Clinton,D,179
-Leavenworth,W6P3,President,,Gary Johnson,LBT,21
-Leavenworth,W6P3,President,,Jill Stein,IND,14
-Leavenworth,W6P3,President,,Donald Trump,R,215
-Leavenworth,W6P3,President,,write-in,,6
-Leavenworth,W6P3,U.S. Senate,,Robert Garrard,LBT,32
-Leavenworth,W6P3,U.S. Senate,,Jerry Moran,R,222
-Leavenworth,W6P3,U.S. Senate,,Patrick Wiesner,D,177
-Leavenworth,W6P3,U.S. Senate,,write-in,,2
-Leavenworth,W6P3,U.S. House 2,CD2,James Bales,LBT,42
-Leavenworth,W6P3,U.S. House 2,CD2,Lynn Jenkins,R,227
-Leavenworth,W6P3,U.S. House 2,CD2,Britani Potter,D,165
-Leavenworth,W6P3,U.S. House 2,CD2,write-in,,1
-Leavenworth,W6P3,State Senate,SD05,Steve Fitzgerald,R,225
-Leavenworth,W6P3,State Senate,SD05,Bill Hutton,D,202
-Leavenworth,W6P3,State House ,HD040,JOHN BRADFORD,R,185
-Leavenworth,W6P3,State House ,HD040,DEBBIE DEERE,D,240
-Leavenworth,W6P3,State House,HD040,write-in,,1
-Leavenworth,W6P3,Voters,,Voter Registration,,788
-Leavenworth,W6P3,Voters,,Total Voted,,437
-Leavenworth,W6P4,President,,Hillary Clinton,D,274
-Leavenworth,W6P4,President,,Gary Johnson,LBT,42
-Leavenworth,W6P4,President,,Jill Stein,IND,25
-Leavenworth,W6P4,President,,Donald Trump,R,444
-Leavenworth,W6P4,President,,write-in,,9
-Leavenworth,W6P4,U.S. Senate,,Robert Garrard,LBT,40
-Leavenworth,W6P4,U.S. Senate,,Jerry Moran,R,479
-Leavenworth,W6P4,U.S. Senate,,Patrick Wiesner,D,268
-Leavenworth,W6P4,U.S. Senate,,write-in,,3
-Leavenworth,W6P4,U.S. House 2,CD2,James Bales,LBT,51
-Leavenworth,W6P4,U.S. House 2,CD2,Lynn Jenkins,R,497
-Leavenworth,W6P4,U.S. House 2,CD2,Britani Potter,D,235
-Leavenworth,W6P4,U.S. House 2,CD2,write-in,,6
-Leavenworth,W6P4,State Senate,SD05,Steve Fitzgerald,R,471
-Leavenworth,W6P4,State Senate,SD05,Bill Hutton,D,315
-Leavenworth,W6P4,State Senate,SD05,write-in,,5
-Leavenworth,W6P4,State House ,HD041,Tony Barton,R,396
-Leavenworth,W6P4,State House ,HD041,Jeff Pittman,D,392
-Leavenworth,W6P4,State House,HD041,write-in,,2
-Leavenworth,W6P4,Voters,,Voter Registration,,1447
-Leavenworth,W6P4,Voters,,Total Voted,,802
-Leavenworth,W6P5,President,,Hillary Clinton,D,318
-Leavenworth,W6P5,President,,Gary Johnson,LBT,51
-Leavenworth,W6P5,President,,Jill Stein,IND,21
-Leavenworth,W6P5,President,,Donald Trump,R,443
-Leavenworth,W6P5,President,,write-in,,13
-Leavenworth,W6P5,U.S. Senate,,Robert Garrard,LBT,47
-Leavenworth,W6P5,U.S. Senate,,Jerry Moran,R,488
-Leavenworth,W6P5,U.S. Senate,,Patrick Wiesner,D,298
-Leavenworth,W6P5,U.S. Senate,,write-in,,2
-Leavenworth,W6P5,U.S. House 2,CD2,James Bales,LBT,51
-Leavenworth,W6P5,U.S. House 2,CD2,Lynn Jenkins,R,540
-Leavenworth,W6P5,U.S. House 2,CD2,Britani Potter,D,242
-Leavenworth,W6P5,U.S. House 2,CD2,write-in,,4
-Leavenworth,W6P5,State Senate,SD05,Steve Fitzgerald,R,470
-Leavenworth,W6P5,State Senate,SD05,Bill Hutton,D,350
-Leavenworth,W6P5,State Senate,SD05,write-in,,6
-Leavenworth,W6P5,State House ,HD041,Tony Barton,R,419
-Leavenworth,W6P5,State House ,HD041,Jeff Pittman,D,415
-Leavenworth,W6P5,State House,HD041,write-in,,3
-Leavenworth,W6P5,Voters,,Voter Registration,,1291
-Leavenworth,W6P5,Voters,,Total Voted,,854
-Leavenworth,W7P1,President,,Hillary Clinton,D,120
-Leavenworth,W7P1,President,,Gary Johnson,LBT,4
-Leavenworth,W7P1,President,,Jill Stein,IND,5
-Leavenworth,W7P1,President,,Donald Trump,R,32
-Leavenworth,W7P1,President,,write-in,,7
-Leavenworth,W7P1,U.S. Senate,,Robert Garrard,LBT,7
-Leavenworth,W7P1,U.S. Senate,,Jerry Moran,R,49
-Leavenworth,W7P1,U.S. Senate,,Patrick Wiesner,D,108
-Leavenworth,W7P1,U.S. House 2,CD2,James Bales,LBT,8
-Leavenworth,W7P1,U.S. House 2,CD2,Lynn Jenkins,R,54
-Leavenworth,W7P1,U.S. House 2,CD2,Britani Potter,D,102
-Leavenworth,W7P1,State Senate,SD05,Steve Fitzgerald,R,40
-Leavenworth,W7P1,State Senate,SD05,Bill Hutton,D,124
-Leavenworth,W7P1,State House ,,JOHN BRADFORD,R,42
-Leavenworth,W7P1,State House ,,DEBBIE DEERE,D,120
-Leavenworth,W7P1,Voters,,Voter Registration,,559
-Leavenworth,W7P1,Voters,,Total Voted,,171
-Leavenworth,W7P2,President,,Hillary Clinton,D,544
-Leavenworth,W7P2,President,,Gary Johnson,LBT,76
-Leavenworth,W7P2,President,,Jill Stein,IND,29
-Leavenworth,W7P2,President,,Donald Trump,R,713
-Leavenworth,W7P2,President,,write-in,,21
-Leavenworth,W7P2,U.S. Senate,,Robert Garrard,LBT,71
-Leavenworth,W7P2,U.S. Senate,,Jerry Moran,R,762
-Leavenworth,W7P2,U.S. Senate,,Patrick Wiesner,D,532
-Leavenworth,W7P2,U.S. House 2,CD2,James Bales,LBT,81
-Leavenworth,W7P2,U.S. House 2,CD2,Lynn Jenkins,R,807
-Leavenworth,W7P2,U.S. House 2,CD2,Britani Potter,D,471
-Leavenworth,W7P2,State Senate,SD05,Steve Fitzgerald,R,765
-Leavenworth,W7P2,State Senate,SD05,Bill Hutton,D,586
-Leavenworth,W7P2,State Senate,SD05,write-in,,2
-Leavenworth,W7P2,State House ,HD040,JOHN BRADFORD,R,654
-Leavenworth,W7P2,State House ,HD040,DEBBIE DEERE,D,701
-Leavenworth,W7P2,State House,HD040,write-in,,2
-Leavenworth,W7P2,Voters,,Voter Registration,,2326
-Leavenworth,W7P2,Voters,,Total Voted,,1396
-Leavenworth,W7P3,President,,Hillary Clinton,D,636
-Leavenworth,W7P3,President,,Gary Johnson,LBT,84
-Leavenworth,W7P3,President,,Jill Stein,IND,40
-Leavenworth,W7P3,President,,Donald Trump,R,858
-Leavenworth,W7P3,President,,write-in,,59
-Leavenworth,W7P3,U.S. Senate,,Robert Garrard,LBT,95
-Leavenworth,W7P3,U.S. Senate,,Jerry Moran,R,999
-Leavenworth,W7P3,U.S. Senate,,Patrick Wiesner,D,570
-Leavenworth,W7P3,U.S. Senate,,write-in,,3
-Leavenworth,W7P3,U.S. House 2,CD2,James Bales,LBT,100
-Leavenworth,W7P3,U.S. House 2,CD2,Lynn Jenkins,R,1065
-Leavenworth,W7P3,U.S. House 2,CD2,Britani Potter,D,506
-Leavenworth,W7P3,U.S. House 2,CD2,write-in,,1
-Leavenworth,W7P3,State Senate,SD05,Steve Fitzgerald,R,963
-Leavenworth,W7P3,State Senate,SD05,Bill Hutton,D,699
-Leavenworth,W7P3,State Senate,SD05,write-in,,3
-Leavenworth,W7P3,State House ,HD040,JOHN BRADFORD,R,834
-Leavenworth,W7P3,State House ,HD040,DEBBIE DEERE,D,825
-Leavenworth,W7P3,State House,HD040,write-in,,3
-Leavenworth,W7P3,Voters,,Voter Registration,,2647
-Leavenworth,W7P3,Voters,,Total Voted,,1694
-Leavenworth,Springdale/Alexandria,President,,Hillary Clinton,D,78
-Leavenworth,Springdale/Alexandria,President,,Gary Johnson,LBT,12
-Leavenworth,Springdale/Alexandria,President,,Jill Stein,IND,14
-Leavenworth,Springdale/Alexandria,President,,Donald Trump,R,313
-Leavenworth,Springdale/Alexandria,President,,write-in,,1
-Leavenworth,Springdale/Alexandria,U.S. Senate,,Robert Garrard,LBT,32
-Leavenworth,Springdale/Alexandria,U.S. Senate,,Jerry Moran,R,307
-Leavenworth,Springdale/Alexandria,U.S. Senate,,Patrick Wiesner,D,76
-Leavenworth,Springdale/Alexandria,U.S. Senate,,write-in,,1
-Leavenworth,Springdale/Alexandria,U.S. House 2,CD2,James Bales,LBT,24
-Leavenworth,Springdale/Alexandria,U.S. House 2,CD2,Lynn Jenkins,R,318
-Leavenworth,Springdale/Alexandria,U.S. House 2,CD2,Britani Potter,D,75
-Leavenworth,Springdale/Alexandria,State Senate ,,TOM HOLLAND,D,96
-Leavenworth,Springdale/Alexandria,State Senate ,,ECHO VAN METEREN,R,317
-Leavenworth,Springdale/Alexandria,State House ,HD042,JIM KARLESKINT,R,287
-Leavenworth,Springdale/Alexandria,State House ,HD042,KARA REED,D,122
-Leavenworth,Springdale/Alexandria,Voters,,Voter Registration,,630
-Leavenworth,Springdale/Alexandria,Voters,,Total Voted,,421
-Leavenworth,Lansing W1,President,,Hillary Clinton,D,273
-Leavenworth,Lansing W1,President,,Gary Johnson,LBT,62
-Leavenworth,Lansing W1,President,,Jill Stein,IND,15
-Leavenworth,Lansing W1,President,,Donald Trump,R,462
-Leavenworth,Lansing W1,President,,write-in,,9
-Leavenworth,Lansing W1,U.S. Senate,,Robert Garrard,LBT,70
-Leavenworth,Lansing W1,U.S. Senate,,Jerry Moran,R,459
-Leavenworth,Lansing W1,U.S. Senate,,Patrick Wiesner,D,276
-Leavenworth,Lansing W1,U.S. House 2,CD2,James Bales,LBT,65
-Leavenworth,Lansing W1,U.S. House 2,CD2,Lynn Jenkins,R,502
-Leavenworth,Lansing W1,U.S. House 2,CD2,Britani Potter,D,242
-Leavenworth,Lansing W1,State Senate ,SD05,Steve Fitzgerald,R,479
-Leavenworth,Lansing W1,State Senate ,SD05,Bill Hutton,D,327
-Leavenworth,Lansing W1,State House,HD040,JOHN BRADFORD,R,383
-Leavenworth,Lansing W1,State House,HD040,DEBBIE DEERE,D,425
-Leavenworth,Lansing W1,State House,HD040,write-in,,1
-Leavenworth,Lansing W1,Voters,,Voter Registration,,1485
-Leavenworth,Lansing W1,Voters,,Total Voted,,826
-Leavenworth,Lansing W2,President,,Hillary Clinton,D,374
-Leavenworth,Lansing W2,President,,Gary Johnson,LBT,67
-Leavenworth,Lansing W2,President,,Jill Stein,IND,19
-Leavenworth,Lansing W2,President,,Donald Trump,R,630
-Leavenworth,Lansing W2,President,,write-in,,18
-Leavenworth,Lansing W2,U.S. Senate,,Robert Garrard,LBT,54
-Leavenworth,Lansing W2,U.S. Senate,,Jerry Moran,R,695
-Leavenworth,Lansing W2,U.S. Senate,,Patrick Wiesner,D,346
-Leavenworth,Lansing W2,U.S. Senate,,write-in,,2
-Leavenworth,Lansing W2,U.S. House 2,CD2,James Bales,LBT,74
-Leavenworth,Lansing W2,U.S. House 2,CD2,Lynn Jenkins,R,733
-Leavenworth,Lansing W2,U.S. House 2,CD2,Britani Potter,D,288
-Leavenworth,Lansing W2,U.S. House 2,CD2,write-in,,3
-Leavenworth,Lansing W2,State Senate ,SD05,Steve Fitzgerald,R,679
-Leavenworth,Lansing W2,State Senate ,SD05,Bill Hutton,D,415
-Leavenworth,Lansing W2,State House ,HD040,JOHN BRADFORD,R,574
-Leavenworth,Lansing W2,State House ,HD040,DEBBIE DEERE,D,522
-Leavenworth,Lansing W2,State House,HD040,write-in,,2
-Leavenworth,Lansing W2,Voters,,Voter Registration,,1720
-Leavenworth,Lansing W2,Voters,,Total Voted,,1111
-Leavenworth,Lansing W3,President,,Hillary Clinton,D,375
-Leavenworth,Lansing W3,President,,Gary Johnson,LBT,68
-Leavenworth,Lansing W3,President,,Jill Stein,IND,19
-Leavenworth,Lansing W3,President,,Donald Trump,R,539
-Leavenworth,Lansing W3,President,,write-in,,25
-Leavenworth,Lansing W3,U.S. Senate,,Robert Garrard,LBT,48
-Leavenworth,Lansing W3,U.S. Senate,,Jerry Moran,R,615
-Leavenworth,Lansing W3,U.S. Senate,,Patrick Wiesner,D,351
-Leavenworth,Lansing W3,U.S. Senate,,write-in,,3
-Leavenworth,Lansing W3,U.S. House 2,CD2,James Bales,LBT,65
-Leavenworth,Lansing W3,U.S. House 2,CD2,Lynn Jenkins,R,638
-Leavenworth,Lansing W3,U.S. House 2,CD2,Britani Potter,D,311
-Leavenworth,Lansing W3,U.S. House 2,CD2,write-in,,1
-Leavenworth,Lansing W3,State Senate ,SD05,Steve Fitzgerald,R,575
-Leavenworth,Lansing W3,State Senate ,SD05,Bill Hutton,D,440
-Leavenworth,Lansing W3,State Senate,SD05,write-in,,2
-Leavenworth,Lansing W3,State House ,HD040,JOHN BRADFORD,R,482
-Leavenworth,Lansing W3,State House ,HD040,DEBBIE DEERE,D,539
-Leavenworth,Lansing W3,State House,HD040,write-in,,2
-Leavenworth,Lansing W3,Voters,,Voter Registration,,1731
-Leavenworth,Lansing W3,Voters,,Total Voted,,1034
-Leavenworth,Lansing W4,President,,Hillary Clinton,D,399
-Leavenworth,Lansing W4,President,,Gary Johnson,LBT,75
-Leavenworth,Lansing W4,President,,Jill Stein,IND,25
-Leavenworth,Lansing W4,President,,Donald Trump,R,610
-Leavenworth,Lansing W4,President,,write-in,,18
-Leavenworth,Lansing W4,U.S. Senate,,Robert Garrard,LBT,65
-Leavenworth,Lansing W4,U.S. Senate,,Jerry Moran,R,652
-Leavenworth,Lansing W4,U.S. Senate,,Patrick Wiesner,D,393
-Leavenworth,Lansing W4,U.S. Senate,,write-in,,2
-Leavenworth,Lansing W4,U.S. House 2,CD2,James Bales,LBT,72
-Leavenworth,Lansing W4,U.S. House 2,CD2,Lynn Jenkins,R,693
-Leavenworth,Lansing W4,U.S. House 2,CD2,Britani Potter,D,339
-Leavenworth,Lansing W4,U.S. House 2,CD2,write-in,,5
-Leavenworth,Lansing W4,State Senate,SD05,Steve Fitzgerald,R,647
-Leavenworth,Lansing W4,State Senate,SD05,Bill Hutton,D,459
-Leavenworth,Lansing W4,State Senate,SD05,write-in,,2
-Leavenworth,Lansing W4,State House,HD040,JOHN BRADFORD,R,504
-Leavenworth,Lansing W4,State House,HD040,DEBBIE DEERE,D,613
-Leavenworth,Lansing W4,State House,HD040,write-in,,3
-Leavenworth,Lansing W4,Voters,,Voter Registration,,1733
-Leavenworth,Lansing W4,Voters,,Total Voted,,1135
-Leavenworth,Delaware 1,President,,Hillary Clinton,D,76
-Leavenworth,Delaware 1,President,,Gary Johnson,LBT,17
-Leavenworth,Delaware 1,President,,Jill Stein,IND,3
-Leavenworth,Delaware 1,President,,Donald Trump,R,168
-Leavenworth,Delaware 1,President,,write-in,,4
-Leavenworth,Delaware 1,U.S. Senate,,Robert Garrard,LBT,14
-Leavenworth,Delaware 1,U.S. Senate,,Jerry Moran,R,183
-Leavenworth,Delaware 1,U.S. Senate,,Patrick Wiesner,D,71
-Leavenworth,Delaware 1,U.S. House 2,CD2,James Bales,LBT,14
-Leavenworth,Delaware 1,U.S. House 2,CD2,Lynn Jenkins,R,193
-Leavenworth,Delaware 1,U.S. House 2,CD2,Britani Potter,D,61
-Leavenworth,Delaware 1,State Senate,SD05,Steve Fitzgerald,R,173
-Leavenworth,Delaware 1,State Senate,SD05,Bill Hutton,D,96
-Leavenworth,Delaware 1,State House,HD040,JOHN BRADFORD,R,140
-Leavenworth,Delaware 1,State House,HD040,DEBBIE DEERE,D,128
-Leavenworth,Delaware 1,Voters,,Voter Registration,,0
-Leavenworth,Delaware 1,Voters,,Total Voted,,271
-Leavenworth,Delaware 2,President,,Hillary Clinton,D,30
-Leavenworth,Delaware 2,President,,Gary Johnson,LBT,8
-Leavenworth,Delaware 2,President,,Jill Stein,IND,1
-Leavenworth,Delaware 2,President,,Donald Trump,R,71
-Leavenworth,Delaware 2,President,,write-in,,1
-Leavenworth,Delaware 2,U.S. Senate,,Robert Garrard,LBT,2
-Leavenworth,Delaware 2,U.S. Senate,,Jerry Moran,R,75
-Leavenworth,Delaware 2,U.S. Senate,,Patrick Wiesner,D,32
-Leavenworth,Delaware 2,U.S. House 2,CD2,James Bales,LBT,6
-Leavenworth,Delaware 2,U.S. House 2,CD2,Lynn Jenkins,R,82
-Leavenworth,Delaware 2,U.S. House 2,CD2,Britani Potter,D,22
-Leavenworth,Delaware 2,State Senate,SD03,TOM HOLLAND,D,38
-Leavenworth,Delaware 2,State Senate,SD03,ECHO VAN METEREN,R,71
-Leavenworth,Delaware 2,State House,HD040,JOHN BRADFORD,R,55
-Leavenworth,Delaware 2,State House,HD040,DEBBIE DEERE,D,54
-Leavenworth,Delaware 2,Voters,,Voter Registration,,0
-Leavenworth,Delaware 2,Voters,,Total Voted,,111
-Leavenworth,Delaware 3,President,,Hillary Clinton,D,34
-Leavenworth,Delaware 3,President,,Gary Johnson,LBT,17
-Leavenworth,Delaware 3,President,,Jill Stein,IND,6
-Leavenworth,Delaware 3,President,,Donald Trump,R,104
-Leavenworth,Delaware 3,President,,write-in,,4
-Leavenworth,Delaware 3,U.S. Senate,,Robert Garrard,LBT,9
-Leavenworth,Delaware 3,U.S. Senate,,Jerry Moran,R,120
-Leavenworth,Delaware 3,U.S. Senate,,Patrick Wiesner,D,35
-Leavenworth,Delaware 3,U.S. House 2,CD2,James Bales,LBT,7
-Leavenworth,Delaware 3,U.S. House 2,CD2,Lynn Jenkins,R,130
-Leavenworth,Delaware 3,U.S. House 2,CD2,Britani Potter,D,27
-Leavenworth,Delaware 3,U.S. House 2,CD2,write-in,,1
-Leavenworth,Delaware 3,State Senate ,SD03,TOM HOLLAND,D,46
-Leavenworth,Delaware 3,State Senate ,SD03,ECHO VAN METEREN,R,115
-Leavenworth,Delaware 3,State Senate,SD03,write-in,,1
-Leavenworth,Delaware 3,State House ,HD038,FREDERICK  CRISTOPHER,LBT,12
-Leavenworth,Delaware 3,State House ,HD038,WILLIE DOVE,R,105
-Leavenworth,Delaware 3,State House ,HD038,MIKE FONKERT,D,41
-Leavenworth,Delaware 3,State House,HD038,write-in,,1
-Leavenworth,Delaware 3,Voters,,Voter Registration,,0
-Leavenworth,Delaware 3,Voters,,Total Voted,,167
-Leavenworth,Delaware 4,President,,Hillary Clinton,D,2
-Leavenworth,Delaware 4,President,,Gary Johnson,LBT,1
-Leavenworth,Delaware 4,President,,Jill Stein,IND,0
-Leavenworth,Delaware 4,President,,Donald Trump,R,1
-Leavenworth,Delaware 4,U.S. Senate,,Robert Garrard,LBT,1
-Leavenworth,Delaware 4,U.S. Senate,,Jerry Moran,R,1
-Leavenworth,Delaware 4,U.S. Senate,,Patrick Wiesner,D,2
-Leavenworth,Delaware 4,U.S. House 2,CD2,James Bales,LBT,1
-Leavenworth,Delaware 4,U.S. House 2,CD2,Lynn Jenkins,R,1
-Leavenworth,Delaware 4,U.S. House 2,CD2,Britani Potter,D,2
-Leavenworth,Delaware 4,State Senate,SD05,Steve Fitzgerald,R,2
-Leavenworth,Delaware 4,State Senate,SD05,Bill Hutton,D,2
-Leavenworth,Delaware 4,State House,HD038,FREDERICK  CRISTOPHER,LBT,1
-Leavenworth,Delaware 4,State House,HD038,WILLIE DOVE,R,1
-Leavenworth,Delaware 4,State House,HD038,MIKE FONKERT,D,2
-Leavenworth,Delaware 4,Voters,,Voter Registration,,6
-Leavenworth,Delaware 4,Voters,,Total Voted,,4
-Leavenworth,Easton/Easton,President,,Hillary Clinton,D,110
-Leavenworth,Easton/Easton,President,,Gary Johnson,LBT,26
-Leavenworth,Easton/Easton,President,,Jill Stein,IND,8
-Leavenworth,Easton/Easton,President,,Donald Trump,R,359
-Leavenworth,Easton/Easton,President,,write-in,,7
-Leavenworth,Easton/Easton,U.S. Senate,,Robert Garrard,LBT,26
-Leavenworth,Easton/Easton,U.S. Senate,,Jerry Moran,R,363
-Leavenworth,Easton/Easton,U.S. Senate,,Patrick Wiesner,D,118
-Leavenworth,Easton/Easton,U.S. Senate,,write-in,,1
-Leavenworth,Easton/Easton,U.S. House 2,CD2,James Bales,LBT,20
-Leavenworth,Easton/Easton,U.S. House 2,CD2,Lynn Jenkins,R,384
-Leavenworth,Easton/Easton,U.S. House 2,CD2,Britani Potter,D,103
-Leavenworth,Easton/Easton,U.S. House 2,CD2,write-in,,2
-Leavenworth,Easton/Easton,State Senate ,,TOM HOLLAND,D,146
-Leavenworth,Easton/Easton,State Senate ,,ECHO VAN METEREN,R,360
-Leavenworth,Easton/Easton,State Senate,SD03,write-in,,1
-Leavenworth,Easton/Easton,State House ,HD042,JIM KARLESKINT,R,350
-Leavenworth,Easton/Easton,State House ,HD042,KARA REED,D,154
-Leavenworth,Easton/Easton,Voters,,Voter Registration,,789
-Leavenworth,Easton/Easton,Voters,,Total Voted,,515
-Leavenworth,Basehor City/ Fairmount,President,,Hillary Clinton,D,881
-Leavenworth,Basehor City/ Fairmount,President,,Gary Johnson,LBT,118
-Leavenworth,Basehor City/ Fairmount,President,,Jill Stein,IND,50
-Leavenworth,Basehor City/ Fairmount,President,,Donald Trump,R,1720
-Leavenworth,Basehor City/ Fairmount,President,,write-in,,39
-Leavenworth,Basehor City/ Fairmount,U.S. Senate,,Robert Garrard,LBT,127
-Leavenworth,Basehor City/ Fairmount,U.S. Senate,,Jerry Moran,R,1742
-Leavenworth,Basehor City/ Fairmount,U.S. Senate,,Patrick Wiesner,D,896
-Leavenworth,Basehor City/ Fairmount,U.S. Senate,,write-in,,1
-Leavenworth,Basehor City/ Fairmount,U.S. House 2,CD2,James Bales,LBT,172
-Leavenworth,Basehor City/ Fairmount,U.S. House 2,CD2,Lynn Jenkins,R,1846
-Leavenworth,Basehor City/ Fairmount,U.S. House 2,CD2,Britani Potter,D,756
-Leavenworth,Basehor City/ Fairmount,U.S. House 2,CD2,write-in,,4
-Leavenworth,Basehor City/ Fairmount,State Senate,SD03,TOM HOLLAND,D,1015
-Leavenworth,Basehor City/ Fairmount,State Senate,SD03,ECHO VAN METEREN,R,1740
-Leavenworth,Basehor City/ Fairmount,State Senate,SD03,write-in,,1
-Leavenworth,Basehor City/ Fairmount,State House,HD038,FREDERICK  CRISTOPHER,LBT,255
-Leavenworth,Basehor City/ Fairmount,State House,HD038,WILLIE DOVE,R,1420
-Leavenworth,Basehor City/ Fairmount,State House,HD038,MIKE FONKERT,D,1083
-Leavenworth,Basehor City/ Fairmount,State House,HD038,write-in,,3
-Leavenworth,Basehor City/ Fairmount,Voters,,Voter Registration,,4127
-Leavenworth,Basehor City/ Fairmount,Voters,,Total Voted,,2826
-Leavenworth,Basehor Twp/ Fairmount,President,,Hillary Clinton,D,258
-Leavenworth,Basehor Twp/ Fairmount,President,,Gary Johnson,LBT,44
-Leavenworth,Basehor Twp/ Fairmount,President,,Jill Stein,IND,15
-Leavenworth,Basehor Twp/ Fairmount,President,,Donald Trump,R,711
-Leavenworth,Basehor Twp/ Fairmount,President,,write-in,,14
-Leavenworth,Basehor Twp/ Fairmount,U.S. Senate,,Robert Garrard,LBT,61
-Leavenworth,Basehor Twp/ Fairmount,U.S. Senate,,Jerry Moran,R,685
-Leavenworth,Basehor Twp/ Fairmount,U.S. Senate,,Patrick Wiesner,D,282
-Leavenworth,Basehor Twp/ Fairmount,U.S. Senate,,write-in,,2
-Leavenworth,Basehor Twp/ Fairmount,U.S. House 2,CD2,James Bales,LBT,72
-Leavenworth,Basehor Twp/ Fairmount,U.S. House 2,CD2,Lynn Jenkins,R,725
-Leavenworth,Basehor Twp/ Fairmount,U.S. House 2,CD2,Britani Potter,D,236
-Leavenworth,Basehor Twp/ Fairmount,U.S. House 2,CD2,write-in,,2
-Leavenworth,Basehor Twp/ Fairmount,State Senate ,,TOM HOLLAND,D,321
-Leavenworth,Basehor Twp/ Fairmount,State Senate ,,ECHO VAN METEREN,R,705
-Leavenworth,Basehor Twp/ Fairmount,State Senate ,SD03,write-in,,2
-Leavenworth,Basehor Twp/ Fairmount,State House ,,FREDERICK  CRISTOPHER,LBT,95
-Leavenworth,Basehor Twp/ Fairmount,State House ,,WILLIE DOVE,R,590
-Leavenworth,Basehor Twp/ Fairmount,State House ,,MIKE FONKERT,D,336
-Leavenworth,Basehor Twp/ Fairmount,State House,HD038,write-in,,4
-Leavenworth,Basehor Twp/ Fairmount,Voters,,Voter Registration,,1495
-Leavenworth,Basehor Twp/ Fairmount,Voters,,Total Voted,,1051
-Leavenworth,Glenwood/ Fairmount,President,,Hillary Clinton,D,460
-Leavenworth,Glenwood/ Fairmount,President,,Gary Johnson,LBT,48
-Leavenworth,Glenwood/ Fairmount,President,,Jill Stein,IND,17
-Leavenworth,Glenwood/ Fairmount,President,,Donald Trump,R,894
-Leavenworth,Glenwood/ Fairmount,President,,write-in,,23
-Leavenworth,Glenwood/ Fairmount,U.S. Senate,,Robert Garrard,LBT,63
-Leavenworth,Glenwood/ Fairmount,U.S. Senate,,Jerry Moran,R,903
-Leavenworth,Glenwood/ Fairmount,U.S. Senate,,Patrick Wiesner,D,453
-Leavenworth,Glenwood/ Fairmount,U.S. Senate,,write-in,,2
-Leavenworth,Glenwood/ Fairmount,U.S. House 2,CD2,James Bales,LBT,79
-Leavenworth,Glenwood/ Fairmount,U.S. House 2,CD2,Lynn Jenkins,R,954
-Leavenworth,Glenwood/ Fairmount,U.S. House 2,CD2,Britani Potter,D,381
-Leavenworth,Glenwood/ Fairmount,U.S. House 2,CD2,write-in,,3
-Leavenworth,Glenwood/ Fairmount,State Senate ,,TOM HOLLAND,D,518
-Leavenworth,Glenwood/ Fairmount,State Senate ,,ECHO VAN METEREN,R,898
-Leavenworth,Glenwood/ Fairmount,State Senate,SD03,write-in,,1
-Leavenworth,Glenwood/ Fairmount,State House ,,FREDERICK  CRISTOPHER,LBT,76
-Leavenworth,Glenwood/ Fairmount,State House ,,WILLIE DOVE,R,811
-Leavenworth,Glenwood/ Fairmount,State House ,,MIKE FONKERT,D,520
-Leavenworth,Glenwood/ Fairmount,Voters,,Voter Registration,,2064
-Leavenworth,Glenwood/ Fairmount,Voters,,Total Voted,,1445
-Leavenworth,Boling/ High Prairie,President,,Hillary Clinton,D,290
-Leavenworth,Boling/ High Prairie,President,,Gary Johnson,LBT,35
-Leavenworth,Boling/ High Prairie,President,,Jill Stein,IND,16
-Leavenworth,Boling/ High Prairie,President,,Donald Trump,R,728
-Leavenworth,Boling/ High Prairie,President,,write-in,,23
-Leavenworth,Boling/ High Prairie,U.S. Senate,,Robert Garrard,LBT,61
-Leavenworth,Boling/ High Prairie,U.S. Senate,,Jerry Moran,R,743
-Leavenworth,Boling/ High Prairie,U.S. Senate,,Patrick Wiesner,D,277
-Leavenworth,Boling/ High Prairie,U.S. Senate,,write-in,,1
-Leavenworth,Boling/ High Prairie,U.S. House 2,CD2,James Bales,LBT,58
-Leavenworth,Boling/ High Prairie,U.S. House 2,CD2,Lynn Jenkins,R,785
-Leavenworth,Boling/ High Prairie,U.S. House 2,CD2,Britani Potter,D,245
-Leavenworth,Boling/ High Prairie,State Senate ,,TOM HOLLAND,D,329
-Leavenworth,Boling/ High Prairie,State Senate ,,ECHO VAN METEREN,R,749
-Leavenworth,Boling/ High Prairie,State Senate,SD03,write-in,,1
-Leavenworth,Boling/ High Prairie,State House ,HD042,JIM KARLESKINT,R,699
-Leavenworth,Boling/ High Prairie,State House ,HD042,KARA REED,D,367
-Leavenworth,Boling/ High Prairie,State House,HD042,write-in,,2
-Leavenworth,Boling/ High Prairie,Voters,,Voter Registration,,1588
-Leavenworth,Boling/ High Prairie,Voters,,Total Voted,,1097
-Leavenworth,Kickapoo/ Kickapoo,President,,Hillary Clinton,D,216
-Leavenworth,Kickapoo/ Kickapoo,President,,Gary Johnson,LBT,45
-Leavenworth,Kickapoo/ Kickapoo,President,,Jill Stein,IND,19
-Leavenworth,Kickapoo/ Kickapoo,President,,Donald Trump,R,694
-Leavenworth,Kickapoo/ Kickapoo,President,,write-in,,21
-Leavenworth,Kickapoo/ Kickapoo,U.S. Senate,,Robert Garrard,LBT,51
-Leavenworth,Kickapoo/ Kickapoo,U.S. Senate,,Jerry Moran,R,725
-Leavenworth,Kickapoo/ Kickapoo,U.S. Senate,,Patrick Wiesner,D,215
-Leavenworth,Kickapoo/ Kickapoo,U.S. Senate,,write-in,,3
-Leavenworth,Kickapoo/ Kickapoo,U.S. House 2,CD2,James Bales,LBT,42
-Leavenworth,Kickapoo/ Kickapoo,U.S. House 2,CD2,Lynn Jenkins,R,751
-Leavenworth,Kickapoo/ Kickapoo,U.S. House 2,CD2,Britani Potter,D,196
-Leavenworth,Kickapoo/ Kickapoo,U.S. House 2,CD2,write-in,,2
-Leavenworth,Kickapoo/ Kickapoo,State Senate,SD03,TOM HOLLAND,D,277
-Leavenworth,Kickapoo/ Kickapoo,State Senate,SD03,ECHO VAN METEREN,R,709
-Leavenworth,Kickapoo/ Kickapoo,State Senate,SD03,write-in,,4
-Leavenworth,Kickapoo/ Kickapoo,State House,HD042,JIM KARLESKINT,R,719
-Leavenworth,Kickapoo/ Kickapoo,State House,HD042,KARA REED,D,260
-Leavenworth,Kickapoo/ Kickapoo,State House,HD042,write-in,,3
-Leavenworth,Kickapoo/ Kickapoo,Voters,,Voter Registration,,1510
-Leavenworth,Kickapoo/ Kickapoo,Voters,,Total Voted,,1009
-Leavenworth,Reno West,President,,Hillary Clinton,D,256
-Leavenworth,Reno West,President,,Gary Johnson,LBT,31
-Leavenworth,Reno West,President,,Jill Stein,IND,10
-Leavenworth,Reno West,President,,Donald Trump,R,336
-Leavenworth,Reno West,President,,write-in,,13
-Leavenworth,Reno West,U.S. Senate,,Robert Garrard,LBT,31
-Leavenworth,Reno West,U.S. Senate,,Jerry Moran,R,357
-Leavenworth,Reno West,U.S. Senate,,Patrick Wiesner,D,250
-Leavenworth,Reno West,U.S. Senate,,write-in,,1
-Leavenworth,Reno West,U.S. House 2,CD2,James Bales,LBT,55
-Leavenworth,Reno West,U.S. House 2,CD2,Lynn Jenkins,R,373
-Leavenworth,Reno West,U.S. House 2,CD2,Britani Potter,D,213
-Leavenworth,Reno West,U.S. House 2,CD2,write-in,,1
-Leavenworth,Reno West,State Senate,SD03,TOM HOLLAND,D,287
-Leavenworth,Reno West,State Senate,SD03,ECHO VAN METEREN,R,348
-Leavenworth,Reno West,State Senate,SD03,write-in,,1
-Leavenworth,Reno West,State House,HD042,JIM KARLESKINT,R,361
-Leavenworth,Reno West,State House,HD042,KARA REED,D,278
-Leavenworth,Reno West,State House,HD042,write-in,,1
-Leavenworth,Reno West,Voters,,Voter Registration,,1102
-Leavenworth,Reno West,Voters,,Total Voted,,650
-Leavenworth,Reno East,President,,Hillary Clinton,D,54
-Leavenworth,Reno East,President,,Gary Johnson,LBT,6
-Leavenworth,Reno East,President,,Jill Stein,IND,1
-Leavenworth,Reno East,President,,Donald Trump,R,71
-Leavenworth,Reno East,U.S. Senate,,Robert Garrard,LBT,6
-Leavenworth,Reno East,U.S. Senate,,Jerry Moran,R,74
-Leavenworth,Reno East,U.S. Senate,,Patrick Wiesner,D,50
-Leavenworth,Reno East,U.S. House 2,CD2,James Bales,LBT,8
-Leavenworth,Reno East,U.S. House 2,CD2,Lynn Jenkins,R,78
-Leavenworth,Reno East,U.S. House 2,CD2,Britani Potter,D,45
-Leavenworth,Reno East,State Senate,SD03,TOM HOLLAND,D,57
-Leavenworth,Reno East,State Senate,SD03,ECHO VAN METEREN,R,74
-Leavenworth,Reno East,State House,HD038,FREDERICK  CRISTOPHER,LBT,6
-Leavenworth,Reno East,State House,HD038,WILLIE DOVE,R,71
-Leavenworth,Reno East,State House,HD038,MIKE FONKERT,D,52
-Leavenworth,Reno East,Voters,,Voter Registration,,0
-Leavenworth,Reno East,Voters,,Total Voted,,134
-Leavenworth,Linwood/ Sherman,President,,Hillary Clinton,D,413
-Leavenworth,Linwood/ Sherman,President,,Gary Johnson,LBT,61
-Leavenworth,Linwood/ Sherman,President,,Jill Stein,IND,31
-Leavenworth,Linwood/ Sherman,President,,Donald Trump,R,883
-Leavenworth,Linwood/ Sherman,President,,write-in,,19
-Leavenworth,Linwood/ Sherman,U.S. Senate,,Robert Garrard,LBT,74
-Leavenworth,Linwood/ Sherman,U.S. Senate,,Jerry Moran,R,878
-Leavenworth,Linwood/ Sherman,U.S. Senate,,Patrick Wiesner,D,433
-Leavenworth,Linwood/ Sherman,U.S. House 2,CD2,James Bales,LBT,80
-Leavenworth,Linwood/ Sherman,U.S. House 2,CD2,Lynn Jenkins,R,928
-Leavenworth,Linwood/ Sherman,U.S. House 2,CD2,Britani Potter,D,378
-Leavenworth,Linwood/ Sherman,U.S. House 2,CD2,write-in,,2
-Leavenworth,Linwood/ Sherman,State Senate ,SD03,TOM HOLLAND,D,488
-Leavenworth,Linwood/ Sherman,State Senate ,SD03,ECHO VAN METEREN,R,895
-Leavenworth,Linwood/ Sherman,State Senate ,SD03,write-in,,1
-Leavenworth,Linwood/ Sherman,State House,HD038,FREDERICK  CRISTOPHER,LBT,79
-Leavenworth,Linwood/ Sherman,State House,HD038,WILLIE DOVE,R,813
-Leavenworth,Linwood/ Sherman,State House,HD038,MIKE FONKERT,D,480
-Leavenworth,Linwood/ Sherman,State House,HD038,write-in,,4
-Leavenworth,Linwood/ Sherman,Voters,,Voter Registration,,2141
-Leavenworth,Linwood/ Sherman,Voters,,Total Voted,,1410
-Leavenworth,Stranger/ Stranger,President,,Hillary Clinton,D,213
-Leavenworth,Stranger/ Stranger,President,,Gary Johnson,LBT,25
-Leavenworth,Stranger/ Stranger,President,,Jill Stein,IND,14
-Leavenworth,Stranger/ Stranger,President,,Donald Trump,R,576
-Leavenworth,Stranger/ Stranger,President,,write-in,,13
-Leavenworth,Stranger/ Stranger,U.S. Senate,,Robert Garrard,LBT,41
-Leavenworth,Stranger/ Stranger,U.S. Senate,,Jerry Moran,R,557
-Leavenworth,Stranger/ Stranger,U.S. Senate,,Patrick Wiesner,D,225
-Leavenworth,Stranger/ Stranger,U.S. House 2,CD2,James Bales,LBT,45
-Leavenworth,Stranger/ Stranger,U.S. House 2,CD2,Lynn Jenkins,R,579
-Leavenworth,Stranger/ Stranger,U.S. House 2,CD2,Britani Potter,D,206
-Leavenworth,Stranger/ Stranger,State Senate,SD03,TOM HOLLAND,D,280
-Leavenworth,Stranger/ Stranger,State Senate,SD03,ECHO VAN METEREN,R,542
-Leavenworth,Stranger/ Stranger,State Senate,SD03,write-in,,1
-Leavenworth,Stranger/ Stranger,State House,HD038,FREDERICK  CRISTOPHER,LBT,43
-Leavenworth,Stranger/ Stranger,State House,HD038,WILLIE DOVE,R,507
-Leavenworth,Stranger/ Stranger,State House,HD038,MIKE FONKERT,D,262
-Leavenworth,Stranger/ Stranger,State House,HD038,write-in,,1
-Leavenworth,Stranger/ Stranger,Voters,,Voter Registration,,1181
-Leavenworth,Stranger/ Stranger,Voters,,Total Voted,,844
-Leavenworth,Walnut/ Stranger,President,,Hillary Clinton,D,171
-Leavenworth,Walnut/ Stranger,President,,Gary Johnson,LBT,20
-Leavenworth,Walnut/ Stranger,President,,Jill Stein,IND,16
-Leavenworth,Walnut/ Stranger,President,,Donald Trump,R,414
-Leavenworth,Walnut/ Stranger,President,,write-in,,6
-Leavenworth,Walnut/ Stranger,U.S. Senate,,Robert Garrard,LBT,23
-Leavenworth,Walnut/ Stranger,U.S. Senate,,Jerry Moran,R,418
-Leavenworth,Walnut/ Stranger,U.S. Senate,,Patrick Wiesner,D,180
-Leavenworth,Walnut/ Stranger,U.S. House 2,CD2,James Bales,LBT,38
-Leavenworth,Walnut/ Stranger,U.S. House 2,CD2,Lynn Jenkins,R,435
-Leavenworth,Walnut/ Stranger,U.S. House 2,CD2,Britani Potter,D,152
-Leavenworth,Walnut/ Stranger,State Senate,SD03,TOM HOLLAND,D,217
-Leavenworth,Walnut/ Stranger,State Senate,SD03,ECHO VAN METEREN,R,403
-Leavenworth,Walnut/ Stranger,State Senate,SD03,write-in,,2
-Leavenworth,Walnut/ Stranger,State House,HD038,Frederick Christopher,LBT,30
-Leavenworth,Walnut/ Stranger,State House,HD038,Willie Dove,R,363
-Leavenworth,Walnut/ Stranger,State House,HD038,Mike Fonkert,D,226
-Leavenworth,Walnut/ Stranger,Voters,,Voter Registration,,876
-Leavenworth,Walnut/ Stranger,Voters,,Total Voted,,635
-Leavenworth,Tonganoxie  North,President,,Hillary Clinton,D,394
-Leavenworth,Tonganoxie  North,President,,Gary Johnson,LBT,83
-Leavenworth,Tonganoxie  North,President,,Jill Stein,IND,40
-Leavenworth,Tonganoxie  North,President,,Donald Trump,R,814
-Leavenworth,Tonganoxie  North,President,,write-in,,18
-Leavenworth,Tonganoxie  North,U.S. Senate,,Robert Garrard,LBT,84
-Leavenworth,Tonganoxie  North,U.S. Senate,,Jerry Moran,R,805
-Leavenworth,Tonganoxie  North,U.S. Senate,,Patrick Wiesner,D,425
-Leavenworth,Tonganoxie  North,U.S. Senate,,write-in,,4
-Leavenworth,Tonganoxie  North,U.S. House 2,CD2,James Bales,LBT,125
-Leavenworth,Tonganoxie  North,U.S. House 2,CD2,Lynn Jenkins,R,829
-Leavenworth,Tonganoxie  North,U.S. House 2,CD2,Britani Potter,D,366
-Leavenworth,Tonganoxie  North,U.S. House 2,CD2,write-in,,4
-Leavenworth,Tonganoxie  North,State Senate,SD03,TOM HOLLAND,D,490
-Leavenworth,Tonganoxie  North,State Senate,SD03,ECHO VAN METEREN,R,819
-Leavenworth,Tonganoxie  North,State Senate,SD03,write-in,,6
-Leavenworth,Tonganoxie  North,State House,HD042,JIM KARLESKINT,R,703
-Leavenworth,Tonganoxie  North,State House,HD042,KARA REED,D,604
-Leavenworth,Tonganoxie  North,State House,HD042,write-in,,5
-Leavenworth,Tonganoxie  North,Voters,,Voter Registration,,2210
-Leavenworth,Tonganoxie  North,Voters,,Total Voted,,1355
-Leavenworth,Tonganoxie South,President,,Hillary Clinton,D,266
-Leavenworth,Tonganoxie South,President,,Gary Johnson,LBT,46
-Leavenworth,Tonganoxie South,President,,Jill Stein,IND,15
-Leavenworth,Tonganoxie South,President,,Donald Trump,R,455
-Leavenworth,Tonganoxie South,President,,write-in,,15
-Leavenworth,Tonganoxie South,U.S. Senate,,Robert Garrard,LBT,42
-Leavenworth,Tonganoxie South,U.S. Senate,,Jerry Moran,R,455
-Leavenworth,Tonganoxie South,U.S. Senate,,Patrick Wiesner,D,289
-Leavenworth,Tonganoxie South,U.S. House 2,CD2,James Bales,LBT,77
-Leavenworth,Tonganoxie South,U.S. House 2,CD2,Lynn Jenkins,R,471
-Leavenworth,Tonganoxie South,U.S. House 2,CD2,Britani Potter,D,235
-Leavenworth,Tonganoxie South,U.S. House 2,CD2,write-in,,1
-Leavenworth,Tonganoxie South,State Senate,SD03,TOM HOLLAND,D,342
-Leavenworth,Tonganoxie South,State Senate,SD03,ECHO VAN METEREN,R,445
-Leavenworth,Tonganoxie South,State House,HD042,JIM KARLESKINT,R,398
-Leavenworth,Tonganoxie South,State House,HD042,KARA REED,D,385
-Leavenworth,Tonganoxie South,State House,HD042,write-in,,1
-Leavenworth,Tonganoxie South,Voters,,Voter Registration,,1333
-Leavenworth,Tonganoxie South,Voters,,Total Voted,,799
-Leavenworth,Tonganoxie Rural,President,,Hillary Clinton,D,352
-Leavenworth,Tonganoxie Rural,President,,Gary Johnson,LBT,80
-Leavenworth,Tonganoxie Rural,President,,Jill Stein,IND,24
-Leavenworth,Tonganoxie Rural,President,,Donald Trump,R,830
-Leavenworth,Tonganoxie Rural,President,,write-in,,22
-Leavenworth,Tonganoxie Rural,U.S. Senate,,Robert Garrard,LBT,90
-Leavenworth,Tonganoxie Rural,U.S. Senate,,Jerry Moran,R,810
-Leavenworth,Tonganoxie Rural,U.S. Senate,,Patrick Wiesner,D,396
-Leavenworth,Tonganoxie Rural,U.S. Senate,,write-in,,3
-Leavenworth,Tonganoxie Rural,U.S. House 2,CD2,James Bales,LBT,112
-Leavenworth,Tonganoxie Rural,U.S. House 2,CD2,Lynn Jenkins,R,843
-Leavenworth,Tonganoxie Rural,U.S. House 2,CD2,Britani Potter,D,339
-Leavenworth,Tonganoxie Rural,State Senate,SD03,TOM HOLLAND,D,476
-Leavenworth,Tonganoxie Rural,State Senate,SD03,ECHO VAN METEREN,R,812
-Leavenworth,Tonganoxie Rural,State Senate,SD03,write-in,,3
-Leavenworth,Tonganoxie Rural,State House,HD042,JIM KARLESKINT,R,741
-Leavenworth,Tonganoxie Rural,State House,HD042,KARA REED,D,550
-Leavenworth,Tonganoxie Rural,State House,HD042,write-in,,5
-Leavenworth,Tonganoxie Rural,Voters,,Voter Registration,,1915
-Leavenworth,Tonganoxie Rural,Voters,,Total Voted,,1316
-Leavenworth,Fort Leavenworth A H41,President,,Hillary Clinton,D,79
-Leavenworth,Fort Leavenworth A H41,President,,Gary Johnson,LBT,16
-Leavenworth,Fort Leavenworth A H41,President,,Jill Stein,IND,3
-Leavenworth,Fort Leavenworth A H41,President,,Donald Trump,R,118
-Leavenworth,Fort Leavenworth A H41,President,,write-in,,4
-Leavenworth,Fort Leavenworth A H41,U.S. Senate,,Robert Garrard,LBT,7
-Leavenworth,Fort Leavenworth A H41,U.S. Senate,,Jerry Moran,R,142
-Leavenworth,Fort Leavenworth A H41,U.S. Senate,,Patrick Wiesner,D,68
-Leavenworth,Fort Leavenworth A H41,U.S. House 2,CD2,James Bales,LBT,16
-Leavenworth,Fort Leavenworth A H41,U.S. House 2,CD2,Lynn Jenkins,R,134
-Leavenworth,Fort Leavenworth A H41,U.S. House 2,CD2,Britani Potter,D,65
-Leavenworth,Fort Leavenworth A H41,State Senate,SD05,Steve Fitzgerald,R,154
-Leavenworth,Fort Leavenworth A H41,State Senate,SD05,Bill Hutton,D,62
-Leavenworth,Fort Leavenworth A H41,State House,HD041,Tony Barton,R,142
-Leavenworth,Fort Leavenworth A H41,State House,HD041,Jeff Pittman,D,70
-Leavenworth,Fort Leavenworth A H41,Voters,,Voter Registration,,0
-Leavenworth,Fort Leavenworth A H41,Voters,,Total Voted,,224
-Leavenworth,Fort Leavenworth A H42,President,,Hillary Clinton,D,56
-Leavenworth,Fort Leavenworth A H42,President,,Gary Johnson,LBT,8
-Leavenworth,Fort Leavenworth A H42,President,,Jill Stein,IND,1
-Leavenworth,Fort Leavenworth A H42,President,,Donald Trump,R,65
-Leavenworth,Fort Leavenworth A H42,President,,write-in,,4
-Leavenworth,Fort Leavenworth A H42,U.S. Senate,,Robert Garrard,LBT,6
-Leavenworth,Fort Leavenworth A H42,U.S. Senate,,Jerry Moran,R,68
-Leavenworth,Fort Leavenworth A H42,U.S. Senate,,Patrick Wiesner,D,57
-Leavenworth,Fort Leavenworth A H42,U.S. House 2,CD2,James Bales,LBT,9
-Leavenworth,Fort Leavenworth A H42,U.S. House 2,CD2,Lynn Jenkins,R,67
-Leavenworth,Fort Leavenworth A H42,U.S. House 2,CD2,Britani Potter,D,54
-Leavenworth,Fort Leavenworth A H42,State Senate,SD05,Steve Fitzgerald,R,81
-Leavenworth,Fort Leavenworth A H42,State Senate,SD05,Bill Hutton,D,47
-Leavenworth,Fort Leavenworth A H42,State House,HD042,Jim Karleskint,R,66
-Leavenworth,Fort Leavenworth A H42,State House,HD042,Kara Reed,D,62
-Leavenworth,Fort Leavenworth A H42,Voters,,Voter Registration,,0
-Leavenworth,Fort Leavenworth A H42,Voters,,Total Voted,,134
+county,precinct,office,district,party,candidate,votes,vtd
+LEAVENWORTH,Alexandria Township,Kansas House of Representatives,42,Democratic,"Reed, Kara",122,000010
+LEAVENWORTH,Alexandria Township,Kansas House of Representatives,42,Republican,"Karleskint, Jim",287,000010
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",1083,000020
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",255,000020
+LEAVENWORTH,Basehor City,Kansas House of Representatives,38,Republican,"Dove, Willie",1420,000020
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",336,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",95,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",590,000030
+LEAVENWORTH,Easton Township,Kansas House of Representatives,42,Democratic,"Reed, Kara",154,000040
+LEAVENWORTH,Easton Township,Kansas House of Representatives,42,Republican,"Karleskint, Jim",350,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",520,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",76,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",811,000050
+LEAVENWORTH,High Prairie Township,Kansas House of Representatives,42,Democratic,"Reed, Kara",367,000060
+LEAVENWORTH,High Prairie Township,Kansas House of Representatives,42,Republican,"Karleskint, Jim",699,000060
+LEAVENWORTH,Kickapoo Township,Kansas House of Representatives,42,Democratic,"Reed, Kara",260,000070
+LEAVENWORTH,Kickapoo Township,Kansas House of Representatives,42,Republican,"Karleskint, Jim",719,000070
+LEAVENWORTH,Lansing Ward 1,Kansas House of Representatives,40,Democratic,"Deere, Debbie",425,000080
+LEAVENWORTH,Lansing Ward 1,Kansas House of Representatives,40,Republican,"Bradford, John",383,000080
+LEAVENWORTH,Lansing Ward 2,Kansas House of Representatives,40,Democratic,"Deere, Debbie",522,000090
+LEAVENWORTH,Lansing Ward 2,Kansas House of Representatives,40,Republican,"Bradford, John",574,000090
+LEAVENWORTH,Lansing Ward 3,Kansas House of Representatives,40,Democratic,"Deere, Debbie",539,000100
+LEAVENWORTH,Lansing Ward 3,Kansas House of Representatives,40,Republican,"Bradford, John",482,000100
+LEAVENWORTH,Lansing Ward 4,Kansas House of Representatives,40,Democratic,"Deere, Debbie",613,000110
+LEAVENWORTH,Lansing Ward 4,Kansas House of Representatives,40,Republican,"Bradford, John",504,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",204,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",119,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",170,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",129,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",172,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas House of Representatives,41,Republican,"Barton, Tony",123,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas House of Representatives,40,Democratic,"Deere, Debbie",254,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",189,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",282,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",198,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",165,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",95,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",233,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",149,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",188,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas House of Representatives,41,Republican,"Barton, Tony",148,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",377,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas House of Representatives,41,Republican,"Barton, Tony",283,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",197,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas House of Representatives,41,Republican,"Barton, Tony",216,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",308,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas House of Representatives,41,Republican,"Barton, Tony",227,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",260,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas House of Representatives,41,Republican,"Barton, Tony",165,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas House of Representatives,40,Democratic,"Deere, Debbie",240,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",185,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",392,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas House of Representatives,41,Republican,"Barton, Tony",396,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",415,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas House of Representatives,41,Republican,"Barton, Tony",419,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas House of Representatives,40,Democratic,"Deere, Debbie",120,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas House of Representatives,40,Republican,"Bradford, John",42,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas House of Representatives,40,Democratic,"Deere, Debbie",701,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas House of Representatives,40,Republican,"Bradford, John",654,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas House of Representatives,40,Democratic,"Deere, Debbie",825,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas House of Representatives,40,Republican,"Bradford, John",834,00029A
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",480,000320
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",79,000320
+LEAVENWORTH,Sherman Township,Kansas House of Representatives,38,Republican,"Dove, Willie",813,000320
+LEAVENWORTH,South Delaware 2,Kansas House of Representatives,40,Democratic,"Deere, Debbie",0,000340
+LEAVENWORTH,South Delaware 2,Kansas House of Representatives,40,Republican,"Bradford, John",0,000340
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",262,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",43,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",507,000350
+LEAVENWORTH,Tonganoxie North Precinct,Kansas House of Representatives,42,Democratic,"Reed, Kara",604,000360
+LEAVENWORTH,Tonganoxie North Precinct,Kansas House of Representatives,42,Republican,"Karleskint, Jim",703,000360
+LEAVENWORTH,Tonganoxie South Precinct,Kansas House of Representatives,42,Democratic,"Reed, Kara",385,000370
+LEAVENWORTH,Tonganoxie South Precinct,Kansas House of Representatives,42,Republican,"Karleskint, Jim",398,000370
+LEAVENWORTH,Tonganoxie Township,Kansas House of Representatives,42,Democratic,"Reed, Kara",550,000380
+LEAVENWORTH,Tonganoxie Township,Kansas House of Representatives,42,Republican,"Karleskint, Jim",741,000380
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",226,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",30,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas House of Representatives,38,Republican,"Dove, Willie",363,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",70,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas House of Representatives,41,Republican,"Barton, Tony",142,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas House of Representatives,42,Democratic,"Reed, Kara",62,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas House of Representatives,42,Republican,"Karleskint, Jim",66,120050
+LEAVENWORTH,Missouri River H41,Kansas House of Representatives,41,Democratic,"Pittman, Jeff",0,120060
+LEAVENWORTH,Missouri River H41,Kansas House of Representatives,41,Republican,"Barton, Tony",0,120060
+LEAVENWORTH,Missouri River H42,Kansas House of Representatives,42,Democratic,"Reed, Kara",0,120070
+LEAVENWORTH,Missouri River H42,Kansas House of Representatives,42,Republican,"Karleskint, Jim",0,120070
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",52,120080
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",6,120080
+LEAVENWORTH,Reno Township H38,Kansas House of Representatives,38,Republican,"Dove, Willie",71,120080
+LEAVENWORTH,Reno Township H42,Kansas House of Representatives,42,Democratic,"Reed, Kara",278,120090
+LEAVENWORTH,Reno Township H42,Kansas House of Representatives,42,Republican,"Karleskint, Jim",361,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",41,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",12,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",105,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Kansas House of Representatives,40,Democratic,"Deere, Debbie",54,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Kansas House of Representatives,40,Republican,"Bradford, John",55,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",2,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",1,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas House of Representatives,38,Republican,"Dove, Willie",1,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas House of Representatives,40,Democratic,"Deere, Debbie",128,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas House of Representatives,40,Republican,"Bradford, John",140,120130
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Democratic,"Fonkert, Mike",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Libertarian,"Cristopher, Frederick Caleb",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas House of Representatives,38,Republican,"Dove, Willie",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Kansas House of Representatives,42,Democratic,"Reed, Kara",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Kansas House of Representatives,42,Republican,"Karleskint, Jim",0,900080
+LEAVENWORTH,Alexandria Township,Kansas Senate,3,Democratic,"Holland, Tom",96,000010
+LEAVENWORTH,Alexandria Township,Kansas Senate,3,Republican,"Van Meteren, Echo",317,000010
+LEAVENWORTH,Basehor City,Kansas Senate,3,Democratic,"Holland, Tom",1015,000020
+LEAVENWORTH,Basehor City,Kansas Senate,3,Republican,"Van Meteren, Echo",1740,000020
+LEAVENWORTH,Basehor Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",321,000030
+LEAVENWORTH,Basehor Township Voting District,Kansas Senate,3,Republican,"Van Meteren, Echo",705,000030
+LEAVENWORTH,Easton Township,Kansas Senate,3,Democratic,"Holland, Tom",146,000040
+LEAVENWORTH,Easton Township,Kansas Senate,3,Republican,"Van Meteren, Echo",360,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",518,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,Kansas Senate,3,Republican,"Van Meteren, Echo",898,000050
+LEAVENWORTH,High Prairie Township,Kansas Senate,3,Democratic,"Holland, Tom",329,000060
+LEAVENWORTH,High Prairie Township,Kansas Senate,3,Republican,"Van Meteren, Echo",749,000060
+LEAVENWORTH,Kickapoo Township,Kansas Senate,3,Democratic,"Holland, Tom",277,000070
+LEAVENWORTH,Kickapoo Township,Kansas Senate,3,Republican,"Van Meteren, Echo",709,000070
+LEAVENWORTH,Lansing Ward 1,Kansas Senate,5,Democratic,"Hutton, Bill",327,000080
+LEAVENWORTH,Lansing Ward 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",479,000080
+LEAVENWORTH,Lansing Ward 2,Kansas Senate,5,Democratic,"Hutton, Bill",415,000090
+LEAVENWORTH,Lansing Ward 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",679,000090
+LEAVENWORTH,Lansing Ward 3,Kansas Senate,5,Democratic,"Hutton, Bill",440,000100
+LEAVENWORTH,Lansing Ward 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",575,000100
+LEAVENWORTH,Lansing Ward 4,Kansas Senate,5,Democratic,"Hutton, Bill",459,000110
+LEAVENWORTH,Lansing Ward 4,Kansas Senate,5,Republican,"Fitzgerald, Steve",647,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",184,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",136,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",139,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",160,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas Senate,5,Democratic,"Hutton, Bill",149,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",143,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas Senate,5,Democratic,"Hutton, Bill",213,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",232,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",220,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",259,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",115,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",143,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",183,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",196,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas Senate,5,Democratic,"Hutton, Bill",157,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",180,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas Senate,5,Democratic,"Hutton, Bill",270,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",389,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas Senate,5,Democratic,"Hutton, Bill",152,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,Kansas Senate,5,Republican,"Fitzgerald, Steve",260,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",228,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",303,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas Senate,5,Democratic,"Hutton, Bill",210,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",220,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas Senate,5,Democratic,"Hutton, Bill",202,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",225,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas Senate,5,Democratic,"Hutton, Bill",315,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,Kansas Senate,5,Republican,"Fitzgerald, Steve",471,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas Senate,5,Democratic,"Hutton, Bill",350,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,Kansas Senate,5,Republican,"Fitzgerald, Steve",470,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas Senate,5,Democratic,"Hutton, Bill",124,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,Kansas Senate,5,Republican,"Fitzgerald, Steve",40,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas Senate,5,Democratic,"Hutton, Bill",586,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",765,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas Senate,5,Democratic,"Hutton, Bill",699,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,Kansas Senate,5,Republican,"Fitzgerald, Steve",963,00029A
+LEAVENWORTH,Sherman Township,Kansas Senate,3,Democratic,"Holland, Tom",488,000320
+LEAVENWORTH,Sherman Township,Kansas Senate,3,Republican,"Van Meteren, Echo",895,000320
+LEAVENWORTH,South Delaware 2,Kansas Senate,5,Democratic,"Hutton, Bill",0,000340
+LEAVENWORTH,South Delaware 2,Kansas Senate,5,Republican,"Fitzgerald, Steve",0,000340
+LEAVENWORTH,Stranger Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",280,000350
+LEAVENWORTH,Stranger Township Voting District,Kansas Senate,3,Republican,"Van Meteren, Echo",542,000350
+LEAVENWORTH,Tonganoxie North Precinct,Kansas Senate,3,Democratic,"Holland, Tom",490,000360
+LEAVENWORTH,Tonganoxie North Precinct,Kansas Senate,3,Republican,"Van Meteren, Echo",819,000360
+LEAVENWORTH,Tonganoxie South Precinct,Kansas Senate,3,Democratic,"Holland, Tom",342,000370
+LEAVENWORTH,Tonganoxie South Precinct,Kansas Senate,3,Republican,"Van Meteren, Echo",445,000370
+LEAVENWORTH,Tonganoxie Township,Kansas Senate,3,Democratic,"Holland, Tom",476,000380
+LEAVENWORTH,Tonganoxie Township,Kansas Senate,3,Republican,"Van Meteren, Echo",812,000380
+LEAVENWORTH,Walnut Township Voting District,Kansas Senate,3,Democratic,"Holland, Tom",217,000390
+LEAVENWORTH,Walnut Township Voting District,Kansas Senate,3,Republican,"Van Meteren, Echo",403,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas Senate,5,Democratic,"Hutton, Bill",62,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,Kansas Senate,5,Republican,"Fitzgerald, Steve",154,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas Senate,5,Democratic,"Hutton, Bill",47,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,Kansas Senate,5,Republican,"Fitzgerald, Steve",81,120050
+LEAVENWORTH,Missouri River H41,Kansas Senate,3,Democratic,"Holland, Tom",0,120060
+LEAVENWORTH,Missouri River H41,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120060
+LEAVENWORTH,Missouri River H42,Kansas Senate,3,Democratic,"Holland, Tom",0,120070
+LEAVENWORTH,Missouri River H42,Kansas Senate,3,Republican,"Van Meteren, Echo",0,120070
+LEAVENWORTH,Reno Township H38,Kansas Senate,3,Democratic,"Holland, Tom",57,120080
+LEAVENWORTH,Reno Township H38,Kansas Senate,3,Republican,"Van Meteren, Echo",74,120080
+LEAVENWORTH,Reno Township H42,Kansas Senate,3,Democratic,"Holland, Tom",287,120090
+LEAVENWORTH,Reno Township H42,Kansas Senate,3,Republican,"Van Meteren, Echo",348,120090
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas Senate,3,Democratic,"Holland, Tom",46,120100
+LEAVENWORTH,South Delaware 3 S3 H38,Kansas Senate,3,Republican,"Van Meteren, Echo",115,120100
+LEAVENWORTH,South Delaware 2 S3 H40,Kansas Senate,3,Democratic,"Holland, Tom",38,120110
+LEAVENWORTH,South Delaware 2 S3 H40,Kansas Senate,3,Republican,"Van Meteren, Echo",71,120110
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas Senate,5,Democratic,"Hutton, Bill",2,120120
+LEAVENWORTH,South Delaware 4 S5 H38,Kansas Senate,5,Republican,"Fitzgerald, Steve",2,120120
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas Senate,5,Democratic,"Hutton, Bill",96,120130
+LEAVENWORTH,South Delaware 1 S5 H40,Kansas Senate,5,Republican,"Fitzgerald, Steve",173,120130
+LEAVENWORTH,Basehor City Exclave 1,Kansas Senate,3,Democratic,"Holland, Tom",0,900010
+LEAVENWORTH,Basehor City Exclave 1,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900010
+LEAVENWORTH,Basehor City Exclave 2,Kansas Senate,3,Democratic,"Holland, Tom",0,900020
+LEAVENWORTH,Basehor City Exclave 2,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900020
+LEAVENWORTH,Basehor City Exclave 3,Kansas Senate,3,Democratic,"Holland, Tom",0,900030
+LEAVENWORTH,Basehor City Exclave 3,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,Kansas Senate,3,Democratic,"Holland, Tom",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,Kansas Senate,3,Republican,"Van Meteren, Echo",0,900080
+LEAVENWORTH,Alexandria Township,President / Vice President,,independent,"Stein, Jill",14,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",78,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000010
+LEAVENWORTH,Alexandria Township,President / Vice President,,Republican,"Trump, Donald J.",313,000010
+LEAVENWORTH,Basehor City,President / Vice President,,independent,"Stein, Jill",50,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Hedges, James A",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"McMullin, Evan",19,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Perry, Darryl",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Smith, Mike",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Sood, Ajay",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",881,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Libertarian,"Johnson, Gary",118,000020
+LEAVENWORTH,Basehor City,President / Vice President,,Republican,"Trump, Donald J.",1720,000020
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,independent,"Stein, Jill",15,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Hedges, James A",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"McMullin, Evan",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Smith, Mike",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Democratic,"Clinton, Hillary Rodham",258,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",44,000030
+LEAVENWORTH,Basehor Township Voting District,President / Vice President,,Republican,"Trump, Donald J.",711,000030
+LEAVENWORTH,Easton Township,President / Vice President,,independent,"Stein, Jill",8,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"McMullin, Evan",3,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Libertarian,"Johnson, Gary",26,000040
+LEAVENWORTH,Easton Township,President / Vice President,,Republican,"Trump, Donald J.",359,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,independent,"Stein, Jill",17,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Castle, Darrell L",1,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Hedges, James A",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"McMullin, Evan",6,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Perry, Darryl",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Smith, Mike",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Sood, Ajay",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,Democratic,"Clinton, Hillary Rodham",460,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",48,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,President / Vice President,,Republican,"Trump, Donald J.",894,000050
+LEAVENWORTH,High Prairie Township,President / Vice President,,independent,"Stein, Jill",16,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Castle, Darrell L",3,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"McMullin, Evan",3,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",290,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",35,000060
+LEAVENWORTH,High Prairie Township,President / Vice President,,Republican,"Trump, Donald J.",728,000060
+LEAVENWORTH,Kickapoo Township,President / Vice President,,independent,"Stein, Jill",19,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Castle, Darrell L",1,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"McMullin, Evan",8,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",216,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Libertarian,"Johnson, Gary",45,000070
+LEAVENWORTH,Kickapoo Township,President / Vice President,,Republican,"Trump, Donald J.",694,000070
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,independent,"Stein, Jill",15,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",273,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",62,000080
+LEAVENWORTH,Lansing Ward 1,President / Vice President,,Republican,"Trump, Donald J.",462,000080
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,independent,"Stein, Jill",19,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",374,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",67,000090
+LEAVENWORTH,Lansing Ward 2,President / Vice President,,Republican,"Trump, Donald J.",630,000090
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,independent,"Stein, Jill",19,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Castle, Darrell L",2,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"McMullin, Evan",5,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",375,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",68,000100
+LEAVENWORTH,Lansing Ward 3,President / Vice President,,Republican,"Trump, Donald J.",539,000100
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,independent,"Stein, Jill",25,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"McMullin, Evan",3,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",399,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",75,000110
+LEAVENWORTH,Lansing Ward 4,President / Vice President,,Republican,"Trump, Donald J.",610,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",15,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",187,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",110,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",7,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",4,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",118,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",160,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",11,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",3,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",22,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",136,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,independent,"Stein, Jill",10,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",1,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",1,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",215,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",21,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",204,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",14,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",2,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",187,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",42,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",242,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",10,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",119,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",16,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",114,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,independent,"Stein, Jill",14,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",170,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",24,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",172,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,independent,"Stein, Jill",11,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",31,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",172,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,independent,"Stein, Jill",16,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",3,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",230,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",47,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",370,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,independent,"Stein, Jill",10,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",1,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",3,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",125,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",31,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",242,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,independent,"Stein, Jill",16,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",4,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",218,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",31,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",267,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,independent,"Stein, Jill",12,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",3,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",213,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",23,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",178,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,independent,"Stein, Jill",14,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",4,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",179,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",21,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",215,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,independent,"Stein, Jill",25,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",1,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"McMullin, Evan",3,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",274,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",42,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",444,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,independent,"Stein, Jill",21,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",3,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",318,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",51,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",443,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",2,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",32,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,independent,"Stein, Jill",29,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",1,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",6,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",544,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",76,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",713,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,independent,"Stein, Jill",40,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",1,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",26,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",636,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",84,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",858,00029A
+LEAVENWORTH,Sherman Township,President / Vice President,,independent,"Stein, Jill",31,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",9,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",413,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",61,000320
+LEAVENWORTH,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",883,000320
+LEAVENWORTH,South Delaware 2,President / Vice President,,independent,"Stein, Jill",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Hedges, James A",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"McMullin, Evan",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Perry, Darryl",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Smith, Mike",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Sood, Ajay",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000340
+LEAVENWORTH,South Delaware 2,President / Vice President,,Republican,"Trump, Donald J.",0,000340
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,independent,"Stein, Jill",14,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Hedges, James A",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"McMullin, Evan",6,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Perry, Darryl",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Smith, Mike",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Sood, Ajay",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Democratic,"Clinton, Hillary Rodham",213,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",25,000350
+LEAVENWORTH,Stranger Township Voting District,President / Vice President,,Republican,"Trump, Donald J.",576,000350
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,independent,"Stein, Jill",40,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Castle, Darrell L",2,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Hedges, James A",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"McMullin, Evan",7,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Smith, Mike",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",394,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Libertarian,"Johnson, Gary",83,000360
+LEAVENWORTH,Tonganoxie North Precinct,President / Vice President,,Republican,"Trump, Donald J.",814,000360
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,independent,"Stein, Jill",15,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Castle, Darrell L",2,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Hedges, James A",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"McMullin, Evan",4,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Smith, Mike",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",266,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Libertarian,"Johnson, Gary",46,000370
+LEAVENWORTH,Tonganoxie South Precinct,President / Vice President,,Republican,"Trump, Donald J.",455,000370
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,independent,"Stein, Jill",24,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Hedges, James A",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Hoefling, Tom",1,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Maturen, Michael A",2,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"McMullin, Evan",2,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Perry, Darryl",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Smith, Mike",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Sood, Ajay",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",352,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Libertarian,"Johnson, Gary",80,000380
+LEAVENWORTH,Tonganoxie Township,President / Vice President,,Republican,"Trump, Donald J.",830,000380
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,independent,"Stein, Jill",16,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Basiago, Andrew D.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Castle, Darrell L",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Giordani, Rocky",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Hedges, James A",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Kahn, Lynn",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"La Riva, Gloria",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Levinson, Michael S.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Maturen, Michael A",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"McMullin, Evan",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Moorehead, Monica G.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Perry, Darryl",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Schriner, Joe C",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Smith, Mike",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Sood, Ajay",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Sterling, Shawna",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Valdivia, Anthony J",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Democratic,"Clinton, Hillary Rodham",171,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Libertarian,"Johnson, Gary",20,000390
+LEAVENWORTH,Walnut Township Voting District,President / Vice President,,Republican,"Trump, Donald J.",414,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,independent,"Stein, Jill",3,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Hedges, James A",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"McMullin, Evan",3,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Perry, Darryl",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Smith, Mike",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Sood, Ajay",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Libertarian,"Johnson, Gary",16,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,President / Vice President,,Republican,"Trump, Donald J.",118,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,independent,"Stein, Jill",1,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Hedges, James A",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"McMullin, Evan",3,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Perry, Darryl",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Smith, Mike",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Sood, Ajay",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Libertarian,"Johnson, Gary",8,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,President / Vice President,,Republican,"Trump, Donald J.",65,120050
+LEAVENWORTH,Missouri River H41,President / Vice President,,independent,"Stein, Jill",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Hedges, James A",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"McMullin, Evan",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Perry, Darryl",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Smith, Mike",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Sood, Ajay",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+LEAVENWORTH,Missouri River H41,President / Vice President,,Republican,"Trump, Donald J.",0,120060
+LEAVENWORTH,Missouri River H42,President / Vice President,,independent,"Stein, Jill",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Hedges, James A",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"McMullin, Evan",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Perry, Darryl",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Smith, Mike",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Sood, Ajay",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+LEAVENWORTH,Missouri River H42,President / Vice President,,Republican,"Trump, Donald J.",0,120070
+LEAVENWORTH,Reno Township H38,President / Vice President,,independent,"Stein, Jill",1,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Hedges, James A",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"McMullin, Evan",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Perry, Darryl",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Smith, Mike",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Sood, Ajay",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Libertarian,"Johnson, Gary",6,120080
+LEAVENWORTH,Reno Township H38,President / Vice President,,Republican,"Trump, Donald J.",71,120080
+LEAVENWORTH,Reno Township H42,President / Vice President,,independent,"Stein, Jill",10,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Castle, Darrell L",1,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Hedges, James A",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"McMullin, Evan",3,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Perry, Darryl",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Smith, Mike",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Sood, Ajay",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Democratic,"Clinton, Hillary Rodham",256,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Libertarian,"Johnson, Gary",31,120090
+LEAVENWORTH,Reno Township H42,President / Vice President,,Republican,"Trump, Donald J.",336,120090
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,independent,"Stein, Jill",6,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Basiago, Andrew D.",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Castle, Darrell L",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Giordani, Rocky",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Hedges, James A",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Kahn, Lynn",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"La Riva, Gloria",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Levinson, Michael S.",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Maturen, Michael A",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"McMullin, Evan",2,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Moorehead, Monica G.",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Perry, Darryl",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Schriner, Joe C",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Smith, Mike",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Sood, Ajay",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Sterling, Shawna",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Valdivia, Anthony J",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,Libertarian,"Johnson, Gary",17,120100
+LEAVENWORTH,South Delaware 3 S3 H38,President / Vice President,,Republican,"Trump, Donald J.",104,120100
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,independent,"Stein, Jill",1,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Basiago, Andrew D.",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Castle, Darrell L",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Giordani, Rocky",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Hedges, James A",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Kahn, Lynn",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"La Riva, Gloria",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Levinson, Michael S.",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Maturen, Michael A",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"McMullin, Evan",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Moorehead, Monica G.",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Perry, Darryl",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Schriner, Joe C",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Smith, Mike",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Sood, Ajay",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Sterling, Shawna",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Valdivia, Anthony J",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,Libertarian,"Johnson, Gary",8,120110
+LEAVENWORTH,South Delaware 2 S3 H40,President / Vice President,,Republican,"Trump, Donald J.",71,120110
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,independent,"Stein, Jill",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Basiago, Andrew D.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Castle, Darrell L",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Giordani, Rocky",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Hedges, James A",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Kahn, Lynn",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"La Riva, Gloria",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Levinson, Michael S.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Maturen, Michael A",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"McMullin, Evan",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Moorehead, Monica G.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Perry, Darryl",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Schriner, Joe C",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Smith, Mike",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Sood, Ajay",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Sterling, Shawna",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Valdivia, Anthony J",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,Libertarian,"Johnson, Gary",1,120120
+LEAVENWORTH,South Delaware 4 S5 H38,President / Vice President,,Republican,"Trump, Donald J.",1,120120
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,independent,"Stein, Jill",3,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Basiago, Andrew D.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Castle, Darrell L",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Giordani, Rocky",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Hedges, James A",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Kahn, Lynn",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"La Riva, Gloria",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Levinson, Michael S.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Maturen, Michael A",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"McMullin, Evan",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Moorehead, Monica G.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Perry, Darryl",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Schriner, Joe C",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Smith, Mike",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Sood, Ajay",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Sterling, Shawna",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Valdivia, Anthony J",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Libertarian,"Johnson, Gary",17,120130
+LEAVENWORTH,South Delaware 1 S5 H40,President / Vice President,,Republican,"Trump, Donald J.",168,120130
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LEAVENWORTH,Basehor City Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+LEAVENWORTH,Basehor City Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,independent,"Stein, Jill",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Hedges, James A",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"McMullin, Evan",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Perry, Darryl",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Smith, Mike",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Sood, Ajay",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+LEAVENWORTH,Basehor City Exclave 3,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,independent,"Stein, Jill",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Hedges, James A",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Smith, Mike",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900080
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Democratic,"Potter, Britani",75,000010
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000010
+LEAVENWORTH,Alexandria Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",318,000010
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Democratic,"Potter, Britani",756,000020
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Libertarian,"Bales, James Houston",172,000020
+LEAVENWORTH,Basehor City,United States House of Representatives,2,Republican,"Jenkins, Lynn",1846,000020
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Democratic,"Potter, Britani",236,000030
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Libertarian,"Bales, James Houston",72,000030
+LEAVENWORTH,Basehor Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",725,000030
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Democratic,"Potter, Britani",103,000040
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000040
+LEAVENWORTH,Easton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",384,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,United States House of Representatives,2,Democratic,"Potter, Britani",381,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States House of Representatives,2,Libertarian,"Bales, James Houston",79,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",954,000050
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Democratic,"Potter, Britani",245,000060
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",58,000060
+LEAVENWORTH,High Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",785,000060
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Democratic,"Potter, Britani",196,000070
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",42,000070
+LEAVENWORTH,Kickapoo Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",751,000070
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",242,000080
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",65,000080
+LEAVENWORTH,Lansing Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",502,000080
+LEAVENWORTH,Lansing Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",288,000090
+LEAVENWORTH,Lansing Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",74,000090
+LEAVENWORTH,Lansing Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",733,000090
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",311,000100
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",65,000100
+LEAVENWORTH,Lansing Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",638,000100
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",339,000110
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",72,000110
+LEAVENWORTH,Lansing Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",693,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",161,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",107,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",30,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",106,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",181,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",30,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",165,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",58,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",262,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",108,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",156,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",41,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",186,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",113,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",42,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",183,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",199,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",53,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",407,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",113,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",29,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",268,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",193,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",44,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",299,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",180,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",31,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",216,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",165,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",42,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",227,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Democratic,"Potter, Britani",235,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",51,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",497,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Democratic,"Potter, Britani",242,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",51,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",540,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",102,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",471,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",81,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",807,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",506,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",100,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",1065,00029A
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Democratic,"Potter, Britani",378,000320
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",80,000320
+LEAVENWORTH,Sherman Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",928,000320
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,000340
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000340
+LEAVENWORTH,South Delaware 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000340
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Democratic,"Potter, Britani",206,000350
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Libertarian,"Bales, James Houston",45,000350
+LEAVENWORTH,Stranger Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",579,000350
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Democratic,"Potter, Britani",366,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Libertarian,"Bales, James Houston",125,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States House of Representatives,2,Republican,"Jenkins, Lynn",829,000360
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Democratic,"Potter, Britani",235,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Libertarian,"Bales, James Houston",77,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States House of Representatives,2,Republican,"Jenkins, Lynn",471,000370
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Democratic,"Potter, Britani",339,000380
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",112,000380
+LEAVENWORTH,Tonganoxie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",843,000380
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Democratic,"Potter, Britani",152,000390
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Libertarian,"Bales, James Houston",38,000390
+LEAVENWORTH,Walnut Township Voting District,United States House of Representatives,2,Republican,"Jenkins, Lynn",435,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Democratic,"Potter, Britani",65,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States House of Representatives,2,Republican,"Jenkins, Lynn",134,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Democratic,"Potter, Britani",54,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",67,120050
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Democratic,"Potter, Britani",0,120060
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120060
+LEAVENWORTH,Missouri River H41,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120060
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Democratic,"Potter, Britani",0,120070
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120070
+LEAVENWORTH,Missouri River H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120070
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Democratic,"Potter, Britani",45,120080
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,120080
+LEAVENWORTH,Reno Township H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,120080
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Democratic,"Potter, Britani",213,120090
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Libertarian,"Bales, James Houston",55,120090
+LEAVENWORTH,Reno Township H42,United States House of Representatives,2,Republican,"Jenkins, Lynn",373,120090
+LEAVENWORTH,South Delaware 3 S3 H38,United States House of Representatives,2,Democratic,"Potter, Britani",27,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",130,120100
+LEAVENWORTH,South Delaware 2 S3 H40,United States House of Representatives,2,Democratic,"Potter, Britani",22,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,120110
+LEAVENWORTH,South Delaware 4 S5 H38,United States House of Representatives,2,Democratic,"Potter, Britani",2,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States House of Representatives,2,Republican,"Jenkins, Lynn",1,120120
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Democratic,"Potter, Britani",61,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,120130
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900080
+LEAVENWORTH,Alexandria Township,United States Senate,,write - in,"Smith, DJ",1,000010
+LEAVENWORTH,Alexandria Township,United States Senate,,Democratic,"Wiesner, Patrick",76,000010
+LEAVENWORTH,Alexandria Township,United States Senate,,Libertarian,"Garrard, Robert D.",32,000010
+LEAVENWORTH,Alexandria Township,United States Senate,,Republican,"Moran, Jerry",307,000010
+LEAVENWORTH,Basehor City,United States Senate,,write - in,"Smith, DJ",1,000020
+LEAVENWORTH,Basehor City,United States Senate,,Democratic,"Wiesner, Patrick",896,000020
+LEAVENWORTH,Basehor City,United States Senate,,Libertarian,"Garrard, Robert D.",127,000020
+LEAVENWORTH,Basehor City,United States Senate,,Republican,"Moran, Jerry",1742,000020
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,write - in,"Smith, DJ",2,000030
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,Democratic,"Wiesner, Patrick",282,000030
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,Libertarian,"Garrard, Robert D.",61,000030
+LEAVENWORTH,Basehor Township Voting District,United States Senate,,Republican,"Moran, Jerry",685,000030
+LEAVENWORTH,Easton Township,United States Senate,,write - in,"Smith, DJ",1,000040
+LEAVENWORTH,Easton Township,United States Senate,,Democratic,"Wiesner, Patrick",118,000040
+LEAVENWORTH,Easton Township,United States Senate,,Libertarian,"Garrard, Robert D.",26,000040
+LEAVENWORTH,Easton Township,United States Senate,,Republican,"Moran, Jerry",363,000040
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,write - in,"Smith, DJ",2,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,Democratic,"Wiesner, Patrick",453,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,Libertarian,"Garrard, Robert D.",63,000050
+LEAVENWORTH,GL / Fairmount Township Voting District,United States Senate,,Republican,"Moran, Jerry",903,000050
+LEAVENWORTH,High Prairie Township,United States Senate,,write - in,"Smith, DJ",1,000060
+LEAVENWORTH,High Prairie Township,United States Senate,,Democratic,"Wiesner, Patrick",277,000060
+LEAVENWORTH,High Prairie Township,United States Senate,,Libertarian,"Garrard, Robert D.",61,000060
+LEAVENWORTH,High Prairie Township,United States Senate,,Republican,"Moran, Jerry",743,000060
+LEAVENWORTH,Kickapoo Township,United States Senate,,write - in,"Smith, DJ",3,000070
+LEAVENWORTH,Kickapoo Township,United States Senate,,Democratic,"Wiesner, Patrick",215,000070
+LEAVENWORTH,Kickapoo Township,United States Senate,,Libertarian,"Garrard, Robert D.",51,000070
+LEAVENWORTH,Kickapoo Township,United States Senate,,Republican,"Moran, Jerry",725,000070
+LEAVENWORTH,Lansing Ward 1,United States Senate,,write - in,"Smith, DJ",0,000080
+LEAVENWORTH,Lansing Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",276,000080
+LEAVENWORTH,Lansing Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",70,000080
+LEAVENWORTH,Lansing Ward 1,United States Senate,,Republican,"Moran, Jerry",459,000080
+LEAVENWORTH,Lansing Ward 2,United States Senate,,write - in,"Smith, DJ",2,000090
+LEAVENWORTH,Lansing Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",346,000090
+LEAVENWORTH,Lansing Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",54,000090
+LEAVENWORTH,Lansing Ward 2,United States Senate,,Republican,"Moran, Jerry",695,000090
+LEAVENWORTH,Lansing Ward 3,United States Senate,,write - in,"Smith, DJ",3,000100
+LEAVENWORTH,Lansing Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",351,000100
+LEAVENWORTH,Lansing Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",48,000100
+LEAVENWORTH,Lansing Ward 3,United States Senate,,Republican,"Moran, Jerry",615,000100
+LEAVENWORTH,Lansing Ward 4,United States Senate,,write - in,"Smith, DJ",2,000110
+LEAVENWORTH,Lansing Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",393,000110
+LEAVENWORTH,Lansing Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",65,000110
+LEAVENWORTH,Lansing Ward 4,United States Senate,,Republican,"Moran, Jerry",652,000110
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",1,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",185,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000120
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",120,000120
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",115,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",161,000130
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",123,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",23,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",147,000140
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",208,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",33,000150
+LEAVENWORTH,Leavenworth Ward 2 Precinct 3,United States Senate,,Republican,"Moran, Jerry",207,000150
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",194,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",60,000160
+LEAVENWORTH,Leavenworth Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",233,000160
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",3,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",127,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",22,00017A
+LEAVENWORTH,Leavenworth Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",108,00017A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",174,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",26,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 1,United States Senate,,Republican,"Moran, Jerry",181,000180
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",128,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",35,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 2,United States Senate,,Republican,"Moran, Jerry",175,00019A
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",228,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",56,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 3,United States Senate,,Republican,"Moran, Jerry",376,000200
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",132,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",25,000210
+LEAVENWORTH,Leavenworth Ward 5 Precinct 4,United States Senate,,Republican,"Moran, Jerry",255,000210
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,write - in,"Smith, DJ",2,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",201,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",39,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 1,United States Senate,,Republican,"Moran, Jerry",293,000220
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",207,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",25,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 2,United States Senate,,Republican,"Moran, Jerry",200,000230
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,write - in,"Smith, DJ",2,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",177,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",32,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 3,United States Senate,,Republican,"Moran, Jerry",222,000240
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,write - in,"Smith, DJ",3,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",268,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",40,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 4,United States Senate,,Republican,"Moran, Jerry",479,000250
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,write - in,"Smith, DJ",2,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",298,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",47,000260
+LEAVENWORTH,Leavenworth Ward 6 Precinct 5,United States Senate,,Republican,"Moran, Jerry",488,000260
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",108,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",7,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 1,United States Senate,,Republican,"Moran, Jerry",49,00027A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",532,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",71,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 2,United States Senate,,Republican,"Moran, Jerry",762,000280
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,write - in,"Smith, DJ",3,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",570,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",95,00029A
+LEAVENWORTH,Leavenworth Ward 7 Precinct 3,United States Senate,,Republican,"Moran, Jerry",999,00029A
+LEAVENWORTH,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000320
+LEAVENWORTH,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",433,000320
+LEAVENWORTH,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",74,000320
+LEAVENWORTH,Sherman Township,United States Senate,,Republican,"Moran, Jerry",878,000320
+LEAVENWORTH,South Delaware 2,United States Senate,,write - in,"Smith, DJ",0,000340
+LEAVENWORTH,South Delaware 2,United States Senate,,Democratic,"Wiesner, Patrick",0,000340
+LEAVENWORTH,South Delaware 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,000340
+LEAVENWORTH,South Delaware 2,United States Senate,,Republican,"Moran, Jerry",0,000340
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,write - in,"Smith, DJ",0,000350
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,Democratic,"Wiesner, Patrick",225,000350
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,Libertarian,"Garrard, Robert D.",41,000350
+LEAVENWORTH,Stranger Township Voting District,United States Senate,,Republican,"Moran, Jerry",557,000350
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,write - in,"Smith, DJ",4,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,Democratic,"Wiesner, Patrick",425,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",84,000360
+LEAVENWORTH,Tonganoxie North Precinct,United States Senate,,Republican,"Moran, Jerry",805,000360
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,write - in,"Smith, DJ",0,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,Democratic,"Wiesner, Patrick",289,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",42,000370
+LEAVENWORTH,Tonganoxie South Precinct,United States Senate,,Republican,"Moran, Jerry",455,000370
+LEAVENWORTH,Tonganoxie Township,United States Senate,,write - in,"Smith, DJ",3,000380
+LEAVENWORTH,Tonganoxie Township,United States Senate,,Democratic,"Wiesner, Patrick",396,000380
+LEAVENWORTH,Tonganoxie Township,United States Senate,,Libertarian,"Garrard, Robert D.",90,000380
+LEAVENWORTH,Tonganoxie Township,United States Senate,,Republican,"Moran, Jerry",810,000380
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,write - in,"Smith, DJ",0,000390
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,Democratic,"Wiesner, Patrick",180,000390
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,Libertarian,"Garrard, Robert D.",23,000390
+LEAVENWORTH,Walnut Township Voting District,United States Senate,,Republican,"Moran, Jerry",418,000390
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,write - in,"Smith, DJ",0,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,Democratic,"Wiesner, Patrick",68,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,Libertarian,"Garrard, Robert D.",7,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H41,United States Senate,,Republican,"Moran, Jerry",142,120040
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,write - in,"Smith, DJ",0,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,Democratic,"Wiesner, Patrick",57,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,Libertarian,"Garrard, Robert D.",6,120050
+LEAVENWORTH,Leavenworth Ward 1 Precinct 1 Fort A H42,United States Senate,,Republican,"Moran, Jerry",68,120050
+LEAVENWORTH,Missouri River H41,United States Senate,,write - in,"Smith, DJ",0,120060
+LEAVENWORTH,Missouri River H41,United States Senate,,Democratic,"Wiesner, Patrick",0,120060
+LEAVENWORTH,Missouri River H41,United States Senate,,Libertarian,"Garrard, Robert D.",0,120060
+LEAVENWORTH,Missouri River H41,United States Senate,,Republican,"Moran, Jerry",0,120060
+LEAVENWORTH,Missouri River H42,United States Senate,,write - in,"Smith, DJ",0,120070
+LEAVENWORTH,Missouri River H42,United States Senate,,Democratic,"Wiesner, Patrick",0,120070
+LEAVENWORTH,Missouri River H42,United States Senate,,Libertarian,"Garrard, Robert D.",0,120070
+LEAVENWORTH,Missouri River H42,United States Senate,,Republican,"Moran, Jerry",0,120070
+LEAVENWORTH,Reno Township H38,United States Senate,,write - in,"Smith, DJ",0,120080
+LEAVENWORTH,Reno Township H38,United States Senate,,Democratic,"Wiesner, Patrick",50,120080
+LEAVENWORTH,Reno Township H38,United States Senate,,Libertarian,"Garrard, Robert D.",6,120080
+LEAVENWORTH,Reno Township H38,United States Senate,,Republican,"Moran, Jerry",74,120080
+LEAVENWORTH,Reno Township H42,United States Senate,,write - in,"Smith, DJ",1,120090
+LEAVENWORTH,Reno Township H42,United States Senate,,Democratic,"Wiesner, Patrick",250,120090
+LEAVENWORTH,Reno Township H42,United States Senate,,Libertarian,"Garrard, Robert D.",31,120090
+LEAVENWORTH,Reno Township H42,United States Senate,,Republican,"Moran, Jerry",357,120090
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,write - in,"Smith, DJ",0,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,Democratic,"Wiesner, Patrick",35,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,Libertarian,"Garrard, Robert D.",9,120100
+LEAVENWORTH,South Delaware 3 S3 H38,United States Senate,,Republican,"Moran, Jerry",120,120100
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,write - in,"Smith, DJ",0,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,Democratic,"Wiesner, Patrick",32,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,Libertarian,"Garrard, Robert D.",2,120110
+LEAVENWORTH,South Delaware 2 S3 H40,United States Senate,,Republican,"Moran, Jerry",75,120110
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,write - in,"Smith, DJ",0,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,Democratic,"Wiesner, Patrick",2,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,Libertarian,"Garrard, Robert D.",1,120120
+LEAVENWORTH,South Delaware 4 S5 H38,United States Senate,,Republican,"Moran, Jerry",1,120120
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,write - in,"Smith, DJ",0,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,Democratic,"Wiesner, Patrick",71,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,Libertarian,"Garrard, Robert D.",14,120130
+LEAVENWORTH,South Delaware 1 S5 H40,United States Senate,,Republican,"Moran, Jerry",183,120130
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+LEAVENWORTH,Basehor City Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+LEAVENWORTH,Basehor City Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900020
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,write - in,"Smith, DJ",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+LEAVENWORTH,Basehor City Exclave 3,United States Senate,,Republican,"Moran, Jerry",0,900030
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,write - in,"Smith, DJ",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900080
+LEAVENWORTH,Tonganoxie South Exclave,United States Senate,,Republican,"Moran, Jerry",0,900080

--- a/2016/20161108__ks__general__lincoln__precinct.csv
+++ b/2016/20161108__ks__general__lincoln__precinct.csv
@@ -1,865 +1,865 @@
-county,precinct,office,district,candidate,party,votes
-LINCOLN,Battle Creek Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Battle Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Battle Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Battle Creek Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Battle Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-LINCOLN,Battle Creek Township,President,,"Johnson, Gary  ",Libertarian,2
-LINCOLN,Battle Creek Township,President,,"Trump, Donald J. ",Republican,19
-LINCOLN,Beaver Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Beaver Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Beaver Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Beaver Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Beaver Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Beaver Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Beaver Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Beaver Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Beaver Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Beaver Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Beaver Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Beaver Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Beaver Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Beaver Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Beaver Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Beaver Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Beaver Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Beaver Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Beaver Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Beaver Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Beaver Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Beaver Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Beaver Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-LINCOLN,Beaver Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Beaver Township,President,,"Trump, Donald J. ",Republican,30
-LINCOLN,Cedron Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Cedron Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Cedron Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Cedron Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Cedron Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Cedron Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Cedron Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Cedron Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Cedron Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Cedron Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Cedron Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Cedron Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Cedron Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Cedron Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Cedron Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Cedron Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Cedron Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Cedron Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Cedron Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Cedron Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Cedron Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Cedron Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Cedron Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-LINCOLN,Cedron Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Cedron Township,President,,"Trump, Donald J. ",Republican,21
-LINCOLN,Colorado Township,President,,"Stein, Jill  ",independent,2
-LINCOLN,Colorado Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Colorado Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Colorado Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Colorado Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Colorado Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Colorado Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Colorado Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Colorado Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Colorado Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Colorado Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Colorado Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Colorado Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Colorado Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Colorado Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Colorado Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Colorado Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Colorado Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Colorado Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Colorado Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Colorado Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Colorado Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Colorado Township,President,,"Clinton, Hillary Rodham ",Democratic,18
-LINCOLN,Colorado Township,President,,"Johnson, Gary  ",Libertarian,4
-LINCOLN,Colorado Township,President,,"Trump, Donald J. ",Republican,88
-LINCOLN,Elkhorn Township Part A,President,,"Stein, Jill  ",independent,1
-LINCOLN,Elkhorn Township Part A,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Hedges, James A ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Elkhorn Township Part A,President,,"Clinton, Hillary Rodham ",Democratic,6
-LINCOLN,Elkhorn Township Part A,President,,"Johnson, Gary  ",Libertarian,2
-LINCOLN,Elkhorn Township Part A,President,,"Trump, Donald J. ",Republican,52
-LINCOLN,Franklin Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Franklin Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Franklin Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Franklin Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Franklin Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Franklin Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Franklin Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Franklin Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Franklin Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Franklin Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Franklin Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Franklin Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Franklin Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Franklin Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Franklin Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Franklin Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Franklin Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Franklin Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Franklin Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Franklin Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Franklin Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Franklin Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Franklin Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-LINCOLN,Franklin Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Franklin Township,President,,"Trump, Donald J. ",Republican,46
-LINCOLN,Golden Belt Township,President,,"Stein, Jill  ",independent,3
-LINCOLN,Golden Belt Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Golden Belt Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Golden Belt Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Golden Belt Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-LINCOLN,Golden Belt Township,President,,"Johnson, Gary  ",Libertarian,2
-LINCOLN,Golden Belt Township,President,,"Trump, Donald J. ",Republican,16
-LINCOLN,Grant Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Grant Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Grant Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Grant Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Grant Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Grant Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Grant Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Grant Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Grant Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Grant Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Grant Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Grant Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Grant Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Grant Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Grant Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Grant Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Grant Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Grant Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Grant Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Grant Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Grant Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Grant Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Grant Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-LINCOLN,Grant Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Grant Township,President,,"Trump, Donald J. ",Republican,40
-LINCOLN,Hanover Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Hanover Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Hanover Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Hanover Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Hanover Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Hanover Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Hanover Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Hanover Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Hanover Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Hanover Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Hanover Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Hanover Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Hanover Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Hanover Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Hanover Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Hanover Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Hanover Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Hanover Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Hanover Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Hanover Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Hanover Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Hanover Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Hanover Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-LINCOLN,Hanover Township,President,,"Johnson, Gary  ",Libertarian,1
-LINCOLN,Hanover Township,President,,"Trump, Donald J. ",Republican,21
-LINCOLN,Highland Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Highland Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Highland Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Highland Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Highland Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Highland Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Highland Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Highland Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Highland Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Highland Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Highland Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Highland Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Highland Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Highland Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Highland Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Highland Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Highland Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Highland Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Highland Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Highland Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Highland Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Highland Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Highland Township,President,,"Clinton, Hillary Rodham ",Democratic,12
-LINCOLN,Highland Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Highland Township,President,,"Trump, Donald J. ",Republican,24
-LINCOLN,Indiana Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Indiana Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Indiana Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Indiana Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Indiana Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Indiana Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Indiana Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Indiana Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Indiana Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Indiana Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Indiana Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Indiana Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Indiana Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Indiana Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Indiana Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Indiana Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Indiana Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Indiana Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Indiana Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Indiana Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Indiana Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Indiana Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Indiana Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-LINCOLN,Indiana Township,President,,"Johnson, Gary  ",Libertarian,1
-LINCOLN,Indiana Township,President,,"Trump, Donald J. ",Republican,36
-LINCOLN,Lincoln Precinct 1,President,,"Stein, Jill  ",independent,7
-LINCOLN,Lincoln Precinct 1,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Hedges, James A ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Lincoln Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,42
-LINCOLN,Lincoln Precinct 1,President,,"Johnson, Gary  ",Libertarian,7
-LINCOLN,Lincoln Precinct 1,President,,"Trump, Donald J. ",Republican,175
-LINCOLN,Lincoln Precinct 2,President,,"Stein, Jill  ",independent,4
-LINCOLN,Lincoln Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Hedges, James A ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Lincoln Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,47
-LINCOLN,Lincoln Precinct 2,President,,"Johnson, Gary  ",Libertarian,12
-LINCOLN,Lincoln Precinct 2,President,,"Trump, Donald J. ",Republican,214
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Stein, Jill  ",independent,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Hedges, James A ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Lincoln Precinct 2 Exclave,President,,"Trump, Donald J. ",Republican,0
-LINCOLN,Logan Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Logan Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Logan Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Logan Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Logan Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Logan Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Logan Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Logan Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Logan Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Logan Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Logan Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Logan Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Logan Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Logan Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Logan Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Logan Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Logan Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Logan Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Logan Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Logan Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Logan Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Logan Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Logan Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-LINCOLN,Logan Township,President,,"Johnson, Gary  ",Libertarian,2
-LINCOLN,Logan Township,President,,"Trump, Donald J. ",Republican,33
-LINCOLN,Madison Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Madison Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Madison Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Madison Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Madison Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Madison Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Madison Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Madison Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Madison Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Madison Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Madison Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Madison Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Madison Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Madison Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Madison Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Madison Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Madison Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Madison Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Madison Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Madison Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Madison Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Madison Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Madison Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-LINCOLN,Madison Township,President,,"Johnson, Gary  ",Libertarian,1
-LINCOLN,Madison Township,President,,"Trump, Donald J. ",Republican,34
-LINCOLN,Marion Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Marion Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Marion Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Marion Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Marion Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Marion Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Marion Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Marion Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Marion Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Marion Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Marion Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Marion Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Marion Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Marion Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Marion Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Marion Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Marion Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Marion Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Marion Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Marion Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Marion Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Marion Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Marion Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-LINCOLN,Marion Township,President,,"Johnson, Gary  ",Libertarian,1
-LINCOLN,Marion Township,President,,"Trump, Donald J. ",Republican,16
-LINCOLN,Orange Township,President,,"Stein, Jill  ",independent,0
-LINCOLN,Orange Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Orange Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Orange Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Orange Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Orange Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Orange Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Orange Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Orange Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Orange Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Orange Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Orange Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Orange Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Orange Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Orange Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Orange Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Orange Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Orange Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Orange Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Orange Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Orange Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Orange Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Orange Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-LINCOLN,Orange Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Orange Township,President,,"Trump, Donald J. ",Republican,34
-LINCOLN,Pleasant Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Pleasant Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Pleasant Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Pleasant Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Pleasant Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Pleasant Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Pleasant Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Pleasant Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Pleasant Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Pleasant Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Pleasant Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Pleasant Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Pleasant Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Pleasant Township,President,,"Clinton, Hillary Rodham ",Democratic,37
-LINCOLN,Pleasant Township,President,,"Johnson, Gary  ",Libertarian,4
-LINCOLN,Pleasant Township,President,,"Trump, Donald J. ",Republican,157
-LINCOLN,Salt Creek Township,President,,"Stein, Jill  ",independent,2
-LINCOLN,Salt Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Salt Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Salt Creek Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Salt Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-LINCOLN,Salt Creek Township,President,,"Johnson, Gary  ",Libertarian,1
-LINCOLN,Salt Creek Township,President,,"Trump, Donald J. ",Republican,22
-LINCOLN,Scott Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Scott Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Scott Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Scott Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Scott Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Scott Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Scott Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Scott Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Scott Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Scott Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Scott Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Scott Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Scott Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Scott Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Scott Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Scott Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Scott Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Scott Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Scott Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Scott Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Scott Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Scott Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Scott Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-LINCOLN,Scott Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Scott Township,President,,"Trump, Donald J. ",Republican,40
-LINCOLN,Valley Township,President,,"Stein, Jill  ",independent,1
-LINCOLN,Valley Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Valley Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Valley Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Valley Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Valley Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Valley Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Valley Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Valley Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Valley Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Valley Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Valley Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Valley Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Valley Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Valley Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Valley Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Valley Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Valley Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Valley Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Valley Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Valley Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Valley Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Valley Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-LINCOLN,Valley Township,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Valley Township,President,,"Trump, Donald J. ",Republican,17
-LINCOLN,Vesper Township,President,,"Stein, Jill  ",independent,3
-LINCOLN,Vesper Township,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Vesper Township,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Vesper Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Vesper Township,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Vesper Township,President,,"Hedges, James A ",write - in,0
-LINCOLN,Vesper Township,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Vesper Township,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Vesper Township,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Vesper Township,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Vesper Township,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Vesper Township,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Vesper Township,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Vesper Township,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Vesper Township,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Vesper Township,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Vesper Township,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Vesper Township,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Vesper Township,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Vesper Township,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Vesper Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Vesper Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Vesper Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-LINCOLN,Vesper Township,President,,"Johnson, Gary  ",Libertarian,1
-LINCOLN,Vesper Township,President,,"Trump, Donald J. ",Republican,44
-LINCOLN,Marion Township Enclave 1,President,,"Stein, Jill  ",independent,0
-LINCOLN,Marion Township Enclave 1,President,,"Basiago, Andrew D. ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Castle, Darrell L ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Giordani, Rocky  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Hedges, James A ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Hoefling, Tom  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Kahn, Lynn  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"La Riva, Gloria  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Levinson, Michael S. ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Maturen, Michael A ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"McMullin, Evan  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Moorehead, Monica G. ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Perry, Darryl  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Schoenke, Marshall R. ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Schriner, Joe C ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Smith, Mike  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Sood, Ajay  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Sterling, Shawna  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Valdivia, Anthony J ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-LINCOLN,Marion Township Enclave 1,President,,"Clinton, Hillary Rodham ",Democratic,0
-LINCOLN,Marion Township Enclave 1,President,,"Johnson, Gary  ",Libertarian,0
-LINCOLN,Marion Township Enclave 1,President,,"Trump, Donald J. ",Republican,0
-LINCOLN,Battle Creek Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Battle Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-LINCOLN,Battle Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-LINCOLN,Battle Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,19
-LINCOLN,Beaver Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Beaver Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-LINCOLN,Beaver Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-LINCOLN,Beaver Township,U.S. Senate,,"Moran, Jerry  ",Republican,29
-LINCOLN,Cedron Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Cedron Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-LINCOLN,Cedron Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Cedron Township,U.S. Senate,,"Moran, Jerry  ",Republican,19
-LINCOLN,Colorado Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Colorado Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,16
-LINCOLN,Colorado Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-LINCOLN,Colorado Township,U.S. Senate,,"Moran, Jerry  ",Republican,89
-LINCOLN,Elkhorn Township Part A,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Elkhorn Township Part A,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-LINCOLN,Elkhorn Township Part A,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-LINCOLN,Elkhorn Township Part A,U.S. Senate,,"Moran, Jerry  ",Republican,59
-LINCOLN,Franklin Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Franklin Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-LINCOLN,Franklin Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-LINCOLN,Franklin Township,U.S. Senate,,"Moran, Jerry  ",Republican,44
-LINCOLN,Golden Belt Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Golden Belt Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-LINCOLN,Golden Belt Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-LINCOLN,Golden Belt Township,U.S. Senate,,"Moran, Jerry  ",Republican,21
-LINCOLN,Grant Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Grant Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-LINCOLN,Grant Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-LINCOLN,Grant Township,U.S. Senate,,"Moran, Jerry  ",Republican,38
-LINCOLN,Hanover Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Hanover Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-LINCOLN,Hanover Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-LINCOLN,Hanover Township,U.S. Senate,,"Moran, Jerry  ",Republican,19
-LINCOLN,Highland Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Highland Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,8
-LINCOLN,Highland Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Highland Township,U.S. Senate,,"Moran, Jerry  ",Republican,28
-LINCOLN,Indiana Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Indiana Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-LINCOLN,Indiana Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-LINCOLN,Indiana Township,U.S. Senate,,"Moran, Jerry  ",Republican,33
-LINCOLN,Lincoln Precinct 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Lincoln Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,31
-LINCOLN,Lincoln Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,14
-LINCOLN,Lincoln Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,190
-LINCOLN,Lincoln Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Lincoln Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,38
-LINCOLN,Lincoln Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-LINCOLN,Lincoln Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,230
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-LINCOLN,Logan Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Logan Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-LINCOLN,Logan Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-LINCOLN,Logan Township,U.S. Senate,,"Moran, Jerry  ",Republican,30
-LINCOLN,Madison Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Madison Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-LINCOLN,Madison Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-LINCOLN,Madison Township,U.S. Senate,,"Moran, Jerry  ",Republican,33
-LINCOLN,Marion Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Marion Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-LINCOLN,Marion Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-LINCOLN,Marion Township,U.S. Senate,,"Moran, Jerry  ",Republican,18
-LINCOLN,Orange Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Orange Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-LINCOLN,Orange Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-LINCOLN,Orange Township,U.S. Senate,,"Moran, Jerry  ",Republican,37
-LINCOLN,Pleasant Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Pleasant Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,31
-LINCOLN,Pleasant Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-LINCOLN,Pleasant Township,U.S. Senate,,"Moran, Jerry  ",Republican,161
-LINCOLN,Salt Creek Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Salt Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-LINCOLN,Salt Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-LINCOLN,Salt Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,25
-LINCOLN,Scott Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Scott Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-LINCOLN,Scott Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Scott Township,U.S. Senate,,"Moran, Jerry  ",Republican,45
-LINCOLN,Valley Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Valley Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-LINCOLN,Valley Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Valley Township,U.S. Senate,,"Moran, Jerry  ",Republican,20
-LINCOLN,Vesper Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Vesper Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-LINCOLN,Vesper Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Vesper Township,U.S. Senate,,"Moran, Jerry  ",Republican,47
-LINCOLN,Marion Township Enclave 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-LINCOLN,Marion Township Enclave 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-LINCOLN,Marion Township Enclave 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-LINCOLN,Marion Township Enclave 1,U.S. Senate,,"Moran, Jerry  ",Republican,0
-LINCOLN,Battle Creek Township,U.S. House,1,"LaPolice, Alan  ",independent,7
-LINCOLN,Battle Creek Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Battle Creek Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-LINCOLN,Battle Creek Township,U.S. House,1,"Marshall, Roger  ",Republican,15
-LINCOLN,Beaver Township,U.S. House,1,"LaPolice, Alan  ",independent,13
-LINCOLN,Beaver Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Beaver Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-LINCOLN,Beaver Township,U.S. House,1,"Marshall, Roger  ",Republican,18
-LINCOLN,Cedron Township,U.S. House,1,"LaPolice, Alan  ",independent,3
-LINCOLN,Cedron Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Cedron Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Cedron Township,U.S. House,1,"Marshall, Roger  ",Republican,18
-LINCOLN,Colorado Township,U.S. House,1,"LaPolice, Alan  ",independent,36
-LINCOLN,Colorado Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Colorado Township,U.S. House,1,"Burt, Kerry  ",Libertarian,8
-LINCOLN,Colorado Township,U.S. House,1,"Marshall, Roger  ",Republican,69
-LINCOLN,Elkhorn Township Part A,U.S. House,1,"LaPolice, Alan  ",independent,22
-LINCOLN,Elkhorn Township Part A,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Elkhorn Township Part A,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-LINCOLN,Elkhorn Township Part A,U.S. House,1,"Marshall, Roger  ",Republican,39
-LINCOLN,Franklin Township,U.S. House,1,"LaPolice, Alan  ",independent,19
-LINCOLN,Franklin Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Franklin Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-LINCOLN,Franklin Township,U.S. House,1,"Marshall, Roger  ",Republican,33
-LINCOLN,Golden Belt Township,U.S. House,1,"LaPolice, Alan  ",independent,9
-LINCOLN,Golden Belt Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Golden Belt Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-LINCOLN,Golden Belt Township,U.S. House,1,"Marshall, Roger  ",Republican,14
-LINCOLN,Grant Township,U.S. House,1,"LaPolice, Alan  ",independent,13
-LINCOLN,Grant Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Grant Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-LINCOLN,Grant Township,U.S. House,1,"Marshall, Roger  ",Republican,28
-LINCOLN,Hanover Township,U.S. House,1,"LaPolice, Alan  ",independent,8
-LINCOLN,Hanover Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Hanover Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Hanover Township,U.S. House,1,"Marshall, Roger  ",Republican,15
-LINCOLN,Highland Township,U.S. House,1,"LaPolice, Alan  ",independent,14
-LINCOLN,Highland Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Highland Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Highland Township,U.S. House,1,"Marshall, Roger  ",Republican,20
-LINCOLN,Indiana Township,U.S. House,1,"LaPolice, Alan  ",independent,16
-LINCOLN,Indiana Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Indiana Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-LINCOLN,Indiana Township,U.S. House,1,"Marshall, Roger  ",Republican,22
-LINCOLN,Lincoln Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,90
-LINCOLN,Lincoln Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Lincoln Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,8
-LINCOLN,Lincoln Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,134
-LINCOLN,Lincoln Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,103
-LINCOLN,Lincoln Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Lincoln Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,10
-LINCOLN,Lincoln Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,163
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. House,1,"LaPolice, Alan  ",independent,0
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Lincoln Precinct 2 Exclave,U.S. House,1,"Marshall, Roger  ",Republican,0
-LINCOLN,Logan Township,U.S. House,1,"LaPolice, Alan  ",independent,14
-LINCOLN,Logan Township,U.S. House,1,"Huelskamp, Tim  ",write - in,3
-LINCOLN,Logan Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-LINCOLN,Logan Township,U.S. House,1,"Marshall, Roger  ",Republican,18
-LINCOLN,Madison Township,U.S. House,1,"LaPolice, Alan  ",independent,13
-LINCOLN,Madison Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Madison Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Madison Township,U.S. House,1,"Marshall, Roger  ",Republican,29
-LINCOLN,Marion Township,U.S. House,1,"LaPolice, Alan  ",independent,5
-LINCOLN,Marion Township,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-LINCOLN,Marion Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-LINCOLN,Marion Township,U.S. House,1,"Marshall, Roger  ",Republican,10
-LINCOLN,Orange Township,U.S. House,1,"LaPolice, Alan  ",independent,9
-LINCOLN,Orange Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Orange Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Orange Township,U.S. House,1,"Marshall, Roger  ",Republican,29
-LINCOLN,Pleasant Township,U.S. House,1,"LaPolice, Alan  ",independent,64
-LINCOLN,Pleasant Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Pleasant Township,U.S. House,1,"Burt, Kerry  ",Libertarian,8
-LINCOLN,Pleasant Township,U.S. House,1,"Marshall, Roger  ",Republican,121
-LINCOLN,Salt Creek Township,U.S. House,1,"LaPolice, Alan  ",independent,10
-LINCOLN,Salt Creek Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Salt Creek Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Salt Creek Township,U.S. House,1,"Marshall, Roger  ",Republican,19
-LINCOLN,Scott Township,U.S. House,1,"LaPolice, Alan  ",independent,15
-LINCOLN,Scott Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Scott Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-LINCOLN,Scott Township,U.S. House,1,"Marshall, Roger  ",Republican,31
-LINCOLN,Valley Township,U.S. House,1,"LaPolice, Alan  ",independent,6
-LINCOLN,Valley Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Valley Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-LINCOLN,Valley Township,U.S. House,1,"Marshall, Roger  ",Republican,13
-LINCOLN,Vesper Township,U.S. House,1,"LaPolice, Alan  ",independent,13
-LINCOLN,Vesper Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Vesper Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Vesper Township,U.S. House,1,"Marshall, Roger  ",Republican,37
-LINCOLN,Marion Township Enclave 1,U.S. House,1,"LaPolice, Alan  ",independent,0
-LINCOLN,Marion Township Enclave 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-LINCOLN,Marion Township Enclave 1,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-LINCOLN,Marion Township Enclave 1,U.S. House,1,"Marshall, Roger  ",Republican,0
-LINCOLN,Battle Creek Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-LINCOLN,Battle Creek Township,State Senate,36,"Bowers, Elaine S. ",Republican,23
-LINCOLN,Beaver Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-LINCOLN,Beaver Township,State Senate,36,"Bowers, Elaine S. ",Republican,29
-LINCOLN,Cedron Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-LINCOLN,Cedron Township,State Senate,36,"Bowers, Elaine S. ",Republican,20
-LINCOLN,Colorado Township,State Senate,36,"Angevine, Brian G. ",Democratic,15
-LINCOLN,Colorado Township,State Senate,36,"Bowers, Elaine S. ",Republican,92
-LINCOLN,Elkhorn Township Part A,State Senate,36,"Angevine, Brian G. ",Democratic,5
-LINCOLN,Elkhorn Township Part A,State Senate,36,"Bowers, Elaine S. ",Republican,60
-LINCOLN,Franklin Township,State Senate,36,"Angevine, Brian G. ",Democratic,10
-LINCOLN,Franklin Township,State Senate,36,"Bowers, Elaine S. ",Republican,43
-LINCOLN,Golden Belt Township,State Senate,36,"Angevine, Brian G. ",Democratic,8
-LINCOLN,Golden Belt Township,State Senate,36,"Bowers, Elaine S. ",Republican,15
-LINCOLN,Grant Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-LINCOLN,Grant Township,State Senate,36,"Bowers, Elaine S. ",Republican,41
-LINCOLN,Hanover Township,State Senate,36,"Angevine, Brian G. ",Democratic,4
-LINCOLN,Hanover Township,State Senate,36,"Bowers, Elaine S. ",Republican,19
-LINCOLN,Highland Township,State Senate,36,"Angevine, Brian G. ",Democratic,9
-LINCOLN,Highland Township,State Senate,36,"Bowers, Elaine S. ",Republican,26
-LINCOLN,Indiana Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-LINCOLN,Indiana Township,State Senate,36,"Bowers, Elaine S. ",Republican,38
-LINCOLN,Lincoln Precinct 1,State Senate,36,"Angevine, Brian G. ",Democratic,40
-LINCOLN,Lincoln Precinct 1,State Senate,36,"Bowers, Elaine S. ",Republican,190
-LINCOLN,Lincoln Precinct 2,State Senate,36,"Angevine, Brian G. ",Democratic,33
-LINCOLN,Lincoln Precinct 2,State Senate,36,"Bowers, Elaine S. ",Republican,240
-LINCOLN,Lincoln Precinct 2 Exclave,State Senate,36,"Angevine, Brian G. ",Democratic,0
-LINCOLN,Lincoln Precinct 2 Exclave,State Senate,36,"Bowers, Elaine S. ",Republican,0
-LINCOLN,Logan Township,State Senate,36,"Angevine, Brian G. ",Democratic,4
-LINCOLN,Logan Township,State Senate,36,"Bowers, Elaine S. ",Republican,34
-LINCOLN,Madison Township,State Senate,36,"Angevine, Brian G. ",Democratic,7
-LINCOLN,Madison Township,State Senate,36,"Bowers, Elaine S. ",Republican,34
-LINCOLN,Marion Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-LINCOLN,Marion Township,State Senate,36,"Bowers, Elaine S. ",Republican,18
-LINCOLN,Orange Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-LINCOLN,Orange Township,State Senate,36,"Bowers, Elaine S. ",Republican,38
-LINCOLN,Pleasant Township,State Senate,36,"Angevine, Brian G. ",Democratic,28
-LINCOLN,Pleasant Township,State Senate,36,"Bowers, Elaine S. ",Republican,166
-LINCOLN,Salt Creek Township,State Senate,36,"Angevine, Brian G. ",Democratic,3
-LINCOLN,Salt Creek Township,State Senate,36,"Bowers, Elaine S. ",Republican,26
-LINCOLN,Scott Township,State Senate,36,"Angevine, Brian G. ",Democratic,4
-LINCOLN,Scott Township,State Senate,36,"Bowers, Elaine S. ",Republican,44
-LINCOLN,Valley Township,State Senate,36,"Angevine, Brian G. ",Democratic,3
-LINCOLN,Valley Township,State Senate,36,"Bowers, Elaine S. ",Republican,17
-LINCOLN,Vesper Township,State Senate,36,"Angevine, Brian G. ",Democratic,5
-LINCOLN,Vesper Township,State Senate,36,"Bowers, Elaine S. ",Republican,45
-LINCOLN,Marion Township Enclave 1,State Senate,36,"Angevine, Brian G. ",Democratic,0
-LINCOLN,Marion Township Enclave 1,State Senate,36,"Bowers, Elaine S. ",Republican,0
-LINCOLN,Battle Creek Township,State House,109,"Waymaster, Troy L. ",Republican,20
-LINCOLN,Beaver Township,State House,107,"Concannon, Susan L. ",Republican,29
-LINCOLN,Cedron Township,State House,109,"Waymaster, Troy L. ",Republican,20
-LINCOLN,Colorado Township,State House,107,"Concannon, Susan L. ",Republican,98
-LINCOLN,Elkhorn Township Part A,State House,107,"Concannon, Susan L. ",Republican,63
-LINCOLN,Franklin Township,State House,107,"Concannon, Susan L. ",Republican,45
-LINCOLN,Golden Belt Township,State House,109,"Waymaster, Troy L. ",Republican,21
-LINCOLN,Grant Township,State House,109,"Waymaster, Troy L. ",Republican,40
-LINCOLN,Hanover Township,State House,109,"Waymaster, Troy L. ",Republican,23
-LINCOLN,Highland Township,State House,109,"Waymaster, Troy L. ",Republican,31
-LINCOLN,Indiana Township,State House,109,"Waymaster, Troy L. ",Republican,35
-LINCOLN,Lincoln Precinct 1,State House,109,"Waymaster, Troy L. ",Republican,207
-LINCOLN,Lincoln Precinct 2,State House,109,"Waymaster, Troy L. ",Republican,249
-LINCOLN,Lincoln Precinct 2 Exclave,State House,107,"Concannon, Susan L. ",Republican,0
-LINCOLN,Logan Township,State House,107,"Concannon, Susan L. ",Republican,30
-LINCOLN,Madison Township,State House,107,"Concannon, Susan L. ",Republican,37
-LINCOLN,Marion Township,State House,109,"Waymaster, Troy L. ",Republican,18
-LINCOLN,Orange Township,State House,109,"Waymaster, Troy L. ",Republican,36
-LINCOLN,Pleasant Township,State House,109,"Waymaster, Troy L. ",Republican,187
-LINCOLN,Salt Creek Township,State House,107,"Concannon, Susan L. ",Republican,27
-LINCOLN,Scott Township,State House,107,"Concannon, Susan L. ",Republican,46
-LINCOLN,Valley Township,State House,109,"Waymaster, Troy L. ",Republican,16
-LINCOLN,Vesper Township,State House,109,"Waymaster, Troy L. ",Republican,47
-LINCOLN,Marion Township Enclave 1,State House,109,"Waymaster, Troy L. ",Republican,0
+county,precinct,office,district,party,candidate,votes,vtd
+LINCOLN,Battle Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",20,000010
+LINCOLN,Beaver Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",29,00002A
+LINCOLN,Cedron Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",20,000030
+LINCOLN,Colorado Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",98,000040
+LINCOLN,Elkhorn Township Part A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",63,00005A
+LINCOLN,Franklin Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",45,000060
+LINCOLN,Golden Belt Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000070
+LINCOLN,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",40,000080
+LINCOLN,Hanover Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000090
+LINCOLN,Highland Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",31,000100
+LINCOLN,Indiana Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",35,000110
+LINCOLN,Lincoln Precinct 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",207,000120
+LINCOLN,Lincoln Precinct 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",249,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00013B
+LINCOLN,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",30,000140
+LINCOLN,Madison Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",37,000150
+LINCOLN,Marion Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",18,000160
+LINCOLN,Orange Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",36,000170
+LINCOLN,Pleasant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",187,000180
+LINCOLN,Salt Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",27,000190
+LINCOLN,Scott Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",46,000200
+LINCOLN,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000210
+LINCOLN,Vesper Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",47,000220
+LINCOLN,Marion Township Enclave 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,900010
+LINCOLN,Battle Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000010
+LINCOLN,Battle Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",23,000010
+LINCOLN,Beaver Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,00002A
+LINCOLN,Beaver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,00002A
+LINCOLN,Cedron Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000030
+LINCOLN,Cedron Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000030
+LINCOLN,Colorado Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,000040
+LINCOLN,Colorado Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",92,000040
+LINCOLN,Elkhorn Township Part A,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,00005A
+LINCOLN,Elkhorn Township Part A,Kansas Senate,36,Republican,"Bowers, Elaine S.",60,00005A
+LINCOLN,Franklin Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000060
+LINCOLN,Franklin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",43,000060
+LINCOLN,Golden Belt Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000070
+LINCOLN,Golden Belt Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000070
+LINCOLN,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000080
+LINCOLN,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000080
+LINCOLN,Hanover Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000090
+LINCOLN,Hanover Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000090
+LINCOLN,Highland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000100
+LINCOLN,Highland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000100
+LINCOLN,Indiana Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000110
+LINCOLN,Indiana Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",38,000110
+LINCOLN,Lincoln Precinct 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",40,000120
+LINCOLN,Lincoln Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",190,000120
+LINCOLN,Lincoln Precinct 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",33,00013A
+LINCOLN,Lincoln Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",240,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00013B
+LINCOLN,Logan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000140
+LINCOLN,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",34,000140
+LINCOLN,Madison Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000150
+LINCOLN,Madison Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",34,000150
+LINCOLN,Marion Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000160
+LINCOLN,Marion Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000160
+LINCOLN,Orange Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000170
+LINCOLN,Orange Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",38,000170
+LINCOLN,Pleasant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",28,000180
+LINCOLN,Pleasant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",166,000180
+LINCOLN,Salt Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000190
+LINCOLN,Salt Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000190
+LINCOLN,Scott Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000200
+LINCOLN,Scott Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",44,000200
+LINCOLN,Valley Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000210
+LINCOLN,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",17,000210
+LINCOLN,Vesper Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000220
+LINCOLN,Vesper Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",45,000220
+LINCOLN,Marion Township Enclave 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,900010
+LINCOLN,Marion Township Enclave 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,900010
+LINCOLN,Battle Creek Township,President / Vice President,,independent,"Stein, Jill",1,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+LINCOLN,Battle Creek Township,President / Vice President,,Republican,"Trump, Donald J.",19,000010
+LINCOLN,Beaver Township,President / Vice President,,independent,"Stein, Jill",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,00002A
+LINCOLN,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00002A
+LINCOLN,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",30,00002A
+LINCOLN,Cedron Township,President / Vice President,,independent,"Stein, Jill",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LINCOLN,Cedron Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LINCOLN,Cedron Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+LINCOLN,Cedron Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+LINCOLN,Cedron Township,President / Vice President,,Republican,"Trump, Donald J.",21,000030
+LINCOLN,Colorado Township,President / Vice President,,independent,"Stein, Jill",2,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LINCOLN,Colorado Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LINCOLN,Colorado Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000040
+LINCOLN,Colorado Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+LINCOLN,Colorado Township,President / Vice President,,Republican,"Trump, Donald J.",88,000040
+LINCOLN,Elkhorn Township Part A,President / Vice President,,independent,"Stein, Jill",1,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Hedges, James A",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"McMullin, Evan",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Smith, Mike",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Libertarian,"Johnson, Gary",2,00005A
+LINCOLN,Elkhorn Township Part A,President / Vice President,,Republican,"Trump, Donald J.",52,00005A
+LINCOLN,Franklin Township,President / Vice President,,independent,"Stein, Jill",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+LINCOLN,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+LINCOLN,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000060
+LINCOLN,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+LINCOLN,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",46,000060
+LINCOLN,Golden Belt Township,President / Vice President,,independent,"Stein, Jill",3,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+LINCOLN,Golden Belt Township,President / Vice President,,Republican,"Trump, Donald J.",16,000070
+LINCOLN,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LINCOLN,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LINCOLN,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000080
+LINCOLN,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+LINCOLN,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",40,000080
+LINCOLN,Hanover Township,President / Vice President,,independent,"Stein, Jill",1,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+LINCOLN,Hanover Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+LINCOLN,Hanover Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000090
+LINCOLN,Hanover Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+LINCOLN,Hanover Township,President / Vice President,,Republican,"Trump, Donald J.",21,000090
+LINCOLN,Highland Township,President / Vice President,,independent,"Stein, Jill",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LINCOLN,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LINCOLN,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000100
+LINCOLN,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+LINCOLN,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",24,000100
+LINCOLN,Indiana Township,President / Vice President,,independent,"Stein, Jill",1,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LINCOLN,Indiana Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LINCOLN,Indiana Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000110
+LINCOLN,Indiana Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+LINCOLN,Indiana Township,President / Vice President,,Republican,"Trump, Donald J.",36,000110
+LINCOLN,Lincoln Precinct 1,President / Vice President,,independent,"Stein, Jill",7,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000120
+LINCOLN,Lincoln Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",175,000120
+LINCOLN,Lincoln Precinct 2,President / Vice President,,independent,"Stein, Jill",4,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,00013A
+LINCOLN,Lincoln Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",214,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00013B
+LINCOLN,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+LINCOLN,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+LINCOLN,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000140
+LINCOLN,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+LINCOLN,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",33,000140
+LINCOLN,Madison Township,President / Vice President,,independent,"Stein, Jill",1,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+LINCOLN,Madison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+LINCOLN,Madison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000150
+LINCOLN,Madison Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+LINCOLN,Madison Township,President / Vice President,,Republican,"Trump, Donald J.",34,000150
+LINCOLN,Marion Township,President / Vice President,,independent,"Stein, Jill",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+LINCOLN,Marion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+LINCOLN,Marion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000160
+LINCOLN,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+LINCOLN,Marion Township,President / Vice President,,Republican,"Trump, Donald J.",16,000160
+LINCOLN,Orange Township,President / Vice President,,independent,"Stein, Jill",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+LINCOLN,Orange Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+LINCOLN,Orange Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000170
+LINCOLN,Orange Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+LINCOLN,Orange Township,President / Vice President,,Republican,"Trump, Donald J.",34,000170
+LINCOLN,Pleasant Township,President / Vice President,,independent,"Stein, Jill",1,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+LINCOLN,Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000180
+LINCOLN,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000180
+LINCOLN,Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",157,000180
+LINCOLN,Salt Creek Township,President / Vice President,,independent,"Stein, Jill",2,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+LINCOLN,Salt Creek Township,President / Vice President,,Republican,"Trump, Donald J.",22,000190
+LINCOLN,Scott Township,President / Vice President,,independent,"Stein, Jill",1,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+LINCOLN,Scott Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+LINCOLN,Scott Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000200
+LINCOLN,Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+LINCOLN,Scott Township,President / Vice President,,Republican,"Trump, Donald J.",40,000200
+LINCOLN,Valley Township,President / Vice President,,independent,"Stein, Jill",1,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+LINCOLN,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+LINCOLN,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000210
+LINCOLN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+LINCOLN,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",17,000210
+LINCOLN,Vesper Township,President / Vice President,,independent,"Stein, Jill",3,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+LINCOLN,Vesper Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+LINCOLN,Vesper Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000220
+LINCOLN,Vesper Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+LINCOLN,Vesper Township,President / Vice President,,Republican,"Trump, Donald J.",44,000220
+LINCOLN,Marion Township Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LINCOLN,Marion Township Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+LINCOLN,Battle Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000010
+LINCOLN,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,00002A
+LINCOLN,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00002A
+LINCOLN,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,00002A
+LINCOLN,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,00002A
+LINCOLN,Cedron Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000030
+LINCOLN,Cedron Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+LINCOLN,Cedron Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+LINCOLN,Cedron Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000030
+LINCOLN,Colorado Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000040
+LINCOLN,Colorado Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+LINCOLN,Colorado Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000040
+LINCOLN,Colorado Township,United States House of Representatives,1,Republican,"Marshall, Roger",69,000040
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,independent,"LaPolice, Alan",22,00005A
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005A
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,00005A
+LINCOLN,Elkhorn Township Part A,United States House of Representatives,1,Republican,"Marshall, Roger",39,00005A
+LINCOLN,Franklin Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000060
+LINCOLN,Franklin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+LINCOLN,Franklin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+LINCOLN,Franklin Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000060
+LINCOLN,Golden Belt Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000070
+LINCOLN,Golden Belt Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+LINCOLN,Golden Belt Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000070
+LINCOLN,Golden Belt Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000070
+LINCOLN,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000080
+LINCOLN,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+LINCOLN,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000080
+LINCOLN,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000080
+LINCOLN,Hanover Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000090
+LINCOLN,Hanover Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+LINCOLN,Hanover Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+LINCOLN,Hanover Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000090
+LINCOLN,Highland Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000100
+LINCOLN,Highland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+LINCOLN,Highland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+LINCOLN,Highland Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000100
+LINCOLN,Indiana Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000110
+LINCOLN,Indiana Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+LINCOLN,Indiana Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000110
+LINCOLN,Indiana Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000110
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",90,000120
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000120
+LINCOLN,Lincoln Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",134,000120
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",103,00013A
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00013A
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,00013A
+LINCOLN,Lincoln Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",163,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00013B
+LINCOLN,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000140
+LINCOLN,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000140
+LINCOLN,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000140
+LINCOLN,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000140
+LINCOLN,Madison Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000150
+LINCOLN,Madison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+LINCOLN,Madison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000150
+LINCOLN,Madison Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000150
+LINCOLN,Marion Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000160
+LINCOLN,Marion Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000160
+LINCOLN,Marion Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+LINCOLN,Marion Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000160
+LINCOLN,Orange Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000170
+LINCOLN,Orange Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+LINCOLN,Orange Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+LINCOLN,Orange Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000170
+LINCOLN,Pleasant Township,United States House of Representatives,1,independent,"LaPolice, Alan",64,000180
+LINCOLN,Pleasant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+LINCOLN,Pleasant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000180
+LINCOLN,Pleasant Township,United States House of Representatives,1,Republican,"Marshall, Roger",121,000180
+LINCOLN,Salt Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000190
+LINCOLN,Salt Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+LINCOLN,Salt Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000190
+LINCOLN,Salt Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000190
+LINCOLN,Scott Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000200
+LINCOLN,Scott Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+LINCOLN,Scott Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000200
+LINCOLN,Scott Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000200
+LINCOLN,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000210
+LINCOLN,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+LINCOLN,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000210
+LINCOLN,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000210
+LINCOLN,Vesper Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000220
+LINCOLN,Vesper Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+LINCOLN,Vesper Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+LINCOLN,Vesper Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000220
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+LINCOLN,Marion Township Enclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+LINCOLN,Battle Creek Township,United States Senate,,write - in,"Smith, DJ",0,000010
+LINCOLN,Battle Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000010
+LINCOLN,Battle Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+LINCOLN,Battle Creek Township,United States Senate,,Republican,"Moran, Jerry",19,000010
+LINCOLN,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,00002A
+LINCOLN,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",1,00002A
+LINCOLN,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,00002A
+LINCOLN,Beaver Township,United States Senate,,Republican,"Moran, Jerry",29,00002A
+LINCOLN,Cedron Township,United States Senate,,write - in,"Smith, DJ",0,000030
+LINCOLN,Cedron Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+LINCOLN,Cedron Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+LINCOLN,Cedron Township,United States Senate,,Republican,"Moran, Jerry",19,000030
+LINCOLN,Colorado Township,United States Senate,,write - in,"Smith, DJ",0,000040
+LINCOLN,Colorado Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000040
+LINCOLN,Colorado Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000040
+LINCOLN,Colorado Township,United States Senate,,Republican,"Moran, Jerry",89,000040
+LINCOLN,Elkhorn Township Part A,United States Senate,,write - in,"Smith, DJ",0,00005A
+LINCOLN,Elkhorn Township Part A,United States Senate,,Democratic,"Wiesner, Patrick",3,00005A
+LINCOLN,Elkhorn Township Part A,United States Senate,,Libertarian,"Garrard, Robert D.",2,00005A
+LINCOLN,Elkhorn Township Part A,United States Senate,,Republican,"Moran, Jerry",59,00005A
+LINCOLN,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000060
+LINCOLN,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000060
+LINCOLN,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000060
+LINCOLN,Franklin Township,United States Senate,,Republican,"Moran, Jerry",44,000060
+LINCOLN,Golden Belt Township,United States Senate,,write - in,"Smith, DJ",0,000070
+LINCOLN,Golden Belt Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000070
+LINCOLN,Golden Belt Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+LINCOLN,Golden Belt Township,United States Senate,,Republican,"Moran, Jerry",21,000070
+LINCOLN,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000080
+LINCOLN,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000080
+LINCOLN,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000080
+LINCOLN,Grant Township,United States Senate,,Republican,"Moran, Jerry",38,000080
+LINCOLN,Hanover Township,United States Senate,,write - in,"Smith, DJ",0,000090
+LINCOLN,Hanover Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000090
+LINCOLN,Hanover Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+LINCOLN,Hanover Township,United States Senate,,Republican,"Moran, Jerry",19,000090
+LINCOLN,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000100
+LINCOLN,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000100
+LINCOLN,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+LINCOLN,Highland Township,United States Senate,,Republican,"Moran, Jerry",28,000100
+LINCOLN,Indiana Township,United States Senate,,write - in,"Smith, DJ",0,000110
+LINCOLN,Indiana Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000110
+LINCOLN,Indiana Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+LINCOLN,Indiana Township,United States Senate,,Republican,"Moran, Jerry",33,000110
+LINCOLN,Lincoln Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000120
+LINCOLN,Lincoln Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",31,000120
+LINCOLN,Lincoln Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000120
+LINCOLN,Lincoln Precinct 1,United States Senate,,Republican,"Moran, Jerry",190,000120
+LINCOLN,Lincoln Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00013A
+LINCOLN,Lincoln Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",38,00013A
+LINCOLN,Lincoln Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",9,00013A
+LINCOLN,Lincoln Precinct 2,United States Senate,,Republican,"Moran, Jerry",230,00013A
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00013B
+LINCOLN,Lincoln Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00013B
+LINCOLN,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000140
+LINCOLN,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000140
+LINCOLN,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000140
+LINCOLN,Logan Township,United States Senate,,Republican,"Moran, Jerry",30,000140
+LINCOLN,Madison Township,United States Senate,,write - in,"Smith, DJ",0,000150
+LINCOLN,Madison Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000150
+LINCOLN,Madison Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000150
+LINCOLN,Madison Township,United States Senate,,Republican,"Moran, Jerry",33,000150
+LINCOLN,Marion Township,United States Senate,,write - in,"Smith, DJ",0,000160
+LINCOLN,Marion Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000160
+LINCOLN,Marion Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+LINCOLN,Marion Township,United States Senate,,Republican,"Moran, Jerry",18,000160
+LINCOLN,Orange Township,United States Senate,,write - in,"Smith, DJ",0,000170
+LINCOLN,Orange Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000170
+LINCOLN,Orange Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000170
+LINCOLN,Orange Township,United States Senate,,Republican,"Moran, Jerry",37,000170
+LINCOLN,Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,000180
+LINCOLN,Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000180
+LINCOLN,Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000180
+LINCOLN,Pleasant Township,United States Senate,,Republican,"Moran, Jerry",161,000180
+LINCOLN,Salt Creek Township,United States Senate,,write - in,"Smith, DJ",0,000190
+LINCOLN,Salt Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000190
+LINCOLN,Salt Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000190
+LINCOLN,Salt Creek Township,United States Senate,,Republican,"Moran, Jerry",25,000190
+LINCOLN,Scott Township,United States Senate,,write - in,"Smith, DJ",0,000200
+LINCOLN,Scott Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000200
+LINCOLN,Scott Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000200
+LINCOLN,Scott Township,United States Senate,,Republican,"Moran, Jerry",45,000200
+LINCOLN,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000210
+LINCOLN,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000210
+LINCOLN,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000210
+LINCOLN,Valley Township,United States Senate,,Republican,"Moran, Jerry",20,000210
+LINCOLN,Vesper Township,United States Senate,,write - in,"Smith, DJ",0,000220
+LINCOLN,Vesper Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000220
+LINCOLN,Vesper Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000220
+LINCOLN,Vesper Township,United States Senate,,Republican,"Moran, Jerry",47,000220
+LINCOLN,Marion Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+LINCOLN,Marion Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+LINCOLN,Marion Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+LINCOLN,Marion Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__linn__precinct.csv
+++ b/2016/20161108__ks__general__linn__precinct.csv
@@ -1,258 +1,458 @@
-county,precinct,office,district,candidate,party,votes
-Linn,Blue Mound twp,President,,Stein and Baraka,I,5
-Linn,Blue Mound twp,President,,Trump and Pence,R,176
-Linn,Blue Mound twp,President,,Clinton and Kaine,D,27
-Linn,Blue Mound twp,President,,Johnson and Weld,L,5
-Linn,Blue Mound twp,U.S. Senate,,Jerry Moran,R,169
-Linn,Blue Mound twp,U.S. Senate,,Patrick Wiesner,D,29
-Linn,Blue Mound twp,U.S. Senate,,Robert D. Garrard,L,13
-Linn,Blue Mound twp,U.S. House,2,Lynn Jenkins,R,168
-Linn,Blue Mound twp,U.S. House,2,Britani Potter,D,36
-Linn,Blue Mound twp,U.S. House,2,James Houston Bales,L,10
-Linn,Blue Mound twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Blue Mound twp,State Senate,12,Christopher B. Johnston,D,35
-Linn,Blue Mound twp,State Senate,12,Caryn Tyson,R,162
-Linn,Blue Mound twp,State Senate,12,Carla Griffith - WI,,14
-Linn,Blue Mound twp,State House,4,Trevor Jacobs,R,173
-Linn,Blue Mound twp,State House,4,Brent Paddock - WI,,1
-Linn,Centerville twp,President,,Stein and Baraka,I,3
-Linn,Centerville twp,President,,Trump and Pence,R,184
-Linn,Centerville twp,President,,Clinton and Kaine,D,40
-Linn,Centerville twp,President,,Johnson and Weld,L,4
-Linn,Centerville twp,U.S. Senate,,Jerry Moran,R,168
-Linn,Centerville twp,U.S. Senate,,Patrick Wiesner,D,45
-Linn,Centerville twp,U.S. Senate,,Robert D. Garrard,L,15
-Linn,Centerville twp,U.S. Senate,,DJ Smith - WI,,2
-Linn,Centerville twp,U.S. House,2,Lynn Jenkins,R,176
-Linn,Centerville twp,U.S. House,2,Britani Potter,D,41
-Linn,Centerville twp,U.S. House,2,James Houston Bales,L,12
-Linn,Centerville twp,State Senate,12,Christopher B. Johnston,D,33
-Linn,Centerville twp,State Senate,12,Caryn Tyson,R,172
-Linn,Centerville twp,State Senate,12,Carla Griffith - WI,,23
-Linn,Centerville twp,State Senate,12,Melissa Griffith - WI,,1
-Linn,Centerville twp,State House,5,Doug Walker,D,79
-Linn,Centerville twp,State House,5,Kevin Jones,R,150
-Linn,Liberty twp,President,,Stein and Baraka,I,4
-Linn,Liberty twp,President,,Trump and Pence,R,373
-Linn,Liberty twp,President,,Clinton and Kaine,D,71
-Linn,Liberty twp,President,,Johnson and Weld,L,15
-Linn,Liberty twp,President,,McMullin and Johnson - WI,,4
-Linn,Liberty twp,U.S. Senate,,Jerry Moran,R,346
-Linn,Liberty twp,U.S. Senate,,Patrick Wiesner,D,81
-Linn,Liberty twp,U.S. Senate,,Robert D. Garrard,L,34
-Linn,Liberty twp,U.S. Senate,,Carla Griffith - WI,,1
-Linn,Liberty twp,U.S. Senate,,Wayne Burk - WI,,1
-Linn,Liberty twp,U.S. House,2,Lynn Jenkins,R,363
-Linn,Liberty twp,U.S. House,2,Britani Potter,D,81
-Linn,Liberty twp,U.S. House,2,James Houston Bales,L,19
-Linn,Liberty twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Liberty twp,U.S. House,2,Wayne Burk - WI,,1
-Linn,Liberty twp,U.S. House,2,Tony Borum - WI,,1
-Linn,Liberty twp,State Senate,12,Christopher B. Johnston,D,59
-Linn,Liberty twp,State Senate,12,Caryn Tyson,R,338
-Linn,Liberty twp,State Senate,12,Carla Griffith - WI,,61
-Linn,Liberty twp,State Senate,12,Cristie Levings - WI,,1
-Linn,Liberty twp,State House,4,Doug Walker,D,176
-Linn,Liberty twp,State House,4,Kevin Jones,R,285
-Linn,Lincoln N twp,President,,Stein and Baraka,I,12
-Linn,Lincoln N twp,President,,Trump and Pence,R,290
-Linn,Lincoln N twp,President,,Clinton and Kaine,D,79
-Linn,Lincoln N twp,President,,Johnson and Weld,L,13
-Linn,Lincoln N twp,President,,McMullin and Johnson - WI,,3
-Linn,Lincoln N twp,President,,Castle and Bradley - WI,,1
-Linn,Lincoln N twp,U.S. Senate,,Jerry Moran,R,252
-Linn,Lincoln N twp,U.S. Senate,,Patrick Wiesner,D,98
-Linn,Lincoln N twp,U.S. Senate,,Robert D. Garrard,L,32
-Linn,Lincoln N twp,U.S. Senate,,Carla Griffith - WI,,1
-Linn,Lincoln N twp,U.S. Senate,,Jeff Thoele - WI,,1
-Linn,Lincoln N twp,U.S. House,2,Lynn Jenkins,R,276
-Linn,Lincoln N twp,U.S. House,2,Britani Potter,D,82
-Linn,Lincoln N twp,U.S. House,2,James Houston Bales,L,20
-Linn,Lincoln N twp,U.S. House,2,Carla Griffith - WI,,3
-Linn,Lincoln N twp,U.S. House,2,Jeff Thoele - WI,,1
-Linn,Lincoln N twp,State Senate,12,Christopher B. Johnston,D,80
-Linn,Lincoln N twp,State Senate,12,Caryn Tyson,R,264
-Linn,Lincoln N twp,State Senate,12,Carla Griffith - WI,,38
-Linn,Lincoln N twp,State Senate,12,Jeff Thoele - WI,,1
-Linn,Lincoln N twp,State House,5,Trevor Jacobs,R,323
-Linn,Lincoln N twp,State House,5,Rick James - WI,,2
-Linn,Lincoln S twp,President,,Stein and Baraka,I,3
-Linn,Lincoln S twp,President,,Trump and Pence,R,198
-Linn,Lincoln S twp,President,,Clinton and Kaine,D,59
-Linn,Lincoln S twp,President,,Johnson and Weld,L,8
-Linn,Lincoln S twp,U.S. Senate,,Jerry Moran,R,180
-Linn,Lincoln S twp,U.S. Senate,,Patrick Wiesner,D,60
-Linn,Lincoln S twp,U.S. Senate,,Robert D. Garrard,L,23
-Linn,Lincoln S twp,U.S. House,2,Lynn Jenkins,R,194
-Linn,Lincoln S twp,U.S. House,2,Britani Potter,D,50
-Linn,Lincoln S twp,U.S. House,2,James Houston Bales,L,20
-Linn,Lincoln S twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Lincoln S twp,State Senate,12,Christopher B. Johnston,D,53
-Linn,Lincoln S twp,State Senate,12,Caryn Tyson,R,187
-Linn,Lincoln S twp,State Senate,12,Carla Griffith - WI,,19
-Linn,Lincoln S twp,State House,5,Trevor Jacobs,R,224
-Linn,Lincoln S twp,State House,5,Carla Griffith - WI,,1
-Linn,Lincoln S twp,State House,5,Rick James - WI,,4
-Linn,Lincoln N - Linn Valley City,President,,Stein and Baraka,I,7
-Linn,Lincoln N - Linn Valley City,President,,Trump and Pence,R,315
-Linn,Lincoln N - Linn Valley City,President,,Clinton and Kaine,D,76
-Linn,Lincoln N - Linn Valley City,President,,Johnson and Weld,L,10
-Linn,Lincoln N - Linn Valley City,U.S. Senate,,Jerry Moran,R,283
-Linn,Lincoln N - Linn Valley City,U.S. Senate,,Patrick Wiesner,D,83
-Linn,Lincoln N - Linn Valley City,U.S. Senate,,Robert D. Garrard,L,27
-Linn,Lincoln N - Linn Valley City,U.S. Senate,,Carla Griffith - WI,,1
-Linn,Lincoln N - Linn Valley City,U.S. House,2,Lynn Jenkins,R,290
-Linn,Lincoln N - Linn Valley City,U.S. House,2,Britani Potter,D,83
-Linn,Lincoln N - Linn Valley City,U.S. House,2,James Houston Bales,L,20
-Linn,Lincoln N - Linn Valley City,State Senate,12,Christopher B. Johnston,D,92
-Linn,Lincoln N - Linn Valley City,State Senate,12,Caryn Tyson,R,286
-Linn,Lincoln N - Linn Valley City,State Senate,12,Carla Griffith - WI,,11
-Linn,Lincoln N - Linn Valley City,State Senate,12,Jad Wolf - WI,,1
-Linn,Lincoln N - Linn Valley City,State House,4,Trevor Jacobs,R,343
-Linn,Lincoln N - Linn Valley City,State House,4,Jad Wolf - WI,,1
-Linn,Lincoln N - Linn Valley City,State House,4,Ron Seymor - WI,,1
-Linn,Lincoln N - Linn Valley City,State House,4,Dennis Shay - WI,,1
-Linn,Mound City twp,President,,Stein and Baraka,I,6
-Linn,Mound City twp,President,,Trump and Pence,R,493
-Linn,Mound City twp,President,,Clinton and Kaine,D,102
-Linn,Mound City twp,President,,Johnson and Weld,L,20
-Linn,Mound City twp,President,,McMullin and Johnson - WI,,3
-Linn,Mound City twp,U.S. Senate,,Jerry Moran,R,479
-Linn,Mound City twp,U.S. Senate,,Patrick Wiesner,D,105
-Linn,Mound City twp,U.S. Senate,,Robert D. Garrard,L,34
-Linn,Mound City twp,U.S. House,2,Lynn Jenkins,R,479
-Linn,Mound City twp,U.S. House,2,Britani Potter,D,109
-Linn,Mound City twp,U.S. House,2,James Houston Bales,L,25
-Linn,Mound City twp,U.S. House,2,Carla Griffith - WI,,2
-Linn,Mound City twp,State Senate,12,Christopher B. Johnston,D,119
-Linn,Mound City twp,State Senate,12,Caryn Tyson,R,458
-Linn,Mound City twp,State Senate,12,Carla Griffith - WI,,29
-Linn,Mound City twp,State House,4,Trevor Jacobs,R,535
-Linn,Mound City twp,State House,4,Carla Griffith - WI,,1
-Linn,Mound City twp,State House,4,Scott Allen - WI,,1
-Linn,Mound City twp,State House,4,Ronald Wier - WI,,1
-Linn,Paris twp,President,,Stein and Baraka,I,8
-Linn,Paris twp,President,,Trump and Pence,R,199
-Linn,Paris twp,President,,Clinton and Kaine,D,48
-Linn,Paris twp,President,,Johnson and Weld,L,9
-Linn,Paris twp,President,,McMullin and Johnson - WI,,2
-Linn,Paris twp,President,,Castle and Bradley - WI,,2
-Linn,Paris twp,U.S. Senate,,Jerry Moran,R,204
-Linn,Paris twp,U.S. Senate,,Patrick Wiesner,D,53
-Linn,Paris twp,U.S. Senate,,Robert D. Garrard,L,10
-Linn,Paris twp,U.S. House,2,Lynn Jenkins,R,207
-Linn,Paris twp,U.S. House,2,Britani Potter,D,49
-Linn,Paris twp,U.S. House,2,James Houston Bales,L,10
-Linn,Paris twp,State Senate,12,Christopher B. Johnston,D,42
-Linn,Paris twp,State Senate,12,Caryn Tyson,R,204
-Linn,Paris twp,State Senate,12,Carla Griffith - WI,,21
-Linn,Paris twp,State House,4,Trevor Jacobs,R,226
-Linn,Paris twp,State House,4,Seth Needham - WI,,1
-Linn,Paris twp,State House,4,Shirley Palmer - WI,,1
-Linn,Paris twp,State House,4,Carolyn Zillner - WI,,1
-Linn,Potosi N twp,President,,Stein and Baraka,I,2
-Linn,Potosi N twp,President,,Trump and Pence,R,333
-Linn,Potosi N twp,President,,Clinton and Kaine,D,64
-Linn,Potosi N twp,President,,Johnson and Weld,L,12
-Linn,Potosi N twp,U.S. Senate,,Jerry Moran,R,301
-Linn,Potosi N twp,U.S. Senate,,Patrick Wiesner,D,70
-Linn,Potosi N twp,U.S. Senate,,Robert D. Garrard,L,26
-Linn,Potosi N twp,U.S. House,2,Lynn Jenkins,R,304
-Linn,Potosi N twp,U.S. House,2,Britani Potter,D,73
-Linn,Potosi N twp,U.S. House,2,James Houston Bales,L,17
-Linn,Potosi N twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Potosi N twp,State Senate,12,Christopher B. Johnston,D,81
-Linn,Potosi N twp,State Senate,12,Caryn Tyson,R,297
-Linn,Potosi N twp,State Senate,12,Carla Griffith - WI,,9
-Linn,Potosi N twp,State Senate,12,Matt Baldwin - WI,,1
-Linn,Potosi N twp,State Senate,12,Laura Lewis - WI ,,1
-Linn,Potosi N twp,State House,4,Trevor Jacobs,R,344
-Linn,Potosi N twp,State House,4,Laura Lewis - WI,,1
-Linn,Potosi N twp,State House,4,Robert Farmer - WI,,1
-Linn,Potosi N twp,State House,4,Bill Rost - WI,,1
-Linn,Potosi N twp,State House,4,Carla Griffith - WI,,1
-Linn,Potosi N twp,State House,4,Seth Needham - WI,,1
-Linn,Potosi N twp,State House,4,Tim Staton - WI,,1
-Linn,Potosi S twp,President,,Stein and Baraka,I,5
-Linn,Potosi S twp,President,,Trump and Pence,R,317
-Linn,Potosi S twp,President,,Clinton and Kaine,D,51
-Linn,Potosi S twp,President,,Johnson and Weld,L,7
-Linn,Potosi S twp,President,,McMullin and Johnson - WI,,3
-Linn,Potosi S twp,U.S. Senate,,Jerry Moran,R,296
-Linn,Potosi S twp,U.S. Senate,,Patrick Wiesner,D,57
-Linn,Potosi S twp,U.S. Senate,,Robert D. Garrard,L,21
-Linn,Potosi S twp,U.S. House,2,Lynn Jenkins,R,308
-Linn,Potosi S twp,U.S. House,2,Britani Potter,D,51
-Linn,Potosi S twp,U.S. House,2,James Houston Bales,L,15
-Linn,Potosi S twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Potosi S twp,State Senate,12,Christopher B. Johnston,D,66
-Linn,Potosi S twp,State Senate,12,Caryn Tyson,R,296
-Linn,Potosi S twp,State Senate,12,Carla Griffith - WI,,10
-Linn,Potosi S twp,State House,4,Trevor Jacobs,R,332
-Linn,Potosi S twp,State House,4,Rick James - WI,,1
-Linn,Potosi S twp,State House,4,Travis Laver - WI,,1
-Linn,Scott twp,President,,Stein and Baraka,I,2
-Linn,Scott twp,President,,Trump and Pence,R,288
-Linn,Scott twp,President,,Clinton and Kaine,D,69
-Linn,Scott twp,President,,Johnson and Weld,L,13
-Linn,Scott twp,President,,McMullin and Johnson - WI,,1
-Linn,Scott twp,U.S. Senate,,Jerry Moran,R,293
-Linn,Scott twp,U.S. Senate,,Patrick Wiesner,D,57
-Linn,Scott twp,U.S. Senate,,Robert D. Garrard,L,21
-Linn,Scott twp,U.S. House,2,Lynn Jenkins,R,300
-Linn,Scott twp,U.S. House,2,Britani Potter,D,56
-Linn,Scott twp,U.S. House,2,James Houston Bales,L,12
-Linn,Scott twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Scott twp,State Senate,12,Christopher B. Johnston,D,58
-Linn,Scott twp,State Senate,12,Caryn Tyson,R,265
-Linn,Scott twp,State Senate,12,Carla Griffith - WI,,38
-Linn,Scott twp,State House,4,Trevor Jacobs,R,324
-Linn,Scott twp,State House,4,George Teagarden - WI,,2
-Linn,Sheridan twp,President,,Stein and Baraka,I,3
-Linn,Sheridan twp,President,,Trump and Pence,R,198
-Linn,Sheridan twp,President,,Clinton and Kaine,D,30
-Linn,Sheridan twp,President,,Johnson and Weld,L,3
-Linn,Sheridan twp,President,,McMullin and Johnson - WI,,2
-Linn,Sheridan twp,U.S. Senate,,Jerry Moran,R,176
-Linn,Sheridan twp,U.S. Senate,,Patrick Wiesner,D,35
-Linn,Sheridan twp,U.S. Senate,,Robert D. Garrard,L,18
-Linn,Sheridan twp,U.S. House,2,Lynn Jenkins,R,196
-Linn,Sheridan twp,U.S. House,2,Britani Potter,D,24
-Linn,Sheridan twp,U.S. House,2,James Houston Bales,L,11
-Linn,Sheridan twp,State Senate,12,Christopher B. Johnston,D,34
-Linn,Sheridan twp,State Senate,12,Caryn Tyson,R,185
-Linn,Sheridan twp,State Senate,12,Carla Griffith - WI,,9
-Linn,Sheridan twp,State House,4,Trevor Jacobs,R,193
-Linn,Sheridan twp,State House,4,Seth Needham - WI,,1
-Linn,Sheridan twp,State House,4,Jerry Brown - WI,,1
-Linn,Stanton twp,President,,Stein and Baraka,I,3
-Linn,Stanton twp,President,,Trump and Pence,R,79
-Linn,Stanton twp,President,,Clinton and Kaine,D,7
-Linn,Stanton twp,President,,Johnson and Weld,L,0
-Linn,Stanton twp,President,,Castle and Bradley - WI,,1
-Linn,Stanton twp,President,,Hoefling and Schulin - WI,,1
-Linn,Stanton twp,U.S. Senate,,Jerry Moran,R,73
-Linn,Stanton twp,U.S. Senate,,Patrick Wiesner,D,11
-Linn,Stanton twp,U.S. Senate,,Robert D. Garrard,L,6
-Linn,Stanton twp,U.S. House,2,Lynn Jenkins,R,70
-Linn,Stanton twp,U.S. House,2,Britani Potter,D,14
-Linn,Stanton twp,U.S. House,2,James Houston Bales,L,6
-Linn,Stanton twp,U.S. House,2,Carla Griffith - WI,,1
-Linn,Stanton twp,State Senate,12,Christopher B. Johnston,D,16
-Linn,Stanton twp,State Senate,12,Caryn Tyson,R,69
-Linn,Stanton twp,State Senate,12,Carla Griffith - WI,,5
-Linn,Stanton twp,State House,4,Trevor Jacobs,R,81
-Linn,Valley twp,President,,Stein and Baraka,I,2
-Linn,Valley twp,President,,Trump and Pence,R,41
-Linn,Valley twp,President,,Clinton and Kaine,D,13
-Linn,Valley twp,President,,Johnson and Weld,L,0
-Linn,Valley twp,U.S. Senate,,Jerry Moran,R,41
-Linn,Valley twp,U.S. Senate,,Patrick Wiesner,D,12
-Linn,Valley twp,U.S. Senate,,Robert D. Garrard,L,2
-Linn,Valley twp,U.S. House,2,Lynn Jenkins,R,41
-Linn,Valley twp,U.S. House,2,Britani Potter,D,12
-Linn,Valley twp,U.S. House,2,James Houston Bales,L,1
-Linn,Valley twp,State Senate,12,Christopher B. Johnston,D,10
-Linn,Valley twp,State Senate,12,Caryn Tyson,R,41
-Linn,Valley twp,State Senate,12,Carla Griffith - WI,,2
-Linn,Valley twp,State House,4,Trevor Jacobs,R,46
+county,precinct,office,district,party,candidate,votes,vtd
+LINN,Blue Mound Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",173,000010
+LINN,Centerville Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",79,000020
+LINN,Centerville Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",150,000020
+LINN,Liberty Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",176,000030
+LINN,Liberty Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",285,000030
+LINN,Mound City Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",535,000040
+LINN,North Lincoln,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",666,000050
+LINN,North Potosi,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",344,000060
+LINN,Paris Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",226,000070
+LINN,Scott Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",324,000080
+LINN,Sheridan Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",193,000090
+LINN,South Lincoln,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",224,000100
+LINN,South Potosi,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",332,000110
+LINN,Stanton Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",81,000120
+LINN,Valley Township,Kansas House of Representatives,4,Republican,"Jacobs, Trevor",46,000130
+LINN,Blue Mound Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",35,000010
+LINN,Blue Mound Township,Kansas Senate,12,Republican,"Tyson, Caryn",162,000010
+LINN,Centerville Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",33,000020
+LINN,Centerville Township,Kansas Senate,12,Republican,"Tyson, Caryn",172,000020
+LINN,Liberty Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",59,000030
+LINN,Liberty Township,Kansas Senate,12,Republican,"Tyson, Caryn",338,000030
+LINN,Mound City Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",119,000040
+LINN,Mound City Township,Kansas Senate,12,Republican,"Tyson, Caryn",458,000040
+LINN,North Lincoln,Kansas Senate,12,Democratic,"Johnston, Christopher B.",172,000050
+LINN,North Lincoln,Kansas Senate,12,Republican,"Tyson, Caryn",550,000050
+LINN,North Potosi,Kansas Senate,12,Democratic,"Johnston, Christopher B.",81,000060
+LINN,North Potosi,Kansas Senate,12,Republican,"Tyson, Caryn",297,000060
+LINN,Paris Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",42,000070
+LINN,Paris Township,Kansas Senate,12,Republican,"Tyson, Caryn",204,000070
+LINN,Scott Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",58,000080
+LINN,Scott Township,Kansas Senate,12,Republican,"Tyson, Caryn",265,000080
+LINN,Sheridan Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",34,000090
+LINN,Sheridan Township,Kansas Senate,12,Republican,"Tyson, Caryn",185,000090
+LINN,South Lincoln,Kansas Senate,12,Democratic,"Johnston, Christopher B.",53,000100
+LINN,South Lincoln,Kansas Senate,12,Republican,"Tyson, Caryn",187,000100
+LINN,South Potosi,Kansas Senate,12,Democratic,"Johnston, Christopher B.",66,000110
+LINN,South Potosi,Kansas Senate,12,Republican,"Tyson, Caryn",296,000110
+LINN,Stanton Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",16,000120
+LINN,Stanton Township,Kansas Senate,12,Republican,"Tyson, Caryn",69,000120
+LINN,Valley Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",10,000130
+LINN,Valley Township,Kansas Senate,12,Republican,"Tyson, Caryn",41,000130
+LINN,Blue Mound Township,President / Vice President,,independent,"Stein, Jill",5,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+LINN,Blue Mound Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+LINN,Blue Mound Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000010
+LINN,Blue Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+LINN,Blue Mound Township,President / Vice President,,Republican,"Trump, Donald J.",176,000010
+LINN,Centerville Township,President / Vice President,,independent,"Stein, Jill",3,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+LINN,Centerville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+LINN,Centerville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000020
+LINN,Centerville Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+LINN,Centerville Township,President / Vice President,,Republican,"Trump, Donald J.",184,000020
+LINN,Liberty Township,President / Vice President,,independent,"Stein, Jill",4,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",4,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LINN,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LINN,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000030
+LINN,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000030
+LINN,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",373,000030
+LINN,Mound City Township,President / Vice President,,independent,"Stein, Jill",6,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"McMullin, Evan",3,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LINN,Mound City Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LINN,Mound City Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",102,000040
+LINN,Mound City Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000040
+LINN,Mound City Township,President / Vice President,,Republican,"Trump, Donald J.",493,000040
+LINN,North Lincoln,President / Vice President,,independent,"Stein, Jill",19,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Castle, Darrell L",1,000050
+LINN,North Lincoln,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Hedges, James A",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"McMullin, Evan",3,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Perry, Darryl",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Smith, Mike",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Sood, Ajay",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+LINN,North Lincoln,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+LINN,North Lincoln,President / Vice President,,Democratic,"Clinton, Hillary Rodham",155,000050
+LINN,North Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",23,000050
+LINN,North Lincoln,President / Vice President,,Republican,"Trump, Donald J.",605,000050
+LINN,North Potosi,President / Vice President,,independent,"Stein, Jill",2,000060
+LINN,North Potosi,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Hedges, James A",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"McMullin, Evan",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Perry, Darryl",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Smith, Mike",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Sood, Ajay",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+LINN,North Potosi,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+LINN,North Potosi,President / Vice President,,Democratic,"Clinton, Hillary Rodham",64,000060
+LINN,North Potosi,President / Vice President,,Libertarian,"Johnson, Gary",12,000060
+LINN,North Potosi,President / Vice President,,Republican,"Trump, Donald J.",333,000060
+LINN,Paris Township,President / Vice President,,independent,"Stein, Jill",8,000070
+LINN,Paris Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Castle, Darrell L",2,000070
+LINN,Paris Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"McMullin, Evan",2,000070
+LINN,Paris Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LINN,Paris Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LINN,Paris Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,000070
+LINN,Paris Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000070
+LINN,Paris Township,President / Vice President,,Republican,"Trump, Donald J.",199,000070
+LINN,Scott Township,President / Vice President,,independent,"Stein, Jill",2,000080
+LINN,Scott Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"McMullin, Evan",1,000080
+LINN,Scott Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LINN,Scott Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LINN,Scott Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,000080
+LINN,Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+LINN,Scott Township,President / Vice President,,Republican,"Trump, Donald J.",288,000080
+LINN,Sheridan Township,President / Vice President,,independent,"Stein, Jill",3,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"McMullin, Evan",2,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+LINN,Sheridan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+LINN,Sheridan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000090
+LINN,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+LINN,Sheridan Township,President / Vice President,,Republican,"Trump, Donald J.",198,000090
+LINN,South Lincoln,President / Vice President,,independent,"Stein, Jill",3,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Hedges, James A",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"McMullin, Evan",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Smith, Mike",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LINN,South Lincoln,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LINN,South Lincoln,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000100
+LINN,South Lincoln,President / Vice President,,Libertarian,"Johnson, Gary",8,000100
+LINN,South Lincoln,President / Vice President,,Republican,"Trump, Donald J.",198,000100
+LINN,South Potosi,President / Vice President,,independent,"Stein, Jill",5,000110
+LINN,South Potosi,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Hedges, James A",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"McMullin, Evan",3,000110
+LINN,South Potosi,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Smith, Mike",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LINN,South Potosi,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LINN,South Potosi,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000110
+LINN,South Potosi,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+LINN,South Potosi,President / Vice President,,Republican,"Trump, Donald J.",317,000110
+LINN,Stanton Township,President / Vice President,,independent,"Stein, Jill",3,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Castle, Darrell L",1,000120
+LINN,Stanton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Hoefling, Tom",1,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+LINN,Stanton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+LINN,Stanton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000120
+LINN,Stanton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+LINN,Stanton Township,President / Vice President,,Republican,"Trump, Donald J.",79,000120
+LINN,Valley Township,President / Vice President,,independent,"Stein, Jill",2,000130
+LINN,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+LINN,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+LINN,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000130
+LINN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+LINN,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",41,000130
+LINN,Blue Mound Township,United States House of Representatives,2,Democratic,"Potter, Britani",36,000010
+LINN,Blue Mound Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000010
+LINN,Blue Mound Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",168,000010
+LINN,Centerville Township,United States House of Representatives,2,Democratic,"Potter, Britani",41,000020
+LINN,Centerville Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000020
+LINN,Centerville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000020
+LINN,Liberty Township,United States House of Representatives,2,Democratic,"Potter, Britani",81,000030
+LINN,Liberty Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000030
+LINN,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",363,000030
+LINN,Mound City Township,United States House of Representatives,2,Democratic,"Potter, Britani",109,000040
+LINN,Mound City Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000040
+LINN,Mound City Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",479,000040
+LINN,North Lincoln,United States House of Representatives,2,Democratic,"Potter, Britani",165,000050
+LINN,North Lincoln,United States House of Representatives,2,Libertarian,"Bales, James Houston",40,000050
+LINN,North Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",566,000050
+LINN,North Potosi,United States House of Representatives,2,Democratic,"Potter, Britani",73,000060
+LINN,North Potosi,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000060
+LINN,North Potosi,United States House of Representatives,2,Republican,"Jenkins, Lynn",304,000060
+LINN,Paris Township,United States House of Representatives,2,Democratic,"Potter, Britani",49,000070
+LINN,Paris Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000070
+LINN,Paris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000070
+LINN,Scott Township,United States House of Representatives,2,Democratic,"Potter, Britani",56,000080
+LINN,Scott Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000080
+LINN,Scott Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",300,000080
+LINN,Sheridan Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000090
+LINN,Sheridan Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000090
+LINN,Sheridan Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",196,000090
+LINN,South Lincoln,United States House of Representatives,2,Democratic,"Potter, Britani",50,000100
+LINN,South Lincoln,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000100
+LINN,South Lincoln,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,000100
+LINN,South Potosi,United States House of Representatives,2,Democratic,"Potter, Britani",51,000110
+LINN,South Potosi,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000110
+LINN,South Potosi,United States House of Representatives,2,Republican,"Jenkins, Lynn",308,000110
+LINN,Stanton Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000120
+LINN,Stanton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000120
+LINN,Stanton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000120
+LINN,Valley Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000130
+LINN,Valley Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000130
+LINN,Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000130
+LINN,Blue Mound Township,United States Senate,,write - in,"Smith, DJ",0,000010
+LINN,Blue Mound Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000010
+LINN,Blue Mound Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000010
+LINN,Blue Mound Township,United States Senate,,Republican,"Moran, Jerry",169,000010
+LINN,Centerville Township,United States Senate,,write - in,"Smith, DJ",2,000020
+LINN,Centerville Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000020
+LINN,Centerville Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000020
+LINN,Centerville Township,United States Senate,,Republican,"Moran, Jerry",168,000020
+LINN,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000030
+LINN,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",81,000030
+LINN,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",34,000030
+LINN,Liberty Township,United States Senate,,Republican,"Moran, Jerry",346,000030
+LINN,Mound City Township,United States Senate,,write - in,"Smith, DJ",0,000040
+LINN,Mound City Township,United States Senate,,Democratic,"Wiesner, Patrick",105,000040
+LINN,Mound City Township,United States Senate,,Libertarian,"Garrard, Robert D.",34,000040
+LINN,Mound City Township,United States Senate,,Republican,"Moran, Jerry",479,000040
+LINN,North Lincoln,United States Senate,,write - in,"Smith, DJ",0,000050
+LINN,North Lincoln,United States Senate,,Democratic,"Wiesner, Patrick",181,000050
+LINN,North Lincoln,United States Senate,,Libertarian,"Garrard, Robert D.",59,000050
+LINN,North Lincoln,United States Senate,,Republican,"Moran, Jerry",535,000050
+LINN,North Potosi,United States Senate,,write - in,"Smith, DJ",0,000060
+LINN,North Potosi,United States Senate,,Democratic,"Wiesner, Patrick",70,000060
+LINN,North Potosi,United States Senate,,Libertarian,"Garrard, Robert D.",26,000060
+LINN,North Potosi,United States Senate,,Republican,"Moran, Jerry",301,000060
+LINN,Paris Township,United States Senate,,write - in,"Smith, DJ",0,000070
+LINN,Paris Township,United States Senate,,Democratic,"Wiesner, Patrick",53,000070
+LINN,Paris Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000070
+LINN,Paris Township,United States Senate,,Republican,"Moran, Jerry",204,000070
+LINN,Scott Township,United States Senate,,write - in,"Smith, DJ",0,000080
+LINN,Scott Township,United States Senate,,Democratic,"Wiesner, Patrick",57,000080
+LINN,Scott Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000080
+LINN,Scott Township,United States Senate,,Republican,"Moran, Jerry",293,000080
+LINN,Sheridan Township,United States Senate,,write - in,"Smith, DJ",0,000090
+LINN,Sheridan Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000090
+LINN,Sheridan Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000090
+LINN,Sheridan Township,United States Senate,,Republican,"Moran, Jerry",176,000090
+LINN,South Lincoln,United States Senate,,write - in,"Smith, DJ",0,000100
+LINN,South Lincoln,United States Senate,,Democratic,"Wiesner, Patrick",60,000100
+LINN,South Lincoln,United States Senate,,Libertarian,"Garrard, Robert D.",23,000100
+LINN,South Lincoln,United States Senate,,Republican,"Moran, Jerry",180,000100
+LINN,South Potosi,United States Senate,,write - in,"Smith, DJ",0,000110
+LINN,South Potosi,United States Senate,,Democratic,"Wiesner, Patrick",57,000110
+LINN,South Potosi,United States Senate,,Libertarian,"Garrard, Robert D.",21,000110
+LINN,South Potosi,United States Senate,,Republican,"Moran, Jerry",296,000110
+LINN,Stanton Township,United States Senate,,write - in,"Smith, DJ",0,000120
+LINN,Stanton Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000120
+LINN,Stanton Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000120
+LINN,Stanton Township,United States Senate,,Republican,"Moran, Jerry",73,000120
+LINN,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000130
+LINN,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000130
+LINN,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000130
+LINN,Valley Township,United States Senate,,Republican,"Moran, Jerry",41,000130

--- a/2016/20161108__ks__general__logan__precinct.csv
+++ b/2016/20161108__ks__general__logan__precinct.csv
@@ -1,166 +1,433 @@
-county,precinct,office,district,candidate,party,votes
-Logan,Augustine,President,,Hillary Clinton,D,0
-Logan,Elkander,President,,Hillary Clinton,D,0
-Logan,Lees,President,,Hillary Clinton,D,2
-Logan,Logansport,President,,Hillary Clinton,D,0
-Logan,McAllastar,President,,Hillary Clinton,D,0
-Logan,Monument,President,,Hillary Clinton,D,5
-Logan,Oakley 1,President,,Hillary Clinton,D,67
-Logan,Oakley 2,President,,Hillary Clinton,D,62
-Logan,Paxton,President,,Hillary Clinton,D,0
-Logan,Russell Sprs,President,,Hillary Clinton,D,0
-Logan,Western,President,,Hillary Clinton,D,0
-Logan,Winona,President,,Hillary Clinton,D,0
-Logan,Augustine,President,,Gary Johnson,LBT,0
-Logan,Elkander,President,,Gary Johnson,LBT,0
-Logan,Lees,President,,Gary Johnson,LBT,0
-Logan,Logansport,President,,Gary Johnson,LBT,1
-Logan,McAllastar,President,,Gary Johnson,LBT,0
-Logan,Monument,President,,Gary Johnson,LBT,2
-Logan,Oakley 1,President,,Gary Johnson,LBT,22
-Logan,Oakley 2,President,,Gary Johnson,LBT,17
-Logan,Paxton,President,,Gary Johnson,LBT,0
-Logan,Russell Sprs,President,,Gary Johnson,LBT,1
-Logan,Western,President,,Gary Johnson,LBT,0
-Logan,Winona,President,,Gary Johnson,LBT,4
-Logan,Augustine,President,,Jill Stein,IND,0
-Logan,Elkander,President,,Jill Stein,IND,0
-Logan,Lees,President,,Jill Stein,IND,0
-Logan,Logansport,President,,Jill Stein,IND,0
-Logan,McAllastar,President,,Jill Stein,IND,0
-Logan,Monument,President,,Jill Stein,IND,1
-Logan,Oakley 1,President,,Jill Stein,IND,11
-Logan,Oakley 2,President,,Jill Stein,IND,10
-Logan,Paxton,President,,Jill Stein,IND,0
-Logan,Russell Sprs,President,,Jill Stein,IND,2
-Logan,Western,President,,Jill Stein,IND,0
-Logan,Winona,President,,Jill Stein,IND,4
-Logan,Augustine,President,,Donald Trump,R,8
-Logan,Elkander,President,,Donald Trump,R,8
-Logan,Lees,President,,Donald Trump,R,5
-Logan,Logansport,President,,Donald Trump,R,4
-Logan,McAllastar,President,,Donald Trump,R,16
-Logan,Monument,President,,Donald Trump,R,66
-Logan,Oakley 1,President,,Donald Trump,R,512
-Logan,Oakley 2,President,,Donald Trump,R,335
-Logan,Paxton,President,,Donald Trump,R,21
-Logan,Russell Sprs,President,,Donald Trump,R,25
-Logan,Western,President,,Donald Trump,R,24
-Logan,Winona,President,,Donald Trump,R,108
-Logan,Oakley 1,President,,Evan McMullin,wri,1
-Logan,Oakley 1,President,,Write-ins,,2
-Logan,Oakley 2,President,,Write-ins,,1
-Logan,Russell Sprs,President,,Write-ins,,1
-Logan,Augustine,U.S. Senate,,Robert Garrard,LBT,0
-Logan,Elkander,U.S. Senate,,Robert Garrard,LBT,0
-Logan,Lees,U.S. Senate,,Robert Garrard,LBT,0
-Logan,Logansport,U.S. Senate,,Robert Garrard,LBT,0
-Logan,McAllastar,U.S. Senate,,Robert Garrard,LBT,0
-Logan,Monument,U.S. Senate,,Robert Garrard,LBT,4
-Logan,Oakley 1,U.S. Senate,,Robert Garrard,LBT,19
-Logan,Oakley 2,U.S. Senate,,Robert Garrard,LBT,11
-Logan,Paxton,U.S. Senate,,Robert Garrard,LBT,0
-Logan,Russell Sprs,U.S. Senate,,Robert Garrard,LBT,3
-Logan,Western,U.S. Senate,,Robert Garrard,LBT,1
-Logan,Winona,U.S. Senate,,Robert Garrard,LBT,5
-Logan,Augustine,U.S. Senate,,Jerry Moran,R,8
-Logan,Elkander,U.S. Senate,,Jerry Moran,R,8
-Logan,Lees,U.S. Senate,,Jerry Moran,R,5
-Logan,Logansport,U.S. Senate,,Jerry Moran,R,4
-Logan,McAllastar,U.S. Senate,,Jerry Moran,R,16
-Logan,Monument,U.S. Senate,,Jerry Moran,R,67
-Logan,Oakley 1,U.S. Senate,,Jerry Moran,R,545
-Logan,Oakley 2,U.S. Senate,,Jerry Moran,R,360
-Logan,Paxton,U.S. Senate,,Jerry Moran,R,21
-Logan,Russell Sprs,U.S. Senate,,Jerry Moran,R,24
-Logan,Western,U.S. Senate,,Jerry Moran,R,20
-Logan,Winona,U.S. Senate,,Jerry Moran,R,119
-Logan,Augustine,U.S. Senate,,Patrick Wiesner,D,0
-Logan,Elkander,U.S. Senate,,Patrick Wiesner,D,0
-Logan,Lees,U.S. Senate,,Patrick Wiesner,D,2
-Logan,Logansport,U.S. Senate,,Patrick Wiesner,D,0
-Logan,McAllastar,U.S. Senate,,Patrick Wiesner,D,0
-Logan,Monument,U.S. Senate,,Patrick Wiesner,D,3
-Logan,Oakley 1,U.S. Senate,,Patrick Wiesner,D,49
-Logan,Oakley 2,U.S. Senate,,Patrick Wiesner,D,48
-Logan,Paxton,U.S. Senate,,Patrick Wiesner,D,0
-Logan,Russell Sprs,U.S. Senate,,Patrick Wiesner,D,2
-Logan,Western,U.S. Senate,,Patrick Wiesner,D,0
-Logan,Winona,U.S. Senate,,Patrick Wiesner,D,2
-Logan,Augustine,U.S. House,1,Alan LaPolice,IND,0
-Logan,Elkander,U.S. House,1,Alan LaPolice,IND,1
-Logan,Lees,U.S. House,1,Alan LaPolice,IND,4
-Logan,Logansport,U.S. House,1,Alan LaPolice,IND,0
-Logan,McAllastar,U.S. House,1,Alan LaPolice,IND,0
-Logan,Monument,U.S. House,1,Alan LaPolice,IND,5
-Logan,Oakley 1,U.S. House,1,Alan LaPolice,IND,75
-Logan,Oakley 2,U.S. House,1,Alan LaPolice,IND,56
-Logan,Paxton,U.S. House,1,Alan LaPolice,IND,0
-Logan,Russell Sprs,U.S. House,1,Alan LaPolice,IND,4
-Logan,Western,U.S. House,1,Alan LaPolice,IND,5
-Logan,Winona,U.S. House,1,Alan LaPolice,IND,19
-Logan,Augustine,U.S. House,1,Roger Marshall,R,8
-Logan,Elkander,U.S. House,1,Roger Marshall,R,7
-Logan,Lees,U.S. House,1,Roger Marshall,R,3
-Logan,Logansport,U.S. House,1,Roger Marshall,R,3
-Logan,McAllastar,U.S. House,1,Roger Marshall,R,16
-Logan,Monument,U.S. House,1,Roger Marshall,R,59
-Logan,Oakley 1,U.S. House,1,Roger Marshall,R,496
-Logan,Oakley 2,U.S. House,1,Roger Marshall,R,328
-Logan,Paxton,U.S. House,1,Roger Marshall,R,20
-Logan,Russell Sprs,U.S. House,1,Roger Marshall,R,22
-Logan,Western,U.S. House,1,Roger Marshall,R,17
-Logan,Winona,U.S. House,1,Roger Marshall,R,97
-Logan,Augustine,U.S. House,1,Kerry Burt,LBT,0
-Logan,Elkander,U.S. House,1,Kerry Burt,LBT,0
-Logan,Lees,U.S. House,1,Kerry Burt,LBT,0
-Logan,Logansport,U.S. House,1,Kerry Burt,LBT,0
-Logan,McAllastar,U.S. House,1,Kerry Burt,LBT,0
-Logan,Monument,U.S. House,1,Kerry Burt,LBT,5
-Logan,Oakley 1,U.S. House,1,Kerry Burt,LBT,25
-Logan,Oakley 2,U.S. House,1,Kerry Burt,LBT,22
-Logan,Paxton,U.S. House,1,Kerry Burt,LBT,0
-Logan,Russell Sprs,U.S. House,1,Kerry Burt,LBT,1
-Logan,Western,U.S. House,1,Kerry Burt,LBT,0
-Logan,Winona,U.S. House,1,Kerry Burt,LBT,8
-Logan,Augustine,State Senate,40,Alex Herman,D,0
-Logan,Elkander,State Senate,40,Alex Herman,D,0
-Logan,Lees,State Senate,40,Alex Herman,D,2
-Logan,Logansport,State Senate,40,Alex Herman,D,0
-Logan,McAllastar,State Senate,40,Alex Herman,D,0
-Logan,Monument,State Senate,40,Alex Herman,D,8
-Logan,Oakley 1,State Senate,40,Alex Herman,D,87
-Logan,Oakley 2,State Senate,40,Alex Herman,D,67
-Logan,Paxton,State Senate,40,Alex Herman,D,0
-Logan,Russell Sprs,State Senate,40,Alex Herman,D,2
-Logan,Western,State Senate,40,Alex Herman,D,2
-Logan,Winona,State Senate,40,Alex Herman,D,7
-Logan,Augustine,State Senate,40,Rick Billinger,R,8
-Logan,Elkander,State Senate,40,Rick Billinger,R,8
-Logan,Lees,State Senate,40,Rick Billinger,R,4
-Logan,Logansport,State Senate,40,Rick Billinger,R,3
-Logan,McAllastar,State Senate,40,Rick Billinger,R,16
-Logan,Monument,State Senate,40,Rick Billinger,R,65
-Logan,Oakley 1,State Senate,40,Rick Billinger,R,515
-Logan,Oakley 2,State Senate,40,Rick Billinger,R,349
-Logan,Paxton,State Senate,40,Rick Billinger,R,21
-Logan,Russell Sprs,State Senate,40,Rick Billinger,R,25
-Logan,Western,State Senate,40,Rick Billinger,R,20
-Logan,Winona,State Senate,40,Rick Billinger,R,117
-Logan,Oakley 1,State Senate,40,Write-ins,,1
-Logan,Winona,State Senate,40,Write-ins,,1
-Logan,Augustine,State House,118,Don Hineman,R,8
-Logan,Elkander,State House,118,Don Hineman,R,7
-Logan,Lees,State House,118,Don Hineman,R,6
-Logan,Logansport,State House,118,Don Hineman,R,3
-Logan,McAllastar,State House,118,Don Hineman,R,15
-Logan,Monument,State House,118,Don Hineman,R,63
-Logan,Oakley 1,State House,118,Don Hineman,R,528
-Logan,Oakley 2,State House,118,Don Hineman,R,368
-Logan,Paxton,State House,118,Don Hineman,R,21
-Logan,Russell Sprs,State House,118,Don Hineman,R,27
-Logan,Western,State House,118,Don Hineman,R,23
-Logan,Winona,State House,118,Don Hineman,R,107
-Logan,Oakley 1,State House,5,Write-ins,,2
-Logan,Oakley 2,State House,5,Write-ins,,1
-Logan,Winona,State House,5,Write-ins,,8
+county,precinct,office,district,party,candidate,votes,vtd
+LOGAN,Augustine Township,Kansas House of Representatives,118,Republican,"Hineman, Don",8,000010
+LOGAN,Elkader Township,Kansas House of Representatives,118,Republican,"Hineman, Don",7,000020
+LOGAN,Lees Township,Kansas House of Representatives,118,Republican,"Hineman, Don",6,000030
+LOGAN,Logansport Township,Kansas House of Representatives,118,Republican,"Hineman, Don",3,000040
+LOGAN,McAllaster Township,Kansas House of Representatives,118,Republican,"Hineman, Don",15,000050
+LOGAN,Monument Township,Kansas House of Representatives,118,Republican,"Hineman, Don",63,000060
+LOGAN,Oakley Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",528,000070
+LOGAN,Oakley Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",368,000080
+LOGAN,Paxton Township,Kansas House of Representatives,118,Republican,"Hineman, Don",21,000090
+LOGAN,Russell Springs Township,Kansas House of Representatives,118,Republican,"Hineman, Don",27,000100
+LOGAN,Western Township,Kansas House of Representatives,118,Republican,"Hineman, Don",23,000110
+LOGAN,Winona Township,Kansas House of Representatives,118,Republican,"Hineman, Don",107,000120
+LOGAN,Augustine Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000010
+LOGAN,Augustine Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",8,000010
+LOGAN,Elkader Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000020
+LOGAN,Elkader Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",8,000020
+LOGAN,Lees Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000030
+LOGAN,Lees Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",4,000030
+LOGAN,Logansport Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000040
+LOGAN,Logansport Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",3,000040
+LOGAN,McAllaster Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000050
+LOGAN,McAllaster Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",16,000050
+LOGAN,Monument Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000060
+LOGAN,Monument Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",65,000060
+LOGAN,Oakley Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",87,000070
+LOGAN,Oakley Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",515,000070
+LOGAN,Oakley Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",67,000080
+LOGAN,Oakley Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",349,000080
+LOGAN,Paxton Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000090
+LOGAN,Paxton Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",21,000090
+LOGAN,Russell Springs Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000100
+LOGAN,Russell Springs Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",25,000100
+LOGAN,Western Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000110
+LOGAN,Western Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",20,000110
+LOGAN,Winona Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000120
+LOGAN,Winona Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",117,000120
+LOGAN,Augustine Township,President / Vice President,,independent,"Stein, Jill",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+LOGAN,Augustine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+LOGAN,Augustine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+LOGAN,Augustine Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+LOGAN,Augustine Township,President / Vice President,,Republican,"Trump, Donald J.",8,000010
+LOGAN,Elkader Township,President / Vice President,,independent,"Stein, Jill",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+LOGAN,Elkader Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+LOGAN,Elkader Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+LOGAN,Elkader Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+LOGAN,Elkader Township,President / Vice President,,Republican,"Trump, Donald J.",8,000020
+LOGAN,Lees Township,President / Vice President,,independent,"Stein, Jill",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LOGAN,Lees Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LOGAN,Lees Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+LOGAN,Lees Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+LOGAN,Lees Township,President / Vice President,,Republican,"Trump, Donald J.",5,000030
+LOGAN,Logansport Township,President / Vice President,,independent,"Stein, Jill",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LOGAN,Logansport Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LOGAN,Logansport Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+LOGAN,Logansport Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+LOGAN,Logansport Township,President / Vice President,,Republican,"Trump, Donald J.",4,000040
+LOGAN,McAllaster Township,President / Vice President,,independent,"Stein, Jill",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+LOGAN,McAllaster Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+LOGAN,McAllaster Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000050
+LOGAN,McAllaster Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+LOGAN,McAllaster Township,President / Vice President,,Republican,"Trump, Donald J.",16,000050
+LOGAN,Monument Township,President / Vice President,,independent,"Stein, Jill",1,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+LOGAN,Monument Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+LOGAN,Monument Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000060
+LOGAN,Monument Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+LOGAN,Monument Township,President / Vice President,,Republican,"Trump, Donald J.",66,000060
+LOGAN,Oakley Precinct 1,President / Vice President,,independent,"Stein, Jill",11,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",22,000070
+LOGAN,Oakley Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",512,000070
+LOGAN,Oakley Precinct 2,President / Vice President,,independent,"Stein, Jill",10,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",17,000080
+LOGAN,Oakley Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",335,000080
+LOGAN,Paxton Township,President / Vice President,,independent,"Stein, Jill",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+LOGAN,Paxton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+LOGAN,Paxton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000090
+LOGAN,Paxton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+LOGAN,Paxton Township,President / Vice President,,Republican,"Trump, Donald J.",21,000090
+LOGAN,Russell Springs Township,President / Vice President,,independent,"Stein, Jill",2,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000100
+LOGAN,Russell Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+LOGAN,Russell Springs Township,President / Vice President,,Republican,"Trump, Donald J.",25,000100
+LOGAN,Western Township,President / Vice President,,independent,"Stein, Jill",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LOGAN,Western Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LOGAN,Western Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000110
+LOGAN,Western Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+LOGAN,Western Township,President / Vice President,,Republican,"Trump, Donald J.",24,000110
+LOGAN,Winona Township,President / Vice President,,independent,"Stein, Jill",4,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+LOGAN,Winona Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+LOGAN,Winona Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000120
+LOGAN,Winona Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000120
+LOGAN,Winona Township,President / Vice President,,Republican,"Trump, Donald J.",108,000120
+LOGAN,Augustine Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000010
+LOGAN,Augustine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+LOGAN,Augustine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+LOGAN,Augustine Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000010
+LOGAN,Elkader Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000020
+LOGAN,Elkader Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+LOGAN,Elkader Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+LOGAN,Elkader Township,United States House of Representatives,1,Republican,"Marshall, Roger",7,000020
+LOGAN,Lees Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000030
+LOGAN,Lees Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+LOGAN,Lees Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+LOGAN,Lees Township,United States House of Representatives,1,Republican,"Marshall, Roger",3,000030
+LOGAN,Logansport Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000040
+LOGAN,Logansport Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+LOGAN,Logansport Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+LOGAN,Logansport Township,United States House of Representatives,1,Republican,"Marshall, Roger",3,000040
+LOGAN,McAllaster Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000050
+LOGAN,McAllaster Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+LOGAN,McAllaster Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+LOGAN,McAllaster Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000050
+LOGAN,Monument Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000060
+LOGAN,Monument Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+LOGAN,Monument Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000060
+LOGAN,Monument Township,United States House of Representatives,1,Republican,"Marshall, Roger",59,000060
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",75,000070
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000070
+LOGAN,Oakley Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",496,000070
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",56,000080
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000080
+LOGAN,Oakley Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",328,000080
+LOGAN,Paxton Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000090
+LOGAN,Paxton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+LOGAN,Paxton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+LOGAN,Paxton Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000090
+LOGAN,Russell Springs Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000100
+LOGAN,Russell Springs Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+LOGAN,Russell Springs Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+LOGAN,Russell Springs Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000100
+LOGAN,Western Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000110
+LOGAN,Western Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+LOGAN,Western Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+LOGAN,Western Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000110
+LOGAN,Winona Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000120
+LOGAN,Winona Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+LOGAN,Winona Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000120
+LOGAN,Winona Township,United States House of Representatives,1,Republican,"Marshall, Roger",97,000120
+LOGAN,Augustine Township,United States Senate,,write - in,"Smith, DJ",0,000010
+LOGAN,Augustine Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+LOGAN,Augustine Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+LOGAN,Augustine Township,United States Senate,,Republican,"Moran, Jerry",8,000010
+LOGAN,Elkader Township,United States Senate,,write - in,"Smith, DJ",0,000020
+LOGAN,Elkader Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+LOGAN,Elkader Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+LOGAN,Elkader Township,United States Senate,,Republican,"Moran, Jerry",8,000020
+LOGAN,Lees Township,United States Senate,,write - in,"Smith, DJ",0,000030
+LOGAN,Lees Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+LOGAN,Lees Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+LOGAN,Lees Township,United States Senate,,Republican,"Moran, Jerry",5,000030
+LOGAN,Logansport Township,United States Senate,,write - in,"Smith, DJ",0,000040
+LOGAN,Logansport Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000040
+LOGAN,Logansport Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+LOGAN,Logansport Township,United States Senate,,Republican,"Moran, Jerry",4,000040
+LOGAN,McAllaster Township,United States Senate,,write - in,"Smith, DJ",0,000050
+LOGAN,McAllaster Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000050
+LOGAN,McAllaster Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+LOGAN,McAllaster Township,United States Senate,,Republican,"Moran, Jerry",16,000050
+LOGAN,Monument Township,United States Senate,,write - in,"Smith, DJ",0,000060
+LOGAN,Monument Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+LOGAN,Monument Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000060
+LOGAN,Monument Township,United States Senate,,Republican,"Moran, Jerry",67,000060
+LOGAN,Oakley Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000070
+LOGAN,Oakley Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",49,000070
+LOGAN,Oakley Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000070
+LOGAN,Oakley Precinct 1,United States Senate,,Republican,"Moran, Jerry",545,000070
+LOGAN,Oakley Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000080
+LOGAN,Oakley Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",48,000080
+LOGAN,Oakley Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,000080
+LOGAN,Oakley Precinct 2,United States Senate,,Republican,"Moran, Jerry",360,000080
+LOGAN,Paxton Township,United States Senate,,write - in,"Smith, DJ",0,000090
+LOGAN,Paxton Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000090
+LOGAN,Paxton Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+LOGAN,Paxton Township,United States Senate,,Republican,"Moran, Jerry",21,000090
+LOGAN,Russell Springs Township,United States Senate,,write - in,"Smith, DJ",0,000100
+LOGAN,Russell Springs Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+LOGAN,Russell Springs Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000100
+LOGAN,Russell Springs Township,United States Senate,,Republican,"Moran, Jerry",24,000100
+LOGAN,Western Township,United States Senate,,write - in,"Smith, DJ",0,000110
+LOGAN,Western Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000110
+LOGAN,Western Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+LOGAN,Western Township,United States Senate,,Republican,"Moran, Jerry",20,000110
+LOGAN,Winona Township,United States Senate,,write - in,"Smith, DJ",0,000120
+LOGAN,Winona Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000120
+LOGAN,Winona Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000120
+LOGAN,Winona Township,United States Senate,,Republican,"Moran, Jerry",119,000120

--- a/2016/20161108__ks__general__lyon__precinct.csv
+++ b/2016/20161108__ks__general__lyon__precinct.csv
@@ -1,753 +1,2069 @@
-county,precinct,office,district,candidate,party,votes
-Lyon,Precinct  01.01,Voters,,Registered,,790
-Lyon,Precinct  02.01,Voters,,Registered,,736
-Lyon,Precinct  03.01,Voters,,Registered,,843
-Lyon,Precinct  04.01,Voters,,Registered,,934
-Lyon,Precinct  4A.01,Voters,,Registered,,2
-Lyon,Precinct  4B.01,Voters,,Registered,,7
-Lyon,Precinct  4C.01,Voters,,Registered,,7
-Lyon,Precinct  05.01,Voters,,Registered,,726
-Lyon,Precinct  06.01,Voters,,Registered,,758
-Lyon,Precinct  07.01,Voters,,Registered,,338
-Lyon,Precinct  08.01,Voters,,Registered,,855
-Lyon,Precinct  09.01,Voters,,Registered,,578
-Lyon,Precinct  10.01,Voters,,Registered,,541
-Lyon,Precinct  11.01,Voters,,Registered,,541
-Lyon,Precinct  12.01,Voters,,Registered,,477
-Lyon,Precinct  13.01,Voters,,Registered,,776
-Lyon,Precinct  14.01,Voters,,Registered,,781
-Lyon,Precinct  15.01,Voters,,Registered,,418
-Lyon,Precinct  16.01,Voters,,Registered,,723
-Lyon,Precinct  17.01,Voters,,Registered,,696
-Lyon,Precinct  18.01,Voters,,Registered,,547
-Lyon,Precinct  19.01,Voters,,Registered,,979
-Lyon,Precinct  20.01,Voters,,Registered,,816
-Lyon,Precinct  21.01,Voters,,Registered,,314
-Lyon,Precinct  22.01,Voters,,Registered,,156
-Lyon,Precinct  23.01,Voters,,Registered,,194
-Lyon,Precinct  24.01,Voters,,Registered,,987
-Lyon,Precinct  25.01,Voters,,Registered,,671
-Lyon,Precinct  26.01,Voters,,Registered,,318
-Lyon,Precinct  27.01,Voters,,Registered,,601
-Lyon,Precinct  28.01,Voters,,Registered,,492
-Lyon,Precinct  29.01,Voters,,Registered,,213
-Lyon,Precinct  29D.01,Voters,,Registered,,7
-Lyon,Precinct  30.01,Voters,,Registered,,683
-Lyon,Precinct  31.01,Voters,,Registered,,833
-Lyon,Precinct  32.01,Voters,,Registered,,534
-Lyon,Precinct  01.01,Voters,,Ballots Cast,,457
-Lyon,Precinct  02.01,Voters,,Ballots Cast,,360
-Lyon,Precinct  03.01,Voters,,Ballots Cast,,437
-Lyon,Precinct  04.01,Voters,,Ballots Cast,,519
-Lyon,Precinct  4A.01,Voters,,Ballots Cast,,2
-Lyon,Precinct  4B.01,Voters,,Ballots Cast,,3
-Lyon,Precinct  4C.01,Voters,,Ballots Cast,,7
-Lyon,Precinct  05.01,Voters,,Ballots Cast,,331
-Lyon,Precinct  06.01,Voters,,Ballots Cast,,380
-Lyon,Precinct  07.01,Voters,,Ballots Cast,,156
-Lyon,Precinct  08.01,Voters,,Ballots Cast,,402
-Lyon,Precinct  09.01,Voters,,Ballots Cast,,340
-Lyon,Precinct  10.01,Voters,,Ballots Cast,,359
-Lyon,Precinct  11.01,Voters,,Ballots Cast,,327
-Lyon,Precinct  12.01,Voters,,Ballots Cast,,306
-Lyon,Precinct  13.01,Voters,,Ballots Cast,,465
-Lyon,Precinct  14.01,Voters,,Ballots Cast,,548
-Lyon,Precinct  15.01,Voters,,Ballots Cast,,280
-Lyon,Precinct  16.01,Voters,,Ballots Cast,,477
-Lyon,Precinct  17.01,Voters,,Ballots Cast,,472
-Lyon,Precinct  18.01,Voters,,Ballots Cast,,409
-Lyon,Precinct  19.01,Voters,,Ballots Cast,,662
-Lyon,Precinct  20.01,Voters,,Ballots Cast,,595
-Lyon,Precinct  21.01,Voters,,Ballots Cast,,227
-Lyon,Precinct  22.01,Voters,,Ballots Cast,,122
-Lyon,Precinct  23.01,Voters,,Ballots Cast,,146
-Lyon,Precinct  24.01,Voters,,Ballots Cast,,676
-Lyon,Precinct  25.01,Voters,,Ballots Cast,,515
-Lyon,Precinct  26.01,Voters,,Ballots Cast,,235
-Lyon,Precinct  27.01,Voters,,Ballots Cast,,412
-Lyon,Precinct  28.01,Voters,,Ballots Cast,,355
-Lyon,Precinct  29.01,Voters,,Ballots Cast,,166
-Lyon,Precinct  29D.01,Voters,,Ballots Cast,,4
-Lyon,Precinct  30.01,Voters,,Ballots Cast,,495
-Lyon,Precinct  31.01,Voters,,Ballots Cast,,614
-Lyon,Precinct  32.01,Voters,,Ballots Cast,,359
-Lyon,Precinct  01.01,President,,Hillary Clinton,D,225
-Lyon,Precinct  02.01,President,,Hillary Clinton,D,165
-Lyon,Precinct  03.01,President,,Hillary Clinton,D,192
-Lyon,Precinct  04.01,President,,Hillary Clinton,D,226
-Lyon,Precinct  4A.01,President,,Hillary Clinton,D,0
-Lyon,Precinct  4B.01,President,,Hillary Clinton,D,3
-Lyon,Precinct  4C.01,President,,Hillary Clinton,D,5
-Lyon,Precinct  05.01,President,,Hillary Clinton,D,174
-Lyon,Precinct  06.01,President,,Hillary Clinton,D,205
-Lyon,Precinct  07.01,President,,Hillary Clinton,D,76
-Lyon,Precinct  08.01,President,,Hillary Clinton,D,185
-Lyon,Precinct  09.01,President,,Hillary Clinton,D,142
-Lyon,Precinct  10.01,President,,Hillary Clinton,D,157
-Lyon,Precinct  11.01,President,,Hillary Clinton,D,148
-Lyon,Precinct  12.01,President,,Hillary Clinton,D,143
-Lyon,Precinct  13.01,President,,Hillary Clinton,D,181
-Lyon,Precinct  14.01,President,,Hillary Clinton,D,242
-Lyon,Precinct  15.01,President,,Hillary Clinton,D,117
-Lyon,Precinct  16.01,President,,Hillary Clinton,D,237
-Lyon,Precinct  17.01,President,,Hillary Clinton,D,198
-Lyon,Precinct  18.01,President,,Hillary Clinton,D,159
-Lyon,Precinct  19.01,President,,Hillary Clinton,D,257
-Lyon,Precinct  20.01,President,,Hillary Clinton,D,224
-Lyon,Precinct  21.01,President,,Hillary Clinton,D,40
-Lyon,Precinct  22.01,President,,Hillary Clinton,D,24
-Lyon,Precinct  23.01,President,,Hillary Clinton,D,28
-Lyon,Precinct  24.01,President,,Hillary Clinton,D,158
-Lyon,Precinct  25.01,President,,Hillary Clinton,D,113
-Lyon,Precinct  26.01,President,,Hillary Clinton,D,64
-Lyon,Precinct  27.01,President,,Hillary Clinton,D,90
-Lyon,Precinct  28.01,President,,Hillary Clinton,D,102
-Lyon,Precinct  29.01,President,,Hillary Clinton,D,41
-Lyon,Precinct  29D.01,President,,Hillary Clinton,D,0
-Lyon,Precinct  30.01,President,,Hillary Clinton,D,120
-Lyon,Precinct  31.01,President,,Hillary Clinton,D,130
-Lyon,Precinct  32.01,President,,Hillary Clinton,D,78
-Lyon,Precinct  01.01,President,,Jill Stein,IND,16
-Lyon,Precinct  02.01,President,,Jill Stein,IND,11
-Lyon,Precinct  03.01,President,,Jill Stein,IND,16
-Lyon,Precinct  04.01,President,,Jill Stein,IND,18
-Lyon,Precinct  4A.01,President,,Jill Stein,IND,0
-Lyon,Precinct  4B.01,President,,Jill Stein,IND,0
-Lyon,Precinct  4C.01,President,,Jill Stein,IND,0
-Lyon,Precinct  05.01,President,,Jill Stein,IND,5
-Lyon,Precinct  06.01,President,,Jill Stein,IND,9
-Lyon,Precinct  07.01,President,,Jill Stein,IND,7
-Lyon,Precinct  08.01,President,,Jill Stein,IND,16
-Lyon,Precinct  09.01,President,,Jill Stein,IND,14
-Lyon,Precinct  10.01,President,,Jill Stein,IND,13
-Lyon,Precinct  11.01,President,,Jill Stein,IND,7
-Lyon,Precinct  12.01,President,,Jill Stein,IND,6
-Lyon,Precinct  13.01,President,,Jill Stein,IND,12
-Lyon,Precinct  14.01,President,,Jill Stein,IND,20
-Lyon,Precinct  15.01,President,,Jill Stein,IND,6
-Lyon,Precinct  16.01,President,,Jill Stein,IND,17
-Lyon,Precinct  17.01,President,,Jill Stein,IND,11
-Lyon,Precinct  18.01,President,,Jill Stein,IND,7
-Lyon,Precinct  19.01,President,,Jill Stein,IND,13
-Lyon,Precinct  20.01,President,,Jill Stein,IND,11
-Lyon,Precinct  21.01,President,,Jill Stein,IND,11
-Lyon,Precinct  22.01,President,,Jill Stein,IND,1
-Lyon,Precinct  23.01,President,,Jill Stein,IND,5
-Lyon,Precinct  24.01,President,,Jill Stein,IND,15
-Lyon,Precinct  25.01,President,,Jill Stein,IND,9
-Lyon,Precinct  26.01,President,,Jill Stein,IND,14
-Lyon,Precinct  27.01,President,,Jill Stein,IND,3
-Lyon,Precinct  28.01,President,,Jill Stein,IND,6
-Lyon,Precinct  29.01,President,,Jill Stein,IND,2
-Lyon,Precinct  29D.01,President,,Jill Stein,IND,0
-Lyon,Precinct  30.01,President,,Jill Stein,IND,7
-Lyon,Precinct  31.01,President,,Jill Stein,IND,12
-Lyon,Precinct  32.01,President,,Jill Stein,IND,11
-Lyon,Precinct  01.01,President,,Donald Trump,R,171
-Lyon,Precinct  02.01,President,,Donald Trump,R,134
-Lyon,Precinct  03.01,President,,Donald Trump,R,201
-Lyon,Precinct  04.01,President,,Donald Trump,R,223
-Lyon,Precinct  4A.01,President,,Donald Trump,R,2
-Lyon,Precinct  4B.01,President,,Donald Trump,R,0
-Lyon,Precinct  4C.01,President,,Donald Trump,R,2
-Lyon,Precinct  05.01,President,,Donald Trump,R,122
-Lyon,Precinct  06.01,President,,Donald Trump,R,138
-Lyon,Precinct  07.01,President,,Donald Trump,R,57
-Lyon,Precinct  08.01,President,,Donald Trump,R,161
-Lyon,Precinct  09.01,President,,Donald Trump,R,155
-Lyon,Precinct  10.01,President,,Donald Trump,R,172
-Lyon,Precinct  11.01,President,,Donald Trump,R,137
-Lyon,Precinct  12.01,President,,Donald Trump,R,135
-Lyon,Precinct  13.01,President,,Donald Trump,R,202
-Lyon,Precinct  14.01,President,,Donald Trump,R,225
-Lyon,Precinct  15.01,President,,Donald Trump,R,133
-Lyon,Precinct  16.01,President,,Donald Trump,R,187
-Lyon,Precinct  17.01,President,,Donald Trump,R,215
-Lyon,Precinct  18.01,President,,Donald Trump,R,222
-Lyon,Precinct  19.01,President,,Donald Trump,R,335
-Lyon,Precinct  20.01,President,,Donald Trump,R,307
-Lyon,Precinct  21.01,President,,Donald Trump,R,153
-Lyon,Precinct  22.01,President,,Donald Trump,R,83
-Lyon,Precinct  23.01,President,,Donald Trump,R,99
-Lyon,Precinct  24.01,President,,Donald Trump,R,450
-Lyon,Precinct  25.01,President,,Donald Trump,R,354
-Lyon,Precinct  26.01,President,,Donald Trump,R,143
-Lyon,Precinct  27.01,President,,Donald Trump,R,293
-Lyon,Precinct  28.01,President,,Donald Trump,R,227
-Lyon,Precinct  29.01,President,,Donald Trump,R,112
-Lyon,Precinct  29D.01,President,,Donald Trump,R,4
-Lyon,Precinct  30.01,President,,Donald Trump,R,327
-Lyon,Precinct  31.01,President,,Donald Trump,R,425
-Lyon,Precinct  32.01,President,,Donald Trump,R,246
-Lyon,Precinct  01.01,President,,Gary Johnson,LBT,30
-Lyon,Precinct  02.01,President,,Gary Johnson,LBT,28
-Lyon,Precinct  03.01,President,,Gary Johnson,LBT,19
-Lyon,Precinct  04.01,President,,Gary Johnson,LBT,35
-Lyon,Precinct  4A.01,President,,Gary Johnson,LBT,0
-Lyon,Precinct  4B.01,President,,Gary Johnson,LBT,0
-Lyon,Precinct  4C.01,President,,Gary Johnson,LBT,0
-Lyon,Precinct  05.01,President,,Gary Johnson,LBT,23
-Lyon,Precinct  06.01,President,,Gary Johnson,LBT,23
-Lyon,Precinct  07.01,President,,Gary Johnson,LBT,14
-Lyon,Precinct  08.01,President,,Gary Johnson,LBT,29
-Lyon,Precinct  09.01,President,,Gary Johnson,LBT,18
-Lyon,Precinct  10.01,President,,Gary Johnson,LBT,9
-Lyon,Precinct  11.01,President,,Gary Johnson,LBT,22
-Lyon,Precinct  12.01,President,,Gary Johnson,LBT,18
-Lyon,Precinct  13.01,President,,Gary Johnson,LBT,51
-Lyon,Precinct  14.01,President,,Gary Johnson,LBT,27
-Lyon,Precinct  15.01,President,,Gary Johnson,LBT,11
-Lyon,Precinct  16.01,President,,Gary Johnson,LBT,19
-Lyon,Precinct  17.01,President,,Gary Johnson,LBT,26
-Lyon,Precinct  18.01,President,,Gary Johnson,LBT,14
-Lyon,Precinct  19.01,President,,Gary Johnson,LBT,36
-Lyon,Precinct  20.01,President,,Gary Johnson,LBT,23
-Lyon,Precinct  21.01,President,,Gary Johnson,LBT,10
-Lyon,Precinct  22.01,President,,Gary Johnson,LBT,10
-Lyon,Precinct  23.01,President,,Gary Johnson,LBT,8
-Lyon,Precinct  24.01,President,,Gary Johnson,LBT,43
-Lyon,Precinct  25.01,President,,Gary Johnson,LBT,22
-Lyon,Precinct  26.01,President,,Gary Johnson,LBT,9
-Lyon,Precinct  27.01,President,,Gary Johnson,LBT,11
-Lyon,Precinct  28.01,President,,Gary Johnson,LBT,15
-Lyon,Precinct  29.01,President,,Gary Johnson,LBT,6
-Lyon,Precinct  29D.01,President,,Gary Johnson,LBT,0
-Lyon,Precinct  30.01,President,,Gary Johnson,LBT,21
-Lyon,Precinct  31.01,President,,Gary Johnson,LBT,26
-Lyon,Precinct  32.01,President,,Gary Johnson,LBT,14
-Lyon,Precinct  01.01,President,,Write-ins,,11
-Lyon,Precinct  02.01,President,,Write-ins,,16
-Lyon,Precinct  03.01,President,,Write-ins,,6
-Lyon,Precinct  04.01,President,,Write-ins,,12
-Lyon,Precinct  4A.01,President,,Write-ins,,0
-Lyon,Precinct  4B.01,President,,Write-ins,,0
-Lyon,Precinct  4C.01,President,,Write-ins,,0
-Lyon,Precinct  05.01,President,,Write-ins,,5
-Lyon,Precinct  06.01,President,,Write-ins,,4
-Lyon,Precinct  07.01,President,,Write-ins,,2
-Lyon,Precinct  08.01,President,,Write-ins,,9
-Lyon,Precinct  09.01,President,,Write-ins,,10
-Lyon,Precinct  10.01,President,,Write-ins,,7
-Lyon,Precinct  11.01,President,,Write-ins,,11
-Lyon,Precinct  12.01,President,,Write-ins,,3
-Lyon,Precinct  13.01,President,,Write-ins,,9
-Lyon,Precinct  14.01,President,,Write-ins,,18
-Lyon,Precinct  15.01,President,,Write-ins,,10
-Lyon,Precinct  16.01,President,,Write-ins,,12
-Lyon,Precinct  17.01,President,,Write-ins,,13
-Lyon,Precinct  18.01,President,,Write-ins,,5
-Lyon,Precinct  19.01,President,,Write-ins,,16
-Lyon,Precinct  20.01,President,,Write-ins,,13
-Lyon,Precinct  21.01,President,,Write-ins,,9
-Lyon,Precinct  22.01,President,,Write-ins,,3
-Lyon,Precinct  23.01,President,,Write-ins,,4
-Lyon,Precinct  24.01,President,,Write-ins,,6
-Lyon,Precinct  25.01,President,,Write-ins,,10
-Lyon,Precinct  26.01,President,,Write-ins,,3
-Lyon,Precinct  27.01,President,,Write-ins,,10
-Lyon,Precinct  28.01,President,,Write-ins,,3
-Lyon,Precinct  29.01,President,,Write-ins,,2
-Lyon,Precinct  29D.01,President,,Write-ins,,0
-Lyon,Precinct  30.01,President,,Write-ins,,13
-Lyon,Precinct  31.01,President,,Write-ins,,9
-Lyon,Precinct  32.01,President,,Write-ins,,6
-Lyon,Precinct  01.01,U.S. Senate,,Jerry Moran,R,226
-Lyon,Precinct  02.01,U.S. Senate,,Jerry Moran,R,186
-Lyon,Precinct  03.01,U.S. Senate,,Jerry Moran,R,233
-Lyon,Precinct  04.01,U.S. Senate,,Jerry Moran,R,277
-Lyon,Precinct  4A.01,U.S. Senate,,Jerry Moran,R,2
-Lyon,Precinct  4B.01,U.S. Senate,,Jerry Moran,R,2
-Lyon,Precinct  4C.01,U.S. Senate,,Jerry Moran,R,3
-Lyon,Precinct  05.01,U.S. Senate,,Jerry Moran,R,147
-Lyon,Precinct  06.01,U.S. Senate,,Jerry Moran,R,175
-Lyon,Precinct  07.01,U.S. Senate,,Jerry Moran,R,76
-Lyon,Precinct  08.01,U.S. Senate,,Jerry Moran,R,192
-Lyon,Precinct  09.01,U.S. Senate,,Jerry Moran,R,186
-Lyon,Precinct  10.01,U.S. Senate,,Jerry Moran,R,205
-Lyon,Precinct  11.01,U.S. Senate,,Jerry Moran,R,167
-Lyon,Precinct  12.01,U.S. Senate,,Jerry Moran,R,160
-Lyon,Precinct  13.01,U.S. Senate,,Jerry Moran,R,266
-Lyon,Precinct  14.01,U.S. Senate,,Jerry Moran,R,329
-Lyon,Precinct  15.01,U.S. Senate,,Jerry Moran,R,168
-Lyon,Precinct  16.01,U.S. Senate,,Jerry Moran,R,259
-Lyon,Precinct  17.01,U.S. Senate,,Jerry Moran,R,277
-Lyon,Precinct  18.01,U.S. Senate,,Jerry Moran,R,273
-Lyon,Precinct  19.01,U.S. Senate,,Jerry Moran,R,448
-Lyon,Precinct  20.01,U.S. Senate,,Jerry Moran,R,424
-Lyon,Precinct  21.01,U.S. Senate,,Jerry Moran,R,168
-Lyon,Precinct  22.01,U.S. Senate,,Jerry Moran,R,93
-Lyon,Precinct  23.01,U.S. Senate,,Jerry Moran,R,111
-Lyon,Precinct  24.01,U.S. Senate,,Jerry Moran,R,507
-Lyon,Precinct  25.01,U.S. Senate,,Jerry Moran,R,400
-Lyon,Precinct  26.01,U.S. Senate,,Jerry Moran,R,155
-Lyon,Precinct  27.01,U.S. Senate,,Jerry Moran,R,321
-Lyon,Precinct  28.01,U.S. Senate,,Jerry Moran,R,259
-Lyon,Precinct  29.01,U.S. Senate,,Jerry Moran,R,131
-Lyon,Precinct  29D.01,U.S. Senate,,Jerry Moran,R,4
-Lyon,Precinct  30.01,U.S. Senate,,Jerry Moran,R,363
-Lyon,Precinct  31.01,U.S. Senate,,Jerry Moran,R,481
-Lyon,Precinct  32.01,U.S. Senate,,Jerry Moran,R,251
-Lyon,Precinct  01.01,U.S. Senate,,Patrick Wiesner,D,188
-Lyon,Precinct  02.01,U.S. Senate,,Patrick Wiesner,D,141
-Lyon,Precinct  03.01,U.S. Senate,,Patrick Wiesner,D,167
-Lyon,Precinct  04.01,U.S. Senate,,Patrick Wiesner,D,188
-Lyon,Precinct  4A.01,U.S. Senate,,Patrick Wiesner,D,0
-Lyon,Precinct  4B.01,U.S. Senate,,Patrick Wiesner,D,1
-Lyon,Precinct  4C.01,U.S. Senate,,Patrick Wiesner,D,4
-Lyon,Precinct  05.01,U.S. Senate,,Patrick Wiesner,D,139
-Lyon,Precinct  06.01,U.S. Senate,,Patrick Wiesner,D,160
-Lyon,Precinct  07.01,U.S. Senate,,Patrick Wiesner,D,71
-Lyon,Precinct  08.01,U.S. Senate,,Patrick Wiesner,D,171
-Lyon,Precinct  09.01,U.S. Senate,,Patrick Wiesner,D,120
-Lyon,Precinct  10.01,U.S. Senate,,Patrick Wiesner,D,129
-Lyon,Precinct  11.01,U.S. Senate,,Patrick Wiesner,D,130
-Lyon,Precinct  12.01,U.S. Senate,,Patrick Wiesner,D,121
-Lyon,Precinct  13.01,U.S. Senate,,Patrick Wiesner,D,157
-Lyon,Precinct  14.01,U.S. Senate,,Patrick Wiesner,D,190
-Lyon,Precinct  15.01,U.S. Senate,,Patrick Wiesner,D,99
-Lyon,Precinct  16.01,U.S. Senate,,Patrick Wiesner,D,190
-Lyon,Precinct  17.01,U.S. Senate,,Patrick Wiesner,D,155
-Lyon,Precinct  18.01,U.S. Senate,,Patrick Wiesner,D,111
-Lyon,Precinct  19.01,U.S. Senate,,Patrick Wiesner,D,176
-Lyon,Precinct  20.01,U.S. Senate,,Patrick Wiesner,D,141
-Lyon,Precinct  21.01,U.S. Senate,,Patrick Wiesner,D,45
-Lyon,Precinct  22.01,U.S. Senate,,Patrick Wiesner,D,25
-Lyon,Precinct  23.01,U.S. Senate,,Patrick Wiesner,D,24
-Lyon,Precinct  24.01,U.S. Senate,,Patrick Wiesner,D,131
-Lyon,Precinct  25.01,U.S. Senate,,Patrick Wiesner,D,85
-Lyon,Precinct  26.01,U.S. Senate,,Patrick Wiesner,D,61
-Lyon,Precinct  27.01,U.S. Senate,,Patrick Wiesner,D,65
-Lyon,Precinct  28.01,U.S. Senate,,Patrick Wiesner,D,72
-Lyon,Precinct  29.01,U.S. Senate,,Patrick Wiesner,D,27
-Lyon,Precinct  29D.01,U.S. Senate,,Patrick Wiesner,D,0
-Lyon,Precinct  30.01,U.S. Senate,,Patrick Wiesner,D,99
-Lyon,Precinct  31.01,U.S. Senate,,Patrick Wiesner,D,100
-Lyon,Precinct  32.01,U.S. Senate,,Patrick Wiesner,D,77
-Lyon,Precinct  01.01,U.S. Senate,,Robert Garrard,LBT,22
-Lyon,Precinct  02.01,U.S. Senate,,Robert Garrard,LBT,19
-Lyon,Precinct  03.01,U.S. Senate,,Robert Garrard,LBT,20
-Lyon,Precinct  04.01,U.S. Senate,,Robert Garrard,LBT,29
-Lyon,Precinct  4A.01,U.S. Senate,,Robert Garrard,LBT,0
-Lyon,Precinct  4B.01,U.S. Senate,,Robert Garrard,LBT,0
-Lyon,Precinct  4C.01,U.S. Senate,,Robert Garrard,LBT,0
-Lyon,Precinct  05.01,U.S. Senate,,Robert Garrard,LBT,30
-Lyon,Precinct  06.01,U.S. Senate,,Robert Garrard,LBT,23
-Lyon,Precinct  07.01,U.S. Senate,,Robert Garrard,LBT,8
-Lyon,Precinct  08.01,U.S. Senate,,Robert Garrard,LBT,29
-Lyon,Precinct  09.01,U.S. Senate,,Robert Garrard,LBT,22
-Lyon,Precinct  10.01,U.S. Senate,,Robert Garrard,LBT,17
-Lyon,Precinct  11.01,U.S. Senate,,Robert Garrard,LBT,18
-Lyon,Precinct  12.01,U.S. Senate,,Robert Garrard,LBT,18
-Lyon,Precinct  13.01,U.S. Senate,,Robert Garrard,LBT,29
-Lyon,Precinct  14.01,U.S. Senate,,Robert Garrard,LBT,21
-Lyon,Precinct  15.01,U.S. Senate,,Robert Garrard,LBT,8
-Lyon,Precinct  16.01,U.S. Senate,,Robert Garrard,LBT,19
-Lyon,Precinct  17.01,U.S. Senate,,Robert Garrard,LBT,28
-Lyon,Precinct  18.01,U.S. Senate,,Robert Garrard,LBT,18
-Lyon,Precinct  19.01,U.S. Senate,,Robert Garrard,LBT,23
-Lyon,Precinct  20.01,U.S. Senate,,Robert Garrard,LBT,18
-Lyon,Precinct  21.01,U.S. Senate,,Robert Garrard,LBT,11
-Lyon,Precinct  22.01,U.S. Senate,,Robert Garrard,LBT,3
-Lyon,Precinct  23.01,U.S. Senate,,Robert Garrard,LBT,10
-Lyon,Precinct  24.01,U.S. Senate,,Robert Garrard,LBT,33
-Lyon,Precinct  25.01,U.S. Senate,,Robert Garrard,LBT,21
-Lyon,Precinct  26.01,U.S. Senate,,Robert Garrard,LBT,14
-Lyon,Precinct  27.01,U.S. Senate,,Robert Garrard,LBT,18
-Lyon,Precinct  28.01,U.S. Senate,,Robert Garrard,LBT,18
-Lyon,Precinct  29.01,U.S. Senate,,Robert Garrard,LBT,5
-Lyon,Precinct  29D.01,U.S. Senate,,Robert Garrard,LBT,0
-Lyon,Precinct  30.01,U.S. Senate,,Robert Garrard,LBT,23
-Lyon,Precinct  31.01,U.S. Senate,,Robert Garrard,LBT,21
-Lyon,Precinct  32.01,U.S. Senate,,Robert Garrard,LBT,22
-Lyon,Precinct  01.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  02.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  03.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  04.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  4A.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  4B.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  4C.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  05.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  06.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  07.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  08.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  09.01,U.S. Senate,,Write-ins,,2
-Lyon,Precinct  10.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  11.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  12.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  13.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  14.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  15.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  16.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  17.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  18.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  19.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  20.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  21.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  22.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  23.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  24.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  25.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  26.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  27.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  28.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  29.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  29D.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  30.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  31.01,U.S. Senate,,Write-ins,,1
-Lyon,Precinct  32.01,U.S. Senate,,Write-ins,,0
-Lyon,Precinct  01.01,U.S. House,1,Alan LaPolice,IND,138
-Lyon,Precinct  02.01,U.S. House,1,Alan LaPolice,IND,111
-Lyon,Precinct  03.01,U.S. House,1,Alan LaPolice,IND,127
-Lyon,Precinct  04.01,U.S. House,1,Alan LaPolice,IND,156
-Lyon,Precinct  4A.01,U.S. House,1,Alan LaPolice,IND,0
-Lyon,Precinct  4B.01,U.S. House,1,Alan LaPolice,IND,1
-Lyon,Precinct  4C.01,U.S. House,1,Alan LaPolice,IND,2
-Lyon,Precinct  05.01,U.S. House,1,Alan LaPolice,IND,87
-Lyon,Precinct  06.01,U.S. House,1,Alan LaPolice,IND,112
-Lyon,Precinct  07.01,U.S. House,1,Alan LaPolice,IND,61
-Lyon,Precinct  08.01,U.S. House,1,Alan LaPolice,IND,138
-Lyon,Precinct  09.01,U.S. House,1,Alan LaPolice,IND,100
-Lyon,Precinct  10.01,U.S. House,1,Alan LaPolice,IND,91
-Lyon,Precinct  11.01,U.S. House,1,Alan LaPolice,IND,94
-Lyon,Precinct  12.01,U.S. House,1,Alan LaPolice,IND,96
-Lyon,Precinct  13.01,U.S. House,1,Alan LaPolice,IND,133
-Lyon,Precinct  14.01,U.S. House,1,Alan LaPolice,IND,131
-Lyon,Precinct  15.01,U.S. House,1,Alan LaPolice,IND,68
-Lyon,Precinct  16.01,U.S. House,1,Alan LaPolice,IND,143
-Lyon,Precinct  17.01,U.S. House,1,Alan LaPolice,IND,132
-Lyon,Precinct  18.01,U.S. House,1,Alan LaPolice,IND,103
-Lyon,Precinct  19.01,U.S. House,1,Alan LaPolice,IND,131
-Lyon,Precinct  20.01,U.S. House,1,Alan LaPolice,IND,112
-Lyon,Precinct  21.01,U.S. House,1,Alan LaPolice,IND,49
-Lyon,Precinct  22.01,U.S. House,1,Alan LaPolice,IND,18
-Lyon,Precinct  23.01,U.S. House,1,Alan LaPolice,IND,32
-Lyon,Precinct  24.01,U.S. House,1,Alan LaPolice,IND,128
-Lyon,Precinct  25.01,U.S. House,1,Alan LaPolice,IND,94
-Lyon,Precinct  26.01,U.S. House,1,Alan LaPolice,IND,65
-Lyon,Precinct  27.01,U.S. House,1,Alan LaPolice,IND,61
-Lyon,Precinct  28.01,U.S. House,1,Alan LaPolice,IND,69
-Lyon,Precinct  29.01,U.S. House,1,Alan LaPolice,IND,31
-Lyon,Precinct  29D.01,U.S. House,1,Alan LaPolice,IND,1
-Lyon,Precinct  30.01,U.S. House,1,Alan LaPolice,IND,88
-Lyon,Precinct  31.01,U.S. House,1,Alan LaPolice,IND,108
-Lyon,Precinct  32.01,U.S. House,1,Alan LaPolice,IND,62
-Lyon,Precinct  01.01,U.S. House,1,Roger Marshall,R,217
-Lyon,Precinct  02.01,U.S. House,1,Roger Marshall,R,156
-Lyon,Precinct  03.01,U.S. House,1,Roger Marshall,R,194
-Lyon,Precinct  04.01,U.S. House,1,Roger Marshall,R,244
-Lyon,Precinct  4A.01,U.S. House,1,Roger Marshall,R,2
-Lyon,Precinct  4B.01,U.S. House,1,Roger Marshall,R,2
-Lyon,Precinct  4C.01,U.S. House,1,Roger Marshall,R,3
-Lyon,Precinct  05.01,U.S. House,1,Roger Marshall,R,135
-Lyon,Precinct  06.01,U.S. House,1,Roger Marshall,R,158
-Lyon,Precinct  07.01,U.S. House,1,Roger Marshall,R,67
-Lyon,Precinct  08.01,U.S. House,1,Roger Marshall,R,161
-Lyon,Precinct  09.01,U.S. House,1,Roger Marshall,R,162
-Lyon,Precinct  10.01,U.S. House,1,Roger Marshall,R,195
-Lyon,Precinct  11.01,U.S. House,1,Roger Marshall,R,156
-Lyon,Precinct  12.01,U.S. House,1,Roger Marshall,R,146
-Lyon,Precinct  13.01,U.S. House,1,Roger Marshall,R,231
-Lyon,Precinct  14.01,U.S. House,1,Roger Marshall,R,318
-Lyon,Precinct  15.01,U.S. House,1,Roger Marshall,R,163
-Lyon,Precinct  16.01,U.S. House,1,Roger Marshall,R,253
-Lyon,Precinct  17.01,U.S. House,1,Roger Marshall,R,247
-Lyon,Precinct  18.01,U.S. House,1,Roger Marshall,R,248
-Lyon,Precinct  19.01,U.S. House,1,Roger Marshall,R,424
-Lyon,Precinct  20.01,U.S. House,1,Roger Marshall,R,391
-Lyon,Precinct  21.01,U.S. House,1,Roger Marshall,R,153
-Lyon,Precinct  22.01,U.S. House,1,Roger Marshall,R,90
-Lyon,Precinct  23.01,U.S. House,1,Roger Marshall,R,99
-Lyon,Precinct  24.01,U.S. House,1,Roger Marshall,R,461
-Lyon,Precinct  25.01,U.S. House,1,Roger Marshall,R,361
-Lyon,Precinct  26.01,U.S. House,1,Roger Marshall,R,128
-Lyon,Precinct  27.01,U.S. House,1,Roger Marshall,R,305
-Lyon,Precinct  28.01,U.S. House,1,Roger Marshall,R,231
-Lyon,Precinct  29.01,U.S. House,1,Roger Marshall,R,120
-Lyon,Precinct  29D.01,U.S. House,1,Roger Marshall,R,3
-Lyon,Precinct  30.01,U.S. House,1,Roger Marshall,R,345
-Lyon,Precinct  31.01,U.S. House,1,Roger Marshall,R,433
-Lyon,Precinct  32.01,U.S. House,1,Roger Marshall,R,239
-Lyon,Precinct  01.01,U.S. House,1,Kerry Burt,LBT,58
-Lyon,Precinct  02.01,U.S. House,1,Kerry Burt,LBT,57
-Lyon,Precinct  03.01,U.S. House,1,Kerry Burt,LBT,56
-Lyon,Precinct  04.01,U.S. House,1,Kerry Burt,LBT,63
-Lyon,Precinct  4A.01,U.S. House,1,Kerry Burt,LBT,0
-Lyon,Precinct  4B.01,U.S. House,1,Kerry Burt,LBT,0
-Lyon,Precinct  4C.01,U.S. House,1,Kerry Burt,LBT,2
-Lyon,Precinct  05.01,U.S. House,1,Kerry Burt,LBT,74
-Lyon,Precinct  06.01,U.S. House,1,Kerry Burt,LBT,45
-Lyon,Precinct  07.01,U.S. House,1,Kerry Burt,LBT,20
-Lyon,Precinct  08.01,U.S. House,1,Kerry Burt,LBT,70
-Lyon,Precinct  09.01,U.S. House,1,Kerry Burt,LBT,51
-Lyon,Precinct  10.01,U.S. House,1,Kerry Burt,LBT,45
-Lyon,Precinct  11.01,U.S. House,1,Kerry Burt,LBT,47
-Lyon,Precinct  12.01,U.S. House,1,Kerry Burt,LBT,45
-Lyon,Precinct  13.01,U.S. House,1,Kerry Burt,LBT,60
-Lyon,Precinct  14.01,U.S. House,1,Kerry Burt,LBT,54
-Lyon,Precinct  15.01,U.S. House,1,Kerry Burt,LBT,32
-Lyon,Precinct  16.01,U.S. House,1,Kerry Burt,LBT,42
-Lyon,Precinct  17.01,U.S. House,1,Kerry Burt,LBT,54
-Lyon,Precinct  18.01,U.S. House,1,Kerry Burt,LBT,34
-Lyon,Precinct  19.01,U.S. House,1,Kerry Burt,LBT,59
-Lyon,Precinct  20.01,U.S. House,1,Kerry Burt,LBT,45
-Lyon,Precinct  21.01,U.S. House,1,Kerry Burt,LBT,13
-Lyon,Precinct  22.01,U.S. House,1,Kerry Burt,LBT,12
-Lyon,Precinct  23.01,U.S. House,1,Kerry Burt,LBT,9
-Lyon,Precinct  24.01,U.S. House,1,Kerry Burt,LBT,52
-Lyon,Precinct  25.01,U.S. House,1,Kerry Burt,LBT,38
-Lyon,Precinct  26.01,U.S. House,1,Kerry Burt,LBT,27
-Lyon,Precinct  27.01,U.S. House,1,Kerry Burt,LBT,28
-Lyon,Precinct  28.01,U.S. House,1,Kerry Burt,LBT,31
-Lyon,Precinct  29.01,U.S. House,1,Kerry Burt,LBT,8
-Lyon,Precinct  29D.01,U.S. House,1,Kerry Burt,LBT,0
-Lyon,Precinct  30.01,U.S. House,1,Kerry Burt,LBT,36
-Lyon,Precinct  31.01,U.S. House,1,Kerry Burt,LBT,40
-Lyon,Precinct  32.01,U.S. House,1,Kerry Burt,LBT,38
-Lyon,Precinct  01.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  02.01,U.S. House,1,Write-ins,,4
-Lyon,Precinct  03.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  04.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  4A.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  4B.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  4C.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  05.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  06.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  07.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  08.01,U.S. House,1,Write-ins,,4
-Lyon,Precinct  09.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  10.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  11.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  12.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  13.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  14.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  15.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  16.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  17.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  18.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  19.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  20.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  21.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  22.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  23.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  24.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  25.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  26.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  27.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  28.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  29.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  29D.01,U.S. House,1,Write-ins,,0
-Lyon,Precinct  30.01,U.S. House,1,Write-ins,,3
-Lyon,Precinct  31.01,U.S. House,1,Write-ins,,2
-Lyon,Precinct  32.01,U.S. House,1,Write-ins,,1
-Lyon,Precinct  01.01,State Senate,17,Jeff Longbine,R,210
-Lyon,Precinct  02.01,State Senate,17,Jeff Longbine,R,165
-Lyon,Precinct  03.01,State Senate,17,Jeff Longbine,R,192
-Lyon,Precinct  04.01,State Senate,17,Jeff Longbine,R,241
-Lyon,Precinct  4A.01,State Senate,17,Jeff Longbine,R,2
-Lyon,Precinct  4B.01,State Senate,17,Jeff Longbine,R,2
-Lyon,Precinct  4C.01,State Senate,17,Jeff Longbine,R,3
-Lyon,Precinct  05.01,State Senate,17,Jeff Longbine,R,133
-Lyon,Precinct  06.01,State Senate,17,Jeff Longbine,R,160
-Lyon,Precinct  07.01,State Senate,17,Jeff Longbine,R,66
-Lyon,Precinct  08.01,State Senate,17,Jeff Longbine,R,167
-Lyon,Precinct  09.01,State Senate,17,Jeff Longbine,R,165
-Lyon,Precinct  10.01,State Senate,17,Jeff Longbine,R,179
-Lyon,Precinct  11.01,State Senate,17,Jeff Longbine,R,161
-Lyon,Precinct  12.01,State Senate,17,Jeff Longbine,R,142
-Lyon,Precinct  13.01,State Senate,17,Jeff Longbine,R,229
-Lyon,Precinct  14.01,State Senate,17,Jeff Longbine,R,296
-Lyon,Precinct  15.01,State Senate,17,Jeff Longbine,R,163
-Lyon,Precinct  16.01,State Senate,17,Jeff Longbine,R,220
-Lyon,Precinct  17.01,State Senate,17,Jeff Longbine,R,255
-Lyon,Precinct  18.01,State Senate,17,Jeff Longbine,R,236
-Lyon,Precinct  19.01,State Senate,17,Jeff Longbine,R,418
-Lyon,Precinct  20.01,State Senate,17,Jeff Longbine,R,384
-Lyon,Precinct  21.01,State Senate,17,Jeff Longbine,R,159
-Lyon,Precinct  22.01,State Senate,17,Jeff Longbine,R,74
-Lyon,Precinct  23.01,State Senate,17,Jeff Longbine,R,96
-Lyon,Precinct  24.01,State Senate,17,Jeff Longbine,R,444
-Lyon,Precinct  25.01,State Senate,17,Jeff Longbine,R,344
-Lyon,Precinct  26.01,State Senate,17,Jeff Longbine,R,131
-Lyon,Precinct  27.01,State Senate,17,Jeff Longbine,R,275
-Lyon,Precinct  28.01,State Senate,17,Jeff Longbine,R,209
-Lyon,Precinct  29.01,State Senate,17,Jeff Longbine,R,112
-Lyon,Precinct  29D.01,State Senate,17,Jeff Longbine,R,4
-Lyon,Precinct  30.01,State Senate,17,Jeff Longbine,R,318
-Lyon,Precinct  31.01,State Senate,17,Jeff Longbine,R,424
-Lyon,Precinct  32.01,State Senate,17,Jeff Longbine,R,215
-Lyon,Precinct  01.01,State Senate,17,Susan Fowler,D,228
-Lyon,Precinct  02.01,State Senate,17,Susan Fowler,D,185
-Lyon,Precinct  03.01,State Senate,17,Susan Fowler,D,230
-Lyon,Precinct  04.01,State Senate,17,Susan Fowler,D,255
-Lyon,Precinct  4A.01,State Senate,17,Susan Fowler,D,0
-Lyon,Precinct  4B.01,State Senate,17,Susan Fowler,D,1
-Lyon,Precinct  4C.01,State Senate,17,Susan Fowler,D,4
-Lyon,Precinct  05.01,State Senate,17,Susan Fowler,D,185
-Lyon,Precinct  06.01,State Senate,17,Susan Fowler,D,200
-Lyon,Precinct  07.01,State Senate,17,Susan Fowler,D,87
-Lyon,Precinct  08.01,State Senate,17,Susan Fowler,D,226
-Lyon,Precinct  09.01,State Senate,17,Susan Fowler,D,167
-Lyon,Precinct  10.01,State Senate,17,Susan Fowler,D,171
-Lyon,Precinct  11.01,State Senate,17,Susan Fowler,D,159
-Lyon,Precinct  12.01,State Senate,17,Susan Fowler,D,161
-Lyon,Precinct  13.01,State Senate,17,Susan Fowler,D,228
-Lyon,Precinct  14.01,State Senate,17,Susan Fowler,D,246
-Lyon,Precinct  15.01,State Senate,17,Susan Fowler,D,116
-Lyon,Precinct  16.01,State Senate,17,Susan Fowler,D,239
-Lyon,Precinct  17.01,State Senate,17,Susan Fowler,D,205
-Lyon,Precinct  18.01,State Senate,17,Susan Fowler,D,165
-Lyon,Precinct  19.01,State Senate,17,Susan Fowler,D,237
-Lyon,Precinct  20.01,State Senate,17,Susan Fowler,D,198
-Lyon,Precinct  21.01,State Senate,17,Susan Fowler,D,67
-Lyon,Precinct  22.01,State Senate,17,Susan Fowler,D,48
-Lyon,Precinct  23.01,State Senate,17,Susan Fowler,D,50
-Lyon,Precinct  24.01,State Senate,17,Susan Fowler,D,218
-Lyon,Precinct  25.01,State Senate,17,Susan Fowler,D,159
-Lyon,Precinct  26.01,State Senate,17,Susan Fowler,D,97
-Lyon,Precinct  27.01,State Senate,17,Susan Fowler,D,131
-Lyon,Precinct  28.01,State Senate,17,Susan Fowler,D,139
-Lyon,Precinct  29.01,State Senate,17,Susan Fowler,D,51
-Lyon,Precinct  29D.01,State Senate,17,Susan Fowler,D,0
-Lyon,Precinct  30.01,State Senate,17,Susan Fowler,D,170
-Lyon,Precinct  31.01,State Senate,17,Susan Fowler,D,175
-Lyon,Precinct  32.01,State Senate,17,Susan Fowler,D,138
-Lyon,Precinct  01.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  02.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  03.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  04.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  4A.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  4B.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  4C.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  05.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  06.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  07.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  08.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  09.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  10.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  11.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  12.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  13.01,State Senate,17,Write-ins,,2
-Lyon,Precinct  14.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  15.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  16.01,State Senate,17,Write-ins,,2
-Lyon,Precinct  17.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  18.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  19.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  20.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  21.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  22.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  23.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  24.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  25.01,State Senate,17,Write-ins,,2
-Lyon,Precinct  26.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  27.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  28.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  29.01,State Senate,17,Write-ins,,1
-Lyon,Precinct  29D.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  30.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  31.01,State Senate,17,Write-ins,,3
-Lyon,Precinct  32.01,State Senate,17,Write-ins,,0
-Lyon,Precinct  21.01,State House,51,Ron Highland,R,114
-Lyon,Precinct  22.01,State House,51,Ron Highland,R,53
-Lyon,Precinct  23.01,State House,51,Ron Highland,R,61
-Lyon,Precinct  26.01,State House,51,Ron Highland,R,89
-Lyon,Precinct  21.01,State House,51,Adrienne Olejnik,D,101
-Lyon,Precinct  22.01,State House,51,Adrienne Olejnik,D,69
-Lyon,Precinct  23.01,State House,51,Adrienne Olejnik,D,82
-Lyon,Precinct  26.01,State House,51,Adrienne Olejnik,D,135
-Lyon,Precinct  01.01,State House,60,William Ballard,D,197
-Lyon,Precinct  02.01,State House,60,William Ballard,D,159
-Lyon,Precinct  05.01,State House,60,William Ballard,D,162
-Lyon,Precinct  06.01,State House,60,William Ballard,D,178
-Lyon,Precinct  07.01,State House,60,William Ballard,D,68
-Lyon,Precinct  08.01,State House,60,William Ballard,D,200
-Lyon,Precinct  09.01,State House,60,William Ballard,D,147
-Lyon,Precinct   11.01,State House,60,William Ballard,D,138
-Lyon,Precinct  12.01,State House,60,William Ballard,D,118
-Lyon,Precinct   13.01,State House,60,William Ballard,D,170
-Lyon,Precinct  14.01,State House,60,William Ballard,D,173
-Lyon,Precinct   15.01,State House,60,William Ballard,D,91
-Lyon,Precinct  16.01,State House,60,William Ballard,D,211
-Lyon,Precinct   17.01,State House,60,William Ballard,D,175
-Lyon,Precinct  18.01,State House,60,William Ballard,D,120
-Lyon,Precinct  19.01,State House,60,William Ballard,D,203
-Lyon,Precinct  20.01,State House,60,William Ballard,D,146
-Lyon,Precinct  24.01,State House,60,William Ballard,D,179
-Lyon,Precinct  25.01,State House,60,William Ballard,D,107
-Lyon,Precinct  27.01,State House,60,William Ballard,D,90
-Lyon,Precinct  29.01,State House,60,William Ballard,D,37
-Lyon,Precinct  29D.01,State House,60,William Ballard,D,0
-Lyon,Precinct  01.01,State House,60,Mark Schreiber,R,231
-Lyon,Precinct  02.01,State House,60,Mark Schreiber,R,183
-Lyon,Precinct  05.01,State House,60,Mark Schreiber,R,148
-Lyon,Precinct  06.01,State House,60,Mark Schreiber,R,168
-Lyon,Precinct  07.01,State House,60,Mark Schreiber,R,83
-Lyon,Precinct  08.01,State House,60,Mark Schreiber,R,185
-Lyon,Precinct  09.01,State House,60,Mark Schreiber,R,175
-Lyon,Precinct  11.01,State House,60,Mark Schreiber,R,174
-Lyon,Precinct  12.01,State House,60,Mark Schreiber,R,172
-Lyon,Precinct  13.01,State House,60,Mark Schreiber,R,274
-Lyon,Precinct  14.01,State House,60,Mark Schreiber,R,362
-Lyon,Precinct  15.01,State House,60,Mark Schreiber,R,178
-Lyon,Precinct  16.01,State House,60,Mark Schreiber,R,247
-Lyon,Precinct  17.01,State House,60,Mark Schreiber,R,274
-Lyon,Precinct  18.01,State House,60,Mark Schreiber,R,273
-Lyon,Precinct  19.01,State House,60,Mark Schreiber,R,432
-Lyon,Precinct  20.01,State House,60,Mark Schreiber,R,429
-Lyon,Precinct  24.01,State House,60,Mark Schreiber,R,471
-Lyon,Precinct  25.01,State House,60,Mark Schreiber,R,391
-Lyon,Precinct  27.01,State House,60,Mark Schreiber,R,312
-Lyon,Precinct  29.01,State House,60,Mark Schreiber,R,126
-Lyon,Precinct  29D.01,State House,60,Mark Schreiber,R,4
-Lyon,Precinct  01.01,State House,60,Write-ins,,0
-Lyon,Precinct  02.01,State House,60,Write-ins,,1
-Lyon,Precinct  05.01,State House,60,Write-ins,,1
-Lyon,Precinct  06.01,State House,60,Write-ins,,1
-Lyon,Precinct  07.01,State House,60,Write-ins,,0
-Lyon,Precinct  08.01,State House,60,Write-ins,,0
-Lyon,Precinct  09.01,State House,60,Write-ins,,0
-Lyon,Precinct  11.01,State House,60,Write-ins,,1
-Lyon,Precinct  12.01,State House,60,Write-ins,,1
-Lyon,Precinct  13.01,State House,60,Write-ins,,2
-Lyon,Precinct  14.01,State House,60,Write-ins,,0
-Lyon,Precinct  15.01,State House,60,Write-ins,,0
-Lyon,Precinct  16.01,State House,60,Write-ins,,1
-Lyon,Precinct  17.01,State House,60,Write-ins,,1
-Lyon,Precinct  18.01,State House,60,Write-ins,,4
-Lyon,Precinct  19.01,State House,60,Write-ins,,1
-Lyon,Precinct  20.01,State House,60,Write-ins,,0
-Lyon,Precinct  24.01,State House,60,Write-ins,,0
-Lyon,Precinct  25.01,State House,60,Write-ins,,0
-Lyon,Precinct  27.01,State House,60,Write-ins,,0
-Lyon,Precinct  29.01,State House,60,Write-ins,,0
-Lyon,Precinct  29D.01,State House,60,Write-ins,,0
-Lyon,Precinct  03.01,State House,76,Teresa Briggs,D,253
-Lyon,Precinct  04.01,State House,76,Teresa Briggs,D,267
-Lyon,Precinct  4A.01,State House,76,Teresa Briggs,D,0
-Lyon,Precinct  4B.01,State House,76,Teresa Briggs,D,3
-Lyon,Precinct  4C.01,State House,76,Teresa Briggs,D,6
-Lyon,Precinct  10.01,State House,76,Teresa Briggs,D,190
-Lyon,Precinct  28.01,State House,76,Teresa Briggs,D,145
-Lyon,Precinct  30.01,State House,76,Teresa Briggs,D,213
-Lyon,Precinct  31.01,State House,76,Teresa Briggs,D,268
-Lyon,Precinct  32.01,State House,76,Teresa Briggs,D,156
-Lyon,Precinct  03.01,State House,76,Eric Smith,R,152
-Lyon,Precinct  04.01,State House,76,Eric Smith,R,221
-Lyon,Precinct  4A.01,State House,76,Eric Smith,R,2
-Lyon,Precinct  4B.01,State House,76,Eric Smith,R,0
-Lyon,Precinct  4C.01,State House,76,Eric Smith,R,1
-Lyon,Precinct  10.01,State House,76,Eric Smith,R,152
-Lyon,Precinct  28.01,State House,76,Eric Smith,R,195
-Lyon,Precinct  30.01,State House,76,Eric Smith,R,270
-Lyon,Precinct  31.01,State House,76,Eric Smith,R,327
-Lyon,Precinct  32.01,State House,76,Eric Smith,R,196
-Lyon,Precinct  03.01,State House,76,Write-ins,,1
-Lyon,Precinct  04.01,State House,76,Write-ins,,0
-Lyon,Precinct  4A.01,State House,76,Write-ins,,0
-Lyon,Precinct  4B.01,State House,76,Write-ins,,0
-Lyon,Precinct  4C.01,State House,76,Write-ins,,0
-Lyon,Precinct  10.01,State House,76,Write-ins,,0
-Lyon,Precinct  28.01,State House,76,Write-ins,,0
-Lyon,Precinct  30.01,State House,76,Write-ins,,0
-Lyon,Precinct  31.01,State House,76,Write-ins,,5
-Lyon,Precinct  32.01,State House,76,Write-ins,,0
+county,precinct,office,district,party,candidate,votes,vtd
+LYON,Precinct 01,Kansas House of Representatives,60,Democratic,"Ballard, William L.",197,000010
+LYON,Precinct 01,Kansas House of Representatives,60,Republican,"Schreiber, Mark",231,000010
+LYON,Precinct 02,Kansas House of Representatives,60,Democratic,"Ballard, William L.",159,000020
+LYON,Precinct 02,Kansas House of Representatives,60,Republican,"Schreiber, Mark",183,000020
+LYON,Precinct 03,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",253,000030
+LYON,Precinct 03,Kansas House of Representatives,76,Republican,"Smith, Eric L.",152,000030
+LYON,Precinct 04,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",267,000040
+LYON,Precinct 04,Kansas House of Representatives,76,Republican,"Smith, Eric L.",221,000040
+LYON,Precinct 05,Kansas House of Representatives,60,Democratic,"Ballard, William L.",162,00005A
+LYON,Precinct 05,Kansas House of Representatives,60,Republican,"Schreiber, Mark",148,00005A
+LYON,Precinct 05 Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00005B
+LYON,Precinct 05 Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00005B
+LYON,Precinct 05 Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00005C
+LYON,Precinct 05 Part B,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00005C
+LYON,Precinct 06 Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",178,00006A
+LYON,Precinct 06 Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",168,00006A
+LYON,Precinct 06 Part A Exclave,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00006B
+LYON,Precinct 06 Part A Exclave,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00006B
+LYON,Precinct 06 Part B Exclave,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00006C
+LYON,Precinct 06 Part B Exclave,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00006C
+LYON,Precinct 07,Kansas House of Representatives,60,Democratic,"Ballard, William L.",68,000070
+LYON,Precinct 07,Kansas House of Representatives,60,Republican,"Schreiber, Mark",83,000070
+LYON,Precinct 08,Kansas House of Representatives,60,Democratic,"Ballard, William L.",200,000080
+LYON,Precinct 08,Kansas House of Representatives,60,Republican,"Schreiber, Mark",185,000080
+LYON,Precinct 09,Kansas House of Representatives,60,Democratic,"Ballard, William L.",147,000090
+LYON,Precinct 09,Kansas House of Representatives,60,Republican,"Schreiber, Mark",175,000090
+LYON,Precinct 10,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",190,000100
+LYON,Precinct 10,Kansas House of Representatives,76,Republican,"Smith, Eric L.",152,000100
+LYON,Precinct 11,Kansas House of Representatives,60,Democratic,"Ballard, William L.",138,000110
+LYON,Precinct 11,Kansas House of Representatives,60,Republican,"Schreiber, Mark",174,000110
+LYON,Precinct 12,Kansas House of Representatives,60,Democratic,"Ballard, William L.",118,000120
+LYON,Precinct 12,Kansas House of Representatives,60,Republican,"Schreiber, Mark",172,000120
+LYON,Precinct 13,Kansas House of Representatives,60,Democratic,"Ballard, William L.",170,000130
+LYON,Precinct 13,Kansas House of Representatives,60,Republican,"Schreiber, Mark",274,000130
+LYON,Precinct 14,Kansas House of Representatives,60,Democratic,"Ballard, William L.",173,000140
+LYON,Precinct 14,Kansas House of Representatives,60,Republican,"Schreiber, Mark",362,000140
+LYON,Precinct 15,Kansas House of Representatives,60,Democratic,"Ballard, William L.",91,000150
+LYON,Precinct 15,Kansas House of Representatives,60,Republican,"Schreiber, Mark",178,000150
+LYON,Precinct 16,Kansas House of Representatives,60,Democratic,"Ballard, William L.",211,000160
+LYON,Precinct 16,Kansas House of Representatives,60,Republican,"Schreiber, Mark",247,000160
+LYON,Precinct 17 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00017A
+LYON,Precinct 17 Exclave Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00017A
+LYON,Precinct 17 Enclave Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00017B
+LYON,Precinct 17 Enclave Part B,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00017B
+LYON,Precinct 17,Kansas House of Representatives,60,Democratic,"Ballard, William L.",175,000170
+LYON,Precinct 17,Kansas House of Representatives,60,Republican,"Schreiber, Mark",274,000170
+LYON,Precinct 18 Enclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00018A
+LYON,Precinct 18 Enclave Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00018A
+LYON,Precinct 18,Kansas House of Representatives,60,Democratic,"Ballard, William L.",120,000180
+LYON,Precinct 18,Kansas House of Representatives,60,Republican,"Schreiber, Mark",273,000180
+LYON,Precinct 19,Kansas House of Representatives,60,Democratic,"Ballard, William L.",203,000190
+LYON,Precinct 19,Kansas House of Representatives,60,Republican,"Schreiber, Mark",432,000190
+LYON,Precinct 20 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00020A
+LYON,Precinct 20 Exclave Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00020A
+LYON,Precinct 20,Kansas House of Representatives,60,Democratic,"Ballard, William L.",146,000200
+LYON,Precinct 20,Kansas House of Representatives,60,Republican,"Schreiber, Mark",429,000200
+LYON,Precinct 21,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",101,000210
+LYON,Precinct 21,Kansas House of Representatives,51,Republican,"Highland, Ron",114,000210
+LYON,Precinct 22,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",69,000220
+LYON,Precinct 22,Kansas House of Representatives,51,Republican,"Highland, Ron",53,000220
+LYON,Precinct 23,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",82,000230
+LYON,Precinct 23,Kansas House of Representatives,51,Republican,"Highland, Ron",61,000230
+LYON,Precinct 24,Kansas House of Representatives,60,Democratic,"Ballard, William L.",179,000240
+LYON,Precinct 24,Kansas House of Representatives,60,Republican,"Schreiber, Mark",471,000240
+LYON,Precinct 25,Kansas House of Representatives,60,Democratic,"Ballard, William L.",107,000250
+LYON,Precinct 25,Kansas House of Representatives,60,Republican,"Schreiber, Mark",391,000250
+LYON,Precinct 26,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",135,000260
+LYON,Precinct 26,Kansas House of Representatives,51,Republican,"Highland, Ron",89,000260
+LYON,Precinct 27,Kansas House of Representatives,60,Democratic,"Ballard, William L.",90,000270
+LYON,Precinct 27,Kansas House of Representatives,60,Republican,"Schreiber, Mark",312,000270
+LYON,Precinct 28,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",145,00028A
+LYON,Precinct 28,Kansas House of Representatives,76,Republican,"Smith, Eric L.",195,00028A
+LYON,Precinct 28 Enclave A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00028B
+LYON,Precinct 28 Enclave A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00028B
+LYON,Precinct 28 Enclave Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00028C
+LYON,Precinct 28 Enclave Part B,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00028C
+LYON,Precinct 29 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,00029A
+LYON,Precinct 29 Exclave Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,00029A
+LYON,Precinct 29,Kansas House of Representatives,60,Democratic,"Ballard, William L.",37,000290
+LYON,Precinct 29,Kansas House of Representatives,60,Republican,"Schreiber, Mark",126,000290
+LYON,Precinct 30,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",213,000300
+LYON,Precinct 30,Kansas House of Representatives,76,Republican,"Smith, Eric L.",270,000300
+LYON,Precinct 31,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",268,000310
+LYON,Precinct 31,Kansas House of Representatives,76,Republican,"Smith, Eric L.",327,000310
+LYON,Precinct 32,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",156,000320
+LYON,Precinct 32,Kansas House of Representatives,76,Republican,"Smith, Eric L.",196,000320
+LYON,Precinct 29 A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,120020
+LYON,Precinct 29 A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,120020
+LYON,Precinct 19 Exclave Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,300010
+LYON,Precinct 19 Exclave Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,300010
+LYON,Precinct 19 Exclave Part B,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,300020
+LYON,Precinct 19 Exclave Part B,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,300020
+LYON,Precinct 04 Part A,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,400010
+LYON,Precinct 04 Part A,Kansas House of Representatives,76,Republican,"Smith, Eric L.",2,400010
+LYON,Precinct 04 Part B,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",3,400020
+LYON,Precinct 04 Part B,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,400020
+LYON,Precinct 04 Part C,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",6,400030
+LYON,Precinct 04 Part C,Kansas House of Representatives,76,Republican,"Smith, Eric L.",1,400030
+LYON,Precinct 04 Part D,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900010
+LYON,Precinct 04 Part D,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900010
+LYON,Precinct 09 Part A,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900020
+LYON,Precinct 09 Part A,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,900020
+LYON,Precinct 29 Enclave,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900030
+LYON,Precinct 29 Enclave,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,900030
+LYON,Precinct 29 Enclave 2,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900040
+LYON,Precinct 29 Enclave 2,Kansas House of Representatives,60,Republican,"Schreiber, Mark",0,900040
+LYON,Precinct 29 Enclave 3,Kansas House of Representatives,60,Democratic,"Ballard, William L.",0,900050
+LYON,Precinct 29 Enclave 3,Kansas House of Representatives,60,Republican,"Schreiber, Mark",4,900050
+LYON,Precinct 01,Kansas Senate,17,Democratic,"Fowler, Susan G",228,000010
+LYON,Precinct 01,Kansas Senate,17,Republican,"Longbine, Jeff",210,000010
+LYON,Precinct 02,Kansas Senate,17,Democratic,"Fowler, Susan G",185,000020
+LYON,Precinct 02,Kansas Senate,17,Republican,"Longbine, Jeff",165,000020
+LYON,Precinct 03,Kansas Senate,17,Democratic,"Fowler, Susan G",230,000030
+LYON,Precinct 03,Kansas Senate,17,Republican,"Longbine, Jeff",192,000030
+LYON,Precinct 04,Kansas Senate,17,Democratic,"Fowler, Susan G",255,000040
+LYON,Precinct 04,Kansas Senate,17,Republican,"Longbine, Jeff",241,000040
+LYON,Precinct 05,Kansas Senate,17,Democratic,"Fowler, Susan G",185,00005A
+LYON,Precinct 05,Kansas Senate,17,Republican,"Longbine, Jeff",133,00005A
+LYON,Precinct 05 Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00005B
+LYON,Precinct 05 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00005B
+LYON,Precinct 05 Part B,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00005C
+LYON,Precinct 05 Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,00005C
+LYON,Precinct 06 Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",200,00006A
+LYON,Precinct 06 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",160,00006A
+LYON,Precinct 06 Part A Exclave,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00006B
+LYON,Precinct 06 Part A Exclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,00006B
+LYON,Precinct 06 Part B Exclave,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00006C
+LYON,Precinct 06 Part B Exclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,00006C
+LYON,Precinct 07,Kansas Senate,17,Democratic,"Fowler, Susan G",87,000070
+LYON,Precinct 07,Kansas Senate,17,Republican,"Longbine, Jeff",66,000070
+LYON,Precinct 08,Kansas Senate,17,Democratic,"Fowler, Susan G",226,000080
+LYON,Precinct 08,Kansas Senate,17,Republican,"Longbine, Jeff",167,000080
+LYON,Precinct 09,Kansas Senate,17,Democratic,"Fowler, Susan G",167,000090
+LYON,Precinct 09,Kansas Senate,17,Republican,"Longbine, Jeff",165,000090
+LYON,Precinct 10,Kansas Senate,17,Democratic,"Fowler, Susan G",171,000100
+LYON,Precinct 10,Kansas Senate,17,Republican,"Longbine, Jeff",179,000100
+LYON,Precinct 11,Kansas Senate,17,Democratic,"Fowler, Susan G",159,000110
+LYON,Precinct 11,Kansas Senate,17,Republican,"Longbine, Jeff",161,000110
+LYON,Precinct 12,Kansas Senate,17,Democratic,"Fowler, Susan G",161,000120
+LYON,Precinct 12,Kansas Senate,17,Republican,"Longbine, Jeff",142,000120
+LYON,Precinct 13,Kansas Senate,17,Democratic,"Fowler, Susan G",228,000130
+LYON,Precinct 13,Kansas Senate,17,Republican,"Longbine, Jeff",229,000130
+LYON,Precinct 14,Kansas Senate,17,Democratic,"Fowler, Susan G",246,000140
+LYON,Precinct 14,Kansas Senate,17,Republican,"Longbine, Jeff",296,000140
+LYON,Precinct 15,Kansas Senate,17,Democratic,"Fowler, Susan G",116,000150
+LYON,Precinct 15,Kansas Senate,17,Republican,"Longbine, Jeff",163,000150
+LYON,Precinct 16,Kansas Senate,17,Democratic,"Fowler, Susan G",239,000160
+LYON,Precinct 16,Kansas Senate,17,Republican,"Longbine, Jeff",220,000160
+LYON,Precinct 17 Exclave Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00017A
+LYON,Precinct 17 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00017A
+LYON,Precinct 17 Enclave Part B,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00017B
+LYON,Precinct 17 Enclave Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,00017B
+LYON,Precinct 17,Kansas Senate,17,Democratic,"Fowler, Susan G",205,000170
+LYON,Precinct 17,Kansas Senate,17,Republican,"Longbine, Jeff",255,000170
+LYON,Precinct 18 Enclave Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00018A
+LYON,Precinct 18 Enclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00018A
+LYON,Precinct 18,Kansas Senate,17,Democratic,"Fowler, Susan G",165,000180
+LYON,Precinct 18,Kansas Senate,17,Republican,"Longbine, Jeff",236,000180
+LYON,Precinct 19,Kansas Senate,17,Democratic,"Fowler, Susan G",237,000190
+LYON,Precinct 19,Kansas Senate,17,Republican,"Longbine, Jeff",418,000190
+LYON,Precinct 20 Exclave Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00020A
+LYON,Precinct 20 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00020A
+LYON,Precinct 20,Kansas Senate,17,Democratic,"Fowler, Susan G",198,000200
+LYON,Precinct 20,Kansas Senate,17,Republican,"Longbine, Jeff",384,000200
+LYON,Precinct 21,Kansas Senate,17,Democratic,"Fowler, Susan G",67,000210
+LYON,Precinct 21,Kansas Senate,17,Republican,"Longbine, Jeff",159,000210
+LYON,Precinct 22,Kansas Senate,17,Democratic,"Fowler, Susan G",48,000220
+LYON,Precinct 22,Kansas Senate,17,Republican,"Longbine, Jeff",74,000220
+LYON,Precinct 23,Kansas Senate,17,Democratic,"Fowler, Susan G",50,000230
+LYON,Precinct 23,Kansas Senate,17,Republican,"Longbine, Jeff",96,000230
+LYON,Precinct 24,Kansas Senate,17,Democratic,"Fowler, Susan G",218,000240
+LYON,Precinct 24,Kansas Senate,17,Republican,"Longbine, Jeff",444,000240
+LYON,Precinct 25,Kansas Senate,17,Democratic,"Fowler, Susan G",159,000250
+LYON,Precinct 25,Kansas Senate,17,Republican,"Longbine, Jeff",344,000250
+LYON,Precinct 26,Kansas Senate,17,Democratic,"Fowler, Susan G",97,000260
+LYON,Precinct 26,Kansas Senate,17,Republican,"Longbine, Jeff",131,000260
+LYON,Precinct 27,Kansas Senate,17,Democratic,"Fowler, Susan G",131,000270
+LYON,Precinct 27,Kansas Senate,17,Republican,"Longbine, Jeff",275,000270
+LYON,Precinct 28,Kansas Senate,17,Democratic,"Fowler, Susan G",139,00028A
+LYON,Precinct 28,Kansas Senate,17,Republican,"Longbine, Jeff",209,00028A
+LYON,Precinct 28 Enclave A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00028B
+LYON,Precinct 28 Enclave A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00028B
+LYON,Precinct 28 Enclave Part B,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00028C
+LYON,Precinct 28 Enclave Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,00028C
+LYON,Precinct 29 Exclave Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,00029A
+LYON,Precinct 29 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,00029A
+LYON,Precinct 29,Kansas Senate,17,Democratic,"Fowler, Susan G",51,000290
+LYON,Precinct 29,Kansas Senate,17,Republican,"Longbine, Jeff",112,000290
+LYON,Precinct 30,Kansas Senate,17,Democratic,"Fowler, Susan G",170,000300
+LYON,Precinct 30,Kansas Senate,17,Republican,"Longbine, Jeff",318,000300
+LYON,Precinct 31,Kansas Senate,17,Democratic,"Fowler, Susan G",175,000310
+LYON,Precinct 31,Kansas Senate,17,Republican,"Longbine, Jeff",424,000310
+LYON,Precinct 32,Kansas Senate,17,Democratic,"Fowler, Susan G",138,000320
+LYON,Precinct 32,Kansas Senate,17,Republican,"Longbine, Jeff",215,000320
+LYON,Precinct 29 A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,120020
+LYON,Precinct 29 A,Kansas Senate,17,Republican,"Longbine, Jeff",0,120020
+LYON,Precinct 07 Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,140010
+LYON,Precinct 07 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,140010
+LYON,Precinct 17 Part C,Kansas Senate,17,Democratic,"Fowler, Susan G",0,140020
+LYON,Precinct 17 Part C,Kansas Senate,17,Republican,"Longbine, Jeff",0,140020
+LYON,Precinct 19 Exclave Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,300010
+LYON,Precinct 19 Exclave Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,300010
+LYON,Precinct 19 Exclave Part B,Kansas Senate,17,Democratic,"Fowler, Susan G",0,300020
+LYON,Precinct 19 Exclave Part B,Kansas Senate,17,Republican,"Longbine, Jeff",0,300020
+LYON,Precinct 04 Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,400010
+LYON,Precinct 04 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",2,400010
+LYON,Precinct 04 Part B,Kansas Senate,17,Democratic,"Fowler, Susan G",1,400020
+LYON,Precinct 04 Part B,Kansas Senate,17,Republican,"Longbine, Jeff",2,400020
+LYON,Precinct 04 Part C,Kansas Senate,17,Democratic,"Fowler, Susan G",4,400030
+LYON,Precinct 04 Part C,Kansas Senate,17,Republican,"Longbine, Jeff",3,400030
+LYON,Precinct 04 Part D,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900010
+LYON,Precinct 04 Part D,Kansas Senate,17,Republican,"Longbine, Jeff",0,900010
+LYON,Precinct 09 Part A,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900020
+LYON,Precinct 09 Part A,Kansas Senate,17,Republican,"Longbine, Jeff",0,900020
+LYON,Precinct 29 Enclave,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900030
+LYON,Precinct 29 Enclave,Kansas Senate,17,Republican,"Longbine, Jeff",0,900030
+LYON,Precinct 29 Enclave 2,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900040
+LYON,Precinct 29 Enclave 2,Kansas Senate,17,Republican,"Longbine, Jeff",0,900040
+LYON,Precinct 29 Enclave 3,Kansas Senate,17,Democratic,"Fowler, Susan G",0,900050
+LYON,Precinct 29 Enclave 3,Kansas Senate,17,Republican,"Longbine, Jeff",4,900050
+LYON,Precinct 01,President / Vice President,,independent,"Stein, Jill",16,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"McMullin, Evan",4,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+LYON,Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+LYON,Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",225,000010
+LYON,Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",30,000010
+LYON,Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",171,000010
+LYON,Precinct 02,President / Vice President,,independent,"Stein, Jill",11,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"McMullin, Evan",1,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+LYON,Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+LYON,Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",165,000020
+LYON,Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",28,000020
+LYON,Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",134,000020
+LYON,Precinct 03,President / Vice President,,independent,"Stein, Jill",16,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"McMullin, Evan",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+LYON,Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+LYON,Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",192,000030
+LYON,Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",19,000030
+LYON,Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",201,000030
+LYON,Precinct 04,President / Vice President,,independent,"Stein, Jill",18,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",4,000040
+LYON,Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"McMullin, Evan",4,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+LYON,Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+LYON,Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",226,000040
+LYON,Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",35,000040
+LYON,Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",223,000040
+LYON,Precinct 05,President / Vice President,,independent,"Stein, Jill",5,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"McMullin, Evan",1,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+LYON,Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+LYON,Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",174,00005A
+LYON,Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",23,00005A
+LYON,Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",122,00005A
+LYON,Precinct 05 Part A,President / Vice President,,independent,"Stein, Jill",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Hedges, James A",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Smith, Mike",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+LYON,Precinct 05 Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+LYON,Precinct 05 Part B,President / Vice President,,independent,"Stein, Jill",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Hedges, James A",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"McMullin, Evan",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Perry, Darryl",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Smith, Mike",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Sood, Ajay",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+LYON,Precinct 05 Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00005C
+LYON,Precinct 06 Part A,President / Vice President,,independent,"Stein, Jill",9,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Hedges, James A",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Smith, Mike",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",205,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Libertarian,"Johnson, Gary",23,00006A
+LYON,Precinct 06 Part A,President / Vice President,,Republican,"Trump, Donald J.",138,00006A
+LYON,Precinct 06 Part A Exclave,President / Vice President,,independent,"Stein, Jill",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Hedges, James A",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Smith, Mike",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+LYON,Precinct 06 Part A Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+LYON,Precinct 06 Part B Exclave,President / Vice President,,independent,"Stein, Jill",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Hedges, James A",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Smith, Mike",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+LYON,Precinct 06 Part B Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00006C
+LYON,Precinct 07,President / Vice President,,independent,"Stein, Jill",7,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"McMullin, Evan",1,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+LYON,Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+LYON,Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,000070
+LYON,Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",14,000070
+LYON,Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",57,000070
+LYON,Precinct 08,President / Vice President,,independent,"Stein, Jill",16,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Castle, Darrell L",2,000080
+LYON,Precinct 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Hedges, James A",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"McMullin, Evan",2,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Perry, Darryl",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Smith, Mike",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Sood, Ajay",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+LYON,Precinct 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+LYON,Precinct 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",185,000080
+LYON,Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",29,000080
+LYON,Precinct 08,President / Vice President,,Republican,"Trump, Donald J.",161,000080
+LYON,Precinct 09,President / Vice President,,independent,"Stein, Jill",14,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"McMullin, Evan",3,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+LYON,Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+LYON,Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",142,000090
+LYON,Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",18,000090
+LYON,Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",155,000090
+LYON,Precinct 10,President / Vice President,,independent,"Stein, Jill",13,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"McMullin, Evan",4,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+LYON,Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+LYON,Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",157,000100
+LYON,Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+LYON,Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",172,000100
+LYON,Precinct 11,President / Vice President,,independent,"Stein, Jill",7,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Hedges, James A",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"McMullin, Evan",3,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Perry, Darryl",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Smith, Mike",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Sood, Ajay",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+LYON,Precinct 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+LYON,Precinct 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",148,000110
+LYON,Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",22,000110
+LYON,Precinct 11,President / Vice President,,Republican,"Trump, Donald J.",137,000110
+LYON,Precinct 12,President / Vice President,,independent,"Stein, Jill",6,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Hedges, James A",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"McMullin, Evan",1,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Perry, Darryl",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Smith, Mike",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Sood, Ajay",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+LYON,Precinct 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+LYON,Precinct 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",143,000120
+LYON,Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",18,000120
+LYON,Precinct 12,President / Vice President,,Republican,"Trump, Donald J.",135,000120
+LYON,Precinct 13,President / Vice President,,independent,"Stein, Jill",12,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Castle, Darrell L",1,000130
+LYON,Precinct 13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Hedges, James A",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"McMullin, Evan",1,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Perry, Darryl",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Smith, Mike",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Sood, Ajay",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+LYON,Precinct 13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+LYON,Precinct 13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",181,000130
+LYON,Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",51,000130
+LYON,Precinct 13,President / Vice President,,Republican,"Trump, Donald J.",202,000130
+LYON,Precinct 14,President / Vice President,,independent,"Stein, Jill",20,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Hedges, James A",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"McMullin, Evan",9,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Perry, Darryl",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Smith, Mike",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Sood, Ajay",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+LYON,Precinct 14,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+LYON,Precinct 14,President / Vice President,,Democratic,"Clinton, Hillary Rodham",242,000140
+LYON,Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",27,000140
+LYON,Precinct 14,President / Vice President,,Republican,"Trump, Donald J.",225,000140
+LYON,Precinct 15,President / Vice President,,independent,"Stein, Jill",6,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Hedges, James A",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"McMullin, Evan",5,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Perry, Darryl",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Smith, Mike",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Sood, Ajay",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+LYON,Precinct 15,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+LYON,Precinct 15,President / Vice President,,Democratic,"Clinton, Hillary Rodham",117,000150
+LYON,Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",11,000150
+LYON,Precinct 15,President / Vice President,,Republican,"Trump, Donald J.",133,000150
+LYON,Precinct 16,President / Vice President,,independent,"Stein, Jill",17,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Hedges, James A",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"McMullin, Evan",2,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Perry, Darryl",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Smith, Mike",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Sood, Ajay",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+LYON,Precinct 16,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+LYON,Precinct 16,President / Vice President,,Democratic,"Clinton, Hillary Rodham",237,000160
+LYON,Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",19,000160
+LYON,Precinct 16,President / Vice President,,Republican,"Trump, Donald J.",187,000160
+LYON,Precinct 17 Exclave Part A,President / Vice President,,independent,"Stein, Jill",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Hedges, James A",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"McMullin, Evan",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Smith, Mike",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00017A
+LYON,Precinct 17 Exclave Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00017A
+LYON,Precinct 17 Enclave Part B,President / Vice President,,independent,"Stein, Jill",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Hedges, James A",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"McMullin, Evan",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Perry, Darryl",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Smith, Mike",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Sood, Ajay",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+LYON,Precinct 17 Enclave Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00017B
+LYON,Precinct 17,President / Vice President,,independent,"Stein, Jill",11,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Hedges, James A",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"McMullin, Evan",3,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Perry, Darryl",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Smith, Mike",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Sood, Ajay",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+LYON,Precinct 17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+LYON,Precinct 17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",198,000170
+LYON,Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",26,000170
+LYON,Precinct 17,President / Vice President,,Republican,"Trump, Donald J.",215,000170
+LYON,Precinct 18 Enclave Part A,President / Vice President,,independent,"Stein, Jill",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Hedges, James A",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"McMullin, Evan",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Perry, Darryl",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Smith, Mike",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Sood, Ajay",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00018A
+LYON,Precinct 18 Enclave Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00018A
+LYON,Precinct 18,President / Vice President,,independent,"Stein, Jill",7,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Hedges, James A",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"McMullin, Evan",2,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Perry, Darryl",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Smith, Mike",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Sood, Ajay",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+LYON,Precinct 18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+LYON,Precinct 18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",159,000180
+LYON,Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",14,000180
+LYON,Precinct 18,President / Vice President,,Republican,"Trump, Donald J.",222,000180
+LYON,Precinct 19,President / Vice President,,independent,"Stein, Jill",13,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Hedges, James A",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"McMullin, Evan",6,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Perry, Darryl",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Smith, Mike",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Sood, Ajay",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+LYON,Precinct 19,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+LYON,Precinct 19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",257,000190
+LYON,Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",36,000190
+LYON,Precinct 19,President / Vice President,,Republican,"Trump, Donald J.",335,000190
+LYON,Precinct 20 Exclave Part A,President / Vice President,,independent,"Stein, Jill",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Hedges, James A",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"McMullin, Evan",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Perry, Darryl",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Smith, Mike",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Sood, Ajay",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00020A
+LYON,Precinct 20 Exclave Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00020A
+LYON,Precinct 20,President / Vice President,,independent,"Stein, Jill",11,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Hedges, James A",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"McMullin, Evan",4,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Perry, Darryl",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Smith, Mike",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Sood, Ajay",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+LYON,Precinct 20,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+LYON,Precinct 20,President / Vice President,,Democratic,"Clinton, Hillary Rodham",224,000200
+LYON,Precinct 20,President / Vice President,,Libertarian,"Johnson, Gary",23,000200
+LYON,Precinct 20,President / Vice President,,Republican,"Trump, Donald J.",307,000200
+LYON,Precinct 21,President / Vice President,,independent,"Stein, Jill",11,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Castle, Darrell L",1,000210
+LYON,Precinct 21,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Hedges, James A",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"McMullin, Evan",2,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Perry, Darryl",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Smith, Mike",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Sood, Ajay",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+LYON,Precinct 21,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+LYON,Precinct 21,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000210
+LYON,Precinct 21,President / Vice President,,Libertarian,"Johnson, Gary",10,000210
+LYON,Precinct 21,President / Vice President,,Republican,"Trump, Donald J.",153,000210
+LYON,Precinct 22,President / Vice President,,independent,"Stein, Jill",1,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Hedges, James A",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"McMullin, Evan",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Perry, Darryl",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Smith, Mike",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Sood, Ajay",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+LYON,Precinct 22,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+LYON,Precinct 22,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000220
+LYON,Precinct 22,President / Vice President,,Libertarian,"Johnson, Gary",10,000220
+LYON,Precinct 22,President / Vice President,,Republican,"Trump, Donald J.",83,000220
+LYON,Precinct 23,President / Vice President,,independent,"Stein, Jill",5,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Hedges, James A",1,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"McMullin, Evan",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Perry, Darryl",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Smith, Mike",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Sood, Ajay",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+LYON,Precinct 23,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+LYON,Precinct 23,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000230
+LYON,Precinct 23,President / Vice President,,Libertarian,"Johnson, Gary",8,000230
+LYON,Precinct 23,President / Vice President,,Republican,"Trump, Donald J.",99,000230
+LYON,Precinct 24,President / Vice President,,independent,"Stein, Jill",15,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Hedges, James A",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"McMullin, Evan",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Perry, Darryl",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Smith, Mike",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Sood, Ajay",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+LYON,Precinct 24,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+LYON,Precinct 24,President / Vice President,,Democratic,"Clinton, Hillary Rodham",158,000240
+LYON,Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",43,000240
+LYON,Precinct 24,President / Vice President,,Republican,"Trump, Donald J.",450,000240
+LYON,Precinct 25,President / Vice President,,independent,"Stein, Jill",9,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Hedges, James A",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"McMullin, Evan",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Perry, Darryl",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Smith, Mike",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Sood, Ajay",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+LYON,Precinct 25,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+LYON,Precinct 25,President / Vice President,,Democratic,"Clinton, Hillary Rodham",113,000250
+LYON,Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",22,000250
+LYON,Precinct 25,President / Vice President,,Republican,"Trump, Donald J.",354,000250
+LYON,Precinct 26,President / Vice President,,independent,"Stein, Jill",14,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Hedges, James A",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"McMullin, Evan",1,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Perry, Darryl",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Smith, Mike",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Sood, Ajay",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+LYON,Precinct 26,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+LYON,Precinct 26,President / Vice President,,Democratic,"Clinton, Hillary Rodham",64,000260
+LYON,Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",9,000260
+LYON,Precinct 26,President / Vice President,,Republican,"Trump, Donald J.",143,000260
+LYON,Precinct 27,President / Vice President,,independent,"Stein, Jill",3,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Hedges, James A",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"McMullin, Evan",1,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Perry, Darryl",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Smith, Mike",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Sood, Ajay",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+LYON,Precinct 27,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+LYON,Precinct 27,President / Vice President,,Democratic,"Clinton, Hillary Rodham",90,000270
+LYON,Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",11,000270
+LYON,Precinct 27,President / Vice President,,Republican,"Trump, Donald J.",293,000270
+LYON,Precinct 28,President / Vice President,,independent,"Stein, Jill",6,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Basiago, Andrew D.",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Castle, Darrell L",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Giordani, Rocky",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Hedges, James A",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Kahn, Lynn",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"La Riva, Gloria",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Levinson, Michael S.",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Maturen, Michael A",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"McMullin, Evan",1,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Moorehead, Monica G.",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Perry, Darryl",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Schriner, Joe C",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Smith, Mike",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Sood, Ajay",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Sterling, Shawna",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Valdivia, Anthony J",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00028A
+LYON,Precinct 28,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00028A
+LYON,Precinct 28,President / Vice President,,Democratic,"Clinton, Hillary Rodham",102,00028A
+LYON,Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",15,00028A
+LYON,Precinct 28,President / Vice President,,Republican,"Trump, Donald J.",227,00028A
+LYON,Precinct 28 Enclave A,President / Vice President,,independent,"Stein, Jill",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00028B
+LYON,Precinct 28 Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00028B
+LYON,Precinct 28 Enclave Part B,President / Vice President,,independent,"Stein, Jill",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Hedges, James A",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"McMullin, Evan",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Perry, Darryl",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Smith, Mike",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Sood, Ajay",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00028C
+LYON,Precinct 28 Enclave Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00028C
+LYON,Precinct 29 Exclave Part A,President / Vice President,,independent,"Stein, Jill",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Hedges, James A",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"McMullin, Evan",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Perry, Darryl",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Smith, Mike",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Sood, Ajay",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00029A
+LYON,Precinct 29 Exclave Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00029A
+LYON,Precinct 29,President / Vice President,,independent,"Stein, Jill",2,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Hedges, James A",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"McMullin, Evan",1,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Perry, Darryl",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Smith, Mike",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Sood, Ajay",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+LYON,Precinct 29,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+LYON,Precinct 29,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000290
+LYON,Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",6,000290
+LYON,Precinct 29,President / Vice President,,Republican,"Trump, Donald J.",112,000290
+LYON,Precinct 30,President / Vice President,,independent,"Stein, Jill",7,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Castle, Darrell L",1,000300
+LYON,Precinct 30,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Hedges, James A",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"McMullin, Evan",8,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Perry, Darryl",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Smith, Mike",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Sood, Ajay",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+LYON,Precinct 30,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+LYON,Precinct 30,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000300
+LYON,Precinct 30,President / Vice President,,Libertarian,"Johnson, Gary",21,000300
+LYON,Precinct 30,President / Vice President,,Republican,"Trump, Donald J.",327,000300
+LYON,Precinct 31,President / Vice President,,independent,"Stein, Jill",12,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Hedges, James A",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"McMullin, Evan",2,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Perry, Darryl",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Smith, Mike",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Sood, Ajay",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+LYON,Precinct 31,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+LYON,Precinct 31,President / Vice President,,Democratic,"Clinton, Hillary Rodham",130,000310
+LYON,Precinct 31,President / Vice President,,Libertarian,"Johnson, Gary",26,000310
+LYON,Precinct 31,President / Vice President,,Republican,"Trump, Donald J.",425,000310
+LYON,Precinct 32,President / Vice President,,independent,"Stein, Jill",11,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Hedges, James A",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"McMullin, Evan",4,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Perry, Darryl",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Smith, Mike",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Sood, Ajay",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+LYON,Precinct 32,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+LYON,Precinct 32,President / Vice President,,Democratic,"Clinton, Hillary Rodham",78,000320
+LYON,Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",14,000320
+LYON,Precinct 32,President / Vice President,,Republican,"Trump, Donald J.",246,000320
+LYON,Precinct 29 A,President / Vice President,,independent,"Stein, Jill",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Hedges, James A",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"McMullin, Evan",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Perry, Darryl",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Smith, Mike",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Sood, Ajay",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+LYON,Precinct 29 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+LYON,Precinct 29 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120020
+LYON,Precinct 29 A,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+LYON,Precinct 29 A,President / Vice President,,Republican,"Trump, Donald J.",0,120020
+LYON,Precinct 07 Part A,President / Vice President,,independent,"Stein, Jill",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Hedges, James A",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"McMullin, Evan",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Perry, Darryl",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Smith, Mike",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Sood, Ajay",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,140010
+LYON,Precinct 07 Part A,President / Vice President,,Republican,"Trump, Donald J.",0,140010
+LYON,Precinct 17 Part C,President / Vice President,,independent,"Stein, Jill",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Basiago, Andrew D.",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Castle, Darrell L",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Giordani, Rocky",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Hedges, James A",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Kahn, Lynn",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"La Riva, Gloria",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Levinson, Michael S.",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Maturen, Michael A",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"McMullin, Evan",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Moorehead, Monica G.",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Perry, Darryl",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Schriner, Joe C",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Smith, Mike",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Sood, Ajay",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Sterling, Shawna",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Valdivia, Anthony J",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,140020
+LYON,Precinct 17 Part C,President / Vice President,,Republican,"Trump, Donald J.",0,140020
+LYON,Precinct 19 Exclave Part A,President / Vice President,,independent,"Stein, Jill",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Castle, Darrell L",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Giordani, Rocky",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Hedges, James A",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Kahn, Lynn",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"La Riva, Gloria",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Maturen, Michael A",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"McMullin, Evan",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Perry, Darryl",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Schriner, Joe C",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Smith, Mike",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Sood, Ajay",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Sterling, Shawna",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,300010
+LYON,Precinct 19 Exclave Part A,President / Vice President,,Republican,"Trump, Donald J.",0,300010
+LYON,Precinct 19 Exclave Part B,President / Vice President,,independent,"Stein, Jill",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Castle, Darrell L",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Giordani, Rocky",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Hedges, James A",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Hoefling, Tom",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Kahn, Lynn",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"La Riva, Gloria",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Maturen, Michael A",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"McMullin, Evan",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Perry, Darryl",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Schriner, Joe C",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Smith, Mike",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Sood, Ajay",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Sterling, Shawna",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,300020
+LYON,Precinct 19 Exclave Part B,President / Vice President,,Republican,"Trump, Donald J.",0,300020
+LYON,Precinct 04 Part A,President / Vice President,,independent,"Stein, Jill",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Hedges, James A",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"McMullin, Evan",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Perry, Darryl",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Smith, Mike",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Sood, Ajay",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,400010
+LYON,Precinct 04 Part A,President / Vice President,,Republican,"Trump, Donald J.",2,400010
+LYON,Precinct 04 Part B,President / Vice President,,independent,"Stein, Jill",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Hedges, James A",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"McMullin, Evan",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Perry, Darryl",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Smith, Mike",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Sood, Ajay",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,400020
+LYON,Precinct 04 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,400020
+LYON,Precinct 04 Part B,President / Vice President,,Republican,"Trump, Donald J.",0,400020
+LYON,Precinct 04 Part C,President / Vice President,,independent,"Stein, Jill",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Basiago, Andrew D.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Castle, Darrell L",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Giordani, Rocky",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Hedges, James A",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Kahn, Lynn",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"La Riva, Gloria",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Levinson, Michael S.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Maturen, Michael A",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"McMullin, Evan",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Moorehead, Monica G.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Perry, Darryl",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Schriner, Joe C",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Smith, Mike",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Sood, Ajay",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Sterling, Shawna",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Valdivia, Anthony J",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,400030
+LYON,Precinct 04 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,400030
+LYON,Precinct 04 Part C,President / Vice President,,Republican,"Trump, Donald J.",2,400030
+LYON,Precinct 04 Part D,President / Vice President,,independent,"Stein, Jill",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Hedges, James A",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"McMullin, Evan",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Perry, Darryl",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Smith, Mike",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Sood, Ajay",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+LYON,Precinct 04 Part D,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+LYON,Precinct 09 Part A,President / Vice President,,independent,"Stein, Jill",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Hedges, James A",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"McMullin, Evan",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Perry, Darryl",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Smith, Mike",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Sood, Ajay",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+LYON,Precinct 09 Part A,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+LYON,Precinct 29 Enclave,President / Vice President,,independent,"Stein, Jill",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Hedges, James A",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Smith, Mike",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+LYON,Precinct 29 Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+LYON,Precinct 29 Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+LYON,Precinct 29 Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+LYON,Precinct 29 Enclave 3,President / Vice President,,independent,"Stein, Jill",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Hedges, James A",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"McMullin, Evan",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Perry, Darryl",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Smith, Mike",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Sood, Ajay",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+LYON,Precinct 29 Enclave 3,President / Vice President,,Republican,"Trump, Donald J.",4,900050
+LYON,Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",138,000010
+LYON,Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+LYON,Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",58,000010
+LYON,Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",217,000010
+LYON,Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",111,000020
+LYON,Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+LYON,Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",57,000020
+LYON,Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",156,000020
+LYON,Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",127,000030
+LYON,Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000030
+LYON,Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",56,000030
+LYON,Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",194,000030
+LYON,Precinct 04,United States House of Representatives,1,independent,"LaPolice, Alan",156,000040
+LYON,Precinct 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+LYON,Precinct 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",63,000040
+LYON,Precinct 04,United States House of Representatives,1,Republican,"Marshall, Roger",244,000040
+LYON,Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",87,00005A
+LYON,Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005A
+LYON,Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",74,00005A
+LYON,Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",135,00005A
+LYON,Precinct 05 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005B
+LYON,Precinct 05 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005B
+LYON,Precinct 05 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005B
+LYON,Precinct 05 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005B
+LYON,Precinct 05 Part B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005C
+LYON,Precinct 05 Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005C
+LYON,Precinct 05 Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005C
+LYON,Precinct 05 Part B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005C
+LYON,Precinct 06 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",112,00006A
+LYON,Precinct 06 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006A
+LYON,Precinct 06 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,00006A
+LYON,Precinct 06 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",158,00006A
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006B
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006B
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006B
+LYON,Precinct 06 Part A Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006B
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006C
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006C
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006C
+LYON,Precinct 06 Part B Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006C
+LYON,Precinct 07,United States House of Representatives,1,independent,"LaPolice, Alan",61,000070
+LYON,Precinct 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+LYON,Precinct 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000070
+LYON,Precinct 07,United States House of Representatives,1,Republican,"Marshall, Roger",67,000070
+LYON,Precinct 08,United States House of Representatives,1,independent,"LaPolice, Alan",138,000080
+LYON,Precinct 08,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000080
+LYON,Precinct 08,United States House of Representatives,1,Libertarian,"Burt, Kerry",70,000080
+LYON,Precinct 08,United States House of Representatives,1,Republican,"Marshall, Roger",161,000080
+LYON,Precinct 09,United States House of Representatives,1,independent,"LaPolice, Alan",100,000090
+LYON,Precinct 09,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+LYON,Precinct 09,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,000090
+LYON,Precinct 09,United States House of Representatives,1,Republican,"Marshall, Roger",162,000090
+LYON,Precinct 10,United States House of Representatives,1,independent,"LaPolice, Alan",91,000100
+LYON,Precinct 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+LYON,Precinct 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,000100
+LYON,Precinct 10,United States House of Representatives,1,Republican,"Marshall, Roger",195,000100
+LYON,Precinct 11,United States House of Representatives,1,independent,"LaPolice, Alan",94,000110
+LYON,Precinct 11,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+LYON,Precinct 11,United States House of Representatives,1,Libertarian,"Burt, Kerry",47,000110
+LYON,Precinct 11,United States House of Representatives,1,Republican,"Marshall, Roger",156,000110
+LYON,Precinct 12,United States House of Representatives,1,independent,"LaPolice, Alan",96,000120
+LYON,Precinct 12,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+LYON,Precinct 12,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,000120
+LYON,Precinct 12,United States House of Representatives,1,Republican,"Marshall, Roger",146,000120
+LYON,Precinct 13,United States House of Representatives,1,independent,"LaPolice, Alan",133,000130
+LYON,Precinct 13,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000130
+LYON,Precinct 13,United States House of Representatives,1,Libertarian,"Burt, Kerry",60,000130
+LYON,Precinct 13,United States House of Representatives,1,Republican,"Marshall, Roger",231,000130
+LYON,Precinct 14,United States House of Representatives,1,independent,"LaPolice, Alan",131,000140
+LYON,Precinct 14,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+LYON,Precinct 14,United States House of Representatives,1,Libertarian,"Burt, Kerry",54,000140
+LYON,Precinct 14,United States House of Representatives,1,Republican,"Marshall, Roger",318,000140
+LYON,Precinct 15,United States House of Representatives,1,independent,"LaPolice, Alan",68,000150
+LYON,Precinct 15,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+LYON,Precinct 15,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,000150
+LYON,Precinct 15,United States House of Representatives,1,Republican,"Marshall, Roger",163,000150
+LYON,Precinct 16,United States House of Representatives,1,independent,"LaPolice, Alan",143,000160
+LYON,Precinct 16,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+LYON,Precinct 16,United States House of Representatives,1,Libertarian,"Burt, Kerry",42,000160
+LYON,Precinct 16,United States House of Representatives,1,Republican,"Marshall, Roger",253,000160
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00017A
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00017A
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00017A
+LYON,Precinct 17 Exclave Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00017A
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00017B
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00017B
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00017B
+LYON,Precinct 17 Enclave Part B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00017B
+LYON,Precinct 17,United States House of Representatives,1,independent,"LaPolice, Alan",132,000170
+LYON,Precinct 17,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000170
+LYON,Precinct 17,United States House of Representatives,1,Libertarian,"Burt, Kerry",54,000170
+LYON,Precinct 17,United States House of Representatives,1,Republican,"Marshall, Roger",247,000170
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00018A
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00018A
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00018A
+LYON,Precinct 18 Enclave Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00018A
+LYON,Precinct 18,United States House of Representatives,1,independent,"LaPolice, Alan",103,000180
+LYON,Precinct 18,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+LYON,Precinct 18,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,000180
+LYON,Precinct 18,United States House of Representatives,1,Republican,"Marshall, Roger",248,000180
+LYON,Precinct 19,United States House of Representatives,1,independent,"LaPolice, Alan",131,000190
+LYON,Precinct 19,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+LYON,Precinct 19,United States House of Representatives,1,Libertarian,"Burt, Kerry",59,000190
+LYON,Precinct 19,United States House of Representatives,1,Republican,"Marshall, Roger",424,000190
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00020A
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00020A
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00020A
+LYON,Precinct 20 Exclave Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00020A
+LYON,Precinct 20,United States House of Representatives,1,independent,"LaPolice, Alan",112,000200
+LYON,Precinct 20,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+LYON,Precinct 20,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,000200
+LYON,Precinct 20,United States House of Representatives,1,Republican,"Marshall, Roger",391,000200
+LYON,Precinct 21,United States House of Representatives,1,independent,"LaPolice, Alan",49,000210
+LYON,Precinct 21,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+LYON,Precinct 21,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000210
+LYON,Precinct 21,United States House of Representatives,1,Republican,"Marshall, Roger",153,000210
+LYON,Precinct 22,United States House of Representatives,1,independent,"LaPolice, Alan",18,000220
+LYON,Precinct 22,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+LYON,Precinct 22,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000220
+LYON,Precinct 22,United States House of Representatives,1,Republican,"Marshall, Roger",90,000220
+LYON,Precinct 23,United States House of Representatives,1,independent,"LaPolice, Alan",32,000230
+LYON,Precinct 23,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+LYON,Precinct 23,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000230
+LYON,Precinct 23,United States House of Representatives,1,Republican,"Marshall, Roger",99,000230
+LYON,Precinct 24,United States House of Representatives,1,independent,"LaPolice, Alan",128,000240
+LYON,Precinct 24,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000240
+LYON,Precinct 24,United States House of Representatives,1,Libertarian,"Burt, Kerry",52,000240
+LYON,Precinct 24,United States House of Representatives,1,Republican,"Marshall, Roger",461,000240
+LYON,Precinct 25,United States House of Representatives,1,independent,"LaPolice, Alan",94,000250
+LYON,Precinct 25,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+LYON,Precinct 25,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000250
+LYON,Precinct 25,United States House of Representatives,1,Republican,"Marshall, Roger",361,000250
+LYON,Precinct 26,United States House of Representatives,1,independent,"LaPolice, Alan",65,000260
+LYON,Precinct 26,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000260
+LYON,Precinct 26,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000260
+LYON,Precinct 26,United States House of Representatives,1,Republican,"Marshall, Roger",128,000260
+LYON,Precinct 27,United States House of Representatives,1,independent,"LaPolice, Alan",61,000270
+LYON,Precinct 27,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+LYON,Precinct 27,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000270
+LYON,Precinct 27,United States House of Representatives,1,Republican,"Marshall, Roger",305,000270
+LYON,Precinct 28,United States House of Representatives,1,independent,"LaPolice, Alan",69,00028A
+LYON,Precinct 28,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00028A
+LYON,Precinct 28,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,00028A
+LYON,Precinct 28,United States House of Representatives,1,Republican,"Marshall, Roger",231,00028A
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00028B
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00028B
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00028B
+LYON,Precinct 28 Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00028B
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00028C
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00028C
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00028C
+LYON,Precinct 28 Enclave Part B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00028C
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00029A
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00029A
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00029A
+LYON,Precinct 29 Exclave Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00029A
+LYON,Precinct 29,United States House of Representatives,1,independent,"LaPolice, Alan",31,000290
+LYON,Precinct 29,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+LYON,Precinct 29,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000290
+LYON,Precinct 29,United States House of Representatives,1,Republican,"Marshall, Roger",120,000290
+LYON,Precinct 30,United States House of Representatives,1,independent,"LaPolice, Alan",88,000300
+LYON,Precinct 30,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000300
+LYON,Precinct 30,United States House of Representatives,1,Libertarian,"Burt, Kerry",36,000300
+LYON,Precinct 30,United States House of Representatives,1,Republican,"Marshall, Roger",345,000300
+LYON,Precinct 31,United States House of Representatives,1,independent,"LaPolice, Alan",108,000310
+LYON,Precinct 31,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+LYON,Precinct 31,United States House of Representatives,1,Libertarian,"Burt, Kerry",40,000310
+LYON,Precinct 31,United States House of Representatives,1,Republican,"Marshall, Roger",433,000310
+LYON,Precinct 32,United States House of Representatives,1,independent,"LaPolice, Alan",62,000320
+LYON,Precinct 32,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000320
+LYON,Precinct 32,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000320
+LYON,Precinct 32,United States House of Representatives,1,Republican,"Marshall, Roger",239,000320
+LYON,Precinct 29 A,United States House of Representatives,1,independent,"LaPolice, Alan",0,120020
+LYON,Precinct 29 A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+LYON,Precinct 29 A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120020
+LYON,Precinct 29 A,United States House of Representatives,1,Republican,"Marshall, Roger",0,120020
+LYON,Precinct 07 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,140010
+LYON,Precinct 07 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140010
+LYON,Precinct 07 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,140010
+LYON,Precinct 07 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,140010
+LYON,Precinct 17 Part C,United States House of Representatives,1,independent,"LaPolice, Alan",0,140020
+LYON,Precinct 17 Part C,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140020
+LYON,Precinct 17 Part C,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,140020
+LYON,Precinct 17 Part C,United States House of Representatives,1,Republican,"Marshall, Roger",0,140020
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,300010
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300010
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300010
+LYON,Precinct 19 Exclave Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,300010
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,independent,"LaPolice, Alan",0,300020
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300020
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300020
+LYON,Precinct 19 Exclave Part B,United States House of Representatives,1,Republican,"Marshall, Roger",0,300020
+LYON,Precinct 04 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,400010
+LYON,Precinct 04 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400010
+LYON,Precinct 04 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,400010
+LYON,Precinct 04 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",2,400010
+LYON,Precinct 04 Part B,United States House of Representatives,1,independent,"LaPolice, Alan",1,400020
+LYON,Precinct 04 Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400020
+LYON,Precinct 04 Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,400020
+LYON,Precinct 04 Part B,United States House of Representatives,1,Republican,"Marshall, Roger",2,400020
+LYON,Precinct 04 Part C,United States House of Representatives,1,independent,"LaPolice, Alan",2,400030
+LYON,Precinct 04 Part C,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400030
+LYON,Precinct 04 Part C,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,400030
+LYON,Precinct 04 Part C,United States House of Representatives,1,Republican,"Marshall, Roger",3,400030
+LYON,Precinct 04 Part D,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+LYON,Precinct 04 Part D,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+LYON,Precinct 04 Part D,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+LYON,Precinct 04 Part D,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+LYON,Precinct 09 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+LYON,Precinct 09 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+LYON,Precinct 09 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+LYON,Precinct 09 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+LYON,Precinct 29 Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900030
+LYON,Precinct 29 Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+LYON,Precinct 29 Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900030
+LYON,Precinct 29 Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900030
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900040
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900040
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900040
+LYON,Precinct 29 Enclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900040
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,independent,"LaPolice, Alan",1,900050
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900050
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900050
+LYON,Precinct 29 Enclave 3,United States House of Representatives,1,Republican,"Marshall, Roger",3,900050
+LYON,Precinct 01,United States Senate,,write - in,"Smith, DJ",0,000010
+LYON,Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",188,000010
+LYON,Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",22,000010
+LYON,Precinct 01,United States Senate,,Republican,"Moran, Jerry",226,000010
+LYON,Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000020
+LYON,Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",141,000020
+LYON,Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",19,000020
+LYON,Precinct 02,United States Senate,,Republican,"Moran, Jerry",186,000020
+LYON,Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000030
+LYON,Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",167,000030
+LYON,Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",20,000030
+LYON,Precinct 03,United States Senate,,Republican,"Moran, Jerry",233,000030
+LYON,Precinct 04,United States Senate,,write - in,"Smith, DJ",0,000040
+LYON,Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",188,000040
+LYON,Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",29,000040
+LYON,Precinct 04,United States Senate,,Republican,"Moran, Jerry",277,000040
+LYON,Precinct 05,United States Senate,,write - in,"Smith, DJ",0,00005A
+LYON,Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",139,00005A
+LYON,Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",30,00005A
+LYON,Precinct 05,United States Senate,,Republican,"Moran, Jerry",147,00005A
+LYON,Precinct 05 Part A,United States Senate,,write - in,"Smith, DJ",0,00005B
+LYON,Precinct 05 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+LYON,Precinct 05 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+LYON,Precinct 05 Part A,United States Senate,,Republican,"Moran, Jerry",0,00005B
+LYON,Precinct 05 Part B,United States Senate,,write - in,"Smith, DJ",0,00005C
+LYON,Precinct 05 Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00005C
+LYON,Precinct 05 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005C
+LYON,Precinct 05 Part B,United States Senate,,Republican,"Moran, Jerry",0,00005C
+LYON,Precinct 06 Part A,United States Senate,,write - in,"Smith, DJ",0,00006A
+LYON,Precinct 06 Part A,United States Senate,,Democratic,"Wiesner, Patrick",160,00006A
+LYON,Precinct 06 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",23,00006A
+LYON,Precinct 06 Part A,United States Senate,,Republican,"Moran, Jerry",175,00006A
+LYON,Precinct 06 Part A Exclave,United States Senate,,write - in,"Smith, DJ",0,00006B
+LYON,Precinct 06 Part A Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+LYON,Precinct 06 Part A Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+LYON,Precinct 06 Part A Exclave,United States Senate,,Republican,"Moran, Jerry",0,00006B
+LYON,Precinct 06 Part B Exclave,United States Senate,,write - in,"Smith, DJ",0,00006C
+LYON,Precinct 06 Part B Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00006C
+LYON,Precinct 06 Part B Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006C
+LYON,Precinct 06 Part B Exclave,United States Senate,,Republican,"Moran, Jerry",0,00006C
+LYON,Precinct 07,United States Senate,,write - in,"Smith, DJ",0,000070
+LYON,Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",71,000070
+LYON,Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",8,000070
+LYON,Precinct 07,United States Senate,,Republican,"Moran, Jerry",76,000070
+LYON,Precinct 08,United States Senate,,write - in,"Smith, DJ",0,000080
+LYON,Precinct 08,United States Senate,,Democratic,"Wiesner, Patrick",171,000080
+LYON,Precinct 08,United States Senate,,Libertarian,"Garrard, Robert D.",29,000080
+LYON,Precinct 08,United States Senate,,Republican,"Moran, Jerry",192,000080
+LYON,Precinct 09,United States Senate,,write - in,"Smith, DJ",0,000090
+LYON,Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",120,000090
+LYON,Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",22,000090
+LYON,Precinct 09,United States Senate,,Republican,"Moran, Jerry",186,000090
+LYON,Precinct 10,United States Senate,,write - in,"Smith, DJ",0,000100
+LYON,Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",129,000100
+LYON,Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",17,000100
+LYON,Precinct 10,United States Senate,,Republican,"Moran, Jerry",205,000100
+LYON,Precinct 11,United States Senate,,write - in,"Smith, DJ",0,000110
+LYON,Precinct 11,United States Senate,,Democratic,"Wiesner, Patrick",130,000110
+LYON,Precinct 11,United States Senate,,Libertarian,"Garrard, Robert D.",18,000110
+LYON,Precinct 11,United States Senate,,Republican,"Moran, Jerry",167,000110
+LYON,Precinct 12,United States Senate,,write - in,"Smith, DJ",0,000120
+LYON,Precinct 12,United States Senate,,Democratic,"Wiesner, Patrick",121,000120
+LYON,Precinct 12,United States Senate,,Libertarian,"Garrard, Robert D.",18,000120
+LYON,Precinct 12,United States Senate,,Republican,"Moran, Jerry",160,000120
+LYON,Precinct 13,United States Senate,,write - in,"Smith, DJ",0,000130
+LYON,Precinct 13,United States Senate,,Democratic,"Wiesner, Patrick",157,000130
+LYON,Precinct 13,United States Senate,,Libertarian,"Garrard, Robert D.",29,000130
+LYON,Precinct 13,United States Senate,,Republican,"Moran, Jerry",266,000130
+LYON,Precinct 14,United States Senate,,write - in,"Smith, DJ",0,000140
+LYON,Precinct 14,United States Senate,,Democratic,"Wiesner, Patrick",190,000140
+LYON,Precinct 14,United States Senate,,Libertarian,"Garrard, Robert D.",21,000140
+LYON,Precinct 14,United States Senate,,Republican,"Moran, Jerry",329,000140
+LYON,Precinct 15,United States Senate,,write - in,"Smith, DJ",0,000150
+LYON,Precinct 15,United States Senate,,Democratic,"Wiesner, Patrick",99,000150
+LYON,Precinct 15,United States Senate,,Libertarian,"Garrard, Robert D.",8,000150
+LYON,Precinct 15,United States Senate,,Republican,"Moran, Jerry",168,000150
+LYON,Precinct 16,United States Senate,,write - in,"Smith, DJ",0,000160
+LYON,Precinct 16,United States Senate,,Democratic,"Wiesner, Patrick",190,000160
+LYON,Precinct 16,United States Senate,,Libertarian,"Garrard, Robert D.",19,000160
+LYON,Precinct 16,United States Senate,,Republican,"Moran, Jerry",259,000160
+LYON,Precinct 17 Exclave Part A,United States Senate,,write - in,"Smith, DJ",0,00017A
+LYON,Precinct 17 Exclave Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00017A
+LYON,Precinct 17 Exclave Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017A
+LYON,Precinct 17 Exclave Part A,United States Senate,,Republican,"Moran, Jerry",0,00017A
+LYON,Precinct 17 Enclave Part B,United States Senate,,write - in,"Smith, DJ",0,00017B
+LYON,Precinct 17 Enclave Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00017B
+LYON,Precinct 17 Enclave Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017B
+LYON,Precinct 17 Enclave Part B,United States Senate,,Republican,"Moran, Jerry",0,00017B
+LYON,Precinct 17,United States Senate,,write - in,"Smith, DJ",0,000170
+LYON,Precinct 17,United States Senate,,Democratic,"Wiesner, Patrick",155,000170
+LYON,Precinct 17,United States Senate,,Libertarian,"Garrard, Robert D.",28,000170
+LYON,Precinct 17,United States Senate,,Republican,"Moran, Jerry",277,000170
+LYON,Precinct 18 Enclave Part A,United States Senate,,write - in,"Smith, DJ",0,00018A
+LYON,Precinct 18 Enclave Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00018A
+LYON,Precinct 18 Enclave Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018A
+LYON,Precinct 18 Enclave Part A,United States Senate,,Republican,"Moran, Jerry",0,00018A
+LYON,Precinct 18,United States Senate,,write - in,"Smith, DJ",0,000180
+LYON,Precinct 18,United States Senate,,Democratic,"Wiesner, Patrick",111,000180
+LYON,Precinct 18,United States Senate,,Libertarian,"Garrard, Robert D.",18,000180
+LYON,Precinct 18,United States Senate,,Republican,"Moran, Jerry",273,000180
+LYON,Precinct 19,United States Senate,,write - in,"Smith, DJ",0,000190
+LYON,Precinct 19,United States Senate,,Democratic,"Wiesner, Patrick",176,000190
+LYON,Precinct 19,United States Senate,,Libertarian,"Garrard, Robert D.",23,000190
+LYON,Precinct 19,United States Senate,,Republican,"Moran, Jerry",448,000190
+LYON,Precinct 20 Exclave Part A,United States Senate,,write - in,"Smith, DJ",0,00020A
+LYON,Precinct 20 Exclave Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00020A
+LYON,Precinct 20 Exclave Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00020A
+LYON,Precinct 20 Exclave Part A,United States Senate,,Republican,"Moran, Jerry",0,00020A
+LYON,Precinct 20,United States Senate,,write - in,"Smith, DJ",0,000200
+LYON,Precinct 20,United States Senate,,Democratic,"Wiesner, Patrick",141,000200
+LYON,Precinct 20,United States Senate,,Libertarian,"Garrard, Robert D.",18,000200
+LYON,Precinct 20,United States Senate,,Republican,"Moran, Jerry",424,000200
+LYON,Precinct 21,United States Senate,,write - in,"Smith, DJ",0,000210
+LYON,Precinct 21,United States Senate,,Democratic,"Wiesner, Patrick",45,000210
+LYON,Precinct 21,United States Senate,,Libertarian,"Garrard, Robert D.",11,000210
+LYON,Precinct 21,United States Senate,,Republican,"Moran, Jerry",168,000210
+LYON,Precinct 22,United States Senate,,write - in,"Smith, DJ",0,000220
+LYON,Precinct 22,United States Senate,,Democratic,"Wiesner, Patrick",25,000220
+LYON,Precinct 22,United States Senate,,Libertarian,"Garrard, Robert D.",3,000220
+LYON,Precinct 22,United States Senate,,Republican,"Moran, Jerry",93,000220
+LYON,Precinct 23,United States Senate,,write - in,"Smith, DJ",0,000230
+LYON,Precinct 23,United States Senate,,Democratic,"Wiesner, Patrick",24,000230
+LYON,Precinct 23,United States Senate,,Libertarian,"Garrard, Robert D.",10,000230
+LYON,Precinct 23,United States Senate,,Republican,"Moran, Jerry",111,000230
+LYON,Precinct 24,United States Senate,,write - in,"Smith, DJ",0,000240
+LYON,Precinct 24,United States Senate,,Democratic,"Wiesner, Patrick",131,000240
+LYON,Precinct 24,United States Senate,,Libertarian,"Garrard, Robert D.",33,000240
+LYON,Precinct 24,United States Senate,,Republican,"Moran, Jerry",507,000240
+LYON,Precinct 25,United States Senate,,write - in,"Smith, DJ",0,000250
+LYON,Precinct 25,United States Senate,,Democratic,"Wiesner, Patrick",85,000250
+LYON,Precinct 25,United States Senate,,Libertarian,"Garrard, Robert D.",21,000250
+LYON,Precinct 25,United States Senate,,Republican,"Moran, Jerry",400,000250
+LYON,Precinct 26,United States Senate,,write - in,"Smith, DJ",0,000260
+LYON,Precinct 26,United States Senate,,Democratic,"Wiesner, Patrick",61,000260
+LYON,Precinct 26,United States Senate,,Libertarian,"Garrard, Robert D.",14,000260
+LYON,Precinct 26,United States Senate,,Republican,"Moran, Jerry",155,000260
+LYON,Precinct 27,United States Senate,,write - in,"Smith, DJ",0,000270
+LYON,Precinct 27,United States Senate,,Democratic,"Wiesner, Patrick",65,000270
+LYON,Precinct 27,United States Senate,,Libertarian,"Garrard, Robert D.",18,000270
+LYON,Precinct 27,United States Senate,,Republican,"Moran, Jerry",321,000270
+LYON,Precinct 28,United States Senate,,write - in,"Smith, DJ",0,00028A
+LYON,Precinct 28,United States Senate,,Democratic,"Wiesner, Patrick",72,00028A
+LYON,Precinct 28,United States Senate,,Libertarian,"Garrard, Robert D.",18,00028A
+LYON,Precinct 28,United States Senate,,Republican,"Moran, Jerry",259,00028A
+LYON,Precinct 28 Enclave A,United States Senate,,write - in,"Smith, DJ",0,00028B
+LYON,Precinct 28 Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00028B
+LYON,Precinct 28 Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00028B
+LYON,Precinct 28 Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00028B
+LYON,Precinct 28 Enclave Part B,United States Senate,,write - in,"Smith, DJ",0,00028C
+LYON,Precinct 28 Enclave Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00028C
+LYON,Precinct 28 Enclave Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00028C
+LYON,Precinct 28 Enclave Part B,United States Senate,,Republican,"Moran, Jerry",0,00028C
+LYON,Precinct 29 Exclave Part A,United States Senate,,write - in,"Smith, DJ",0,00029A
+LYON,Precinct 29 Exclave Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00029A
+LYON,Precinct 29 Exclave Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00029A
+LYON,Precinct 29 Exclave Part A,United States Senate,,Republican,"Moran, Jerry",0,00029A
+LYON,Precinct 29,United States Senate,,write - in,"Smith, DJ",0,000290
+LYON,Precinct 29,United States Senate,,Democratic,"Wiesner, Patrick",27,000290
+LYON,Precinct 29,United States Senate,,Libertarian,"Garrard, Robert D.",5,000290
+LYON,Precinct 29,United States Senate,,Republican,"Moran, Jerry",131,000290
+LYON,Precinct 30,United States Senate,,write - in,"Smith, DJ",0,000300
+LYON,Precinct 30,United States Senate,,Democratic,"Wiesner, Patrick",99,000300
+LYON,Precinct 30,United States Senate,,Libertarian,"Garrard, Robert D.",23,000300
+LYON,Precinct 30,United States Senate,,Republican,"Moran, Jerry",363,000300
+LYON,Precinct 31,United States Senate,,write - in,"Smith, DJ",0,000310
+LYON,Precinct 31,United States Senate,,Democratic,"Wiesner, Patrick",100,000310
+LYON,Precinct 31,United States Senate,,Libertarian,"Garrard, Robert D.",21,000310
+LYON,Precinct 31,United States Senate,,Republican,"Moran, Jerry",481,000310
+LYON,Precinct 32,United States Senate,,write - in,"Smith, DJ",0,000320
+LYON,Precinct 32,United States Senate,,Democratic,"Wiesner, Patrick",77,000320
+LYON,Precinct 32,United States Senate,,Libertarian,"Garrard, Robert D.",22,000320
+LYON,Precinct 32,United States Senate,,Republican,"Moran, Jerry",251,000320
+LYON,Precinct 29 A,United States Senate,,write - in,"Smith, DJ",0,120020
+LYON,Precinct 29 A,United States Senate,,Democratic,"Wiesner, Patrick",0,120020
+LYON,Precinct 29 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,120020
+LYON,Precinct 29 A,United States Senate,,Republican,"Moran, Jerry",0,120020
+LYON,Precinct 07 Part A,United States Senate,,write - in,"Smith, DJ",0,140010
+LYON,Precinct 07 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,140010
+LYON,Precinct 07 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,140010
+LYON,Precinct 07 Part A,United States Senate,,Republican,"Moran, Jerry",0,140010
+LYON,Precinct 17 Part C,United States Senate,,write - in,"Smith, DJ",0,140020
+LYON,Precinct 17 Part C,United States Senate,,Democratic,"Wiesner, Patrick",0,140020
+LYON,Precinct 17 Part C,United States Senate,,Libertarian,"Garrard, Robert D.",0,140020
+LYON,Precinct 17 Part C,United States Senate,,Republican,"Moran, Jerry",0,140020
+LYON,Precinct 19 Exclave Part A,United States Senate,,write - in,"Smith, DJ",0,300010
+LYON,Precinct 19 Exclave Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,300010
+LYON,Precinct 19 Exclave Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,300010
+LYON,Precinct 19 Exclave Part A,United States Senate,,Republican,"Moran, Jerry",0,300010
+LYON,Precinct 19 Exclave Part B,United States Senate,,write - in,"Smith, DJ",0,300020
+LYON,Precinct 19 Exclave Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,300020
+LYON,Precinct 19 Exclave Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,300020
+LYON,Precinct 19 Exclave Part B,United States Senate,,Republican,"Moran, Jerry",0,300020
+LYON,Precinct 04 Part A,United States Senate,,write - in,"Smith, DJ",0,400010
+LYON,Precinct 04 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,400010
+LYON,Precinct 04 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,400010
+LYON,Precinct 04 Part A,United States Senate,,Republican,"Moran, Jerry",2,400010
+LYON,Precinct 04 Part B,United States Senate,,write - in,"Smith, DJ",0,400020
+LYON,Precinct 04 Part B,United States Senate,,Democratic,"Wiesner, Patrick",1,400020
+LYON,Precinct 04 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,400020
+LYON,Precinct 04 Part B,United States Senate,,Republican,"Moran, Jerry",2,400020
+LYON,Precinct 04 Part C,United States Senate,,write - in,"Smith, DJ",0,400030
+LYON,Precinct 04 Part C,United States Senate,,Democratic,"Wiesner, Patrick",4,400030
+LYON,Precinct 04 Part C,United States Senate,,Libertarian,"Garrard, Robert D.",0,400030
+LYON,Precinct 04 Part C,United States Senate,,Republican,"Moran, Jerry",3,400030
+LYON,Precinct 04 Part D,United States Senate,,write - in,"Smith, DJ",0,900010
+LYON,Precinct 04 Part D,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+LYON,Precinct 04 Part D,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+LYON,Precinct 04 Part D,United States Senate,,Republican,"Moran, Jerry",0,900010
+LYON,Precinct 09 Part A,United States Senate,,write - in,"Smith, DJ",0,900020
+LYON,Precinct 09 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+LYON,Precinct 09 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+LYON,Precinct 09 Part A,United States Senate,,Republican,"Moran, Jerry",0,900020
+LYON,Precinct 29 Enclave,United States Senate,,write - in,"Smith, DJ",0,900030
+LYON,Precinct 29 Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+LYON,Precinct 29 Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+LYON,Precinct 29 Enclave,United States Senate,,Republican,"Moran, Jerry",0,900030
+LYON,Precinct 29 Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900040
+LYON,Precinct 29 Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+LYON,Precinct 29 Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+LYON,Precinct 29 Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900040
+LYON,Precinct 29 Enclave 3,United States Senate,,write - in,"Smith, DJ",0,900050
+LYON,Precinct 29 Enclave 3,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+LYON,Precinct 29 Enclave 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+LYON,Precinct 29 Enclave 3,United States Senate,,Republican,"Moran, Jerry",4,900050

--- a/2016/20161108__ks__general__marion__precinct.csv
+++ b/2016/20161108__ks__general__marion__precinct.csv
@@ -1,540 +1,1276 @@
-county,precinct,office,district,candidate,party,votes
-Marion,Blaine,President,,Jill Stein,IND,1
-Marion,Catlin,President,,Jill Stein,IND,6
-Marion,Center,President,,Jill Stein,IND,4
-Marion,Clark,President,,Jill Stein,IND,3
-Marion,Clear Creek,President,,Jill Stein,IND,6
-Marion,Colfax,President,,Jill Stein,IND,5
-Marion,Doyle,President,,Jill Stein,IND,0
-Marion,Durham Park,President,,Jill Stein,IND,3
-Marion,E Branch,President,,Jill Stein,IND,3
-Marion,Fairplay,President,,Jill Stein,IND,0
-Marion,Gale,President,,Jill Stein,IND,4
-Marion,Grant,President,,Jill Stein,IND,2
-Marion,Lehigh,President,,Jill Stein,IND,3
-Marion,Liberty,President,,Jill Stein,IND,6
-Marion,Logan,President,,Jill Stein,IND,1
-Marion,Lost Springs,President,,Jill Stein,IND,0
-Marion,Menno,President,,Jill Stein,IND,5
-Marion,Milton,President,,Jill Stein,IND,2
-Marion,Moore,President,,Jill Stein,IND,0
-Marion,Risley,President,,Jill Stein,IND,2
-Marion,Summit,President,,Jill Stein,IND,1
-Marion,West Branch,President,,Jill Stein,IND,16
-Marion,Wilson,President,,Jill Stein,IND,2
-Marion,Florence 1,President,,Jill Stein,IND,1
-Marion,Florence 2,President,,Jill Stein,IND,4
-Marion,Hillsboro 1,President,,Jill Stein,IND,13
-Marion,Hillsboro 2,President,,Jill Stein,IND,11
-Marion,Marion N,President,,Jill Stein,IND,11
-Marion,Marion S,President,,Jill Stein,IND,11
-Marion,Peabody twp E,President,,Jill Stein,IND,2
-Marion,Peabody twp W,President,,Jill Stein,IND,0
-Marion,Peabody City E,President,,Jill Stein,IND,6
-Marion,Peabody City W,President,,Jill Stein,IND,9
-Marion,Blaine,President,,Donald Trump,REP,65
-Marion,Catlin,President,,Donald Trump,REP,75
-Marion,Center,President,,Donald Trump,REP,229
-Marion,Clark,President,,Donald Trump,REP,61
-Marion,Clear Creek,President,,Donald Trump,REP,196
-Marion,Colfax,President,,Donald Trump,REP,54
-Marion,Doyle,President,,Donald Trump,REP,18
-Marion,Durham Park,President,,Donald Trump,REP,67
-Marion,E Branch,President,,Donald Trump,REP,71
-Marion,Fairplay,President,,Donald Trump,REP,58
-Marion,Gale,President,,Donald Trump,REP,107
-Marion,Grant,President,,Donald Trump,REP,57
-Marion,Lehigh,President,,Donald Trump,REP,96
-Marion,Liberty,President,,Donald Trump,REP,130
-Marion,Logan,President,,Donald Trump,REP,23
-Marion,Lost Springs,President,,Donald Trump,REP,81
-Marion,Menno,President,,Donald Trump,REP,116
-Marion,Milton,President,,Donald Trump,REP,83
-Marion,Moore,President,,Donald Trump,REP,24
-Marion,Risley,President,,Donald Trump,REP,105
-Marion,Summit,President,,Donald Trump,REP,26
-Marion,West Branch,President,,Donald Trump,REP,263
-Marion,Wilson,President,,Donald Trump,REP,89
-Marion,Florence 1,President,,Donald Trump,REP,59
-Marion,Florence 2,President,,Donald Trump,REP,66
-Marion,Hillsboro 1,President,,Donald Trump,REP,388
-Marion,Hillsboro 2,President,,Donald Trump,REP,450
-Marion,Marion N,President,,Donald Trump,REP,331
-Marion,Marion S,President,,Donald Trump,REP,314
-Marion,Peabody twp E,President,,Donald Trump,REP,27
-Marion,Peabody twp W,President,,Donald Trump,REP,33
-Marion,Peabody City E,President,,Donald Trump,REP,93
-Marion,Peabody City W,President,,Donald Trump,REP,148
-Marion,Blaine,President,,Hillary Clinton,DEM,17
-Marion,Catlin,President,,Hillary Clinton,DEM,23
-Marion,Center,President,,Hillary Clinton,DEM,57
-Marion,Clark,President,,Hillary Clinton,DEM,10
-Marion,Clear Creek,President,,Hillary Clinton,DEM,31
-Marion,Colfax,President,,Hillary Clinton,DEM,21
-Marion,Doyle,President,,Hillary Clinton,DEM,4
-Marion,Durham Park,President,,Hillary Clinton,DEM,30
-Marion,E Branch,President,,Hillary Clinton,DEM,30
-Marion,Fairplay,President,,Hillary Clinton,DEM,8
-Marion,Gale,President,,Hillary Clinton,DEM,21
-Marion,Grant,President,,Hillary Clinton,DEM,20
-Marion,Lehigh,President,,Hillary Clinton,DEM,25
-Marion,Liberty,President,,Hillary Clinton,DEM,33
-Marion,Logan,President,,Hillary Clinton,DEM,4
-Marion,Lost Springs,President,,Hillary Clinton,DEM,11
-Marion,Menno,President,,Hillary Clinton,DEM,43
-Marion,Milton,President,,Hillary Clinton,DEM,15
-Marion,Moore,President,,Hillary Clinton,DEM,6
-Marion,Risley,President,,Hillary Clinton,DEM,19
-Marion,Summit,President,,Hillary Clinton,DEM,12
-Marion,West Branch,President,,Hillary Clinton,DEM,151
-Marion,Wilson,President,,Hillary Clinton,DEM,11
-Marion,Florence 1,President,,Hillary Clinton,DEM,20
-Marion,Florence 2,President,,Hillary Clinton,DEM,19
-Marion,Hillsboro 1,President,,Hillary Clinton,DEM,112
-Marion,Hillsboro 2,President,,Hillary Clinton,DEM,122
-Marion,Marion N,President,,Hillary Clinton,DEM,117
-Marion,Marion S,President,,Hillary Clinton,DEM,92
-Marion,Peabody twp E,President,,Hillary Clinton,DEM,12
-Marion,Peabody twp W,President,,Hillary Clinton,DEM,7
-Marion,Peabody City E,President,,Hillary Clinton,DEM,48
-Marion,Peabody City W,President,,Hillary Clinton,DEM,53
-Marion,Blaine,President,,Gary Johnson,LBT,1
-Marion,Catlin,President,,Gary Johnson,LBT,3
-Marion,Center,President,,Gary Johnson,LBT,11
-Marion,Clark,President,,Gary Johnson,LBT,3
-Marion,Clear Creek,President,,Gary Johnson,LBT,6
-Marion,Colfax,President,,Gary Johnson,LBT,6
-Marion,Doyle,President,,Gary Johnson,LBT,0
-Marion,Durham Park,President,,Gary Johnson,LBT,4
-Marion,E Branch,President,,Gary Johnson,LBT,2
-Marion,Fairplay,President,,Gary Johnson,LBT,2
-Marion,Gale,President,,Gary Johnson,LBT,5
-Marion,Grant,President,,Gary Johnson,LBT,1
-Marion,Lehigh,President,,Gary Johnson,LBT,3
-Marion,Liberty,President,,Gary Johnson,LBT,6
-Marion,Logan,President,,Gary Johnson,LBT,0
-Marion,Lost Springs,President,,Gary Johnson,LBT,1
-Marion,Menno,President,,Gary Johnson,LBT,6
-Marion,Milton,President,,Gary Johnson,LBT,2
-Marion,Moore,President,,Gary Johnson,LBT,3
-Marion,Risley,President,,Gary Johnson,LBT,6
-Marion,Summit,President,,Gary Johnson,LBT,0
-Marion,West Branch,President,,Gary Johnson,LBT,22
-Marion,Wilson,President,,Gary Johnson,LBT,2
-Marion,Florence 1,President,,Gary Johnson,LBT,5
-Marion,Florence 2,President,,Gary Johnson,LBT,3
-Marion,Hillsboro 1,President,,Gary Johnson,LBT,31
-Marion,Hillsboro 2,President,,Gary Johnson,LBT,30
-Marion,Marion N,President,,Gary Johnson,LBT,18
-Marion,Marion S,President,,Gary Johnson,LBT,23
-Marion,Peabody twp E,President,,Gary Johnson,LBT,1
-Marion,Peabody twp W,President,,Gary Johnson,LBT,1
-Marion,Peabody City E,President,,Gary Johnson,LBT,5
-Marion,Peabody City W,President,,Gary Johnson,LBT,15
-Marion,Blaine,President,,Evan McMullin,,2
-Marion,Catlin,President,,Evan McMullin,,1
-Marion,Center,President,,Evan McMullin,,1
-Marion,Clark,President,,Evan McMullin,,1
-Marion,Clear Creek,President,,Evan McMullin,,0
-Marion,Colfax,President,,Evan McMullin,,0
-Marion,Doyle,President,,Evan McMullin,,2
-Marion,Durham Park,President,,Evan McMullin,,0
-Marion,E Branch,President,,Evan McMullin,,1
-Marion,Fairplay,President,,Evan McMullin,,1
-Marion,Gale,President,,Evan McMullin,,2
-Marion,Grant,President,,Evan McMullin,,0
-Marion,Lehigh,President,,Evan McMullin,,1
-Marion,Liberty,President,,Evan McMullin,,2
-Marion,Logan,President,,Evan McMullin,,0
-Marion,Lost Springs,President,,Evan McMullin,,0
-Marion,Menno,President,,Evan McMullin,,2
-Marion,Milton,President,,Evan McMullin,,2
-Marion,Moore,President,,Evan McMullin,,0
-Marion,Risley,President,,Evan McMullin,,2
-Marion,Summit,President,,Evan McMullin,,0
-Marion,West Branch,President,,Evan McMullin,,2
-Marion,Wilson,President,,Evan McMullin,,0
-Marion,Florence 1,President,,Evan McMullin,,0
-Marion,Florence 2,President,,Evan McMullin,,0
-Marion,Hillsboro 1,President,,Evan McMullin,,6
-Marion,Hillsboro 2,President,,Evan McMullin,,10
-Marion,Marion N,President,,Evan McMullin,,1
-Marion,Marion S,President,,Evan McMullin,,0
-Marion,Peabody twp E,President,,Evan McMullin,,0
-Marion,Peabody twp W,President,,Evan McMullin,,0
-Marion,Peabody City E,President,,Evan McMullin,,1
-Marion,Peabody City W,President,,Evan McMullin,,0
-Marion,Blaine,President,,other write-ins,,0
-Marion,Catlin,President,,other write-ins,,0
-Marion,Center,President,,other write-ins,,3
-Marion,Clark,President,,other write-ins,,0
-Marion,Clear Creek,President,,other write-ins,,2
-Marion,Colfax,President,,other write-ins,,1
-Marion,Doyle,President,,other write-ins,,2
-Marion,Durham Park,President,,other write-ins,,0
-Marion,E Branch,President,,other write-ins,,0
-Marion,Fairplay,President,,other write-ins,,0
-Marion,Gale,President,,other write-ins,,1
-Marion,Grant,President,,other write-ins,,1
-Marion,Lehigh,President,,other write-ins,,0
-Marion,Liberty,President,,other write-ins,,5
-Marion,Logan,President,,other write-ins,,0
-Marion,Lost Springs,President,,other write-ins,,1
-Marion,Menno,President,,other write-ins,,4
-Marion,Milton,President,,other write-ins,,0
-Marion,Moore,President,,other write-ins,,0
-Marion,Risley,President,,other write-ins,,0
-Marion,Summit,President,,other write-ins,,0
-Marion,West Branch,President,,other write-ins,,4
-Marion,Wilson,President,,other write-ins,,1
-Marion,Florence 1,President,,other write-ins,,0
-Marion,Florence 2,President,,other write-ins,,3
-Marion,Hillsboro 1,President,,other write-ins,,2
-Marion,Hillsboro 2,President,,other write-ins,,9
-Marion,Marion N,President,,other write-ins,,6
-Marion,Marion S,President,,other write-ins,,4
-Marion,Peabody twp E,President,,other write-ins,,0
-Marion,Peabody twp W,President,,other write-ins,,0
-Marion,Peabody City E,President,,other write-ins,,2
-Marion,Peabody City W,President,,other write-ins,,3
-Marion,Blaine,U.S. Senate,,Jerry Moran,REP,71
-Marion,Catlin,U.S. Senate,,Jerry Moran,REP,82
-Marion,Center,U.S. Senate,,Jerry Moran,REP,248
-Marion,Clark,U.S. Senate,,Jerry Moran,REP,66
-Marion,Clear Creek,U.S. Senate,,Jerry Moran,REP,201
-Marion,Colfax,U.S. Senate,,Jerry Moran,REP,60
-Marion,Doyle,U.S. Senate,,Jerry Moran,REP,21
-Marion,Durham Park,U.S. Senate,,Jerry Moran,REP,86
-Marion,E Branch,U.S. Senate,,Jerry Moran,REP,79
-Marion,Fairplay,U.S. Senate,,Jerry Moran,REP,63
-Marion,Gale,U.S. Senate,,Jerry Moran,REP,109
-Marion,Grant,U.S. Senate,,Jerry Moran,REP,67
-Marion,Lehigh,U.S. Senate,,Jerry Moran,REP,99
-Marion,Liberty,U.S. Senate,,Jerry Moran,REP,150
-Marion,Logan,U.S. Senate,,Jerry Moran,REP,25
-Marion,Lost Springs,U.S. Senate,,Jerry Moran,REP,85
-Marion,Menno,U.S. Senate,,Jerry Moran,REP,149
-Marion,Milton,U.S. Senate,,Jerry Moran,REP,83
-Marion,Moore,U.S. Senate,,Jerry Moran,REP,27
-Marion,Risley,U.S. Senate,,Jerry Moran,REP,120
-Marion,Summit,U.S. Senate,,Jerry Moran,REP,29
-Marion,West Branch,U.S. Senate,,Jerry Moran,REP,329
-Marion,Wilson,U.S. Senate,,Jerry Moran,REP,88
-Marion,Florence 1,U.S. Senate,,Jerry Moran,REP,66
-Marion,Florence 2,U.S. Senate,,Jerry Moran,REP,65
-Marion,Hillsboro 1,U.S. Senate,,Jerry Moran,REP,448
-Marion,Hillsboro 2,U.S. Senate,,Jerry Moran,REP,543
-Marion,Marion N,U.S. Senate,,Jerry Moran,REP,364
-Marion,Marion S,U.S. Senate,,Jerry Moran,REP,345
-Marion,Peabody twp E,U.S. Senate,,Jerry Moran,REP,32
-Marion,Peabody twp W,U.S. Senate,,Jerry Moran,REP,35
-Marion,Peabody City E,U.S. Senate,,Jerry Moran,REP,103
-Marion,Peabody City W,U.S. Senate,,Jerry Moran,REP,152
-Marion,Blaine,U.S. Senate,,Patrick Wiesner,DEM,12
-Marion,Catlin,U.S. Senate,,Patrick Wiesner,DEM,20
-Marion,Center,U.S. Senate,,Patrick Wiesner,DEM,40
-Marion,Clark,U.S. Senate,,Patrick Wiesner,DEM,8
-Marion,Clear Creek,U.S. Senate,,Patrick Wiesner,DEM,24
-Marion,Colfax,U.S. Senate,,Patrick Wiesner,DEM,16
-Marion,Doyle,U.S. Senate,,Patrick Wiesner,DEM,3
-Marion,Durham Park,U.S. Senate,,Patrick Wiesner,DEM,19
-Marion,E Branch,U.S. Senate,,Patrick Wiesner,DEM,23
-Marion,Fairplay,U.S. Senate,,Patrick Wiesner,DEM,4
-Marion,Gale,U.S. Senate,,Patrick Wiesner,DEM,20
-Marion,Grant,U.S. Senate,,Patrick Wiesner,DEM,13
-Marion,Lehigh,U.S. Senate,,Patrick Wiesner,DEM,21
-Marion,Liberty,U.S. Senate,,Patrick Wiesner,DEM,24
-Marion,Logan,U.S. Senate,,Patrick Wiesner,DEM,3
-Marion,Lost Springs,U.S. Senate,,Patrick Wiesner,DEM,5
-Marion,Menno,U.S. Senate,,Patrick Wiesner,DEM,20
-Marion,Milton,U.S. Senate,,Patrick Wiesner,DEM,18
-Marion,Moore,U.S. Senate,,Patrick Wiesner,DEM,6
-Marion,Risley,U.S. Senate,,Patrick Wiesner,DEM,11
-Marion,Summit,U.S. Senate,,Patrick Wiesner,DEM,9
-Marion,West Branch,U.S. Senate,,Patrick Wiesner,DEM,108
-Marion,Wilson,U.S. Senate,,Patrick Wiesner,DEM,13
-Marion,Florence 1,U.S. Senate,,Patrick Wiesner,DEM,14
-Marion,Florence 2,U.S. Senate,,Patrick Wiesner,DEM,24
-Marion,Hillsboro 1,U.S. Senate,,Patrick Wiesner,DEM,85
-Marion,Hillsboro 2,U.S. Senate,,Patrick Wiesner,DEM,82
-Marion,Marion N,U.S. Senate,,Patrick Wiesner,DEM,96
-Marion,Marion S,U.S. Senate,,Patrick Wiesner,DEM,70
-Marion,Peabody twp E,U.S. Senate,,Patrick Wiesner,DEM,8
-Marion,Peabody twp W,U.S. Senate,,Patrick Wiesner,DEM,3
-Marion,Peabody City E,U.S. Senate,,Patrick Wiesner,DEM,39
-Marion,Peabody City W,U.S. Senate,,Patrick Wiesner,DEM,52
-Marion,Blaine,U.S. Senate,,Robert Garrard,LBT,4
-Marion,Catlin,U.S. Senate,,Robert Garrard,LBT,5
-Marion,Center,U.S. Senate,,Robert Garrard,LBT,16
-Marion,Clark,U.S. Senate,,Robert Garrard,LBT,3
-Marion,Clear Creek,U.S. Senate,,Robert Garrard,LBT,13
-Marion,Colfax,U.S. Senate,,Robert Garrard,LBT,10
-Marion,Doyle,U.S. Senate,,Robert Garrard,LBT,0
-Marion,Durham Park,U.S. Senate,,Robert Garrard,LBT,3
-Marion,E Branch,U.S. Senate,,Robert Garrard,LBT,5
-Marion,Fairplay,U.S. Senate,,Robert Garrard,LBT,2
-Marion,Gale,U.S. Senate,,Robert Garrard,LBT,9
-Marion,Grant,U.S. Senate,,Robert Garrard,LBT,3
-Marion,Lehigh,U.S. Senate,,Robert Garrard,LBT,8
-Marion,Liberty,U.S. Senate,,Robert Garrard,LBT,5
-Marion,Logan,U.S. Senate,,Robert Garrard,LBT,0
-Marion,Lost Springs,U.S. Senate,,Robert Garrard,LBT,4
-Marion,Menno,U.S. Senate,,Robert Garrard,LBT,8
-Marion,Milton,U.S. Senate,,Robert Garrard,LBT,4
-Marion,Moore,U.S. Senate,,Robert Garrard,LBT,0
-Marion,Risley,U.S. Senate,,Robert Garrard,LBT,2
-Marion,Summit,U.S. Senate,,Robert Garrard,LBT,2
-Marion,West Branch,U.S. Senate,,Robert Garrard,LBT,18
-Marion,Wilson,U.S. Senate,,Robert Garrard,LBT,3
-Marion,Florence 1,U.S. Senate,,Robert Garrard,LBT,4
-Marion,Florence 2,U.S. Senate,,Robert Garrard,LBT,7
-Marion,Hillsboro 1,U.S. Senate,,Robert Garrard,LBT,17
-Marion,Hillsboro 2,U.S. Senate,,Robert Garrard,LBT,15
-Marion,Marion N,U.S. Senate,,Robert Garrard,LBT,23
-Marion,Marion S,U.S. Senate,,Robert Garrard,LBT,22
-Marion,Peabody twp E,U.S. Senate,,Robert Garrard,LBT,1
-Marion,Peabody twp W,U.S. Senate,,Robert Garrard,LBT,3
-Marion,Peabody City E,U.S. Senate,,Robert Garrard,LBT,10
-Marion,Peabody City W,U.S. Senate,,Robert Garrard,LBT,20
-Marion,Colfax,U.S. Senate,,Write-ins,,1
-Marion,West Branch,U.S. Senate,,Write-ins,,1
-Marion,Marion N,U.S. Senate,,Write-ins,,1
-Marion,Peabody City W,U.S. Senate,,Write-ins,,1
-Marion,Blaine,U.S. House,1,Alan LaPolice,IND,20
-Marion,Catlin,U.S. House,1,Alan LaPolice,IND,35
-Marion,Center,U.S. House,1,Alan LaPolice,IND,59
-Marion,Clark,U.S. House,1,Alan LaPolice,IND,11
-Marion,Clear Creek,U.S. House,1,Alan LaPolice,IND,50
-Marion,Colfax,U.S. House,1,Alan LaPolice,IND,29
-Marion,Doyle,U.S. House,1,Alan LaPolice,IND,5
-Marion,Durham Park,U.S. House,1,Alan LaPolice,IND,29
-Marion,E Branch,U.S. House,1,Alan LaPolice,IND,25
-Marion,Fairplay,U.S. House,1,Alan LaPolice,IND,15
-Marion,Gale,U.S. House,1,Alan LaPolice,IND,40
-Marion,Grant,U.S. House,1,Alan LaPolice,IND,22
-Marion,Lehigh,U.S. House,1,Alan LaPolice,IND,26
-Marion,Liberty,U.S. House,1,Alan LaPolice,IND,36
-Marion,Logan,U.S. House,1,Alan LaPolice,IND,6
-Marion,Lost Springs,U.S. House,1,Alan LaPolice,IND,18
-Marion,Menno,U.S. House,1,Alan LaPolice,IND,36
-Marion,Milton,U.S. House,1,Alan LaPolice,IND,20
-Marion,Moore,U.S. House,1,Alan LaPolice,IND,9
-Marion,Risley,U.S. House,1,Alan LaPolice,IND,20
-Marion,Summit,U.S. House,1,Alan LaPolice,IND,7
-Marion,West Branch,U.S. House,1,Alan LaPolice,IND,121
-Marion,Wilson,U.S. House,1,Alan LaPolice,IND,17
-Marion,Florence 1,U.S. House,1,Alan LaPolice,IND,12
-Marion,Florence 2,U.S. House,1,Alan LaPolice,IND,24
-Marion,Hillsboro 1,U.S. House,1,Alan LaPolice,IND,104
-Marion,Hillsboro 2,U.S. House,1,Alan LaPolice,IND,111
-Marion,Marion N,U.S. House,1,Alan LaPolice,IND,121
-Marion,Marion S,U.S. House,1,Alan LaPolice,IND,84
-Marion,Peabody twp E,U.S. House,1,Alan LaPolice,IND,6
-Marion,Peabody twp W,U.S. House,1,Alan LaPolice,IND,6
-Marion,Peabody City E,U.S. House,1,Alan LaPolice,IND,46
-Marion,Peabody City W,U.S. House,1,Alan LaPolice,IND,61
-Marion,Blaine,U.S. Senate,,Roger Marshall,REP,63
-Marion,Catlin,U.S. Senate,,Roger Marshall,REP,63
-Marion,Center,U.S. Senate,,Roger Marshall,REP,229
-Marion,Clark,U.S. Senate,,Roger Marshall,REP,62
-Marion,Clear Creek,U.S. Senate,,Roger Marshall,REP,176
-Marion,Colfax,U.S. Senate,,Roger Marshall,REP,44
-Marion,Doyle,U.S. Senate,,Roger Marshall,REP,14
-Marion,Durham Park,U.S. Senate,,Roger Marshall,REP,74
-Marion,E Branch,U.S. Senate,,Roger Marshall,REP,79
-Marion,Fairplay,U.S. Senate,,Roger Marshall,REP,51
-Marion,Gale,U.S. Senate,,Roger Marshall,REP,92
-Marion,Grant,U.S. Senate,,Roger Marshall,REP,57
-Marion,Lehigh,U.S. Senate,,Roger Marshall,REP,93
-Marion,Liberty,U.S. Senate,,Roger Marshall,REP,129
-Marion,Logan,U.S. Senate,,Roger Marshall,REP,21
-Marion,Lost Springs,U.S. Senate,,Roger Marshall,REP,70
-Marion,Menno,U.S. Senate,,Roger Marshall,REP,130
-Marion,Milton,U.S. Senate,,Roger Marshall,REP,74
-Marion,Moore,U.S. Senate,,Roger Marshall,REP,23
-Marion,Risley,U.S. Senate,,Roger Marshall,REP,106
-Marion,Summit,U.S. Senate,,Roger Marshall,REP,31
-Marion,West Branch,U.S. Senate,,Roger Marshall,REP,292
-Marion,Wilson,U.S. Senate,,Roger Marshall,REP,83
-Marion,Florence 1,U.S. Senate,,Roger Marshall,REP,60
-Marion,Florence 2,U.S. Senate,,Roger Marshall,REP,66
-Marion,Hillsboro 1,U.S. Senate,,Roger Marshall,REP,395
-Marion,Hillsboro 2,U.S. Senate,,Roger Marshall,REP,485
-Marion,Marion N,U.S. Senate,,Roger Marshall,REP,311
-Marion,Marion S,U.S. Senate,,Roger Marshall,REP,305
-Marion,Peabody twp E,U.S. Senate,,Roger Marshall,REP,29
-Marion,Peabody twp W,U.S. Senate,,Roger Marshall,REP,33
-Marion,Peabody City E,U.S. Senate,,Roger Marshall,REP,92
-Marion,Peabody City W,U.S. Senate,,Roger Marshall,REP,128
-Marion,Blaine,U.S. Senate,,Kerry Burt,LBT,1
-Marion,Catlin,U.S. Senate,,Kerry Burt,LBT,8
-Marion,Center,U.S. Senate,,Kerry Burt,LBT,10
-Marion,Clark,U.S. Senate,,Kerry Burt,LBT,3
-Marion,Clear Creek,U.S. Senate,,Kerry Burt,LBT,9
-Marion,Colfax,U.S. Senate,,Kerry Burt,LBT,11
-Marion,Doyle,U.S. Senate,,Kerry Burt,LBT,1
-Marion,Durham Park,U.S. Senate,,Kerry Burt,LBT,4
-Marion,E Branch,U.S. Senate,,Kerry Burt,LBT,3
-Marion,Fairplay,U.S. Senate,,Kerry Burt,LBT,2
-Marion,Gale,U.S. Senate,,Kerry Burt,LBT,2
-Marion,Grant,U.S. Senate,,Kerry Burt,LBT,0
-Marion,Lehigh,U.S. Senate,,Kerry Burt,LBT,7
-Marion,Liberty,U.S. Senate,,Kerry Burt,LBT,8
-Marion,Logan,U.S. Senate,,Kerry Burt,LBT,0
-Marion,Lost Springs,U.S. Senate,,Kerry Burt,LBT,2
-Marion,Menno,U.S. Senate,,Kerry Burt,LBT,5
-Marion,Milton,U.S. Senate,,Kerry Burt,LBT,9
-Marion,Moore,U.S. Senate,,Kerry Burt,LBT,0
-Marion,Risley,U.S. Senate,,Kerry Burt,LBT,5
-Marion,Summit,U.S. Senate,,Kerry Burt,LBT,2
-Marion,West Branch,U.S. Senate,,Kerry Burt,LBT,31
-Marion,Wilson,U.S. Senate,,Kerry Burt,LBT,2
-Marion,Florence 1,U.S. Senate,,Kerry Burt,LBT,8
-Marion,Florence 2,U.S. Senate,,Kerry Burt,LBT,6
-Marion,Hillsboro 1,U.S. Senate,,Kerry Burt,LBT,37
-Marion,Hillsboro 2,U.S. Senate,,Kerry Burt,LBT,33
-Marion,Marion N,U.S. Senate,,Kerry Burt,LBT,27
-Marion,Marion S,U.S. Senate,,Kerry Burt,LBT,29
-Marion,Peabody twp E,U.S. Senate,,Kerry Burt,LBT,5
-Marion,Peabody twp W,U.S. Senate,,Kerry Burt,LBT,2
-Marion,Peabody City E,U.S. Senate,,Kerry Burt,LBT,10
-Marion,Peabody City W,U.S. Senate,,Kerry Burt,LBT,26
-Marion,Blaine,U.S. Senate,,Tim Huelskamp,,2
-Marion,Clear Creek,U.S. Senate,,Tim Huelskamp,,1
-Marion,Colfax,U.S. Senate,,Tim Huelskamp,,1
-Marion,Menno,U.S. Senate,,Tim Huelskamp,,2
-Marion,Milton,U.S. Senate,,Tim Huelskamp,,1
-Marion,Risley,U.S. Senate,,Tim Huelskamp,,1
-Marion,West Branch,U.S. Senate,,Tim Huelskamp,,1
-Marion,West Branch,U.S. Senate,,Write-ins,,1
-Marion,Hillsboro 2,U.S. Senate,,Tim Huelskamp,,1
-Marion,Marion N,U.S. Senate,,Write-ins,,2
-Marion,Marion S,U.S. Senate,,Tim Huelskamp,,2
-Marion,Peabody City W,U.S. Senate,,Tim Huelskamp,,3
-Marion,Marion S,U.S. Senate,,Write-ins,,1
-Marion,Blaine,State Senate,35,Levi Morris,DEM,20
-Marion,Catlin,State Senate,35,Levi Morris,DEM,32
-Marion,Center,State Senate,35,Levi Morris,DEM,87
-Marion,Clark,State Senate,35,Levi Morris,DEM,14
-Marion,Clear Creek,State Senate,35,Levi Morris,DEM,63
-Marion,Colfax,State Senate,35,Levi Morris,DEM,2
-Marion,Doyle,State Senate,35,Levi Morris,DEM,5
-Marion,Durham Park,State Senate,35,Levi Morris,DEM,30
-Marion,E Branch,State Senate,35,Levi Morris,DEM,30
-Marion,Fairplay,State Senate,35,Levi Morris,DEM,7
-Marion,Gale,State Senate,35,Levi Morris,DEM,26
-Marion,Grant,State Senate,35,Levi Morris,DEM,27
-Marion,Lehigh,State Senate,35,Levi Morris,DEM,27
-Marion,Liberty,State Senate,35,Levi Morris,DEM,46
-Marion,Logan,State Senate,35,Levi Morris,DEM,5
-Marion,Lost Springs,State Senate,35,Levi Morris,DEM,13
-Marion,Menno,State Senate,35,Levi Morris,DEM,34
-Marion,Milton,State Senate,35,Levi Morris,DEM,21
-Marion,Moore,State Senate,35,Levi Morris,DEM,7
-Marion,Risley,State Senate,35,Levi Morris,DEM,17
-Marion,Summit,State Senate,35,Levi Morris,DEM,10
-Marion,West Branch,State Senate,35,Levi Morris,DEM,138
-Marion,Wilson,State Senate,35,Levi Morris,DEM,18
-Marion,Florence 1,State Senate,35,Levi Morris,DEM,29
-Marion,Florence 2,State Senate,35,Levi Morris,DEM,40
-Marion,Hillsboro 1,State Senate,35,Levi Morris,DEM,127
-Marion,Hillsboro 2,State Senate,35,Levi Morris,DEM,127
-Marion,Marion N,State Senate,35,Levi Morris,DEM,144
-Marion,Marion S,State Senate,35,Levi Morris,DEM,109
-Marion,Peabody twp E,State Senate,35,Levi Morris,DEM,12
-Marion,Peabody twp W,State Senate,35,Levi Morris,DEM,5
-Marion,Peabody City E,State Senate,35,Levi Morris,DEM,58
-Marion,Peabody City W,State Senate,35,Levi Morris,DEM,82
-Marion,Blaine,State Senate,35,Richard Wilborn,REP,63
-Marion,Catlin,State Senate,35,Richard Wilborn,REP,72
-Marion,Center,State Senate,35,Richard Wilborn,REP,208
-Marion,Clark,State Senate,35,Richard Wilborn,REP,60
-Marion,Clear Creek,State Senate,35,Richard Wilborn,REP,169
-Marion,Colfax,State Senate,35,Richard Wilborn,REP,53
-Marion,Doyle,State Senate,35,Richard Wilborn,REP,17
-Marion,Durham Park,State Senate,35,Richard Wilborn,REP,78
-Marion,E Branch,State Senate,35,Richard Wilborn,REP,76
-Marion,Fairplay,State Senate,35,Richard Wilborn,REP,56
-Marion,Gale,State Senate,35,Richard Wilborn,REP,109
-Marion,Grant,State Senate,35,Richard Wilborn,REP,54
-Marion,Lehigh,State Senate,35,Richard Wilborn,REP,100
-Marion,Liberty,State Senate,35,Richard Wilborn,REP,130
-Marion,Logan,State Senate,35,Richard Wilborn,REP,23
-Marion,Lost Springs,State Senate,35,Richard Wilborn,REP,76
-Marion,Menno,State Senate,35,Richard Wilborn,REP,138
-Marion,Milton,State Senate,35,Richard Wilborn,REP,80
-Marion,Moore,State Senate,35,Richard Wilborn,REP,25
-Marion,Risley,State Senate,35,Richard Wilborn,REP,115
-Marion,Summit,State Senate,35,Richard Wilborn,REP,28
-Marion,West Branch,State Senate,35,Richard Wilborn,REP,310
-Marion,Wilson,State Senate,35,Richard Wilborn,REP,81
-Marion,Florence 1,State Senate,35,Richard Wilborn,REP,53
-Marion,Florence 2,State Senate,35,Richard Wilborn,REP,56
-Marion,Hillsboro 1,State Senate,35,Richard Wilborn,REP,410
-Marion,Hillsboro 2,State Senate,35,Richard Wilborn,REP,502
-Marion,Marion N,State Senate,35,Richard Wilborn,REP,319
-Marion,Marion S,State Senate,35,Richard Wilborn,REP,312
-Marion,Peabody twp E,State Senate,35,Richard Wilborn,REP,28
-Marion,Peabody twp W,State Senate,35,Richard Wilborn,REP,35
-Marion,Peabody City E,State Senate,35,Richard Wilborn,REP,89
-Marion,Peabody City W,State Senate,35,Richard Wilborn,REP,134
-Marion,Menno,State Senate,35,Write-ins,,1
-Marion,Marion N,State Senate,35,Write-ins,,2
-Marion,Blaine,State House,70,Jo Schwartz,DEM,26
-Marion,Center,State House,70,Jo Schwartz,DEM,102
-Marion,Clark,State House,70,Jo Schwartz,DEM,18
-Marion,Clear Creek,State House,70,Jo Schwartz,DEM,62
-Marion,Colfax,State House,70,Jo Schwartz,DEM,33
-Marion,Durham Park,State House,70,Jo Schwartz,DEM,33
-Marion,Gale,State House,70,Jo Schwartz,DEM,44
-Marion,Grant,State House,70,Jo Schwartz,DEM,24
-Marion,Lehigh,State House,70,Jo Schwartz,DEM,33
-Marion,Logan,State House,70,Jo Schwartz,DEM,7
-Marion,Lost Springs,State House,70,Jo Schwartz,DEM,18
-Marion,Milton,State House,74,Write-ins,,1
-Marion,Moore,State House,70,Jo Schwartz,DEM,10
-Marion,Summit,State House,74,Write-ins,,1
-Marion,West Branch,State House,74,Write-ins,,6
-Marion,Florence 2,State House,74,Write-ins,,1
-Marion,Hillsboro 1,State House,74,Write-ins,,5
-Marion,Hillsboro 2,State House,74,Write-ins,,3
-Marion,Marion N,State House,70,Jo Schwartz,DEM,173
-Marion,Marion S,State House,70,Jo Schwartz,DEM,148
-Marion,Peabody twp E,State House,74,Write-ins,DEM,1
-Marion,Peabody City E,State House,74,Write-ins,DEM,4
-Marion,Peabody City W,State House,74,Write-ins,DEM,2
-Marion,Blaine,State House,70,John Barker,REP,58
-Marion,Catlin,State House,74,Don Schroeder,REP,94
-Marion,Center,State House,70,John Barker,REP,190
-Marion,Clark,State House,70,John Barker,REP,56
-Marion,Clear Creek,State House,70,John Barker,REP,169
-Marion,Colfax,State House,70,John Barker,REP,49
-Marion,Doyle,State House,74,Don Schroeder,REP,18
-Marion,Durham Park,State House,70,John Barker,REP,73
-Marion,E Branch,State House,74,Don Schroeder,REP,99
-Marion,Fairplay,State House,74,Don Schroeder,REP,60
-Marion,Gale,State House,70,John Barker,REP,92
-Marion,Grant,State House,70,John Barker,REP,54
-Marion,Lehigh,State House,70,John Barker,REP,93
-Marion,Liberty,State House,74,Don Schroeder,REP,165
-Marion,Logan,State House,70,John Barker,REP,21
-Marion,Lost Springs,State House,70,John Barker,REP,74
-Marion,Menno,State House,74,Don Schroeder,REP,165
-Marion,Milton,State House,74,Don Schroeder,REP,91
-Marion,Moore,State House,70,John Barker,REP,21
-Marion,Risley,State House,74,Don Schroeder,REP,129
-Marion,Summit,State House,74,Don Schroeder,REP,35
-Marion,West Branch,State House,74,Don Schroeder,REP,421
-Marion,Wilson,State House,74,Don Schroeder,REP,94
-Marion,Florence 1,State House,74,Don Schroeder,REP,72
-Marion,Florence 2,State House,74,Don Schroeder,REP,82
-Marion,Hillsboro 1,State House,74,Don Schroeder,REP,505
-Marion,Hillsboro 2,State House,74,Don Schroeder,REP,595
-Marion,Marion N,State House,70,John Barker,REP,288
-Marion,Marion S,State House,70,John Barker,REP,267
-Marion,Peabody twp E,State House,74,Don Schroeder,REP,33
-Marion,Peabody twp W,State House,74,Don Schroeder,REP,34
-Marion,Peabody City E,State House,74,Don Schroeder,REP,124
-Marion,Peabody City W,State House,74,Don Schroeder,REP,190
-Marion,Marion N,State House,70,Write-ins,,2
-Marion,Marion S,State House,70,Write-ins,,1
+county,precinct,office,district,party,candidate,votes,vtd
+MARION,Blaine Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",26,000010
+MARION,Blaine Township,Kansas House of Representatives,70,Republican,"Barker, John E.",58,000010
+MARION,Catlin Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",94,000020
+MARION,Centre Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",102,000030
+MARION,Centre Township,Kansas House of Representatives,70,Republican,"Barker, John E.",190,000030
+MARION,Clark Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",18,000040
+MARION,Clark Township,Kansas House of Representatives,70,Republican,"Barker, John E.",56,000040
+MARION,Clear Creek Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",62,000050
+MARION,Clear Creek Township,Kansas House of Representatives,70,Republican,"Barker, John E.",169,000050
+MARION,Colfax Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",33,000060
+MARION,Colfax Township,Kansas House of Representatives,70,Republican,"Barker, John E.",49,000060
+MARION,Doyle Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",18,000070
+MARION,Durham Park Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",33,000080
+MARION,Durham Park Township,Kansas House of Representatives,70,Republican,"Barker, John E.",73,000080
+MARION,East Branch Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",99,000090
+MARION,Fairplay Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",60,000100
+MARION,Florence Ward 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",72,00011A
+MARION,Florence Ward 1 Exclave,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,00011B
+MARION,Florence Ward 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",82,000120
+MARION,Gale Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",44,000130
+MARION,Gale Township,Kansas House of Representatives,70,Republican,"Barker, John E.",92,000130
+MARION,Grant Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",24,000140
+MARION,Grant Township,Kansas House of Representatives,70,Republican,"Barker, John E.",54,000140
+MARION,Hillsboro Ward 1,Kansas House of Representatives,74,Republican,"Schroeder, Don",505,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,00016C
+MARION,Lehigh Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",33,000170
+MARION,Lehigh Township,Kansas House of Representatives,70,Republican,"Barker, John E.",93,000170
+MARION,Liberty Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",165,000180
+MARION,Logan Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",7,000190
+MARION,Logan Township,Kansas House of Representatives,70,Republican,"Barker, John E.",21,000190
+MARION,Lost Springs Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",18,000200
+MARION,Lost Springs Township,Kansas House of Representatives,70,Republican,"Barker, John E.",74,000200
+MARION,Marion North Ward,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",173,000210
+MARION,Marion North Ward,Kansas House of Representatives,70,Republican,"Barker, John E.",288,000210
+MARION,Marion South Ward,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",148,00022A
+MARION,Marion South Ward,Kansas House of Representatives,70,Republican,"Barker, John E.",267,00022A
+MARION,Marion South Ward Exclave,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",0,00022B
+MARION,Marion South Ward Exclave,Kansas House of Representatives,70,Republican,"Barker, John E.",0,00022B
+MARION,Menno Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",165,000230
+MARION,Milton Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",91,000240
+MARION,Moore Township,Kansas House of Representatives,70,Democratic,"Schwartz, Jo",10,000250
+MARION,Moore Township,Kansas House of Representatives,70,Republican,"Barker, John E.",21,000250
+MARION,Peabody East,Kansas House of Representatives,74,Republican,"Schroeder, Don",157,000260
+MARION,Peabody West,Kansas House of Representatives,74,Republican,"Schroeder, Don",224,000270
+MARION,Risley Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",129,000280
+MARION,Summit Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",35,000290
+MARION,West Branch Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",421,000300
+MARION,Wilson Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",94,000310
+MARION,Hillsboro Ward 2,Kansas House of Representatives,74,Republican,"Schroeder, Don",595,900010
+MARION,Hillsboro Ward 2 Exclave A,Kansas House of Representatives,74,Republican,"Schroeder, Don",0,900020
+MARION,Blaine Township,Kansas Senate,35,Democratic,"Morris, Levi",20,000010
+MARION,Blaine Township,Kansas Senate,35,Republican,"Wilborn, Richard",63,000010
+MARION,Catlin Township,Kansas Senate,35,Democratic,"Morris, Levi",32,000020
+MARION,Catlin Township,Kansas Senate,35,Republican,"Wilborn, Richard",72,000020
+MARION,Centre Township,Kansas Senate,35,Democratic,"Morris, Levi",87,000030
+MARION,Centre Township,Kansas Senate,35,Republican,"Wilborn, Richard",208,000030
+MARION,Clark Township,Kansas Senate,35,Democratic,"Morris, Levi",14,000040
+MARION,Clark Township,Kansas Senate,35,Republican,"Wilborn, Richard",60,000040
+MARION,Clear Creek Township,Kansas Senate,35,Democratic,"Morris, Levi",63,000050
+MARION,Clear Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",169,000050
+MARION,Colfax Township,Kansas Senate,35,Democratic,"Morris, Levi",32,000060
+MARION,Colfax Township,Kansas Senate,35,Republican,"Wilborn, Richard",53,000060
+MARION,Doyle Township,Kansas Senate,35,Democratic,"Morris, Levi",5,000070
+MARION,Doyle Township,Kansas Senate,35,Republican,"Wilborn, Richard",17,000070
+MARION,Durham Park Township,Kansas Senate,35,Democratic,"Morris, Levi",30,000080
+MARION,Durham Park Township,Kansas Senate,35,Republican,"Wilborn, Richard",78,000080
+MARION,East Branch Township,Kansas Senate,35,Democratic,"Morris, Levi",30,000090
+MARION,East Branch Township,Kansas Senate,35,Republican,"Wilborn, Richard",76,000090
+MARION,Fairplay Township,Kansas Senate,35,Democratic,"Morris, Levi",7,000100
+MARION,Fairplay Township,Kansas Senate,35,Republican,"Wilborn, Richard",56,000100
+MARION,Florence Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",29,00011A
+MARION,Florence Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",53,00011A
+MARION,Florence Ward 1 Exclave,Kansas Senate,35,Democratic,"Morris, Levi",0,00011B
+MARION,Florence Ward 1 Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,00011B
+MARION,Florence Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",40,000120
+MARION,Florence Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",56,000120
+MARION,Gale Township,Kansas Senate,35,Democratic,"Morris, Levi",26,000130
+MARION,Gale Township,Kansas Senate,35,Republican,"Wilborn, Richard",109,000130
+MARION,Grant Township,Kansas Senate,35,Democratic,"Morris, Levi",27,000140
+MARION,Grant Township,Kansas Senate,35,Republican,"Wilborn, Richard",54,000140
+MARION,Hillsboro Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",127,000150
+MARION,Hillsboro Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",410,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas Senate,35,Democratic,"Morris, Levi",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,Kansas Senate,35,Republican,"Wilborn, Richard",0,00016C
+MARION,Lehigh Township,Kansas Senate,35,Democratic,"Morris, Levi",27,000170
+MARION,Lehigh Township,Kansas Senate,35,Republican,"Wilborn, Richard",100,000170
+MARION,Liberty Township,Kansas Senate,35,Democratic,"Morris, Levi",46,000180
+MARION,Liberty Township,Kansas Senate,35,Republican,"Wilborn, Richard",130,000180
+MARION,Logan Township,Kansas Senate,35,Democratic,"Morris, Levi",5,000190
+MARION,Logan Township,Kansas Senate,35,Republican,"Wilborn, Richard",23,000190
+MARION,Lost Springs Township,Kansas Senate,35,Democratic,"Morris, Levi",13,000200
+MARION,Lost Springs Township,Kansas Senate,35,Republican,"Wilborn, Richard",76,000200
+MARION,Marion North Ward,Kansas Senate,35,Democratic,"Morris, Levi",144,000210
+MARION,Marion North Ward,Kansas Senate,35,Republican,"Wilborn, Richard",319,000210
+MARION,Marion South Ward,Kansas Senate,35,Democratic,"Morris, Levi",109,00022A
+MARION,Marion South Ward,Kansas Senate,35,Republican,"Wilborn, Richard",312,00022A
+MARION,Marion South Ward Exclave,Kansas Senate,35,Democratic,"Morris, Levi",0,00022B
+MARION,Marion South Ward Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,00022B
+MARION,Menno Township,Kansas Senate,35,Democratic,"Morris, Levi",34,000230
+MARION,Menno Township,Kansas Senate,35,Republican,"Wilborn, Richard",138,000230
+MARION,Milton Township,Kansas Senate,35,Democratic,"Morris, Levi",21,000240
+MARION,Milton Township,Kansas Senate,35,Republican,"Wilborn, Richard",80,000240
+MARION,Moore Township,Kansas Senate,35,Democratic,"Morris, Levi",7,000250
+MARION,Moore Township,Kansas Senate,35,Republican,"Wilborn, Richard",25,000250
+MARION,Peabody East,Kansas Senate,35,Democratic,"Morris, Levi",70,000260
+MARION,Peabody East,Kansas Senate,35,Republican,"Wilborn, Richard",117,000260
+MARION,Peabody West,Kansas Senate,35,Democratic,"Morris, Levi",87,000270
+MARION,Peabody West,Kansas Senate,35,Republican,"Wilborn, Richard",169,000270
+MARION,Risley Township,Kansas Senate,35,Democratic,"Morris, Levi",17,000280
+MARION,Risley Township,Kansas Senate,35,Republican,"Wilborn, Richard",115,000280
+MARION,Summit Township,Kansas Senate,35,Democratic,"Morris, Levi",10,000290
+MARION,Summit Township,Kansas Senate,35,Republican,"Wilborn, Richard",28,000290
+MARION,West Branch Township,Kansas Senate,35,Democratic,"Morris, Levi",138,000300
+MARION,West Branch Township,Kansas Senate,35,Republican,"Wilborn, Richard",310,000300
+MARION,Wilson Township,Kansas Senate,35,Democratic,"Morris, Levi",18,000310
+MARION,Wilson Township,Kansas Senate,35,Republican,"Wilborn, Richard",81,000310
+MARION,Hillsboro Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",127,900010
+MARION,Hillsboro Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",502,900010
+MARION,Hillsboro Ward 2 Exclave A,Kansas Senate,35,Democratic,"Morris, Levi",0,900020
+MARION,Hillsboro Ward 2 Exclave A,Kansas Senate,35,Republican,"Wilborn, Richard",0,900020
+MARION,Blaine Township,President / Vice President,,independent,"Stein, Jill",1,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"McMullin, Evan",2,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MARION,Blaine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MARION,Blaine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000010
+MARION,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+MARION,Blaine Township,President / Vice President,,Republican,"Trump, Donald J.",65,000010
+MARION,Catlin Township,President / Vice President,,independent,"Stein, Jill",6,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"McMullin, Evan",1,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MARION,Catlin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MARION,Catlin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000020
+MARION,Catlin Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+MARION,Catlin Township,President / Vice President,,Republican,"Trump, Donald J.",75,000020
+MARION,Centre Township,President / Vice President,,independent,"Stein, Jill",4,000030
+MARION,Centre Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"McMullin, Evan",1,000030
+MARION,Centre Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MARION,Centre Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MARION,Centre Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000030
+MARION,Centre Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000030
+MARION,Centre Township,President / Vice President,,Republican,"Trump, Donald J.",229,000030
+MARION,Clark Township,President / Vice President,,independent,"Stein, Jill",3,000040
+MARION,Clark Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"McMullin, Evan",1,000040
+MARION,Clark Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MARION,Clark Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MARION,Clark Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000040
+MARION,Clark Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+MARION,Clark Township,President / Vice President,,Republican,"Trump, Donald J.",61,000040
+MARION,Clear Creek Township,President / Vice President,,independent,"Stein, Jill",6,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MARION,Clear Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MARION,Clear Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000050
+MARION,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+MARION,Clear Creek Township,President / Vice President,,Republican,"Trump, Donald J.",196,000050
+MARION,Colfax Township,President / Vice President,,independent,"Stein, Jill",5,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MARION,Colfax Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MARION,Colfax Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000060
+MARION,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000060
+MARION,Colfax Township,President / Vice President,,Republican,"Trump, Donald J.",54,000060
+MARION,Doyle Township,President / Vice President,,independent,"Stein, Jill",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Castle, Darrell L",2,000070
+MARION,Doyle Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"McMullin, Evan",2,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MARION,Doyle Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MARION,Doyle Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000070
+MARION,Doyle Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MARION,Doyle Township,President / Vice President,,Republican,"Trump, Donald J.",18,000070
+MARION,Durham Park Township,President / Vice President,,independent,"Stein, Jill",3,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MARION,Durham Park Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MARION,Durham Park Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000080
+MARION,Durham Park Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+MARION,Durham Park Township,President / Vice President,,Republican,"Trump, Donald J.",67,000080
+MARION,East Branch Township,President / Vice President,,independent,"Stein, Jill",3,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"McMullin, Evan",1,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MARION,East Branch Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MARION,East Branch Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000090
+MARION,East Branch Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+MARION,East Branch Township,President / Vice President,,Republican,"Trump, Donald J.",71,000090
+MARION,Fairplay Township,President / Vice President,,independent,"Stein, Jill",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"McMullin, Evan",1,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MARION,Fairplay Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MARION,Fairplay Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000100
+MARION,Fairplay Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+MARION,Fairplay Township,President / Vice President,,Republican,"Trump, Donald J.",58,000100
+MARION,Florence Ward 1,President / Vice President,,independent,"Stein, Jill",1,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011A
+MARION,Florence Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011A
+MARION,Florence Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,00011A
+MARION,Florence Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00011A
+MARION,Florence Ward 1,President / Vice President,,Republican,"Trump, Donald J.",59,00011A
+MARION,Florence Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00011B
+MARION,Florence Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00011B
+MARION,Florence Ward 2,President / Vice President,,independent,"Stein, Jill",4,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+MARION,Florence Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+MARION,Florence Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000120
+MARION,Florence Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+MARION,Florence Ward 2,President / Vice President,,Republican,"Trump, Donald J.",66,000120
+MARION,Gale Township,President / Vice President,,independent,"Stein, Jill",4,000130
+MARION,Gale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"McMullin, Evan",2,000130
+MARION,Gale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+MARION,Gale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+MARION,Gale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000130
+MARION,Gale Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000130
+MARION,Gale Township,President / Vice President,,Republican,"Trump, Donald J.",107,000130
+MARION,Grant Township,President / Vice President,,independent,"Stein, Jill",2,000140
+MARION,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MARION,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MARION,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000140
+MARION,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+MARION,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",57,000140
+MARION,Hillsboro Ward 1,President / Vice President,,independent,"Stein, Jill",13,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"McMullin, Evan",6,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",112,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",31,000150
+MARION,Hillsboro Ward 1,President / Vice President,,Republican,"Trump, Donald J.",388,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,independent,"Stein, Jill",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Castle, Darrell L",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Giordani, Rocky",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Hedges, James A",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Hoefling, Tom",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Kahn, Lynn",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"La Riva, Gloria",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Levinson, Michael S.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Maturen, Michael A",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"McMullin, Evan",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Perry, Darryl",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Schriner, Joe C",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Smith, Mike",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Sood, Ajay",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Sterling, Shawna",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Libertarian,"Johnson, Gary",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,President / Vice President,,Republican,"Trump, Donald J.",0,00016C
+MARION,Lehigh Township,President / Vice President,,independent,"Stein, Jill",3,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"McMullin, Evan",1,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+MARION,Lehigh Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+MARION,Lehigh Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000170
+MARION,Lehigh Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+MARION,Lehigh Township,President / Vice President,,Republican,"Trump, Donald J.",96,000170
+MARION,Liberty Township,President / Vice President,,independent,"Stein, Jill",6,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",2,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+MARION,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+MARION,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000180
+MARION,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+MARION,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",130,000180
+MARION,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000190
+MARION,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+MARION,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+MARION,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000190
+MARION,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+MARION,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",23,000190
+MARION,Lost Springs Township,President / Vice President,,independent,"Stein, Jill",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+MARION,Lost Springs Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+MARION,Lost Springs Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000200
+MARION,Lost Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+MARION,Lost Springs Township,President / Vice President,,Republican,"Trump, Donald J.",81,000200
+MARION,Marion North Ward,President / Vice President,,independent,"Stein, Jill",11,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Hedges, James A",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Maturen, Michael A",1,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"McMullin, Evan",1,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Perry, Darryl",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Smith, Mike",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Sood, Ajay",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+MARION,Marion North Ward,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+MARION,Marion North Ward,President / Vice President,,Democratic,"Clinton, Hillary Rodham",117,000210
+MARION,Marion North Ward,President / Vice President,,Libertarian,"Johnson, Gary",18,000210
+MARION,Marion North Ward,President / Vice President,,Republican,"Trump, Donald J.",331,000210
+MARION,Marion South Ward,President / Vice President,,independent,"Stein, Jill",11,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Castle, Darrell L",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Giordani, Rocky",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Hedges, James A",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Kahn, Lynn",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"La Riva, Gloria",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Levinson, Michael S.",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Maturen, Michael A",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"McMullin, Evan",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Perry, Darryl",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Schriner, Joe C",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Smith, Mike",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Sood, Ajay",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Sterling, Shawna",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022A
+MARION,Marion South Ward,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022A
+MARION,Marion South Ward,President / Vice President,,Democratic,"Clinton, Hillary Rodham",92,00022A
+MARION,Marion South Ward,President / Vice President,,Libertarian,"Johnson, Gary",23,00022A
+MARION,Marion South Ward,President / Vice President,,Republican,"Trump, Donald J.",314,00022A
+MARION,Marion South Ward Exclave,President / Vice President,,independent,"Stein, Jill",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Hedges, James A",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Smith, Mike",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+MARION,Marion South Ward Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00022B
+MARION,Menno Township,President / Vice President,,independent,"Stein, Jill",5,000230
+MARION,Menno Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Castle, Darrell L",1,000230
+MARION,Menno Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"McMullin, Evan",2,000230
+MARION,Menno Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+MARION,Menno Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+MARION,Menno Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000230
+MARION,Menno Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000230
+MARION,Menno Township,President / Vice President,,Republican,"Trump, Donald J.",116,000230
+MARION,Milton Township,President / Vice President,,independent,"Stein, Jill",2,000240
+MARION,Milton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"McMullin, Evan",2,000240
+MARION,Milton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+MARION,Milton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+MARION,Milton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000240
+MARION,Milton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+MARION,Milton Township,President / Vice President,,Republican,"Trump, Donald J.",83,000240
+MARION,Moore Township,President / Vice President,,independent,"Stein, Jill",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+MARION,Moore Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+MARION,Moore Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000250
+MARION,Moore Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000250
+MARION,Moore Township,President / Vice President,,Republican,"Trump, Donald J.",24,000250
+MARION,Peabody East,President / Vice President,,independent,"Stein, Jill",8,000260
+MARION,Peabody East,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Hedges, James A",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"McMullin, Evan",1,000260
+MARION,Peabody East,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Perry, Darryl",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Smith, Mike",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Sood, Ajay",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+MARION,Peabody East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+MARION,Peabody East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000260
+MARION,Peabody East,President / Vice President,,Libertarian,"Johnson, Gary",6,000260
+MARION,Peabody East,President / Vice President,,Republican,"Trump, Donald J.",120,000260
+MARION,Peabody West,President / Vice President,,independent,"Stein, Jill",9,000270
+MARION,Peabody West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Hedges, James A",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"McMullin, Evan",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Perry, Darryl",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Smith, Mike",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Sood, Ajay",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+MARION,Peabody West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+MARION,Peabody West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000270
+MARION,Peabody West,President / Vice President,,Libertarian,"Johnson, Gary",16,000270
+MARION,Peabody West,President / Vice President,,Republican,"Trump, Donald J.",181,000270
+MARION,Risley Township,President / Vice President,,independent,"Stein, Jill",2,000280
+MARION,Risley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"McMullin, Evan",2,000280
+MARION,Risley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+MARION,Risley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+MARION,Risley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000280
+MARION,Risley Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000280
+MARION,Risley Township,President / Vice President,,Republican,"Trump, Donald J.",105,000280
+MARION,Summit Township,President / Vice President,,independent,"Stein, Jill",1,000290
+MARION,Summit Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+MARION,Summit Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+MARION,Summit Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000290
+MARION,Summit Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000290
+MARION,Summit Township,President / Vice President,,Republican,"Trump, Donald J.",26,000290
+MARION,West Branch Township,President / Vice President,,independent,"Stein, Jill",16,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"McMullin, Evan",2,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+MARION,West Branch Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+MARION,West Branch Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",151,000300
+MARION,West Branch Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000300
+MARION,West Branch Township,President / Vice President,,Republican,"Trump, Donald J.",263,000300
+MARION,Wilson Township,President / Vice President,,independent,"Stein, Jill",2,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Castle, Darrell L",1,000310
+MARION,Wilson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"McMullin, Evan",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+MARION,Wilson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+MARION,Wilson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000310
+MARION,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000310
+MARION,Wilson Township,President / Vice President,,Republican,"Trump, Donald J.",89,000310
+MARION,Hillsboro Ward 2,President / Vice President,,independent,"Stein, Jill",11,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Castle, Darrell L",2,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Hedges, James A",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"McMullin, Evan",10,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Smith, Mike",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",30,900010
+MARION,Hillsboro Ward 2,President / Vice President,,Republican,"Trump, Donald J.",450,900010
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,independent,"Stein, Jill",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MARION,Hillsboro Ward 2 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+MARION,Blaine Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000010
+MARION,Blaine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000010
+MARION,Blaine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+MARION,Blaine Township,United States House of Representatives,1,Republican,"Marshall, Roger",63,000010
+MARION,Catlin Township,United States House of Representatives,1,independent,"LaPolice, Alan",35,000020
+MARION,Catlin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+MARION,Catlin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000020
+MARION,Catlin Township,United States House of Representatives,1,Republican,"Marshall, Roger",63,000020
+MARION,Centre Township,United States House of Representatives,1,independent,"LaPolice, Alan",59,000030
+MARION,Centre Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+MARION,Centre Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000030
+MARION,Centre Township,United States House of Representatives,1,Republican,"Marshall, Roger",229,000030
+MARION,Clark Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000040
+MARION,Clark Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+MARION,Clark Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000040
+MARION,Clark Township,United States House of Representatives,1,Republican,"Marshall, Roger",62,000040
+MARION,Clear Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",50,000050
+MARION,Clear Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+MARION,Clear Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000050
+MARION,Clear Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",176,000050
+MARION,Colfax Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000060
+MARION,Colfax Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000060
+MARION,Colfax Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000060
+MARION,Colfax Township,United States House of Representatives,1,Republican,"Marshall, Roger",44,000060
+MARION,Doyle Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000070
+MARION,Doyle Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+MARION,Doyle Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000070
+MARION,Doyle Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000070
+MARION,Durham Park Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000080
+MARION,Durham Park Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+MARION,Durham Park Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000080
+MARION,Durham Park Township,United States House of Representatives,1,Republican,"Marshall, Roger",74,000080
+MARION,East Branch Township,United States House of Representatives,1,independent,"LaPolice, Alan",25,000090
+MARION,East Branch Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+MARION,East Branch Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000090
+MARION,East Branch Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000090
+MARION,Fairplay Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000100
+MARION,Fairplay Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+MARION,Fairplay Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000100
+MARION,Fairplay Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000100
+MARION,Florence Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",12,00011A
+MARION,Florence Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011A
+MARION,Florence Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,00011A
+MARION,Florence Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",60,00011A
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00011B
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011B
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00011B
+MARION,Florence Ward 1 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00011B
+MARION,Florence Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",24,000120
+MARION,Florence Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+MARION,Florence Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000120
+MARION,Florence Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",66,000120
+MARION,Gale Township,United States House of Representatives,1,independent,"LaPolice, Alan",40,000130
+MARION,Gale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+MARION,Gale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000130
+MARION,Gale Township,United States House of Representatives,1,Republican,"Marshall, Roger",92,000130
+MARION,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000140
+MARION,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+MARION,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+MARION,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",57,000140
+MARION,Hillsboro Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",104,000150
+MARION,Hillsboro Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+MARION,Hillsboro Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",37,000150
+MARION,Hillsboro Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",395,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,independent,"LaPolice, Alan",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States House of Representatives,1,Republican,"Marshall, Roger",0,00016C
+MARION,Lehigh Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000170
+MARION,Lehigh Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+MARION,Lehigh Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000170
+MARION,Lehigh Township,United States House of Representatives,1,Republican,"Marshall, Roger",93,000170
+MARION,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000180
+MARION,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+MARION,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000180
+MARION,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",129,000180
+MARION,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000190
+MARION,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+MARION,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000190
+MARION,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000190
+MARION,Lost Springs Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000200
+MARION,Lost Springs Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+MARION,Lost Springs Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000200
+MARION,Lost Springs Township,United States House of Representatives,1,Republican,"Marshall, Roger",70,000200
+MARION,Marion North Ward,United States House of Representatives,1,independent,"LaPolice, Alan",121,000210
+MARION,Marion North Ward,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+MARION,Marion North Ward,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000210
+MARION,Marion North Ward,United States House of Representatives,1,Republican,"Marshall, Roger",311,000210
+MARION,Marion South Ward,United States House of Representatives,1,independent,"LaPolice, Alan",84,00022A
+MARION,Marion South Ward,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00022A
+MARION,Marion South Ward,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,00022A
+MARION,Marion South Ward,United States House of Representatives,1,Republican,"Marshall, Roger",305,00022A
+MARION,Marion South Ward Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022B
+MARION,Marion South Ward Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022B
+MARION,Marion South Ward Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022B
+MARION,Marion South Ward Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022B
+MARION,Menno Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000230
+MARION,Menno Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000230
+MARION,Menno Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000230
+MARION,Menno Township,United States House of Representatives,1,Republican,"Marshall, Roger",130,000230
+MARION,Milton Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000240
+MARION,Milton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000240
+MARION,Milton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000240
+MARION,Milton Township,United States House of Representatives,1,Republican,"Marshall, Roger",74,000240
+MARION,Moore Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000250
+MARION,Moore Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+MARION,Moore Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000250
+MARION,Moore Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000250
+MARION,Peabody East,United States House of Representatives,1,independent,"LaPolice, Alan",52,000260
+MARION,Peabody East,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+MARION,Peabody East,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000260
+MARION,Peabody East,United States House of Representatives,1,Republican,"Marshall, Roger",121,000260
+MARION,Peabody West,United States House of Representatives,1,independent,"LaPolice, Alan",67,000270
+MARION,Peabody West,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000270
+MARION,Peabody West,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000270
+MARION,Peabody West,United States House of Representatives,1,Republican,"Marshall, Roger",161,000270
+MARION,Risley Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000280
+MARION,Risley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000280
+MARION,Risley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000280
+MARION,Risley Township,United States House of Representatives,1,Republican,"Marshall, Roger",106,000280
+MARION,Summit Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000290
+MARION,Summit Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+MARION,Summit Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000290
+MARION,Summit Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000290
+MARION,West Branch Township,United States House of Representatives,1,independent,"LaPolice, Alan",121,000300
+MARION,West Branch Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000300
+MARION,West Branch Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,000300
+MARION,West Branch Township,United States House of Representatives,1,Republican,"Marshall, Roger",292,000300
+MARION,Wilson Township,United States House of Representatives,1,independent,"LaPolice, Alan",17,000310
+MARION,Wilson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+MARION,Wilson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000310
+MARION,Wilson Township,United States House of Representatives,1,Republican,"Marshall, Roger",83,000310
+MARION,Hillsboro Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",111,900010
+MARION,Hillsboro Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,900010
+MARION,Hillsboro Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,900010
+MARION,Hillsboro Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",485,900010
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+MARION,Blaine Township,United States Senate,,write - in,"Smith, DJ",0,000010
+MARION,Blaine Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000010
+MARION,Blaine Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+MARION,Blaine Township,United States Senate,,Republican,"Moran, Jerry",71,000010
+MARION,Catlin Township,United States Senate,,write - in,"Smith, DJ",0,000020
+MARION,Catlin Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000020
+MARION,Catlin Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000020
+MARION,Catlin Township,United States Senate,,Republican,"Moran, Jerry",82,000020
+MARION,Centre Township,United States Senate,,write - in,"Smith, DJ",0,000030
+MARION,Centre Township,United States Senate,,Democratic,"Wiesner, Patrick",40,000030
+MARION,Centre Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000030
+MARION,Centre Township,United States Senate,,Republican,"Moran, Jerry",248,000030
+MARION,Clark Township,United States Senate,,write - in,"Smith, DJ",0,000040
+MARION,Clark Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000040
+MARION,Clark Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000040
+MARION,Clark Township,United States Senate,,Republican,"Moran, Jerry",66,000040
+MARION,Clear Creek Township,United States Senate,,write - in,"Smith, DJ",0,000050
+MARION,Clear Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000050
+MARION,Clear Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000050
+MARION,Clear Creek Township,United States Senate,,Republican,"Moran, Jerry",201,000050
+MARION,Colfax Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MARION,Colfax Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000060
+MARION,Colfax Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000060
+MARION,Colfax Township,United States Senate,,Republican,"Moran, Jerry",60,000060
+MARION,Doyle Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MARION,Doyle Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000070
+MARION,Doyle Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+MARION,Doyle Township,United States Senate,,Republican,"Moran, Jerry",21,000070
+MARION,Durham Park Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MARION,Durham Park Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000080
+MARION,Durham Park Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000080
+MARION,Durham Park Township,United States Senate,,Republican,"Moran, Jerry",86,000080
+MARION,East Branch Township,United States Senate,,write - in,"Smith, DJ",0,000090
+MARION,East Branch Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000090
+MARION,East Branch Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000090
+MARION,East Branch Township,United States Senate,,Republican,"Moran, Jerry",79,000090
+MARION,Fairplay Township,United States Senate,,write - in,"Smith, DJ",0,000100
+MARION,Fairplay Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000100
+MARION,Fairplay Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000100
+MARION,Fairplay Township,United States Senate,,Republican,"Moran, Jerry",63,000100
+MARION,Florence Ward 1,United States Senate,,write - in,"Smith, DJ",0,00011A
+MARION,Florence Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",14,00011A
+MARION,Florence Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",4,00011A
+MARION,Florence Ward 1,United States Senate,,Republican,"Moran, Jerry",66,00011A
+MARION,Florence Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00011B
+MARION,Florence Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00011B
+MARION,Florence Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00011B
+MARION,Florence Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00011B
+MARION,Florence Ward 2,United States Senate,,write - in,"Smith, DJ",0,000120
+MARION,Florence Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",24,000120
+MARION,Florence Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",7,000120
+MARION,Florence Ward 2,United States Senate,,Republican,"Moran, Jerry",65,000120
+MARION,Gale Township,United States Senate,,write - in,"Smith, DJ",0,000130
+MARION,Gale Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000130
+MARION,Gale Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000130
+MARION,Gale Township,United States Senate,,Republican,"Moran, Jerry",109,000130
+MARION,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000140
+MARION,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000140
+MARION,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000140
+MARION,Grant Township,United States Senate,,Republican,"Moran, Jerry",67,000140
+MARION,Hillsboro Ward 1,United States Senate,,write - in,"Smith, DJ",0,000150
+MARION,Hillsboro Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",85,000150
+MARION,Hillsboro Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000150
+MARION,Hillsboro Ward 1,United States Senate,,Republican,"Moran, Jerry",448,000150
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,write - in,"Smith, DJ",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,Democratic,"Wiesner, Patrick",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016C
+MARION,Hillsboro Ward 2 Exclave Industrial Park,United States Senate,,Republican,"Moran, Jerry",0,00016C
+MARION,Lehigh Township,United States Senate,,write - in,"Smith, DJ",0,000170
+MARION,Lehigh Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000170
+MARION,Lehigh Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000170
+MARION,Lehigh Township,United States Senate,,Republican,"Moran, Jerry",99,000170
+MARION,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000180
+MARION,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000180
+MARION,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000180
+MARION,Liberty Township,United States Senate,,Republican,"Moran, Jerry",150,000180
+MARION,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000190
+MARION,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000190
+MARION,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000190
+MARION,Logan Township,United States Senate,,Republican,"Moran, Jerry",25,000190
+MARION,Lost Springs Township,United States Senate,,write - in,"Smith, DJ",0,000200
+MARION,Lost Springs Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000200
+MARION,Lost Springs Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000200
+MARION,Lost Springs Township,United States Senate,,Republican,"Moran, Jerry",85,000200
+MARION,Marion North Ward,United States Senate,,write - in,"Smith, DJ",0,000210
+MARION,Marion North Ward,United States Senate,,Democratic,"Wiesner, Patrick",96,000210
+MARION,Marion North Ward,United States Senate,,Libertarian,"Garrard, Robert D.",23,000210
+MARION,Marion North Ward,United States Senate,,Republican,"Moran, Jerry",364,000210
+MARION,Marion South Ward,United States Senate,,write - in,"Smith, DJ",0,00022A
+MARION,Marion South Ward,United States Senate,,Democratic,"Wiesner, Patrick",70,00022A
+MARION,Marion South Ward,United States Senate,,Libertarian,"Garrard, Robert D.",22,00022A
+MARION,Marion South Ward,United States Senate,,Republican,"Moran, Jerry",345,00022A
+MARION,Marion South Ward Exclave,United States Senate,,write - in,"Smith, DJ",0,00022B
+MARION,Marion South Ward Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00022B
+MARION,Marion South Ward Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022B
+MARION,Marion South Ward Exclave,United States Senate,,Republican,"Moran, Jerry",0,00022B
+MARION,Menno Township,United States Senate,,write - in,"Smith, DJ",0,000230
+MARION,Menno Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000230
+MARION,Menno Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000230
+MARION,Menno Township,United States Senate,,Republican,"Moran, Jerry",149,000230
+MARION,Milton Township,United States Senate,,write - in,"Smith, DJ",0,000240
+MARION,Milton Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000240
+MARION,Milton Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000240
+MARION,Milton Township,United States Senate,,Republican,"Moran, Jerry",83,000240
+MARION,Moore Township,United States Senate,,write - in,"Smith, DJ",0,000250
+MARION,Moore Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000250
+MARION,Moore Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000250
+MARION,Moore Township,United States Senate,,Republican,"Moran, Jerry",27,000250
+MARION,Peabody East,United States Senate,,write - in,"Smith, DJ",0,000260
+MARION,Peabody East,United States Senate,,Democratic,"Wiesner, Patrick",47,000260
+MARION,Peabody East,United States Senate,,Libertarian,"Garrard, Robert D.",11,000260
+MARION,Peabody East,United States Senate,,Republican,"Moran, Jerry",135,000260
+MARION,Peabody West,United States Senate,,write - in,"Smith, DJ",0,000270
+MARION,Peabody West,United States Senate,,Democratic,"Wiesner, Patrick",55,000270
+MARION,Peabody West,United States Senate,,Libertarian,"Garrard, Robert D.",23,000270
+MARION,Peabody West,United States Senate,,Republican,"Moran, Jerry",187,000270
+MARION,Risley Township,United States Senate,,write - in,"Smith, DJ",0,000280
+MARION,Risley Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000280
+MARION,Risley Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000280
+MARION,Risley Township,United States Senate,,Republican,"Moran, Jerry",120,000280
+MARION,Summit Township,United States Senate,,write - in,"Smith, DJ",0,000290
+MARION,Summit Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000290
+MARION,Summit Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000290
+MARION,Summit Township,United States Senate,,Republican,"Moran, Jerry",29,000290
+MARION,West Branch Township,United States Senate,,write - in,"Smith, DJ",0,000300
+MARION,West Branch Township,United States Senate,,Democratic,"Wiesner, Patrick",108,000300
+MARION,West Branch Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000300
+MARION,West Branch Township,United States Senate,,Republican,"Moran, Jerry",329,000300
+MARION,Wilson Township,United States Senate,,write - in,"Smith, DJ",0,000310
+MARION,Wilson Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000310
+MARION,Wilson Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000310
+MARION,Wilson Township,United States Senate,,Republican,"Moran, Jerry",88,000310
+MARION,Hillsboro Ward 2,United States Senate,,write - in,"Smith, DJ",0,900010
+MARION,Hillsboro Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",82,900010
+MARION,Hillsboro Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",15,900010
+MARION,Hillsboro Ward 2,United States Senate,,Republican,"Moran, Jerry",543,900010
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,write - in,"Smith, DJ",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+MARION,Hillsboro Ward 2 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,900020

--- a/2016/20161108__ks__general__marshall__precinct.csv
+++ b/2016/20161108__ks__general__marshall__precinct.csv
@@ -1,538 +1,1314 @@
-county,precinct,office,district,party,candidate,votes
-Marshall,Balderson,Voters,,,Registration,56
-Marshall,Balderson,Voters,,,Ballots Cast,41
-Marshall,Balderson,President,,IND,Jill Stein,1
-Marshall,Balderson,President,,R,Donald Trump,36
-Marshall,Balderson,President,,D,Hillary Clinton,2
-Marshall,Balderson,President,,LBT,Gary Johnson,1
-Marshall,Balderson,President,,,write-in,1
-Marshall,Bigelow,Voters,,,Registration,30
-Marshall,Bigelow,Voters,,,Ballots Cast,21
-Marshall,Bigelow,President,,IND,Jill Stein,1
-Marshall,Bigelow,President,,R,Donald Trump,14
-Marshall,Bigelow,President,,D,Hillary Clinton,6
-Marshall,Bigelow,President,,LBT,Gary Johnson,0
-Marshall,Bigelow,President,,,write-in,0
-Marshall,Blue Rapids twp,Voters,,,Registration,47
-Marshall,Blue Rapids twp,Voters,,,Ballots Cast,38
-Marshall,Blue Rapids twp,President,,IND,Jill Stein,0
-Marshall,Blue Rapids twp,President,,R,Donald Trump,29
-Marshall,Blue Rapids twp,President,,D,Hillary Clinton,7
-Marshall,Blue Rapids twp,President,,LBT,Gary Johnson,0
-Marshall,Blue Rapids twp,President,,,write-in,2
-Marshall,Blue Rapids City,Voters,,,Registration,587
-Marshall,Blue Rapids City,Voters,,,Ballots Cast,398
-Marshall,Blue Rapids City,President,,IND,Jill Stein,10
-Marshall,Blue Rapids City,President,,R,Donald Trump,269
-Marshall,Blue Rapids City,President,,D,Hillary Clinton,73
-Marshall,Blue Rapids City,President,,LBT,Gary Johnson,36
-Marshall,Blue Rapids City,President,,,write-in,6
-Marshall,Center twp,Voters,,,Registration,82
-Marshall,Center twp,Voters,,,Ballots Cast,65
-Marshall,Center twp,President,,IND,Jill Stein,2
-Marshall,Center twp,President,,R,Donald Trump,43
-Marshall,Center twp,President,,D,Hillary Clinton,9
-Marshall,Center twp,President,,LBT,Gary Johnson,4
-Marshall,Center twp,President,,,write-in,3
-Marshall,Clear Fork twp,Voters,,,Registration,30
-Marshall,Clear Fork twp,Voters,,,Ballots Cast,17
-Marshall,Clear Fork twp,President,,IND,Jill Stein,0
-Marshall,Clear Fork twp,President,,R,Donald Trump,12
-Marshall,Clear Fork twp,President,,D,Hillary Clinton,4
-Marshall,Clear Fork twp,President,,LBT,Gary Johnson,1
-Marshall,Clear Fork twp,President,,,write-in,0
-Marshall,Cleveland twp,Voters,,,Registration,68
-Marshall,Cleveland twp,Voters,,,Ballots Cast,53
-Marshall,Cleveland twp,President,,IND,Jill Stein,0
-Marshall,Cleveland twp,President,,R,Donald Trump,34
-Marshall,Cleveland twp,President,,D,Hillary Clinton,18
-Marshall,Cleveland twp,President,,LBT,Gary Johnson,1
-Marshall,Cleveland twp,President,,,write-in,0
-Marshall,Cottage Hill twp,Voters,,,Registration,89
-Marshall,Cottage Hill twp,Voters,,,Ballots Cast,66
-Marshall,Cottage Hill twp,President,,IND,Jill Stein,1
-Marshall,Cottage Hill twp,President,,R,Donald Trump,52
-Marshall,Cottage Hill twp,President,,D,Hillary Clinton,4
-Marshall,Cottage Hill twp,President,,LBT,Gary Johnson,5
-Marshall,Cottage Hill twp,President,,,write-in,1
-Marshall,Elm Creek twp,Voters,,,Registration,114
-Marshall,Elm Creek twp,Voters,,,Ballots Cast,92
-Marshall,Elm Creek twp,President,,IND,Jill Stein,2
-Marshall,Elm Creek twp,President,,R,Donald Trump,62
-Marshall,Elm Creek twp,President,,D,Hillary Clinton,19
-Marshall,Elm Creek twp,President,,LBT,Gary Johnson,8
-Marshall,Elm Creek twp,President,,,write-in,0
-Marshall,Franklin twp,Voters CD1,,,Registration,126
-Marshall,Franklin twp,Voters CD1,,,Ballots Cast,93
-Marshall,Franklin twp,Voters CD2,,,Registration,82
-Marshall,Franklin twp,Voters CD2,,,Ballots Cast,61
-Marshall,Franklin twp,President,,IND,Jill Stein,1
-Marshall,Franklin twp,President,,R,Donald Trump,120
-Marshall,Franklin twp,President,,D,Hillary Clinton,26
-Marshall,Franklin twp,President,,LBT,Gary Johnson,6
-Marshall,Franklin twp,President,,,write-in,1
-Marshall,Guittard twp,Voters CD2,,,Registration,232
-Marshall,Guittard twp,Voters CD2,,,Ballots Cast,186
-Marshall,Guittard twp,Voters CD1,,,Registration,3
-Marshall,Guittard twp,Voters CD1,,,Ballots Cast,2
-Marshall,Guittard twp,President,,IND,Jill Stein,0
-Marshall,Guittard twp,President,,R,Donald Trump,126
-Marshall,Guittard twp,President,,D,Hillary Clinton,43
-Marshall,Guittard twp,President,,LBT,Gary Johnson,9
-Marshall,Guittard twp,President,,,write-in,2
-Marshall,Herkimer twp,Voters,,,Registration,147
-Marshall,Herkimer twp,Voters,,,Ballots Cast,125
-Marshall,Herkimer twp,President,,IND,Jill Stein,1
-Marshall,Herkimer twp,President,,R,Donald Trump,99
-Marshall,Herkimer twp,President,,D,Hillary Clinton,17
-Marshall,Herkimer twp,President,,LBT,Gary Johnson,6
-Marshall,Herkimer twp,President,,,write-in,2
-Marshall,Lincoln twp,Voters,,,Registration,97
-Marshall,Lincoln twp,Voters,,,Ballots Cast,80
-Marshall,Lincoln twp,President,,IND,Jill Stein,0
-Marshall,Lincoln twp,President,,R,Donald Trump,62
-Marshall,Lincoln twp,President,,D,Hillary Clinton,7
-Marshall,Lincoln twp,President,,LBT,Gary Johnson,3
-Marshall,Lincoln twp,President,,,write-in,1
-Marshall,Logan twp,Voters,,,Registration,200
-Marshall,Logan twp,Voters,,,Ballots Cast,150
-Marshall,Logan twp,President,,IND,Jill Stein,1
-Marshall,Logan twp,President,,R,Donald Trump,107
-Marshall,Logan twp,President,,D,Hillary Clinton,33
-Marshall,Logan twp,President,,LBT,Gary Johnson,7
-Marshall,Logan twp,President,,,write-in,0
-Marshall,Marysville twp,Voters,,,Registration,187
-Marshall,Marysville twp,Voters,,,Ballots Cast,147
-Marshall,Marysville twp,President,,IND,Jill Stein,0
-Marshall,Marysville twp,President,,R,Donald Trump,104
-Marshall,Marysville twp,President,,D,Hillary Clinton,35
-Marshall,Marysville twp,President,,LBT,Gary Johnson,1
-Marshall,Marysville twp,President,,,write-in,6
-Marshall,Murray twp,Voters,,,Registration,415
-Marshall,Murray twp,Voters,,,Ballots Cast,306
-Marshall,Murray twp,President,,IND,Jill Stein,10
-Marshall,Murray twp,President,,R,Donald Trump,227
-Marshall,Murray twp,President,,D,Hillary Clinton,46
-Marshall,Murray twp,President,,LBT,Gary Johnson,14
-Marshall,Murray twp,President,,,write-in,2
-Marshall,Noble twp,Voters,,,Registration,148
-Marshall,Noble twp,Voters,,,Ballots Cast,107
-Marshall,Noble twp,President,,IND,Jill Stein,1
-Marshall,Noble twp,President,,R,Donald Trump,84
-Marshall,Noble twp,President,,D,Hillary Clinton,18
-Marshall,Noble twp,President,,LBT,Gary Johnson,2
-Marshall,Noble twp,President,,,write-in,0
-Marshall,Okelo twp,Voters,,,Registration,159
-Marshall,Okelo twp,Voters,,,Ballots Cast,107
-Marshall,Okelo twp,President,,IND,Jill Stein,0
-Marshall,Okelo twp,President,,R,Donald Trump,70
-Marshall,Okelo twp,President,,D,Hillary Clinton,34
-Marshall,Okelo twp,President,,LBT,Gary Johnson,1
-Marshall,Okelo twp,President,,,write-in,1
-Marshall,Richland twp,Voters,,,Registration,123
-Marshall,Richland twp,Voters,,,Ballots Cast,92
-Marshall,Richland twp,President,,IND,Jill Stein,0
-Marshall,Richland twp,President,,R,Donald Trump,72
-Marshall,Richland twp,President,,D,Hillary Clinton,18
-Marshall,Richland twp,President,,LBT,Gary Johnson,0
-Marshall,Richland twp,President,,,write-in,1
-Marshall,Rock twp,Voters,,,Registration,87
-Marshall,Rock twp,Voters,,,Ballots Cast,76
-Marshall,Rock twp,President,,IND,Jill Stein,0
-Marshall,Rock twp,President,,R,Donald Trump,56
-Marshall,Rock twp,President,,D,Hillary Clinton,16
-Marshall,Rock twp,President,,LBT,Gary Johnson,2
-Marshall,Rock twp,President,,,write-in,0
-Marshall,St Bridget twp,Voters,,,Registration,116
-Marshall,St Bridget twp,Voters,,,Ballots Cast,88
-Marshall,St Bridget twp,President,,IND,Jill Stein,1
-Marshall,St Bridget twp,President,,R,Donald Trump,67
-Marshall,St Bridget twp,President,,D,Hillary Clinton,17
-Marshall,St Bridget twp,President,,LBT,Gary Johnson,2
-Marshall,St Bridget twp,President,,,write-in,0
-Marshall,Vermilion twp East,Voters,,,Registration,323
-Marshall,Vermilion twp East,Voters,,,Ballots Cast,253
-Marshall,Vermilion twp East,President,,IND,Jill Stein,5
-Marshall,Vermilion twp East,President,,R,Donald Trump,148
-Marshall,Vermilion twp East,President,,D,Hillary Clinton,77
-Marshall,Vermilion twp East,President,,LBT,Gary Johnson,13
-Marshall,Vermilion twp East,President,,,write-in,2
-Marshall,Vermilion twp West,Voters,,,Registration,281
-Marshall,Vermilion twp West,Voters,,,Ballots Cast,201
-Marshall,Vermilion twp West,President,,IND,Jill Stein,7
-Marshall,Vermilion twp West,President,,R,Donald Trump,129
-Marshall,Vermilion twp West,President,,D,Hillary Clinton,54
-Marshall,Vermilion twp West,President,,LBT,Gary Johnson,7
-Marshall,Vermilion twp West,President,,,write-in,2
-Marshall,Walnut twp,Voters,,,Registration,82
-Marshall,Walnut twp,Voters,,,Ballots Cast,69
-Marshall,Walnut twp,President,,IND,Jill Stein,2
-Marshall,Walnut twp,President,,R,Donald Trump,49
-Marshall,Walnut twp,President,,D,Hillary Clinton,11
-Marshall,Walnut twp,President,,LBT,Gary Johnson,2
-Marshall,Walnut twp,President,,,write-in,0
-Marshall,Waterville twp,Voters,,,Registration,501
-Marshall,Waterville twp,Voters,,,Ballots Cast,336
-Marshall,Waterville twp,President,,IND,Jill Stein,4
-Marshall,Waterville twp,President,,R,Donald Trump,249
-Marshall,Waterville twp,President,,D,Hillary Clinton,70
-Marshall,Waterville twp,President,,LBT,Gary Johnson,10
-Marshall,Waterville twp,President,,,write-in,2
-Marshall,Wells twp,Voters,,,Registration,88
-Marshall,Wells twp,Voters,,,Ballots Cast,72
-Marshall,Wells twp,President,,IND,Jill Stein,1
-Marshall,Wells twp,President,,R,Donald Trump,41
-Marshall,Wells twp,President,,D,Hillary Clinton,21
-Marshall,Wells twp,President,,LBT,Gary Johnson,7
-Marshall,Wells twp,President,,,write-in,1
-Marshall,Marysville City W1,Voters,,,Registration,559
-Marshall,Marysville City W1,Voters,,,Ballots Cast,448
-Marshall,Marysville City W1,President,,IND,Jill Stein,2
-Marshall,Marysville City W1,President,,R,Donald Trump,300
-Marshall,Marysville City W1,President,,D,Hillary Clinton,120
-Marshall,Marysville City W1,President,,LBT,Gary Johnson,13
-Marshall,Marysville City W1,President,,,write-in,6
-Marshall,Marysville City W2,Voters,,,Registration,514
-Marshall,Marysville City W2,Voters,,,Ballots Cast,361
-Marshall,Marysville City W2,President,,IND,Jill Stein,7
-Marshall,Marysville City W2,President,,R,Donald Trump,237
-Marshall,Marysville City W2,President,,D,Hillary Clinton,94
-Marshall,Marysville City W2,President,,LBT,Gary Johnson,15
-Marshall,Marysville City W2,President,,,write-in,4
-Marshall,Marysville City W3,Voters,,,Registration,364
-Marshall,Marysville City W3,Voters,,,Ballots Cast,233
-Marshall,Marysville City W3,President,,IND,Jill Stein,5
-Marshall,Marysville City W3,President,,R,Donald Trump,158
-Marshall,Marysville City W3,President,,D,Hillary Clinton,55
-Marshall,Marysville City W3,President,,LBT,Gary Johnson,11
-Marshall,Marysville City W3,President,,,write-in,2
-Marshall,Marysville City W4,Voters,,,Registration,553
-Marshall,Marysville City W4,Voters,,,Ballots Cast,404
-Marshall,Marysville City W4,President,,IND,Jill Stein,8
-Marshall,Marysville City W4,President,,R,Donald Trump,251
-Marshall,Marysville City W4,President,,D,Hillary Clinton,118
-Marshall,Marysville City W4,President,,LBT,Gary Johnson,17
-Marshall,Marysville City W4,President,,,write-in,3
-Marshall,Balderson,U.S. Senate,,R,Jerry Moran,37
-Marshall,Balderson,U.S. Senate,,D,Patrick Wiesner,3
-Marshall,Balderson,U.S. Senate,,LBT,Robert Garrard,0
-Marshall,Balderson,U.S. House,1,IND,Alan La Police,3
-Marshall,Balderson,U.S. House,1,R,Roger Marshall,35
-Marshall,Balderson,U.S. House,1,LBT,Kerry Burt,1
-Marshall,Bigelow,U.S. Senate,,R,Jerry Moran,17
-Marshall,Bigelow,U.S. Senate,,D,Patrick Wiesner,3
-Marshall,Bigelow,U.S. Senate,,LBT,Robert Garrard,1
-Marshall,Bigelow,U.S. House,2,R,Lynn Jenkins,16
-Marshall,Bigelow,U.S. House,2,D,Britani Potter,4
-Marshall,Bigelow,U.S. House,2,LBT,James Bates,0
-Marshall,Blue Rapids twp,U.S. Senate,,R,Jerry Moran,29
-Marshall,Blue Rapids twp,U.S. Senate,,D,Patrick Wiesner,4
-Marshall,Blue Rapids twp,U.S. Senate,,LBT,Robert Garrard,4
-Marshall,Blue Rapids twp,U.S. House,2,R,Lynn Jenkins,31
-Marshall,Blue Rapids twp,U.S. House,2,D,Britani Potter,5
-Marshall,Blue Rapids twp,U.S. House,2,LBT,James Bates,1
-Marshall,Blue Rapids City,U.S. Senate,,R,Jerry Moran,291
-Marshall,Blue Rapids City,U.S. Senate,,D,Patrick Wiesner,70
-Marshall,Blue Rapids City,U.S. Senate,,LBT,Robert Garrard,21
-Marshall,Blue Rapids City,U.S. House,2,R,Lynn Jenkins,279
-Marshall,Blue Rapids City,U.S. House,2,D,Britani Potter,81
-Marshall,Blue Rapids City,U.S. House,2,LBT,James Bates,23
-Marshall,Center twp,U.S. Senate,,R,Jerry Moran,54
-Marshall,Center twp,U.S. Senate,,D,Patrick Wiesner,6
-Marshall,Center twp,U.S. Senate,,LBT,Robert Garrard,4
-Marshall,Center twp,U.S. House,2,R,Lynn Jenkins,53
-Marshall,Center twp,U.S. House,2,D,Britani Potter,8
-Marshall,Center twp,U.S. House,2,LBT,James Bates,2
-Marshall,Clear Fork twp,U.S. Senate,,R,Jerry Moran,13
-Marshall,Clear Fork twp,U.S. Senate,,D,Patrick Wiesner,4
-Marshall,Clear Fork twp,U.S. Senate,,LBT,Robert Garrard,0
-Marshall,Clear Fork twp,U.S. House,2,R,Lynn Jenkins,9
-Marshall,Clear Fork twp,U.S. House,2,D,Britani Potter,5
-Marshall,Clear Fork twp,U.S. House,2,LBT,James Bates,2
-Marshall,Cleveland twp,U.S. Senate,,R,Jerry Moran,39
-Marshall,Cleveland twp,U.S. Senate,,D,Patrick Wiesner,14
-Marshall,Cleveland twp,U.S. Senate,,LBT,Robert Garrard,0
-Marshall,Cleveland twp,U.S. House,2,R,Lynn Jenkins,38
-Marshall,Cleveland twp,U.S. House,2,D,Britani Potter,12
-Marshall,Cleveland twp,U.S. House,2,LBT,James Bates,1
-Marshall,Cottage Hill twp,U.S. Senate,,R,Jerry Moran,59
-Marshall,Cottage Hill twp,U.S. Senate,,D,Patrick Wiesner,4
-Marshall,Cottage Hill twp,U.S. Senate,,LBT,Robert Garrard,1
-Marshall,Cottage Hill twp,U.S. House,2,R,Lynn Jenkins,59
-Marshall,Cottage Hill twp,U.S. House,2,D,Britani Potter,5
-Marshall,Cottage Hill twp,U.S. House,2,LBT,James Bates,1
-Marshall,Elm Creek twp,U.S. Senate,,R,Jerry Moran,68
-Marshall,Elm Creek twp,U.S. Senate,,D,Patrick Wiesner,15
-Marshall,Elm Creek twp,U.S. Senate,,LBT,Robert Garrard,7
-Marshall,Elm Creek twp,U.S. House,2,R,Lynn Jenkins,65
-Marshall,Elm Creek twp,U.S. House,2,D,Britani Potter,18
-Marshall,Elm Creek twp,U.S. House,2,LBT,James Bates,5
-Marshall,Elm Creek twp,U.S. House,2,,write-in,1
-Marshall,Franklin twp,U.S. Senate,,R,Jerry Moran,117
-Marshall,Franklin twp,U.S. Senate,,D,Patrick Wiesner,27
-Marshall,Franklin twp,U.S. Senate,,LBT,Robert Garrard,9
-Marshall,Franklin twp,U.S. House,1,IND,Alan La Police,27
-Marshall,Franklin twp,U.S. House,1,R,Roger Marshall,59
-Marshall,Franklin twp,U.S. House,1,LBT,Kerry Burt,2
-Marshall,Franklin twp,U.S. House,2,R,Lynn Jenkins,48
-Marshall,Franklin twp,U.S. House,2,D,Britani Potter,10
-Marshall,Franklin twp,U.S. House,2,LBT,James Bates,3
-Marshall,Guittard twp,U.S. Senate,,R,Jerry Moran,138
-Marshall,Guittard twp,U.S. Senate,,D,Patrick Wiesner,39
-Marshall,Guittard twp,U.S. Senate,,LBT,Robert Garrard,7
-Marshall,Guittard twp,U.S. House,1,IND,Alan La Police,0
-Marshall,Guittard twp,U.S. House,1,R,Roger Marshall,2
-Marshall,Guittard twp,U.S. House,1,LBT,Kerry Burt,0
-Marshall,Guittard twp,U.S. House,2,R,Lynn Jenkins,131
-Marshall,Guittard twp,U.S. House,2,D,Britani Potter,40
-Marshall,Guittard twp,U.S. House,2,LBT,James Bates,7
-Marshall,Herkimer twp,U.S. Senate,,R,Jerry Moran,103
-Marshall,Herkimer twp,U.S. Senate,,D,Patrick Wiesner,13
-Marshall,Herkimer twp,U.S. Senate,,LBT,Robert Garrard,5
-Marshall,Herkimer twp,U.S. House,1,IND,Alan La Police,29
-Marshall,Herkimer twp,U.S. House,1,R,Roger Marshall,79
-Marshall,Herkimer twp,U.S. House,1,LBT,Kerry Burt,9
-Marshall,Lincoln twp,U.S. Senate,,R,Jerry Moran,73
-Marshall,Lincoln twp,U.S. Senate,,D,Patrick Wiesner,4
-Marshall,Lincoln twp,U.S. Senate,,LBT,Robert Garrard,1
-Marshall,Lincoln twp,U.S. House,2,R,Lynn Jenkins,70
-Marshall,Lincoln twp,U.S. House,2,D,Britani Potter,5
-Marshall,Lincoln twp,U.S. House,2,LBT,James Bates,4
-Marshall,Logan twp,U.S. Senate,,R,Jerry Moran,117
-Marshall,Logan twp,U.S. Senate,,D,Patrick Wiesner,24
-Marshall,Logan twp,U.S. Senate,,LBT,Robert Garrard,8
-Marshall,Logan twp,U.S. House,1,IND,Alan La Police,32
-Marshall,Logan twp,U.S. House,1,R,Roger Marshall,104
-Marshall,Logan twp,U.S. House,1,LBT,Kerry Burt,7
-Marshall,Marysville twp,U.S. Senate,,R,Jerry Moran,105
-Marshall,Marysville twp,U.S. Senate,,D,Patrick Wiesner,29
-Marshall,Marysville twp,U.S. Senate,,LBT,Robert Garrard,4
-Marshall,Marysville twp,U.S. House,1,IND,Alan La Police,44
-Marshall,Marysville twp,U.S. House,1,R,Roger Marshall,92
-Marshall,Marysville twp,U.S. House,1,LBT,Kerry Burt,4
-Marshall,Murray twp,U.S. Senate,,R,Jerry Moran,240
-Marshall,Murray twp,U.S. Senate,,D,Patrick Wiesner,24
-Marshall,Murray twp,U.S. Senate,,LBT,Robert Garrard,13
-Marshall,Murray twp,U.S. Senate,,,write-in,1
-Marshall,Murray twp,U.S. House,2,R,Lynn Jenkins,237
-Marshall,Murray twp,U.S. House,2,D,Britani Potter,50
-Marshall,Murray twp,U.S. House,2,LBT,James Bates,13
-Marshall,Murray twp,U.S. House,2,,write-in,1
-Marshall,Noble twp,U.S. Senate,,R,Jerry Moran,85
-Marshall,Noble twp,U.S. Senate,,D,Patrick Wiesner,16
-Marshall,Noble twp,U.S. Senate,,LBT,Robert Garrard,2
-Marshall,Noble twp,U.S. House,2,R,Lynn Jenkins,79
-Marshall,Noble twp,U.S. House,2,D,Britani Potter,19
-Marshall,Noble twp,U.S. House,2,LBT,James Bates,3
-Marshall,Okelo twp,U.S. Senate,,R,Jerry Moran,73
-Marshall,Okelo twp,U.S. Senate,,D,Patrick Wiesner,29
-Marshall,Okelo twp,U.S. Senate,,LBT,Robert Garrard,2
-Marshall,Okelo twp,U.S. House,1,IND,Alan La Police,26
-Marshall,Okelo twp,U.S. House,1,R,Roger Marshall,61
-Marshall,Okelo twp,U.S. House,1,LBT,Kerry Burt,5
-Marshall,Okelo twp,U.S. House,1,,write-in,1
-Marshall,Richland twp,U.S. Senate,,R,Jerry Moran,71
-Marshall,Richland twp,U.S. Senate,,D,Patrick Wiesner,12
-Marshall,Richland twp,U.S. Senate,,LBT,Robert Garrard,1
-Marshall,Richland twp,U.S. House,1,IND,Alan La Police,16
-Marshall,Richland twp,U.S. House,1,R,Roger Marshall,55
-Marshall,Richland twp,U.S. House,1,LBT,Kerry Burt,5
-Marshall,Rock twp,U.S. Senate,,R,Jerry Moran,65
-Marshall,Rock twp,U.S. Senate,,D,Patrick Wiesner,7
-Marshall,Rock twp,U.S. Senate,,LBT,Robert Garrard,2
-Marshall,Rock twp,U.S. House,2,R,Lynn Jenkins,60
-Marshall,Rock twp,U.S. House,2,D,Britani Potter,12
-Marshall,Rock twp,U.S. House,2,LBT,James Bates,1
-Marshall,St Bridget twp,U.S. Senate,,R,Jerry Moran,64
-Marshall,St Bridget twp,U.S. Senate,,D,Patrick Wiesner,17
-Marshall,St Bridget twp,U.S. Senate,,LBT,Robert Garrard,5
-Marshall,St Bridget twp,U.S. House,1,IND,Alan La Police,27
-Marshall,St Bridget twp,U.S. House,1,R,Roger Marshall,40
-Marshall,St Bridget twp,U.S. House,1,LBT,Kerry Burt,5
-Marshall,St Bridget twp,U.S. House,1,,write-in,3
-Marshall,Vermilion twp East,U.S. Senate,,R,Jerry Moran,190
-Marshall,Vermilion twp East,U.S. Senate,,D,Patrick Wiesner,49
-Marshall,Vermilion twp East,U.S. Senate,,LBT,Robert Garrard,10
-Marshall,Vermilion twp East,U.S. House,2,R,Lynn Jenkins,183
-Marshall,Vermilion twp East,U.S. House,2,D,Britani Potter,53
-Marshall,Vermilion twp East,U.S. House,2,LBT,James Bates,8
-Marshall,Vermilion twp West,U.S. Senate,,R,Jerry Moran,151
-Marshall,Vermilion twp West,U.S. Senate,,D,Patrick Wiesner,43
-Marshall,Vermilion twp West,U.S. Senate,,LBT,Robert Garrard,5
-Marshall,Vermilion twp West,U.S. House,2,R,Lynn Jenkins,137
-Marshall,Vermilion twp West,U.S. House,2,D,Britani Potter,55
-Marshall,Vermilion twp West,U.S. House,2,LBT,James Bates,5
-Marshall,Walnut twp,U.S. Senate,,R,Jerry Moran,53
-Marshall,Walnut twp,U.S. Senate,,D,Patrick Wiesner,9
-Marshall,Walnut twp,U.S. Senate,,LBT,Robert Garrard,4
-Marshall,Walnut twp,U.S. House,2,R,Lynn Jenkins,54
-Marshall,Walnut twp,U.S. House,2,D,Britani Potter,8
-Marshall,Walnut twp,U.S. House,2,LBT,James Bates,3
-Marshall,Waterville twp,U.S. Senate,,R,Jerry Moran,258
-Marshall,Waterville twp,U.S. Senate,,D,Patrick Wiesner,64
-Marshall,Waterville twp,U.S. Senate,,LBT,Robert Garrard,8
-Marshall,Waterville twp,U.S. House,2,R,Lynn Jenkins,252
-Marshall,Waterville twp,U.S. House,2,D,Britani Potter,68
-Marshall,Waterville twp,U.S. House,2,LBT,James Bates,10
-Marshall,Wells twp,U.S. Senate,,R,Jerry Moran,53
-Marshall,Wells twp,U.S. Senate,,D,Patrick Wiesner,15
-Marshall,Wells twp,U.S. Senate,,LBT,Robert Garrard,4
-Marshall,Wells twp,U.S. House,2,R,Lynn Jenkins,50
-Marshall,Wells twp,U.S. House,2,D,Britani Potter,16
-Marshall,Wells twp,U.S. House,2,LBT,James Bates,6
-Marshall,Marysville City W1,U.S. Senate,,R,Jerry Moran,310
-Marshall,Marysville City W1,U.S. Senate,,D,Patrick Wiesner,105
-Marshall,Marysville City W1,U.S. Senate,,LBT,Robert Garrard,17
-Marshall,Marysville City W1,U.S. House,1,IND,Alan La Police,137
-Marshall,Marysville City W1,U.S. House,1,R,Roger Marshall,251
-Marshall,Marysville City W1,U.S. House,1,LBT,Kerry Burt,16
-Marshall,Marysville City W1,U.S. House,1,,write-in,1
-Marshall,Marysville City W2,U.S. Senate,,R,Jerry Moran,261
-Marshall,Marysville City W2,U.S. Senate,,D,Patrick Wiesner,74
-Marshall,Marysville City W2,U.S. Senate,,LBT,Robert Garrard,13
-Marshall,Marysville City W2,U.S. House,1,IND,Alan La Police,96
-Marshall,Marysville City W2,U.S. House,1,R,Roger Marshall,205
-Marshall,Marysville City W2,U.S. House,1,LBT,Kerry Burt,23
-Marshall,Marysville City W2,U.S. House,1,,write-in,1
-Marshall,Marysville City W3,U.S. Senate,,R,Jerry Moran,168
-Marshall,Marysville City W3,U.S. Senate,,D,Patrick Wiesner,44
-Marshall,Marysville City W3,U.S. Senate,,LBT,Robert Garrard,12
-Marshall,Marysville City W3,U.S. Senate,,,write-in,1
-Marshall,Marysville City W3,U.S. House,1,IND,Alan La Police,55
-Marshall,Marysville City W3,U.S. House,1,R,Roger Marshall,137
-Marshall,Marysville City W3,U.S. House,1,LBT,Kerry Burt,15
-Marshall,Marysville City W4,U.S. Senate,,R,Jerry Moran,289
-Marshall,Marysville City W4,U.S. Senate,,D,Patrick Wiesner,82
-Marshall,Marysville City W4,U.S. Senate,,LBT,Robert Garrard,21
-Marshall,Marysville City W4,U.S. Senate,,,write-in,1
-Marshall,Marysville City W4,U.S. House,1,IND,Alan La Police,107
-Marshall,Marysville City W4,U.S. House,1,R,Roger Marshall,252
-Marshall,Marysville City W4,U.S. House,1,LBT,Kerry Burt,19
-Marshall,Marysville City W4,U.S. House,1,,write-in,2
-Marshall,Balderson,State Senate,1,R,Dennis Pyle,32
-Marshall,Balderson,State Senate,1,D,Jerry Henry,7
-Marshall,Balderson,State House,106,R,Clay Aurand,22
-Marshall,Balderson,State House,106,D,Todd Frye,16
-Marshall,Bigelow,State Senate,1,R,Dennis Pyle,12
-Marshall,Bigelow,State Senate,1,D,Jerry Henry,8
-Marshall,Bigelow,State House,106,R,Clay Aurand,7
-Marshall,Bigelow,State House,106,D,Todd Frye,12
-Marshall,Blue Rapids twp,State Senate,36,D,Brian Angevine,8
-Marshall,Blue Rapids twp,State Senate,36,R,Elaine Bowers,27
-Marshall,Blue Rapids twp,State House,106,R,Clay Aurand,22
-Marshall,Blue Rapids twp,State House,106,D,Todd Frye,15
-Marshall,Blue Rapids City,State Senate,36,D,Brian Angevine,93
-Marshall,Blue Rapids City,State Senate,36,R,Elaine Bowers,269
-Marshall,Blue Rapids City,State House,106,R,Clay Aurand,176
-Marshall,Blue Rapids City,State House,106,D,Todd Frye,202
-Marshall,Blue Rapids City,State House,106,,write-in,1
-Marshall,Center twp,State Senate,1,R,Dennis Pyle,49
-Marshall,Center twp,State Senate,1,D,Jerry Henry,13
-Marshall,Center twp,State House,106,R,Clay Aurand,35
-Marshall,Center twp,State House,106,D,Todd Frye,28
-Marshall,Clear Fork twp,State Senate,1,R,Dennis Pyle,10
-Marshall,Clear Fork twp,State Senate,1,D,Jerry Henry,7
-Marshall,Clear Fork twp,State House,106,R,Clay Aurand,5
-Marshall,Clear Fork twp,State House,106,D,Todd Frye,11
-Marshall,Cleveland twp,State Senate,1,R,Dennis Pyle,31
-Marshall,Cleveland twp,State Senate,1,D,Jerry Henry,21
-Marshall,Cleveland twp,State House,106,R,Clay Aurand,25
-Marshall,Cleveland twp,State House,106,D,Todd Frye,27
-Marshall,Cottage Hill twp,State Senate,36,D,Brian Angevine,8
-Marshall,Cottage Hill twp,State Senate,36,R,Elaine Bowers,50
-Marshall,Cottage Hill twp,State House,106,R,Clay Aurand,31
-Marshall,Cottage Hill twp,State House,106,D,Todd Frye,29
-Marshall,Elm Creek twp,State Senate,36,D,Brian Angevine,25
-Marshall,Elm Creek twp,State Senate,36,R,Elaine Bowers,62
-Marshall,Elm Creek twp,State House,106,R,Clay Aurand,40
-Marshall,Elm Creek twp,State House,106,D,Todd Frye,51
-Marshall,Franklin twp,State Senate,1,R,Dennis Pyle,107
-Marshall,Franklin twp,State Senate,1,D,Jerry Henry,39
-Marshall,Franklin twp,State House,106,R,Clay Aurand,69
-Marshall,Franklin twp,State House,106,D,Todd Frye,82
-Marshall,Guittard twp,State Senate,1,R,Dennis Pyle,128
-Marshall,Guittard twp,State Senate,1,D,Jerry Henry,51
-Marshall,Guittard twp,State House,106,R,Clay Aurand,80
-Marshall,Guittard twp,State House,106,D,Todd Frye,105
-Marshall,Herkimer twp,State Senate,36,D,Brian Angevine,19
-Marshall,Herkimer twp,State Senate,36,R,Elaine Bowers,100
-Marshall,Herkimer twp,State House,106,R,Clay Aurand,62
-Marshall,Herkimer twp,State House,106,D,Todd Frye,58
-Marshall,Lincoln twp,State Senate,1,R,Dennis Pyle,58
-Marshall,Lincoln twp,State Senate,1,D,Jerry Henry,21
-Marshall,Lincoln twp,State House,106,R,Clay Aurand,44
-Marshall,Lincoln twp,State House,106,D,Todd Frye,33
-Marshall,Logan twp,State Senate,36,D,Brian Angevine,32
-Marshall,Logan twp,State Senate,36,R,Elaine Bowers,108
-Marshall,Logan twp,State House,106,R,Clay Aurand,67
-Marshall,Logan twp,State House,106,D,Todd Frye,77
-Marshall,Marysville twp,State Senate,36,D,Brian Angevine,28
-Marshall,Marysville twp,State Senate,36,R,Elaine Bowers,111
-Marshall,Marysville twp,State House,106,R,Clay Aurand,70
-Marshall,Marysville twp,State House,106,D,Todd Frye,75
-Marshall,Murray twp,State Senate,1,R,Dennis Pyle,189
-Marshall,Murray twp,State Senate,1,D,Jerry Henry,107
-Marshall,Murray twp,State Senate,1,,write-in,1
-Marshall,Murray twp,State House,106,R,Clay Aurand,120
-Marshall,Murray twp,State House,106,D,Todd Frye,171
-Marshall,Noble twp,State Senate,1,R,Dennis Pyle,72
-Marshall,Noble twp,State Senate,1,D,Jerry Henry,26
-Marshall,Noble twp,State House,106,R,Clay Aurand,55
-Marshall,Noble twp,State House,106,D,Todd Frye,43
-Marshall,Oketo twp,State Senate,36,D,Brian Angevine,29
-Marshall,Oketo twp,State Senate,36,R,Elaine Bowers,63
-Marshall,Oketo twp,State House,106,R,Clay Aurand,46
-Marshall,Oketo twp,State House,106,D,Todd Frye,55
-Marshall,Richland twp,State Senate,1,R,Dennis Pyle,60
-Marshall,Richland twp,State Senate,1,D,Jerry Henry,26
-Marshall,Richland twp,State House,106,R,Clay Aurand,44
-Marshall,Richland twp,State House,106,D,Todd Frye,38
-Marshall,Rock twp,State Senate,1,R,Dennis Pyle,49
-Marshall,Rock twp,State Senate,1,D,Jerry Henry,24
-Marshall,Rock twp,State House,106,R,Clay Aurand,35
-Marshall,Rock twp,State House,106,D,Todd Frye,37
-Marshall,Rock twp,State House,106,,write-in,1
-Marshall,St Bridget twp,State Senate,1,R,Dennis Pyle,57
-Marshall,St Bridget twp,State Senate,1,D,Jerry Henry,30
-Marshall,St Bridget twp,State House,106,R,Clay Aurand,38
-Marshall,St Bridget twp,State House,106,D,Todd Frye,46
-Marshall,Vermilion twp East,State Senate,1,R,Dennis Pyle,146
-Marshall,Vermilion twp East,State Senate,1,D,Jerry Henry,94
-Marshall,Vermilion twp East,State Senate,1,,write-in,2
-Marshall,Vermilion twp East,State House,106,R,Clay Aurand,97
-Marshall,Vermilion twp East,State House,106,D,Todd Frye,145
-Marshall,Vermilion twp West,State Senate,1,R,Dennis Pyle,113
-Marshall,Vermilion twp West,State Senate,1,D,Jerry Henry,81
-Marshall,Vermilion twp West,State House,106,R,Clay Aurand,72
-Marshall,Vermilion twp West,State House,106,D,Todd Frye,120
-Marshall,Walnut twp,State Senate,36,D,Brian Angevine,9
-Marshall,Walnut twp,State Senate,36,R,Elaine Bowers,50
-Marshall,Walnut twp,State House,106,R,Clay Aurand,27
-Marshall,Walnut twp,State House,106,D,Todd Frye,38
-Marshall,Waterville twp,State Senate,36,D,Brian Angevine,77
-Marshall,Waterville twp,State Senate,36,R,Elaine Bowers,237
-Marshall,Waterville twp,State House,106,R,Clay Aurand,148
-Marshall,Waterville twp,State House,106,D,Todd Frye,172
-Marshall,Wells twp,State Senate,1,R,Dennis Pyle,43
-Marshall,Wells twp,State Senate,1,D,Jerry Henry,28
-Marshall,Wells twp,State House,106,R,Clay Aurand,24
-Marshall,Wells twp,State House,106,D,Todd Frye,46
-Marshall,Marysville City W1,State Senate,36,D,Brian Angevine,109
-Marshall,Marysville City W1,State Senate,36,R,Elaine Bowers,310
-Marshall,Marysville City W1,State House,106,R,Clay Aurand,184
-Marshall,Marysville City W1,State House,106,D,Todd Frye,256
-Marshall,Marysville City W2,State Senate,36,D,Brian Angevine,77
-Marshall,Marysville City W2,State Senate,36,R,Elaine Bowers,259
-Marshall,Marysville City W2,State House,106,R,Clay Aurand,140
-Marshall,Marysville City W2,State House,106,D,Todd Frye,210
-Marshall,Marysville City W3,State Senate,36,D,Brian Angevine,58
-Marshall,Marysville City W3,State Senate,36,R,Elaine Bowers,151
-Marshall,Marysville City W3,State Senate,36,,write-in,1
-Marshall,Marysville City W3,State House,106,R,Clay Aurand,102
-Marshall,Marysville City W3,State House,106,D,Todd Frye,120
-Marshall,Marysville City W4,State Senate,36,D,Brian Angevine,87
-Marshall,Marysville City W4,State Senate,36,R,Elaine Bowers,289
-Marshall,Marysville City W4,State Senate,36,,write-in,1
-Marshall,Marysville City W4,State House,106,R,Clay Aurand,161
-Marshall,Marysville City W4,State House,106,D,Todd Frye,230
-Marshall,Marysville City W4,State House,106,,write-in,1
+county,precinct,office,district,party,candidate,votes,vtd
+MARSHALL,Balderson Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",16,000010
+MARSHALL,Balderson Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",22,000010
+MARSHALL,Bigelow Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",12,000020
+MARSHALL,Bigelow Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",7,000020
+MARSHALL,Blue Rapids City,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",202,000030
+MARSHALL,Blue Rapids City,Kansas House of Representatives,106,Republican,"Aurand, Clay",176,000030
+MARSHALL,Blue Rapids Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",15,000040
+MARSHALL,Blue Rapids Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",22,000040
+MARSHALL,Center Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",28,000050
+MARSHALL,Center Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",35,000050
+MARSHALL,Clear Fork Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",11,000060
+MARSHALL,Clear Fork Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",5,000060
+MARSHALL,Cleveland Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",27,000070
+MARSHALL,Cleveland Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",25,000070
+MARSHALL,Cottage Hill Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",29,000080
+MARSHALL,Cottage Hill Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",31,000080
+MARSHALL,East Vermillion Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",145,000090
+MARSHALL,East Vermillion Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",97,000090
+MARSHALL,Elm Creek Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",51,000100
+MARSHALL,Elm Creek Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",40,000100
+MARSHALL,Herkimer Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",58,000130
+MARSHALL,Herkimer Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",62,000130
+MARSHALL,Lincoln Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",33,000140
+MARSHALL,Lincoln Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",44,000140
+MARSHALL,Logan Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",77,000150
+MARSHALL,Logan Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",67,000150
+MARSHALL,Marysville City Ward 1,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",256,000160
+MARSHALL,Marysville City Ward 1,Kansas House of Representatives,106,Republican,"Aurand, Clay",184,000160
+MARSHALL,Marysville City Ward 2,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",210,00017A
+MARSHALL,Marysville City Ward 2,Kansas House of Representatives,106,Republican,"Aurand, Clay",140,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00017B
+MARSHALL,Marysville City Ward 3,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",120,00018A
+MARSHALL,Marysville City Ward 3,Kansas House of Representatives,106,Republican,"Aurand, Clay",102,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",230,00019A
+MARSHALL,Marysville City Ward 4 Part A,Kansas House of Representatives,106,Republican,"Aurand, Clay",161,00019A
+MARSHALL,Marysville City Ward 4 Part B,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00019C
+MARSHALL,Marysville Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",75,000200
+MARSHALL,Marysville Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",70,000200
+MARSHALL,Murray Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",171,000210
+MARSHALL,Murray Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",120,000210
+MARSHALL,Noble Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",43,000220
+MARSHALL,Noble Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",55,000220
+MARSHALL,Oketo Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",55,000230
+MARSHALL,Oketo Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",46,000230
+MARSHALL,Richland Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",38,000240
+MARSHALL,Richland Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",44,000240
+MARSHALL,Rock Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",37,000250
+MARSHALL,Rock Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",35,000250
+MARSHALL,St. Bridget Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",46,000260
+MARSHALL,St. Bridget Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",38,000260
+MARSHALL,Walnut Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",38,000270
+MARSHALL,Walnut Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",27,000270
+MARSHALL,Waterville Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",172,000280
+MARSHALL,Waterville Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",148,000280
+MARSHALL,Wells Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",46,000290
+MARSHALL,Wells Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",24,000290
+MARSHALL,West Vermillion Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",120,000300
+MARSHALL,West Vermillion Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",72,000300
+MARSHALL,Franklin Township C1,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",44,120020
+MARSHALL,Franklin Township C1,Kansas House of Representatives,106,Republican,"Aurand, Clay",43,120020
+MARSHALL,Franklin Township C2,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",38,120030
+MARSHALL,Franklin Township C2,Kansas House of Representatives,106,Republican,"Aurand, Clay",26,120030
+MARSHALL,Guittard Township C1,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,120040
+MARSHALL,Guittard Township C1,Kansas House of Representatives,106,Republican,"Aurand, Clay",2,120040
+MARSHALL,Guittard Township C2,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",105,120050
+MARSHALL,Guittard Township C2,Kansas House of Representatives,106,Republican,"Aurand, Clay",78,120050
+MARSHALL,Balderson Township,Kansas Senate,1,Democratic,"Henry, Jerry",7,000010
+MARSHALL,Balderson Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",32,000010
+MARSHALL,Bigelow Township,Kansas Senate,1,Democratic,"Henry, Jerry",8,000020
+MARSHALL,Bigelow Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",12,000020
+MARSHALL,Blue Rapids City,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000030
+MARSHALL,Blue Rapids City,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000030
+MARSHALL,Blue Rapids Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",93,000040
+MARSHALL,Blue Rapids Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",269,000040
+MARSHALL,Center Township,Kansas Senate,1,Democratic,"Henry, Jerry",13,000050
+MARSHALL,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",49,000050
+MARSHALL,Clear Fork Township,Kansas Senate,1,Democratic,"Henry, Jerry",7,000060
+MARSHALL,Clear Fork Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",10,000060
+MARSHALL,Cleveland Township,Kansas Senate,1,Democratic,"Henry, Jerry",21,000070
+MARSHALL,Cleveland Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",31,000070
+MARSHALL,Cottage Hill Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000080
+MARSHALL,Cottage Hill Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",50,000080
+MARSHALL,East Vermillion Township,Kansas Senate,1,Democratic,"Henry, Jerry",94,000090
+MARSHALL,East Vermillion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",146,000090
+MARSHALL,Elm Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,000100
+MARSHALL,Elm Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",62,000100
+MARSHALL,Herkimer Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",19,000130
+MARSHALL,Herkimer Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",100,000130
+MARSHALL,Lincoln Township,Kansas Senate,1,Democratic,"Henry, Jerry",21,000140
+MARSHALL,Lincoln Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",58,000140
+MARSHALL,Logan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",32,000150
+MARSHALL,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",108,000150
+MARSHALL,Marysville City Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",109,000160
+MARSHALL,Marysville City Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",310,000160
+MARSHALL,Marysville City Ward 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",77,00017A
+MARSHALL,Marysville City Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",259,00017A
+MARSHALL,Marysville City Ward 2 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00017B
+MARSHALL,Marysville City Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",58,00018A
+MARSHALL,Marysville City Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",151,00018A
+MARSHALL,Marysville City Ward 3 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,Kansas Senate,36,Democratic,"Angevine, Brian G.",87,00019A
+MARSHALL,Marysville City Ward 4 Part A,Kansas Senate,36,Republican,"Bowers, Elaine S.",289,00019A
+MARSHALL,Marysville City Ward 4 Part B,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00019C
+MARSHALL,Marysville Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",28,000200
+MARSHALL,Marysville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",111,000200
+MARSHALL,Murray Township,Kansas Senate,1,Democratic,"Henry, Jerry",107,000210
+MARSHALL,Murray Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",189,000210
+MARSHALL,Noble Township,Kansas Senate,1,Democratic,"Henry, Jerry",26,000220
+MARSHALL,Noble Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",72,000220
+MARSHALL,Oketo Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",29,000230
+MARSHALL,Oketo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",63,000230
+MARSHALL,Richland Township,Kansas Senate,1,Democratic,"Henry, Jerry",26,000240
+MARSHALL,Richland Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",60,000240
+MARSHALL,Rock Township,Kansas Senate,1,Democratic,"Henry, Jerry",24,000250
+MARSHALL,Rock Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",49,000250
+MARSHALL,St. Bridget Township,Kansas Senate,1,Democratic,"Henry, Jerry",30,000260
+MARSHALL,St. Bridget Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",57,000260
+MARSHALL,Walnut Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000270
+MARSHALL,Walnut Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",50,000270
+MARSHALL,Waterville Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",77,000280
+MARSHALL,Waterville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",237,000280
+MARSHALL,Wells Township,Kansas Senate,1,Democratic,"Henry, Jerry",28,000290
+MARSHALL,Wells Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",43,000290
+MARSHALL,West Vermillion Township,Kansas Senate,1,Democratic,"Henry, Jerry",81,000300
+MARSHALL,West Vermillion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",113,000300
+MARSHALL,Franklin Township C1,Kansas Senate,1,Democratic,"Henry, Jerry",39,120020
+MARSHALL,Franklin Township C1,Kansas Senate,1,Republican,"Pyle, Dennis D.",107,120020
+MARSHALL,Franklin Township C2,Kansas Senate,1,Democratic,"Henry, Jerry",0,120030
+MARSHALL,Franklin Township C2,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,120030
+MARSHALL,Guittard Township C1,Kansas Senate,1,Democratic,"Henry, Jerry",51,120040
+MARSHALL,Guittard Township C1,Kansas Senate,1,Republican,"Pyle, Dennis D.",128,120040
+MARSHALL,Guittard Township C2,Kansas Senate,1,Democratic,"Henry, Jerry",0,120050
+MARSHALL,Guittard Township C2,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,120050
+MARSHALL,Balderson Township,President / Vice President,,independent,"Stein, Jill",1,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"McMullin, Evan",3,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MARSHALL,Balderson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MARSHALL,Balderson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+MARSHALL,Balderson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+MARSHALL,Balderson Township,President / Vice President,,Republican,"Trump, Donald J.",36,000010
+MARSHALL,Bigelow Township,President / Vice President,,independent,"Stein, Jill",1,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000020
+MARSHALL,Bigelow Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+MARSHALL,Bigelow Township,President / Vice President,,Republican,"Trump, Donald J.",14,000020
+MARSHALL,Blue Rapids City,President / Vice President,,independent,"Stein, Jill",10,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Castle, Darrell L",2,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Hedges, James A",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"McMullin, Evan",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Smith, Mike",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",73,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Libertarian,"Johnson, Gary",36,000030
+MARSHALL,Blue Rapids City,President / Vice President,,Republican,"Trump, Donald J.",269,000030
+MARSHALL,Blue Rapids Township,President / Vice President,,independent,"Stein, Jill",1,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+MARSHALL,Blue Rapids Township,President / Vice President,,Republican,"Trump, Donald J.",29,000040
+MARSHALL,Center Township,President / Vice President,,independent,"Stein, Jill",2,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"McMullin, Evan",3,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MARSHALL,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MARSHALL,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000050
+MARSHALL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+MARSHALL,Center Township,President / Vice President,,Republican,"Trump, Donald J.",43,000050
+MARSHALL,Clear Fork Township,President / Vice President,,independent,"Stein, Jill",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+MARSHALL,Clear Fork Township,President / Vice President,,Republican,"Trump, Donald J.",12,000060
+MARSHALL,Cleveland Township,President / Vice President,,independent,"Stein, Jill",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MARSHALL,Cleveland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000070
+MARSHALL,Cleveland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+MARSHALL,Cleveland Township,President / Vice President,,Republican,"Trump, Donald J.",34,000070
+MARSHALL,Cottage Hill Township,President / Vice President,,independent,"Stein, Jill",1,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"McMullin, Evan",1,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000080
+MARSHALL,Cottage Hill Township,President / Vice President,,Republican,"Trump, Donald J.",52,000080
+MARSHALL,East Vermillion Township,President / Vice President,,independent,"Stein, Jill",5,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"McMullin, Evan",1,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000090
+MARSHALL,East Vermillion Township,President / Vice President,,Republican,"Trump, Donald J.",148,000090
+MARSHALL,Elm Creek Township,President / Vice President,,independent,"Stein, Jill",2,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000100
+MARSHALL,Elm Creek Township,President / Vice President,,Republican,"Trump, Donald J.",62,000100
+MARSHALL,Herkimer Township,President / Vice President,,independent,"Stein, Jill",1,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"McMullin, Evan",1,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+MARSHALL,Herkimer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000130
+MARSHALL,Herkimer Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000130
+MARSHALL,Herkimer Township,President / Vice President,,Republican,"Trump, Donald J.",99,000130
+MARSHALL,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",1,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MARSHALL,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000140
+MARSHALL,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+MARSHALL,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",62,000140
+MARSHALL,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+MARSHALL,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+MARSHALL,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000150
+MARSHALL,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000150
+MARSHALL,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",107,000150
+MARSHALL,Marysville City Ward 1,President / Vice President,,independent,"Stein, Jill",2,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000160
+MARSHALL,Marysville City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",300,000160
+MARSHALL,Marysville City Ward 2,President / Vice President,,independent,"Stein, Jill",7,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",94,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,00017A
+MARSHALL,Marysville City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",237,00017A
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00017B
+MARSHALL,Marysville City Ward 3,President / Vice President,,independent,"Stein, Jill",5,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",11,00018A
+MARSHALL,Marysville City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",158,00018A
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,independent,"Stein, Jill",8,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Hedges, James A",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Smith, Mike",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",118,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Libertarian,"Johnson, Gary",17,00019A
+MARSHALL,Marysville City Ward 4 Part A,President / Vice President,,Republican,"Trump, Donald J.",251,00019A
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,independent,"Stein, Jill",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Hedges, James A",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"McMullin, Evan",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Perry, Darryl",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Smith, Mike",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Sood, Ajay",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,independent,"Stein, Jill",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Hedges, James A",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Smith, Mike",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00019C
+MARSHALL,Marysville Township,President / Vice President,,independent,"Stein, Jill",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+MARSHALL,Marysville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+MARSHALL,Marysville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000200
+MARSHALL,Marysville Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+MARSHALL,Marysville Township,President / Vice President,,Republican,"Trump, Donald J.",104,000200
+MARSHALL,Murray Township,President / Vice President,,independent,"Stein, Jill",10,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"McMullin, Evan",2,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+MARSHALL,Murray Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+MARSHALL,Murray Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",46,000210
+MARSHALL,Murray Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000210
+MARSHALL,Murray Township,President / Vice President,,Republican,"Trump, Donald J.",227,000210
+MARSHALL,Noble Township,President / Vice President,,independent,"Stein, Jill",1,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+MARSHALL,Noble Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+MARSHALL,Noble Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000220
+MARSHALL,Noble Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+MARSHALL,Noble Township,President / Vice President,,Republican,"Trump, Donald J.",84,000220
+MARSHALL,Oketo Township,President / Vice President,,independent,"Stein, Jill",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+MARSHALL,Oketo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+MARSHALL,Oketo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000230
+MARSHALL,Oketo Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+MARSHALL,Oketo Township,President / Vice President,,Republican,"Trump, Donald J.",70,000230
+MARSHALL,Richland Township,President / Vice President,,independent,"Stein, Jill",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+MARSHALL,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+MARSHALL,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000240
+MARSHALL,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+MARSHALL,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",72,000240
+MARSHALL,Rock Township,President / Vice President,,independent,"Stein, Jill",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+MARSHALL,Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+MARSHALL,Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000250
+MARSHALL,Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+MARSHALL,Rock Township,President / Vice President,,Republican,"Trump, Donald J.",56,000250
+MARSHALL,St. Bridget Township,President / Vice President,,independent,"Stein, Jill",1,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+MARSHALL,St. Bridget Township,President / Vice President,,Republican,"Trump, Donald J.",67,000260
+MARSHALL,Walnut Township,President / Vice President,,independent,"Stein, Jill",2,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+MARSHALL,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+MARSHALL,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000270
+MARSHALL,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000270
+MARSHALL,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",49,000270
+MARSHALL,Waterville Township,President / Vice President,,independent,"Stein, Jill",4,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"McMullin, Evan",1,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+MARSHALL,Waterville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+MARSHALL,Waterville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,000280
+MARSHALL,Waterville Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000280
+MARSHALL,Waterville Township,President / Vice President,,Republican,"Trump, Donald J.",249,000280
+MARSHALL,Wells Township,President / Vice President,,independent,"Stein, Jill",1,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+MARSHALL,Wells Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+MARSHALL,Wells Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000290
+MARSHALL,Wells Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000290
+MARSHALL,Wells Township,President / Vice President,,Republican,"Trump, Donald J.",41,000290
+MARSHALL,West Vermillion Township,President / Vice President,,independent,"Stein, Jill",7,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000300
+MARSHALL,West Vermillion Township,President / Vice President,,Republican,"Trump, Donald J.",129,000300
+MARSHALL,Franklin Township C1,President / Vice President,,independent,"Stein, Jill",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Hedges, James A",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"McMullin, Evan",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Perry, Darryl",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Smith, Mike",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Sood, Ajay",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Libertarian,"Johnson, Gary",6,120020
+MARSHALL,Franklin Township C1,President / Vice President,,Republican,"Trump, Donald J.",75,120020
+MARSHALL,Franklin Township C2,President / Vice President,,independent,"Stein, Jill",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Hedges, James A",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"McMullin, Evan",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Perry, Darryl",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Smith, Mike",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Sood, Ajay",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Libertarian,"Johnson, Gary",2,120030
+MARSHALL,Franklin Township C2,President / Vice President,,Republican,"Trump, Donald J.",45,120030
+MARSHALL,Guittard Township C1,President / Vice President,,independent,"Stein, Jill",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Hedges, James A",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"McMullin, Evan",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Perry, Darryl",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Smith, Mike",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Sood, Ajay",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Libertarian,"Johnson, Gary",0,120040
+MARSHALL,Guittard Township C1,President / Vice President,,Republican,"Trump, Donald J.",2,120040
+MARSHALL,Guittard Township C2,President / Vice President,,independent,"Stein, Jill",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Hedges, James A",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"McMullin, Evan",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Perry, Darryl",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Smith, Mike",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Sood, Ajay",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Libertarian,"Johnson, Gary",8,120050
+MARSHALL,Guittard Township C2,President / Vice President,,Republican,"Trump, Donald J.",124,120050
+MARSHALL,Balderson Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000010
+MARSHALL,Balderson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+MARSHALL,Balderson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+MARSHALL,Balderson Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000010
+MARSHALL,Bigelow Township,United States House of Representatives,2,Democratic,"Potter, Britani",4,000020
+MARSHALL,Bigelow Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000020
+MARSHALL,Bigelow Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",16,000020
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Democratic,"Potter, Britani",81,000030
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000030
+MARSHALL,Blue Rapids City,United States House of Representatives,2,Republican,"Jenkins, Lynn",279,000030
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Democratic,"Potter, Britani",5,000040
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000040
+MARSHALL,Blue Rapids Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,000040
+MARSHALL,Center Township,United States House of Representatives,2,Democratic,"Potter, Britani",8,000050
+MARSHALL,Center Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000050
+MARSHALL,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",53,000050
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Democratic,"Potter, Britani",5,000060
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000060
+MARSHALL,Clear Fork Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",9,000060
+MARSHALL,Cleveland Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000070
+MARSHALL,Cleveland Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000070
+MARSHALL,Cleveland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",38,000070
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Democratic,"Potter, Britani",5,000080
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000080
+MARSHALL,Cottage Hill Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000080
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Democratic,"Potter, Britani",53,000090
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000090
+MARSHALL,East Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",183,000090
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",18,000100
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000100
+MARSHALL,Elm Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,000100
+MARSHALL,Herkimer Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000130
+MARSHALL,Herkimer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+MARSHALL,Herkimer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000130
+MARSHALL,Herkimer Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000130
+MARSHALL,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",5,000140
+MARSHALL,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000140
+MARSHALL,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000140
+MARSHALL,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",32,000150
+MARSHALL,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+MARSHALL,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000150
+MARSHALL,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",104,000150
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",137,000160
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000160
+MARSHALL,Marysville City Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",251,000160
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",96,00017A
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00017A
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,00017A
+MARSHALL,Marysville City Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",205,00017A
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00017B
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",55,00018A
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00018A
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,00018A
+MARSHALL,Marysville City Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",137,00018A
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",107,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",252,00019A
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00019C
+MARSHALL,Marysville Township,United States House of Representatives,1,independent,"LaPolice, Alan",44,000200
+MARSHALL,Marysville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+MARSHALL,Marysville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000200
+MARSHALL,Marysville Township,United States House of Representatives,1,Republican,"Marshall, Roger",92,000200
+MARSHALL,Murray Township,United States House of Representatives,2,Democratic,"Potter, Britani",50,000210
+MARSHALL,Murray Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000210
+MARSHALL,Murray Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",237,000210
+MARSHALL,Noble Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,000220
+MARSHALL,Noble Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000220
+MARSHALL,Noble Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",79,000220
+MARSHALL,Oketo Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000230
+MARSHALL,Oketo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+MARSHALL,Oketo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000230
+MARSHALL,Oketo Township,United States House of Representatives,1,Republican,"Marshall, Roger",61,000230
+MARSHALL,Richland Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000240
+MARSHALL,Richland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+MARSHALL,Richland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000240
+MARSHALL,Richland Township,United States House of Representatives,1,Republican,"Marshall, Roger",55,000240
+MARSHALL,Rock Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000250
+MARSHALL,Rock Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000250
+MARSHALL,Rock Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",60,000250
+MARSHALL,St. Bridget Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000260
+MARSHALL,St. Bridget Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+MARSHALL,St. Bridget Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000260
+MARSHALL,St. Bridget Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000260
+MARSHALL,Walnut Township,United States House of Representatives,2,Democratic,"Potter, Britani",8,000270
+MARSHALL,Walnut Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000270
+MARSHALL,Walnut Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",54,000270
+MARSHALL,Waterville Township,United States House of Representatives,2,Democratic,"Potter, Britani",68,000280
+MARSHALL,Waterville Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000280
+MARSHALL,Waterville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",252,000280
+MARSHALL,Wells Township,United States House of Representatives,2,Democratic,"Potter, Britani",16,000290
+MARSHALL,Wells Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000290
+MARSHALL,Wells Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000290
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Democratic,"Potter, Britani",55,000300
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000300
+MARSHALL,West Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,000300
+MARSHALL,Franklin Township C1,United States House of Representatives,1,independent,"LaPolice, Alan",27,120020
+MARSHALL,Franklin Township C1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+MARSHALL,Franklin Township C1,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120020
+MARSHALL,Franklin Township C1,United States House of Representatives,1,Republican,"Marshall, Roger",59,120020
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Democratic,"Potter, Britani",10,120030
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,120030
+MARSHALL,Franklin Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,120030
+MARSHALL,Guittard Township C1,United States House of Representatives,1,independent,"LaPolice, Alan",0,120040
+MARSHALL,Guittard Township C1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+MARSHALL,Guittard Township C1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120040
+MARSHALL,Guittard Township C1,United States House of Representatives,1,Republican,"Marshall, Roger",2,120040
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Democratic,"Potter, Britani",40,120050
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,120050
+MARSHALL,Guittard Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",131,120050
+MARSHALL,Balderson Township,United States Senate,,write - in,"Smith, DJ",0,000010
+MARSHALL,Balderson Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000010
+MARSHALL,Balderson Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+MARSHALL,Balderson Township,United States Senate,,Republican,"Moran, Jerry",37,000010
+MARSHALL,Bigelow Township,United States Senate,,write - in,"Smith, DJ",0,000020
+MARSHALL,Bigelow Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+MARSHALL,Bigelow Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+MARSHALL,Bigelow Township,United States Senate,,Republican,"Moran, Jerry",17,000020
+MARSHALL,Blue Rapids City,United States Senate,,write - in,"Smith, DJ",0,000030
+MARSHALL,Blue Rapids City,United States Senate,,Democratic,"Wiesner, Patrick",70,000030
+MARSHALL,Blue Rapids City,United States Senate,,Libertarian,"Garrard, Robert D.",21,000030
+MARSHALL,Blue Rapids City,United States Senate,,Republican,"Moran, Jerry",291,000030
+MARSHALL,Blue Rapids Township,United States Senate,,write - in,"Smith, DJ",0,000040
+MARSHALL,Blue Rapids Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000040
+MARSHALL,Blue Rapids Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000040
+MARSHALL,Blue Rapids Township,United States Senate,,Republican,"Moran, Jerry",29,000040
+MARSHALL,Center Township,United States Senate,,write - in,"Smith, DJ",0,000050
+MARSHALL,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000050
+MARSHALL,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000050
+MARSHALL,Center Township,United States Senate,,Republican,"Moran, Jerry",54,000050
+MARSHALL,Clear Fork Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MARSHALL,Clear Fork Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000060
+MARSHALL,Clear Fork Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+MARSHALL,Clear Fork Township,United States Senate,,Republican,"Moran, Jerry",13,000060
+MARSHALL,Cleveland Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MARSHALL,Cleveland Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000070
+MARSHALL,Cleveland Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+MARSHALL,Cleveland Township,United States Senate,,Republican,"Moran, Jerry",39,000070
+MARSHALL,Cottage Hill Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MARSHALL,Cottage Hill Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+MARSHALL,Cottage Hill Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+MARSHALL,Cottage Hill Township,United States Senate,,Republican,"Moran, Jerry",59,000080
+MARSHALL,East Vermillion Township,United States Senate,,write - in,"Smith, DJ",0,000090
+MARSHALL,East Vermillion Township,United States Senate,,Democratic,"Wiesner, Patrick",49,000090
+MARSHALL,East Vermillion Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000090
+MARSHALL,East Vermillion Township,United States Senate,,Republican,"Moran, Jerry",190,000090
+MARSHALL,Elm Creek Township,United States Senate,,write - in,"Smith, DJ",0,000100
+MARSHALL,Elm Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000100
+MARSHALL,Elm Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000100
+MARSHALL,Elm Creek Township,United States Senate,,Republican,"Moran, Jerry",68,000100
+MARSHALL,Herkimer Township,United States Senate,,write - in,"Smith, DJ",0,000130
+MARSHALL,Herkimer Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000130
+MARSHALL,Herkimer Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000130
+MARSHALL,Herkimer Township,United States Senate,,Republican,"Moran, Jerry",103,000130
+MARSHALL,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000140
+MARSHALL,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000140
+MARSHALL,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+MARSHALL,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",73,000140
+MARSHALL,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000150
+MARSHALL,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000150
+MARSHALL,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000150
+MARSHALL,Logan Township,United States Senate,,Republican,"Moran, Jerry",117,000150
+MARSHALL,Marysville City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000160
+MARSHALL,Marysville City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",105,000160
+MARSHALL,Marysville City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000160
+MARSHALL,Marysville City Ward 1,United States Senate,,Republican,"Moran, Jerry",310,000160
+MARSHALL,Marysville City Ward 2,United States Senate,,write - in,"Smith, DJ",0,00017A
+MARSHALL,Marysville City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",74,00017A
+MARSHALL,Marysville City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",13,00017A
+MARSHALL,Marysville City Ward 2,United States Senate,,Republican,"Moran, Jerry",261,00017A
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017B
+MARSHALL,Marysville City Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00017B
+MARSHALL,Marysville City Ward 3,United States Senate,,write - in,"Smith, DJ",0,00018A
+MARSHALL,Marysville City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",44,00018A
+MARSHALL,Marysville City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",12,00018A
+MARSHALL,Marysville City Ward 3,United States Senate,,Republican,"Moran, Jerry",168,00018A
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018B
+MARSHALL,Marysville City Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00018B
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,write - in,"Smith, DJ",0,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,Democratic,"Wiesner, Patrick",82,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",21,00019A
+MARSHALL,Marysville City Ward 4 Part A,United States Senate,,Republican,"Moran, Jerry",289,00019A
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,write - in,"Smith, DJ",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00019B
+MARSHALL,Marysville City Ward 4 Part B,United States Senate,,Republican,"Moran, Jerry",0,00019B
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,write - in,"Smith, DJ",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00019C
+MARSHALL,Marysville City Ward 4 Part B Exclave,United States Senate,,Republican,"Moran, Jerry",0,00019C
+MARSHALL,Marysville Township,United States Senate,,write - in,"Smith, DJ",0,000200
+MARSHALL,Marysville Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000200
+MARSHALL,Marysville Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000200
+MARSHALL,Marysville Township,United States Senate,,Republican,"Moran, Jerry",105,000200
+MARSHALL,Murray Township,United States Senate,,write - in,"Smith, DJ",0,000210
+MARSHALL,Murray Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000210
+MARSHALL,Murray Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000210
+MARSHALL,Murray Township,United States Senate,,Republican,"Moran, Jerry",240,000210
+MARSHALL,Noble Township,United States Senate,,write - in,"Smith, DJ",0,000220
+MARSHALL,Noble Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000220
+MARSHALL,Noble Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000220
+MARSHALL,Noble Township,United States Senate,,Republican,"Moran, Jerry",85,000220
+MARSHALL,Oketo Township,United States Senate,,write - in,"Smith, DJ",0,000230
+MARSHALL,Oketo Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000230
+MARSHALL,Oketo Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000230
+MARSHALL,Oketo Township,United States Senate,,Republican,"Moran, Jerry",73,000230
+MARSHALL,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000240
+MARSHALL,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000240
+MARSHALL,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+MARSHALL,Richland Township,United States Senate,,Republican,"Moran, Jerry",71,000240
+MARSHALL,Rock Township,United States Senate,,write - in,"Smith, DJ",0,000250
+MARSHALL,Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000250
+MARSHALL,Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000250
+MARSHALL,Rock Township,United States Senate,,Republican,"Moran, Jerry",65,000250
+MARSHALL,St. Bridget Township,United States Senate,,write - in,"Smith, DJ",0,000260
+MARSHALL,St. Bridget Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000260
+MARSHALL,St. Bridget Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000260
+MARSHALL,St. Bridget Township,United States Senate,,Republican,"Moran, Jerry",64,000260
+MARSHALL,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000270
+MARSHALL,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000270
+MARSHALL,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000270
+MARSHALL,Walnut Township,United States Senate,,Republican,"Moran, Jerry",53,000270
+MARSHALL,Waterville Township,United States Senate,,write - in,"Smith, DJ",0,000280
+MARSHALL,Waterville Township,United States Senate,,Democratic,"Wiesner, Patrick",64,000280
+MARSHALL,Waterville Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000280
+MARSHALL,Waterville Township,United States Senate,,Republican,"Moran, Jerry",258,000280
+MARSHALL,Wells Township,United States Senate,,write - in,"Smith, DJ",0,000290
+MARSHALL,Wells Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000290
+MARSHALL,Wells Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000290
+MARSHALL,Wells Township,United States Senate,,Republican,"Moran, Jerry",53,000290
+MARSHALL,West Vermillion Township,United States Senate,,write - in,"Smith, DJ",0,000300
+MARSHALL,West Vermillion Township,United States Senate,,Democratic,"Wiesner, Patrick",43,000300
+MARSHALL,West Vermillion Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000300
+MARSHALL,West Vermillion Township,United States Senate,,Republican,"Moran, Jerry",151,000300
+MARSHALL,Franklin Township C1,United States Senate,,write - in,"Smith, DJ",0,120020
+MARSHALL,Franklin Township C1,United States Senate,,Democratic,"Wiesner, Patrick",10,120020
+MARSHALL,Franklin Township C1,United States Senate,,Libertarian,"Garrard, Robert D.",3,120020
+MARSHALL,Franklin Township C1,United States Senate,,Republican,"Moran, Jerry",47,120020
+MARSHALL,Franklin Township C2,United States Senate,,write - in,"Smith, DJ",0,120030
+MARSHALL,Franklin Township C2,United States Senate,,Democratic,"Wiesner, Patrick",17,120030
+MARSHALL,Franklin Township C2,United States Senate,,Libertarian,"Garrard, Robert D.",6,120030
+MARSHALL,Franklin Township C2,United States Senate,,Republican,"Moran, Jerry",70,120030
+MARSHALL,Guittard Township C1,United States Senate,,write - in,"Smith, DJ",0,120040
+MARSHALL,Guittard Township C1,United States Senate,,Democratic,"Wiesner, Patrick",0,120040
+MARSHALL,Guittard Township C1,United States Senate,,Libertarian,"Garrard, Robert D.",0,120040
+MARSHALL,Guittard Township C1,United States Senate,,Republican,"Moran, Jerry",2,120040
+MARSHALL,Guittard Township C2,United States Senate,,write - in,"Smith, DJ",0,120050
+MARSHALL,Guittard Township C2,United States Senate,,Democratic,"Wiesner, Patrick",39,120050
+MARSHALL,Guittard Township C2,United States Senate,,Libertarian,"Garrard, Robert D.",7,120050
+MARSHALL,Guittard Township C2,United States Senate,,Republican,"Moran, Jerry",136,120050

--- a/2016/20161108__ks__general__mcpherson__precinct.csv
+++ b/2016/20161108__ks__general__mcpherson__precinct.csv
@@ -1,469 +1,1220 @@
-county,precinct,office,district,party,candidate,votes
-McPherson,CANTON,President,,I,Stein - Baraka,4
-McPherson,CASTLE,President,,I,Stein - Baraka,2
-McPherson,DELMORE,President,,I,Stein - Baraka,4
-McPherson,EMPIRE,President,,I,Stein - Baraka,7
-McPherson,GROVELAND,President,,I,Stein - Baraka,4
-McPherson,GYPSUM CREEK,President,,I,Stein - Baraka,2
-McPherson,HARPER,President,,I,Stein - Baraka,1
-McPherson,HAVES,President,,I,Stein - Baraka,3
-McPherson,KING CITY,President,,I,Stein - Baraka,9
-McPherson,LITTLE VALLEY,President,,I,Stein - Baraka,1
-McPherson,LONE TREE,President,,I,Stein - Baraka,2
-McPherson,MARQUETTE,President,,I,Stein - Baraka,9
-McPherson,MCPHERSON,President,,I,Stein - Baraka,3
-McPherson,MERIDIAN,President,,I,Stein - Baraka,4
-McPherson,MOUND,President,,I,Stein - Baraka,35
-McPherson,NEW GOTTLAND,President,,I,Stein - Baraka,3
-McPherson,SMOKY HILL,President,,I,Stein - Baraka,2
-McPherson,SPRING VALLEY,President,,I,Stein - Baraka,4
-McPherson,SUPERIOR,President,,I,Stein - Baraka,16
-McPherson,TURKEY CREEK,President,,I,Stein - Baraka,3
-McPherson,UNION,President,,I,Stein - Baraka,1
-McPherson,LINDSBORG - 1,President,,I,Stein - Baraka,10
-McPherson,LINDSRORG - 2,President,,I,Stein - Baraka,12
-McPherson,LINDSBORG - 3,President,,I,Stein - Baraka,6
-McPherson,LINDSBORG - 4,President,,I,Stein - Baraka,8
-McPherson,McPHERSON - 1,President,,I,Stein - Baraka,71
-McPherson,McPHERSON - 2,President,,I,Stein - Baraka,18
-McPherson,McPHERSON - 3,President,,I,Stein - Baraka,17
-McPherson,McPHERSON - 4,President,,I,Stein - Baraka,34
-McPherson,BATTLE HILL,President,,R,Trump - Pence,37
-McPherson,BONAVILLE,President,,R,Trump - Pence,40
-McPherson,CANTON,President,,R,Trump - Pence,296
-McPherson,CASTLE,President,,R,Trump - Pence,55
-McPherson,DELMORE,President,,R,Trump - Pence,64
-McPherson,EMPIRE,President,,R,Trump - Pence,409
-McPherson,GROVELAND,President,,R,Trump - Pence,73
-McPherson,GYPSUM CREEK,President,,R,Trump - Pence,70
-McPherson,HARPER,President,,R,Trump - Pence,65
-McPherson,HAVES,President,,R,Trump - Pence,95
-McPherson,JACKSON,President,,R,Trump - Pence,71
-McPherson,KING CITY,President,,R,Trump - Pence,197
-McPherson,LITTLE VALLEY,President,,R,Trump - Pence,171
-McPherson,LONE TREE,President,,R,Trump - Pence,64
-McPherson,MARQUETTE,President,,R,Trump - Pence,250
-McPherson,MCPHERSON,President,,R,Trump - Pence,204
-McPherson,MERIDIAN,President,,R,Trump - Pence,81
-McPherson,MOUND,President,,R,Trump - Pence,533
-McPherson,NEW GOTTLAND,President,,R,Trump - Pence,209
-McPherson,SMOKY HILL,President,,R,Trump - Pence,124
-McPherson,S SHARPS CREEK,President,,R,Trump - Pence,41
-McPherson,SPRING VALLEY,President,,R,Trump - Pence,113
-McPherson,SUPERIOR,President,,R,Trump - Pence,577
-McPherson,TURKEY CREEK,President,,R,Trump - Pence,105
-McPherson,UNION,President,,R,Trump - Pence,71
-McPherson,LINDSBORG - 1,President,,R,Trump - Pence,178
-McPherson,LINDSRORG - 2,President,,R,Trump - Pence,241
-McPherson,LINDSBORG - 3,President,,R,Trump - Pence,188
-McPherson,LINDSBORG - 4,President,,R,Trump - Pence,208
-McPherson,McPHERSON - 1,President,,R,Trump - Pence,1910
-McPherson,McPHERSON - 2,President,,R,Trump - Pence,638
-McPherson,McPHERSON - 3,President,,R,Trump - Pence,364
-McPherson,McPHERSON - 4,President,,R,Trump - Pence,807
-McPherson,BATTLE HILL,President,,D,Clinton - Kaine,14
-McPherson,BONAVILLE,President,,D,Clinton - Kaine,5
-McPherson,CANTON,President,,D,Clinton - Kaine,70
-McPherson,CASTLE,President,,D,Clinton - Kaine,19
-McPherson,DELMORE,President,,D,Clinton - Kaine,12
-McPherson,EMPIRE,President,,D,Clinton - Kaine,74
-McPherson,GROVELAND,President,,D,Clinton - Kaine,18
-McPherson,GYPSUM CREEK,President,,D,Clinton - Kaine,16
-McPherson,HARPER,President,,D,Clinton - Kaine,10
-McPherson,HAVES,President,,D,Clinton - Kaine,20
-McPherson,JACKSON,President,,D,Clinton - Kaine,23
-McPherson,KING CITY,President,,D,Clinton - Kaine,56
-McPherson,LITTLE VALLEY,President,,D,Clinton - Kaine,30
-McPherson,LONE TREE,President,,D,Clinton - Kaine,27
-McPherson,MARQUETTE,President,,D,Clinton - Kaine,83
-McPherson,MCPHERSON,President,,D,Clinton - Kaine,66
-McPherson,MERIDIAN,President,,D,Clinton - Kaine,29
-McPherson,MOUND,President,,D,Clinton - Kaine,238
-McPherson,NEW GOTTLAND,President,,D,Clinton - Kaine,44
-McPherson,SMOKY HILL,President,,D,Clinton - Kaine,42
-McPherson,S SHARPS CREEK,President,,D,Clinton - Kaine,4
-McPherson,SPRING VALLEY,President,,D,Clinton - Kaine,22
-McPherson,SUPERIOR,President,,D,Clinton - Kaine,110
-McPherson,TURKEY CREEK,President,,D,Clinton - Kaine,30
-McPherson,UNION,President,,D,Clinton - Kaine,17
-McPherson,LINDSBORG - 1,President,,D,Clinton - Kaine,140
-McPherson,LINDSRORG - 2,President,,D,Clinton - Kaine,209
-McPherson,LINDSBORG - 3,President,,D,Clinton - Kaine,161
-McPherson,LINDSBORG - 4,President,,D,Clinton - Kaine,154
-McPherson,McPHERSON - 1,President,,D,Clinton - Kaine,859
-McPherson,McPHERSON - 2,President,,D,Clinton - Kaine,231
-McPherson,McPHERSON - 3,President,,D,Clinton - Kaine,121
-McPherson,McPHERSON - 4,President,,D,Clinton - Kaine,272
-McPherson,CANTON,President,,L,Johnson - Weld,13
-McPherson,CASTLE,President,,L,Johnson - Weld,5
-McPherson,DELMORE,President,,L,Johnson - Weld,4
-McPherson,EMPIRE,President,,L,Johnson - Weld,27
-McPherson,GROVELAND,President,,L,Johnson - Weld,2
-McPherson,GYPSUM CREEK,President,,L,Johnson - Weld,4
-McPherson,HARPER,President,,L,Johnson - Weld,5
-McPherson,HAVES,President,,L,Johnson - Weld,1
-McPherson,JACKSON,President,,L,Johnson - Weld,6
-McPherson,KING CITY,President,,L,Johnson - Weld,16
-McPherson,LITTLE VALLEY,President,,L,Johnson - Weld,9
-McPherson,LONE TREE,President,,L,Johnson - Weld,5
-McPherson,MARQUETTE,President,,L,Johnson - Weld,18
-McPherson,MCPHERSON,President,,L,Johnson - Weld,9
-McPherson,MERIDIAN,President,,L,Johnson - Weld,11
-McPherson,MOUND,President,,L,Johnson - Weld,36
-McPherson,NEW GOTTLAND,President,,L,Johnson - Weld,6
-McPherson,SMOKY HILL,President,,L,Johnson - Weld,9
-McPherson,S SHARPS CREEK,President,,L,Johnson - Weld,1
-McPherson,SPRING VALLEY,President,,L,Johnson - Weld,7
-McPherson,SUPERIOR,President,,L,Johnson - Weld,30
-McPherson,TURKEY CREEK,President,,L,Johnson - Weld,5
-McPherson,UNION,President,,L,Johnson - Weld,7
-McPherson,LINDSBORG - 1,President,,L,Johnson - Weld,12
-McPherson,LINDSRORG - 2,President,,L,Johnson - Weld,27
-McPherson,LINDSBORG - 3,President,,L,Johnson - Weld,16
-McPherson,LINDSBORG - 4,President,,L,Johnson - Weld,19
-McPherson,McPHERSON - 1,President,,L,Johnson - Weld,128
-McPherson,McPHERSON - 2,President,,L,Johnson - Weld,39
-McPherson,McPHERSON - 3,President,,L,Johnson - Weld,26
-McPherson,McPHERSON - 4,President,,L,Johnson - Weld,71
-McPherson,BONAVILLE,President,,,McMullin - Johnson,1
-McPherson,CANTON,President,,,McMullin - Johnson,1
-McPherson,DELMORE,President,,,McMullin - Johnson,2
-McPherson,GYPSUM CREEK,President,,,McMullin - Johnson,2
-McPherson,MARQUETTE,President,,,McMullin - Johnson,3
-McPherson,SMOKY HILL,President,,,McMullin - Johnson,1
-McPherson,SUPERIOR,President,,,McMullin - Johnson,2
-McPherson,LINDSBORG - 1,President,,,McMullin - Johnson,3
-McPherson,LINDSBORG - 3,President,,,McMullin - Johnson,4
-McPherson,LINDSBORG - 4,President,,,McMullin - Johnson,2
-McPherson,McPHERSON - 1,President,,,McMullin - Johnson,24
-McPherson,McPHERSON - 2,President,,,McMullin - Johnson,13
-McPherson,McPHERSON - 3,President,,,McMullin - Johnson,26
-McPherson,McPHERSON - 4,President,,,McMullin - Johnson,14
-McPherson,BATTLE HILL,U.S. Senate,,R,Jerry Moran,38
-McPherson,BONAVILLE,U.S. Senate,,R,Jerry Moran,39
-McPherson,CANTON,U.S. Senate,,R,Jerry Moran,304
-McPherson,CASTLE,U.S. Senate,,R,Jerry Moran,57
-McPherson,DELMORE,U.S. Senate,,R,Jerry Moran,69
-McPherson,EMPIRE,U.S. Senate,,R,Jerry Moran,422
-McPherson,GROVELAND,U.S. Senate,,R,Jerry Moran,79
-McPherson,GYPSUM CREEK,U.S. Senate,,R,Jerry Moran,79
-McPherson,HARPER,U.S. Senate,,R,Jerry Moran,65
-McPherson,HAVES,U.S. Senate,,R,Jerry Moran,98
-McPherson,JACKSON,U.S. Senate,,R,Jerry Moran,81
-McPherson,KING CITY,U.S. Senate,,R,Jerry Moran,224
-McPherson,LITTLE VALLEY,U.S. Senate,,R,Jerry Moran,185
-McPherson,LONE TREE,U.S. Senate,,R,Jerry Moran,76
-McPherson,MARQUETTE,U.S. Senate,,R,Jerry Moran,260
-McPherson,MCPHERSON,U.S. Senate,,R,Jerry Moran,220
-McPherson,MERIDIAN,U.S. Senate,,R,Jerry Moran,106
-McPherson,MOUND,U.S. Senate,,R,Jerry Moran,625
-McPherson,NEW GOTTLAND,U.S. Senate,,R,Jerry Moran,219
-McPherson,SMOKY HILL,U.S. Senate,,R,Jerry Moran,142
-McPherson,S SHARPS CREEK,U.S. Senate,,R,Jerry Moran,37
-McPherson,SPRING VALLEY,U.S. Senate,,R,Jerry Moran,130
-McPherson,SUPERIOR,U.S. Senate,,R,Jerry Moran,620
-McPherson,TURKEY CREEK,U.S. Senate,,R,Jerry Moran,112
-McPherson,UNION,U.S. Senate,,R,Jerry Moran,80
-McPherson,LINDSBORG - 1,U.S. Senate,,R,Jerry Moran,223
-McPherson,LINDSRORG - 2,U.S. Senate,,R,Jerry Moran,314
-McPherson,LINDSBORG - 3,U.S. Senate,,R,Jerry Moran,252
-McPherson,LINDSBORG - 4,U.S. Senate,,R,Jerry Moran,232
-McPherson,McPHERSON - 1,U.S. Senate,,R,Jerry Moran,2228
-McPherson,McPHERSON - 2,U.S. Senate,,R,Jerry Moran,713
-McPherson,McPHERSON - 3,U.S. Senate,,R,Jerry Moran,403
-McPherson,McPHERSON - 4,U.S. Senate,,R,Jerry Moran,905
-McPherson,BATTLE HILL,U.S. Senate,,D,Patrick Wiesner,10
-McPherson,BONAVILLE,U.S. Senate,,D,Patrick Wiesner,3
-McPherson,CANTON,U.S. Senate,,D,Patrick Wiesner,59
-McPherson,CASTLE,U.S. Senate,,D,Patrick Wiesner,18
-McPherson,DELMORE,U.S. Senate,,D,Patrick Wiesner,13
-McPherson,EMPIRE,U.S. Senate,,D,Patrick Wiesner,62
-McPherson,GROVELAND,U.S. Senate,,D,Patrick Wiesner,15
-McPherson,GYPSUM CREEK,U.S. Senate,,D,Patrick Wiesner,12
-McPherson,HARPER,U.S. Senate,,D,Patrick Wiesner,8
-McPherson,HAVES,U.S. Senate,,D,Patrick Wiesner,14
-McPherson,JACKSON,U.S. Senate,,D,Patrick Wiesner,18
-McPherson,KING CITY,U.S. Senate,,D,Patrick Wiesner,42
-McPherson,LITTLE VALLEY,U.S. Senate,,D,Patrick Wiesner,21
-McPherson,LONE TREE,U.S. Senate,,D,Patrick Wiesner,21
-McPherson,MARQUETTE,U.S. Senate,,D,Patrick Wiesner,83
-McPherson,MCPHERSON,U.S. Senate,,D,Patrick Wiesner,49
-McPherson,MERIDIAN,U.S. Senate,,D,Patrick Wiesner,18
-McPherson,MOUND,U.S. Senate,,D,Patrick Wiesner,185
-McPherson,NEW GOTTLAND,U.S. Senate,,D,Patrick Wiesner,29
-McPherson,SMOKY HILL,U.S. Senate,,D,Patrick Wiesner,35
-McPherson,S SHARPS CREEK,U.S. Senate,,D,Patrick Wiesner,5
-McPherson,SPRING VALLEY,U.S. Senate,,D,Patrick Wiesner,11
-McPherson,SUPERIOR,U.S. Senate,,D,Patrick Wiesner,91
-McPherson,TURKEY CREEK,U.S. Senate,,D,Patrick Wiesner,26
-McPherson,UNION,U.S. Senate,,D,Patrick Wiesner,10
-McPherson,LINDSBORG - 1,U.S. Senate,,D,Patrick Wiesner,113
-McPherson,LINDSRORG - 2,U.S. Senate,,D,Patrick Wiesner,161
-McPherson,LINDSBORG - 3,U.S. Senate,,D,Patrick Wiesner,112
-McPherson,LINDSBORG - 4,U.S. Senate,,D,Patrick Wiesner,135
-McPherson,McPHERSON - 1,U.S. Senate,,D,Patrick Wiesner,655
-McPherson,McPHERSON - 2,U.S. Senate,,D,Patrick Wiesner,178
-McPherson,McPHERSON - 3,U.S. Senate,,D,Patrick Wiesner,101
-McPherson,McPHERSON - 4,U.S. Senate,,D,Patrick Wiesner,214
-McPherson,BATTLE HILL,U.S. Senate,,L,Robert D. Garrard,3
-McPherson,BONAVILLE,U.S. Senate,,L,Robert D. Garrard,2
-McPherson,CANTON,U.S. Senate,,L,Robert D. Garrard,18
-McPherson,CASTLE,U.S. Senate,,L,Robert D. Garrard,6
-McPherson,DELMORE,U.S. Senate,,L,Robert D. Garrard,4
-McPherson,EMPIRE,U.S. Senate,,L,Robert D. Garrard,29
-McPherson,GROVELAND,U.S. Senate,,L,Robert D. Garrard,3
-McPherson,GYPSUM CREEK,U.S. Senate,,L,Robert D. Garrard,3
-McPherson,HARPER,U.S. Senate,,L,Robert D. Garrard,7
-McPherson,HAVES,U.S. Senate,,L,Robert D. Garrard,6
-McPherson,JACKSON,U.S. Senate,,L,Robert D. Garrard,3
-McPherson,KING CITY,U.S. Senate,,L,Robert D. Garrard,15
-McPherson,LITTLE VALLEY,U.S. Senate,,L,Robert D. Garrard,7
-McPherson,LONE TREE,U.S. Senate,,L,Robert D. Garrard,4
-McPherson,MARQUETTE,U.S. Senate,,L,Robert D. Garrard,18
-McPherson,MCPHERSON,U.S. Senate,,L,Robert D. Garrard,20
-McPherson,MERIDIAN,U.S. Senate,,L,Robert D. Garrard,5
-McPherson,MOUND,U.S. Senate,,L,Robert D. Garrard,41
-McPherson,NEW GOTTLAND,U.S. Senate,,L,Robert D. Garrard,13
-McPherson,SMOKY HILL,U.S. Senate,,L,Robert D. Garrard,6
-McPherson,S SHARPS CREEK,U.S. Senate,,L,Robert D. Garrard,4
-McPherson,SPRING VALLEY,U.S. Senate,,L,Robert D. Garrard,7
-McPherson,SUPERIOR,U.S. Senate,,L,Robert D. Garrard,34
-McPherson,TURKEY CREEK,U.S. Senate,,L,Robert D. Garrard,3
-McPherson,UNION,U.S. Senate,,L,Robert D. Garrard,5
-McPherson,LINDSBORG - 1,U.S. Senate,,L,Robert D. Garrard,10
-McPherson,LINDSRORG - 2,U.S. Senate,,L,Robert D. Garrard,19
-McPherson,LINDSBORG - 3,U.S. Senate,,L,Robert D. Garrard,22
-McPherson,LINDSBORG - 4,U.S. Senate,,L,Robert D. Garrard,28
-McPherson,McPHERSON - 1,U.S. Senate,,L,Robert D. Garrard,124
-McPherson,McPHERSON - 2,U.S. Senate,,L,Robert D. Garrard,44
-McPherson,McPHERSON - 3,U.S. Senate,,L,Robert D. Garrard,32
-McPherson,McPHERSON - 4,U.S. Senate,,L,Robert D. Garrard,68
-McPherson,BATTLE HILL,U.S. House,1,D,Alan LaPolice,16
-McPherson,BONAVILLE,U.S. House,1,D,Alan LaPolice,7
-McPherson,CANTON,U.S. House,1,D,Alan LaPolice,86
-McPherson,CASTLE,U.S. House,1,D,Alan LaPolice,19
-McPherson,DELMORE,U.S. House,1,D,Alan LaPolice,25
-McPherson,EMPIRE,U.S. House,1,D,Alan LaPolice,115
-McPherson,GROVELAND,U.S. House,1,D,Alan LaPolice,20
-McPherson,GYPSUM CREEK,U.S. House,1,D,Alan LaPolice,19
-McPherson,HARPER,U.S. House,1,D,Alan LaPolice,23
-McPherson,HAVES,U.S. House,1,D,Alan LaPolice,33
-McPherson,JACKSON,U.S. House,1,D,Alan LaPolice,26
-McPherson,KING CITY,U.S. House,1,D,Alan LaPolice,70
-McPherson,LITTLE VALLEY,U.S. House,1,D,Alan LaPolice,39
-McPherson,LONE TREE,U.S. House,1,D,Alan LaPolice,24
-McPherson,MARQUETTE,U.S. House,1,D,Alan LaPolice,119
-McPherson,MCPHERSON,U.S. House,1,D,Alan LaPolice,74
-McPherson,MERIDIAN,U.S. House,1,D,Alan LaPolice,37
-McPherson,MOUND,U.S. House,1,D,Alan LaPolice,222
-McPherson,NEW GOTTLAND,U.S. House,1,D,Alan LaPolice,58
-McPherson,SMOKY HILL,U.S. House,1,D,Alan LaPolice,57
-McPherson,S SHARPS CREEK,U.S. House,1,D,Alan LaPolice,9
-McPherson,SPRING VALLEY,U.S. House,1,D,Alan LaPolice,27
-McPherson,SUPERIOR,U.S. House,1,D,Alan LaPolice,131
-McPherson,TURKEY CREEK,U.S. House,1,D,Alan LaPolice,27
-McPherson,UNION,U.S. House,1,D,Alan LaPolice,25
-McPherson,LINDSBORG - 1,U.S. House,1,D,Alan LaPolice,161
-McPherson,LINDSRORG - 2,U.S. House,1,D,Alan LaPolice,216
-McPherson,LINDSBORG - 3,U.S. House,1,D,Alan LaPolice,149
-McPherson,LINDSBORG - 4,U.S. House,1,D,Alan LaPolice,181
-McPherson,McPHERSON - 1,U.S. House,1,D,Alan LaPolice,740
-McPherson,McPHERSON - 2,U.S. House,1,D,Alan LaPolice,206
-McPherson,McPHERSON - 3,U.S. House,1,D,Alan LaPolice,138
-McPherson,McPHERSON - 4,U.S. House,1,D,Alan LaPolice,257
-McPherson,BATTLE HILL,U.S. House,1,R,Roger Marshall,34
-McPherson,BONAVILLE,U.S. House,1,R,Roger Marshall,32
-McPherson,CANTON,U.S. House,1,R,Roger Marshall,269
-McPherson,CASTLE,U.S. House,1,R,Roger Marshall,51
-McPherson,DELMORE,U.S. House,1,R,Roger Marshall,58
-McPherson,EMPIRE,U.S. House,1,R,Roger Marshall,360
-McPherson,GROVELAND,U.S. House,1,R,Roger Marshall,75
-McPherson,GYPSUM CREEK,U.S. House,1,R,Roger Marshall,70
-McPherson,HARPER,U.S. House,1,R,Roger Marshall,49
-McPherson,HAVES,U.S. House,1,R,Roger Marshall,75
-McPherson,JACKSON,U.S. House,1,R,Roger Marshall,70
-McPherson,KING CITY,U.S. House,1,R,Roger Marshall,183
-McPherson,LITTLE VALLEY,U.S. House,1,R,Roger Marshall,153
-McPherson,LONE TREE,U.S. House,1,R,Roger Marshall,67
-McPherson,MARQUETTE,U.S. House,1,R,Roger Marshall,223
-McPherson,MCPHERSON,U.S. House,1,R,Roger Marshall,187
-McPherson,MERIDIAN,U.S. House,1,R,Roger Marshall,82
-McPherson,MOUND,U.S. House,1,R,Roger Marshall,540
-McPherson,NEW GOTTLAND,U.S. House,1,R,Roger Marshall,190
-McPherson,SMOKY HILL,U.S. House,1,R,Roger Marshall,113
-McPherson,S SHARPS CREEK,U.S. House,1,R,Roger Marshall,33
-McPherson,SPRING VALLEY,U.S. House,1,R,Roger Marshall,115
-McPherson,SUPERIOR,U.S. House,1,R,Roger Marshall,561
-McPherson,TURKEY CREEK,U.S. House,1,R,Roger Marshall,100
-McPherson,UNION,U.S. House,1,R,Roger Marshall,69
-McPherson,LINDSBORG - 1,U.S. House,1,R,Roger Marshall,170
-McPherson,LINDSRORG - 2,U.S. House,1,R,Roger Marshall,241
-McPherson,LINDSBORG - 3,U.S. House,1,R,Roger Marshall,198
-McPherson,LINDSBORG - 4,U.S. House,1,R,Roger Marshall,173
-McPherson,McPHERSON - 1,U.S. House,1,R,Roger Marshall,1987
-McPherson,McPHERSON - 2,U.S. House,1,R,Roger Marshall,645
-McPherson,McPHERSON - 3,U.S. House,1,R,Roger Marshall,353
-McPherson,McPHERSON - 4,U.S. House,1,R,Roger Marshall,812
-McPherson,BATTLE HILL,U.S. House,1,L,Kerry Burt,1
-McPherson,BONAVILLE,U.S. House,1,L,Kerry Burt,2
-McPherson,CANTON,U.S. House,1,L,Kerry Burt,18
-McPherson,CASTLE,U.S. House,1,L,Kerry Burt,11
-McPherson,DELMORE,U.S. House,1,L,Kerry Burt,2
-McPherson,EMPIRE,U.S. House,1,L,Kerry Burt,27
-McPherson,GROVELAND,U.S. House,1,L,Kerry Burt,2
-McPherson,GYPSUM CREEK,U.S. House,1,L,Kerry Burt,4
-McPherson,HARPER,U.S. House,1,L,Kerry Burt,4
-McPherson,HAVES,U.S. House,1,L,Kerry Burt,5
-McPherson,JACKSON,U.S. House,1,L,Kerry Burt,4
-McPherson,KING CITY,U.S. House,1,L,Kerry Burt,12
-McPherson,LITTLE VALLEY,U.S. House,1,L,Kerry Burt,16
-McPherson,LONE TREE,U.S. House,1,L,Kerry Burt,3
-McPherson,MARQUETTE,U.S. House,1,L,Kerry Burt,18
-McPherson,MCPHERSON,U.S. House,1,L,Kerry Burt,15
-McPherson,MERIDIAN,U.S. House,1,L,Kerry Burt,3
-McPherson,MOUND,U.S. House,1,L,Kerry Burt,56
-McPherson,NEW GOTTLAND,U.S. House,1,L,Kerry Burt,5
-McPherson,SMOKY HILL,U.S. House,1,L,Kerry Burt,6
-McPherson,S SHARPS CREEK,U.S. House,1,L,Kerry Burt,3
-McPherson,SPRING VALLEY,U.S. House,1,L,Kerry Burt,4
-McPherson,SUPERIOR,U.S. House,1,L,Kerry Burt,43
-McPherson,TURKEY CREEK,U.S. House,1,L,Kerry Burt,7
-McPherson,UNION,U.S. House,1,L,Kerry Burt,1
-McPherson,LINDSBORG - 1,U.S. House,1,L,Kerry Burt,11
-McPherson,LINDSRORG - 2,U.S. House,1,L,Kerry Burt,22
-McPherson,LINDSBORG - 3,U.S. House,1,L,Kerry Burt,31
-McPherson,LINDSBORG - 4,U.S. House,1,L,Kerry Burt,34
-McPherson,McPHERSON - 1,U.S. House,1,L,Kerry Burt,197
-McPherson,McPHERSON - 2,U.S. House,1,L,Kerry Burt,62
-McPherson,McPHERSON - 3,U.S. House,1,L,Kerry Burt,32
-McPherson,McPHERSON - 4,U.S. House,1,L,Kerry Burt,88
-McPherson,BATTLE HILL,State Senate,35,R,Richard Wilborn,39
-McPherson,BONAVILLE,State Senate,35,R,Richard Wilborn,41
-McPherson,CANTON,State Senate,35,R,Richard Wilborn,296
-McPherson,CASTLE,State Senate,35,R,Richard Wilborn,57
-McPherson,DELMORE,State Senate,35,R,Richard Wilborn,66
-McPherson,EMPIRE,State Senate,35,R,Richard Wilborn,409
-McPherson,GROVELAND,State Senate,35,R,Richard Wilborn,80
-McPherson,GYPSUM CREEK,State Senate,35,R,Richard Wilborn,73
-McPherson,HARPER,State Senate,35,R,Richard Wilborn,69
-McPherson,HAVES,State Senate,35,R,Richard Wilborn,88
-McPherson,JACKSON,State Senate,35,R,Richard Wilborn,72
-McPherson,KING CITY,State Senate,35,R,Richard Wilborn,217
-McPherson,LITTLE VALLEY,State Senate,35,R,Richard Wilborn,178
-McPherson,LONE TREE,State Senate,35,R,Richard Wilborn,73
-McPherson,MARQUETTE,State Senate,35,R,Richard Wilborn,258
-McPherson,MCPHERSON,State Senate,35,R,Richard Wilborn,211
-McPherson,MERIDIAN,State Senate,35,R,Richard Wilborn,104
-McPherson,MOUND,State Senate,35,R,Richard Wilborn,579
-McPherson,NEW GOTTLAND,State Senate,35,R,Richard Wilborn,223
-McPherson,SMOKY HILL,State Senate,35,R,Richard Wilborn,134
-McPherson,S SHARPS CREEK,State Senate,35,R,Richard Wilborn,39
-McPherson,SPRING VALLEY,State Senate,35,R,Richard Wilborn,122
-McPherson,SUPERIOR,State Senate,35,R,Richard Wilborn,620
-McPherson,TURKEY CREEK,State Senate,35,R,Richard Wilborn,110
-McPherson,UNION,State Senate,35,R,Richard Wilborn,75
-McPherson,LINDSBORG - 1,State Senate,35,R,Richard Wilborn,209
-McPherson,LINDSRORG - 2,State Senate,35,R,Richard Wilborn,278
-McPherson,LINDSBORG - 3,State Senate,35,R,Richard Wilborn,231
-McPherson,LINDSBORG - 4,State Senate,35,R,Richard Wilborn,233
-McPherson,McPHERSON - 1,State Senate,35,R,Richard Wilborn,2153
-McPherson,McPHERSON - 2,State Senate,35,R,Richard Wilborn,695
-McPherson,McPHERSON - 3,State Senate,35,R,Richard Wilborn,398
-McPherson,McPHERSON - 4,State Senate,35,R,Richard Wilborn,889
-McPherson,BATTLE HILL,State Senate,35,D,Levi Morris,13
-McPherson,BONAVILLE,State Senate,35,D,Levi Morris,3
-McPherson,CANTON,State Senate,35,D,Levi Morris,81
-McPherson,CASTLE,State Senate,35,D,Levi Morris,23
-McPherson,DELMORE,State Senate,35,D,Levi Morris,16
-McPherson,EMPIRE,State Senate,35,D,Levi Morris,89
-McPherson,GROVELAND,State Senate,35,D,Levi Morris,17
-McPherson,GYPSUM CREEK,State Senate,35,D,Levi Morris,19
-McPherson,HARPER,State Senate,35,D,Levi Morris,11
-McPherson,HAVES,State Senate,35,D,Levi Morris,28
-McPherson,JACKSON,State Senate,35,D,Levi Morris,29
-McPherson,KING CITY,State Senate,35,D,Levi Morris,56
-McPherson,LITTLE VALLEY,State Senate,35,D,Levi Morris,29
-McPherson,LONE TREE,State Senate,35,D,Levi Morris,23
-McPherson,MARQUETTE,State Senate,35,D,Levi Morris,103
-McPherson,MCPHERSON,State Senate,35,D,Levi Morris,72
-McPherson,MERIDIAN,State Senate,35,D,Levi Morris,20
-McPherson,MOUND,State Senate,35,D,Levi Morris,242
-McPherson,NEW GOTTLAND,State Senate,35,D,Levi Morris,35
-McPherson,SMOKY HILL,State Senate,35,D,Levi Morris,46
-McPherson,S SHARPS CREEK,State Senate,35,D,Levi Morris,6
-McPherson,SPRING VALLEY,State Senate,35,D,Levi Morris,25
-McPherson,SUPERIOR,State Senate,35,D,Levi Morris,121
-McPherson,TURKEY CREEK,State Senate,35,D,Levi Morris,30
-McPherson,UNION,State Senate,35,D,Levi Morris,21
-McPherson,LINDSBORG - 1,State Senate,35,D,Levi Morris,130
-McPherson,LINDSRORG - 2,State Senate,35,D,Levi Morris,208
-McPherson,LINDSBORG - 3,State Senate,35,D,Levi Morris,145
-McPherson,LINDSBORG - 4,State Senate,35,D,Levi Morris,152
-McPherson,McPHERSON - 1,State Senate,35,D,Levi Morris,822
-McPherson,McPHERSON - 2,State Senate,35,D,Levi Morris,235
-McPherson,McPHERSON - 3,State Senate,35,D,Levi Morris,135
-McPherson,McPHERSON - 4,State Senate,35,D,Levi Morris,284
-McPherson,BATTLE HILL,State House,73,D,Terrance J. Krier,18
-McPherson,BONAVILLE,State House,73,D,Terrance J. Krier,7
-McPherson,CANTON,State House,73,D,Terrance J. Krier,110
-McPherson,CASTLE,State House,73,D,Terrance J. Krier,23
-McPherson,DELMORE,State House,73,D,Terrance J. Krier,21
-McPherson,EMPIRE,State House,73,D,Terrance J. Krier,130
-McPherson,GROVELAND,State House,73,D,Terrance J. Krier,21
-McPherson,GYPSUM CREEK,State House,73,D,Terrance J. Krier,17
-McPherson,HARPER,State House,73,D,Terrance J. Krier,15
-McPherson,HAVES,State House,73,D,Terrance J. Krier,26
-McPherson,JACKSON,State House,73,D,Terrance J. Krier,35
-McPherson,KING CITY,State House,73,D,Terrance J. Krier,76
-McPherson,LITTLE VALLEY,State House,73,D,Terrance J. Krier,27
-McPherson,LONE TREE,State House,73,D,Terrance J. Krier,27
-McPherson,MARQUETTE,State House,73,D,Terrance J. Krier,108
-McPherson,MCPHERSON,State House,73,D,Terrance J. Krier,86
-McPherson,NEW GOTTLAND,State House,73,D,Terrance J. Krier,52
-McPherson,S SHARPS CREEK,State House,73,D,Terrance J. Krier,13
-McPherson,SPRING VALLEY,State House,73,D,Terrance J. Krier,26
-McPherson,SUPERIOR,State House,73,D,Terrance J. Krier,144
-McPherson,TURKEY CREEK,State House,73,D,Terrance J. Krier,30
-McPherson,UNION,State House,73,D,Terrance J. Krier,22
-McPherson,McPHERSON - 1,State House,73,D,Terrance J. Krier,1086
-McPherson,McPHERSON - 2,State House,73,D,Terrance J. Krier,303
-McPherson,McPHERSON - 3,State House,73,D,Terrance J. Krier,166
-McPherson,McPHERSON - 4,State House,73,D,Terrance J. Krier,387
-McPherson,BATTLE HILL,State House,73,R,Les Mason,31
-McPherson,BONAVILLE,State House,73,R,Les Mason,36
-McPherson,CANTON,State House,73,R,Les Mason,259
-McPherson,CASTLE,State House,73,R,Les Mason,58
-McPherson,DELMORE,State House,73,R,Les Mason,62
-McPherson,EMPIRE,State House,73,R,Les Mason,369
-McPherson,GROVELAND,State House,73,R,Les Mason,73
-McPherson,GYPSUM CREEK,State House,73,R,Les Mason,76
-McPherson,HARPER,State House,73,R,Les Mason,61
-McPherson,HAVES,State House,73,R,Les Mason,88
-McPherson,JACKSON,State House,73,R,Les Mason,65
-McPherson,KING CITY,State House,73,R,Les Mason,197
-McPherson,LITTLE VALLEY,State House,73,R,Les Mason,177
-McPherson,LONE TREE,State House,73,R,Les Mason,69
-McPherson,MARQUETTE,State House,73,R,Les Mason,246
-McPherson,MCPHERSON,State House,73,R,Les Mason,198
-McPherson,NEW GOTTLAND,State House,73,R,Les Mason,199
-McPherson,S SHARPS CREEK,State House,73,R,Les Mason,33
-McPherson,SPRING VALLEY,State House,73,R,Les Mason,118
-McPherson,SUPERIOR,State House,73,R,Les Mason,585
-McPherson,TURKEY CREEK,State House,73,R,Les Mason,106
-McPherson,UNION,State House,73,R,Les Mason,73
-McPherson,McPHERSON - 1,State House,73,R,Les Mason,1876
-McPherson,McPHERSON - 2,State House,73,R,Les Mason,620
-McPherson,McPHERSON - 3,State House,73,R,Les Mason,363
-McPherson,McPHERSON - 4,State House,73,R,Les Mason,780
-McPherson,MERIDIAN,State House,74,R,Don Schroeder,116
-McPherson,MOUND,State House,74,R,Don Schroeder,716
-McPherson,SMOKY HILL,State House,108,R,Steven Johnson,125
-McPherson,LINDSBORG - 1,State House,108,R,Steven Johnson,168
-McPherson,LINDSRORG - 2,State House,108,R,Steven Johnson,231
-McPherson,LINDSBORG - 3,State House,108,R,Steven Johnson,187
-McPherson,LINDSBORG - 4,State House,108,R,Steven Johnson,195
-McPherson,SMOKY HILL,State House,108,D,Kelley Menke,57
-McPherson,LINDSBORG - 1,State House,108,D,Kelley Menke,176
-McPherson,LINDSRORG - 2,State House,108,D,Kelley Menke,261
-McPherson,LINDSBORG - 3,State House,108,D,Kelley Menke,194
-McPherson,LINDSBORG - 4,State House,108,D,Kelley Menke,201
+county,precinct,office,district,party,candidate,votes,vtd
+MCPHERSON,Battle Hill Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",18,000010
+MCPHERSON,Battle Hill Township,Kansas House of Representatives,73,Republican,"Mason, Les",31,000010
+MCPHERSON,Bonaville Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",7,000020
+MCPHERSON,Bonaville Township,Kansas House of Representatives,73,Republican,"Mason, Les",36,000020
+MCPHERSON,Canton Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",110,000030
+MCPHERSON,Canton Township,Kansas House of Representatives,73,Republican,"Mason, Les",259,000030
+MCPHERSON,Castle Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",23,000040
+MCPHERSON,Castle Township,Kansas House of Representatives,73,Republican,"Mason, Les",58,000040
+MCPHERSON,Delmore Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",21,000050
+MCPHERSON,Delmore Township,Kansas House of Representatives,73,Republican,"Mason, Les",62,000050
+MCPHERSON,Empire Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",130,000060
+MCPHERSON,Empire Township,Kansas House of Representatives,73,Republican,"Mason, Les",369,000060
+MCPHERSON,Groveland Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",21,000070
+MCPHERSON,Groveland Township,Kansas House of Representatives,73,Republican,"Mason, Les",73,000070
+MCPHERSON,Gypsum Creek Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",17,000080
+MCPHERSON,Gypsum Creek Township,Kansas House of Representatives,73,Republican,"Mason, Les",76,000080
+MCPHERSON,Harper Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",15,000090
+MCPHERSON,Harper Township,Kansas House of Representatives,73,Republican,"Mason, Les",61,000090
+MCPHERSON,Hayes Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",26,000100
+MCPHERSON,Hayes Township,Kansas House of Representatives,73,Republican,"Mason, Les",88,000100
+MCPHERSON,Jackson Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",35,000110
+MCPHERSON,Jackson Township,Kansas House of Representatives,73,Republican,"Mason, Les",65,000110
+MCPHERSON,King City Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",76,000120
+MCPHERSON,King City Township,Kansas House of Representatives,73,Republican,"Mason, Les",197,000120
+MCPHERSON,Lindsborg Ward 1,Kansas House of Representatives,108,Democratic,"Menke, Kelley",176,000130
+MCPHERSON,Lindsborg Ward 1,Kansas House of Representatives,108,Republican,"Johnson, Steven",168,000130
+MCPHERSON,Lindsborg Ward 2,Kansas House of Representatives,108,Democratic,"Menke, Kelley",261,000140
+MCPHERSON,Lindsborg Ward 2,Kansas House of Representatives,108,Republican,"Johnson, Steven",231,000140
+MCPHERSON,Lindsborg Ward 3,Kansas House of Representatives,108,Democratic,"Menke, Kelley",194,000150
+MCPHERSON,Lindsborg Ward 3,Kansas House of Representatives,108,Republican,"Johnson, Steven",187,000150
+MCPHERSON,Lindsborg Ward 4,Kansas House of Representatives,108,Democratic,"Menke, Kelley",201,000160
+MCPHERSON,Lindsborg Ward 4,Kansas House of Representatives,108,Republican,"Johnson, Steven",195,000160
+MCPHERSON,Little Valley Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",27,000170
+MCPHERSON,Little Valley Township,Kansas House of Representatives,73,Republican,"Mason, Les",177,000170
+MCPHERSON,Lone Tree Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",27,000180
+MCPHERSON,Lone Tree Township,Kansas House of Representatives,73,Republican,"Mason, Les",69,000180
+MCPHERSON,Marquette Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",108,000190
+MCPHERSON,Marquette Township,Kansas House of Representatives,73,Republican,"Mason, Les",246,000190
+MCPHERSON,McPherson Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",86,000200
+MCPHERSON,McPherson Township,Kansas House of Representatives,73,Republican,"Mason, Les",198,000200
+MCPHERSON,Meridian Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",116,000290
+MCPHERSON,Mound Township,Kansas House of Representatives,74,Republican,"Schroeder, Don",716,000300
+MCPHERSON,New Gottland Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",52,000310
+MCPHERSON,New Gottland Township,Kansas House of Representatives,73,Republican,"Mason, Les",199,000310
+MCPHERSON,Smoky Hill Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",57,000320
+MCPHERSON,Smoky Hill Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",125,000320
+MCPHERSON,South Sharps Creek Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",13,000330
+MCPHERSON,South Sharps Creek Township,Kansas House of Representatives,73,Republican,"Mason, Les",33,000330
+MCPHERSON,Spring Valley Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",26,000340
+MCPHERSON,Spring Valley Township,Kansas House of Representatives,73,Republican,"Mason, Les",118,000340
+MCPHERSON,Superior Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",144,000350
+MCPHERSON,Superior Township,Kansas House of Representatives,73,Republican,"Mason, Les",585,000350
+MCPHERSON,Turkey Creek Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",30,000360
+MCPHERSON,Turkey Creek Township,Kansas House of Representatives,73,Republican,"Mason, Les",106,000360
+MCPHERSON,Union Township,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",22,000370
+MCPHERSON,Union Township,Kansas House of Representatives,73,Republican,"Mason, Les",73,000370
+MCPHERSON,McPherson Ward 2,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",303,900020
+MCPHERSON,McPherson Ward 2,Kansas House of Representatives,73,Republican,"Mason, Les",620,900020
+MCPHERSON,McPherson Ward 3 Part A,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",166,900030
+MCPHERSON,McPherson Ward 3 Part A,Kansas House of Representatives,73,Republican,"Mason, Les",363,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",387,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas House of Representatives,73,Republican,"Mason, Les",780,900040
+MCPHERSON,McPherson Ward 1 Exclave,Kansas House of Representatives,73,Democratic,"Krier, Terrance J.",1086,900050
+MCPHERSON,McPherson Ward 1 Exclave,Kansas House of Representatives,73,Republican,"Mason, Les",1876,900050
+MCPHERSON,Battle Hill Township,Kansas Senate,35,Democratic,"Morris, Levi",13,000010
+MCPHERSON,Battle Hill Township,Kansas Senate,35,Republican,"Wilborn, Richard",39,000010
+MCPHERSON,Bonaville Township,Kansas Senate,35,Democratic,"Morris, Levi",3,000020
+MCPHERSON,Bonaville Township,Kansas Senate,35,Republican,"Wilborn, Richard",41,000020
+MCPHERSON,Canton Township,Kansas Senate,35,Democratic,"Morris, Levi",81,000030
+MCPHERSON,Canton Township,Kansas Senate,35,Republican,"Wilborn, Richard",296,000030
+MCPHERSON,Castle Township,Kansas Senate,35,Democratic,"Morris, Levi",23,000040
+MCPHERSON,Castle Township,Kansas Senate,35,Republican,"Wilborn, Richard",57,000040
+MCPHERSON,Delmore Township,Kansas Senate,35,Democratic,"Morris, Levi",16,000050
+MCPHERSON,Delmore Township,Kansas Senate,35,Republican,"Wilborn, Richard",66,000050
+MCPHERSON,Empire Township,Kansas Senate,35,Democratic,"Morris, Levi",89,000060
+MCPHERSON,Empire Township,Kansas Senate,35,Republican,"Wilborn, Richard",409,000060
+MCPHERSON,Groveland Township,Kansas Senate,35,Democratic,"Morris, Levi",17,000070
+MCPHERSON,Groveland Township,Kansas Senate,35,Republican,"Wilborn, Richard",80,000070
+MCPHERSON,Gypsum Creek Township,Kansas Senate,35,Democratic,"Morris, Levi",19,000080
+MCPHERSON,Gypsum Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",73,000080
+MCPHERSON,Harper Township,Kansas Senate,35,Democratic,"Morris, Levi",11,000090
+MCPHERSON,Harper Township,Kansas Senate,35,Republican,"Wilborn, Richard",69,000090
+MCPHERSON,Hayes Township,Kansas Senate,35,Democratic,"Morris, Levi",28,000100
+MCPHERSON,Hayes Township,Kansas Senate,35,Republican,"Wilborn, Richard",88,000100
+MCPHERSON,Jackson Township,Kansas Senate,35,Democratic,"Morris, Levi",29,000110
+MCPHERSON,Jackson Township,Kansas Senate,35,Republican,"Wilborn, Richard",72,000110
+MCPHERSON,King City Township,Kansas Senate,35,Democratic,"Morris, Levi",56,000120
+MCPHERSON,King City Township,Kansas Senate,35,Republican,"Wilborn, Richard",217,000120
+MCPHERSON,Lindsborg Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",130,000130
+MCPHERSON,Lindsborg Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",209,000130
+MCPHERSON,Lindsborg Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",208,000140
+MCPHERSON,Lindsborg Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",278,000140
+MCPHERSON,Lindsborg Ward 3,Kansas Senate,35,Democratic,"Morris, Levi",145,000150
+MCPHERSON,Lindsborg Ward 3,Kansas Senate,35,Republican,"Wilborn, Richard",231,000150
+MCPHERSON,Lindsborg Ward 4,Kansas Senate,35,Democratic,"Morris, Levi",152,000160
+MCPHERSON,Lindsborg Ward 4,Kansas Senate,35,Republican,"Wilborn, Richard",233,000160
+MCPHERSON,Little Valley Township,Kansas Senate,35,Democratic,"Morris, Levi",29,000170
+MCPHERSON,Little Valley Township,Kansas Senate,35,Republican,"Wilborn, Richard",178,000170
+MCPHERSON,Lone Tree Township,Kansas Senate,35,Democratic,"Morris, Levi",23,000180
+MCPHERSON,Lone Tree Township,Kansas Senate,35,Republican,"Wilborn, Richard",73,000180
+MCPHERSON,Marquette Township,Kansas Senate,35,Democratic,"Morris, Levi",103,000190
+MCPHERSON,Marquette Township,Kansas Senate,35,Republican,"Wilborn, Richard",258,000190
+MCPHERSON,McPherson Township,Kansas Senate,35,Democratic,"Morris, Levi",72,000200
+MCPHERSON,McPherson Township,Kansas Senate,35,Republican,"Wilborn, Richard",211,000200
+MCPHERSON,Meridian Township,Kansas Senate,35,Democratic,"Morris, Levi",20,000290
+MCPHERSON,Meridian Township,Kansas Senate,35,Republican,"Wilborn, Richard",104,000290
+MCPHERSON,Mound Township,Kansas Senate,35,Democratic,"Morris, Levi",242,000300
+MCPHERSON,Mound Township,Kansas Senate,35,Republican,"Wilborn, Richard",579,000300
+MCPHERSON,New Gottland Township,Kansas Senate,35,Democratic,"Morris, Levi",35,000310
+MCPHERSON,New Gottland Township,Kansas Senate,35,Republican,"Wilborn, Richard",223,000310
+MCPHERSON,Smoky Hill Township,Kansas Senate,35,Democratic,"Morris, Levi",46,000320
+MCPHERSON,Smoky Hill Township,Kansas Senate,35,Republican,"Wilborn, Richard",134,000320
+MCPHERSON,South Sharps Creek Township,Kansas Senate,35,Democratic,"Morris, Levi",6,000330
+MCPHERSON,South Sharps Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",39,000330
+MCPHERSON,Spring Valley Township,Kansas Senate,35,Democratic,"Morris, Levi",25,000340
+MCPHERSON,Spring Valley Township,Kansas Senate,35,Republican,"Wilborn, Richard",122,000340
+MCPHERSON,Superior Township,Kansas Senate,35,Democratic,"Morris, Levi",121,000350
+MCPHERSON,Superior Township,Kansas Senate,35,Republican,"Wilborn, Richard",620,000350
+MCPHERSON,Turkey Creek Township,Kansas Senate,35,Democratic,"Morris, Levi",30,000360
+MCPHERSON,Turkey Creek Township,Kansas Senate,35,Republican,"Wilborn, Richard",110,000360
+MCPHERSON,Union Township,Kansas Senate,35,Democratic,"Morris, Levi",21,000370
+MCPHERSON,Union Township,Kansas Senate,35,Republican,"Wilborn, Richard",75,000370
+MCPHERSON,McPherson Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",235,900020
+MCPHERSON,McPherson Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",695,900020
+MCPHERSON,McPherson Ward 3 Part A,Kansas Senate,35,Democratic,"Morris, Levi",135,900030
+MCPHERSON,McPherson Ward 3 Part A,Kansas Senate,35,Republican,"Wilborn, Richard",398,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas Senate,35,Democratic,"Morris, Levi",284,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,Kansas Senate,35,Republican,"Wilborn, Richard",889,900040
+MCPHERSON,McPherson Ward 1 Exclave,Kansas Senate,35,Democratic,"Morris, Levi",822,900050
+MCPHERSON,McPherson Ward 1 Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",2153,900050
+MCPHERSON,Battle Hill Township,President / Vice President,,independent,"Stein, Jill",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+MCPHERSON,Battle Hill Township,President / Vice President,,Republican,"Trump, Donald J.",37,000010
+MCPHERSON,Bonaville Township,President / Vice President,,independent,"Stein, Jill",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"McMullin, Evan",1,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+MCPHERSON,Bonaville Township,President / Vice President,,Republican,"Trump, Donald J.",40,000020
+MCPHERSON,Canton Township,President / Vice President,,independent,"Stein, Jill",4,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"McMullin, Evan",1,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MCPHERSON,Canton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MCPHERSON,Canton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,000030
+MCPHERSON,Canton Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000030
+MCPHERSON,Canton Township,President / Vice President,,Republican,"Trump, Donald J.",296,000030
+MCPHERSON,Castle Township,President / Vice President,,independent,"Stein, Jill",2,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MCPHERSON,Castle Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MCPHERSON,Castle Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000040
+MCPHERSON,Castle Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+MCPHERSON,Castle Township,President / Vice President,,Republican,"Trump, Donald J.",55,000040
+MCPHERSON,Delmore Township,President / Vice President,,independent,"Stein, Jill",4,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"McMullin, Evan",2,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MCPHERSON,Delmore Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000050
+MCPHERSON,Delmore Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+MCPHERSON,Delmore Township,President / Vice President,,Republican,"Trump, Donald J.",64,000050
+MCPHERSON,Empire Township,President / Vice President,,independent,"Stein, Jill",7,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MCPHERSON,Empire Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MCPHERSON,Empire Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000060
+MCPHERSON,Empire Township,President / Vice President,,Libertarian,"Johnson, Gary",27,000060
+MCPHERSON,Empire Township,President / Vice President,,Republican,"Trump, Donald J.",409,000060
+MCPHERSON,Groveland Township,President / Vice President,,independent,"Stein, Jill",4,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MCPHERSON,Groveland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000070
+MCPHERSON,Groveland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000070
+MCPHERSON,Groveland Township,President / Vice President,,Republican,"Trump, Donald J.",73,000070
+MCPHERSON,Gypsum Creek Township,President / Vice President,,independent,"Stein, Jill",2,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"McMullin, Evan",2,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+MCPHERSON,Gypsum Creek Township,President / Vice President,,Republican,"Trump, Donald J.",70,000080
+MCPHERSON,Harper Township,President / Vice President,,independent,"Stein, Jill",1,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MCPHERSON,Harper Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MCPHERSON,Harper Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000090
+MCPHERSON,Harper Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+MCPHERSON,Harper Township,President / Vice President,,Republican,"Trump, Donald J.",65,000090
+MCPHERSON,Hayes Township,President / Vice President,,independent,"Stein, Jill",3,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MCPHERSON,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000100
+MCPHERSON,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+MCPHERSON,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",95,000100
+MCPHERSON,Jackson Township,President / Vice President,,independent,"Stein, Jill",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+MCPHERSON,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000110
+MCPHERSON,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000110
+MCPHERSON,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",71,000110
+MCPHERSON,King City Township,President / Vice President,,independent,"Stein, Jill",9,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+MCPHERSON,King City Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+MCPHERSON,King City Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000120
+MCPHERSON,King City Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000120
+MCPHERSON,King City Township,President / Vice President,,Republican,"Trump, Donald J.",197,000120
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,independent,"Stein, Jill",10,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"McMullin, Evan",3,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",140,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000130
+MCPHERSON,Lindsborg Ward 1,President / Vice President,,Republican,"Trump, Donald J.",178,000130
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,independent,"Stein, Jill",12,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",209,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",27,000140
+MCPHERSON,Lindsborg Ward 2,President / Vice President,,Republican,"Trump, Donald J.",241,000140
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,independent,"Stein, Jill",6,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"McMullin, Evan",4,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",161,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",16,000150
+MCPHERSON,Lindsborg Ward 3,President / Vice President,,Republican,"Trump, Donald J.",188,000150
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,independent,"Stein, Jill",8,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",154,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",19,000160
+MCPHERSON,Lindsborg Ward 4,President / Vice President,,Republican,"Trump, Donald J.",208,000160
+MCPHERSON,Little Valley Township,President / Vice President,,independent,"Stein, Jill",1,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+MCPHERSON,Little Valley Township,President / Vice President,,Republican,"Trump, Donald J.",171,000170
+MCPHERSON,Lone Tree Township,President / Vice President,,independent,"Stein, Jill",2,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000180
+MCPHERSON,Lone Tree Township,President / Vice President,,Republican,"Trump, Donald J.",64,000180
+MCPHERSON,Marquette Township,President / Vice President,,independent,"Stein, Jill",9,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"McMullin, Evan",3,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+MCPHERSON,Marquette Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000190
+MCPHERSON,Marquette Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000190
+MCPHERSON,Marquette Township,President / Vice President,,Republican,"Trump, Donald J.",250,000190
+MCPHERSON,McPherson Township,President / Vice President,,independent,"Stein, Jill",3,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+MCPHERSON,McPherson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,000200
+MCPHERSON,McPherson Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000200
+MCPHERSON,McPherson Township,President / Vice President,,Republican,"Trump, Donald J.",204,000200
+MCPHERSON,Meridian Township,President / Vice President,,independent,"Stein, Jill",4,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+MCPHERSON,Meridian Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000290
+MCPHERSON,Meridian Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000290
+MCPHERSON,Meridian Township,President / Vice President,,Republican,"Trump, Donald J.",81,000290
+MCPHERSON,Mound Township,President / Vice President,,independent,"Stein, Jill",35,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+MCPHERSON,Mound Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+MCPHERSON,Mound Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",238,000300
+MCPHERSON,Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",36,000300
+MCPHERSON,Mound Township,President / Vice President,,Republican,"Trump, Donald J.",533,000300
+MCPHERSON,New Gottland Township,President / Vice President,,independent,"Stein, Jill",3,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"McMullin, Evan",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000310
+MCPHERSON,New Gottland Township,President / Vice President,,Republican,"Trump, Donald J.",209,000310
+MCPHERSON,Smoky Hill Township,President / Vice President,,independent,"Stein, Jill",2,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Hedges, James A",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"McMullin, Evan",1,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Perry, Darryl",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Smith, Mike",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Sood, Ajay",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000320
+MCPHERSON,Smoky Hill Township,President / Vice President,,Republican,"Trump, Donald J.",124,000320
+MCPHERSON,South Sharps Creek Township,President / Vice President,,independent,"Stein, Jill",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000330
+MCPHERSON,South Sharps Creek Township,President / Vice President,,Republican,"Trump, Donald J.",41,000330
+MCPHERSON,Spring Valley Township,President / Vice President,,independent,"Stein, Jill",4,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000340
+MCPHERSON,Spring Valley Township,President / Vice President,,Republican,"Trump, Donald J.",113,000340
+MCPHERSON,Superior Township,President / Vice President,,independent,"Stein, Jill",16,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Hedges, James A",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"McMullin, Evan",2,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Perry, Darryl",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Smith, Mike",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Sood, Ajay",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+MCPHERSON,Superior Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+MCPHERSON,Superior Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,000350
+MCPHERSON,Superior Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000350
+MCPHERSON,Superior Township,President / Vice President,,Republican,"Trump, Donald J.",577,000350
+MCPHERSON,Turkey Creek Township,President / Vice President,,independent,"Stein, Jill",3,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000360
+MCPHERSON,Turkey Creek Township,President / Vice President,,Republican,"Trump, Donald J.",105,000360
+MCPHERSON,Union Township,President / Vice President,,independent,"Stein, Jill",1,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+MCPHERSON,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+MCPHERSON,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000370
+MCPHERSON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000370
+MCPHERSON,Union Township,President / Vice President,,Republican,"Trump, Donald J.",71,000370
+MCPHERSON,McPherson Ward 2,President / Vice President,,independent,"Stein, Jill",18,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"McMullin, Evan",13,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",231,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",39,900020
+MCPHERSON,McPherson Ward 2,President / Vice President,,Republican,"Trump, Donald J.",638,900020
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,independent,"Stein, Jill",17,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Hedges, James A",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"McMullin, Evan",26,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Perry, Darryl",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Smith, Mike",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Sood, Ajay",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",121,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Libertarian,"Johnson, Gary",26,900030
+MCPHERSON,McPherson Ward 3 Part A,President / Vice President,,Republican,"Trump, Donald J.",364,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,independent,"Stein, Jill",34,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Hedges, James A",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"McMullin, Evan",14,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Perry, Darryl",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Smith, Mike",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Sood, Ajay",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",272,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Libertarian,"Johnson, Gary",71,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,President / Vice President,,Republican,"Trump, Donald J.",807,900040
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",71,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",24,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",859,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",128,900050
+MCPHERSON,McPherson Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",1910,900050
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000010
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+MCPHERSON,Battle Hill Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000010
+MCPHERSON,Bonaville Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000020
+MCPHERSON,Bonaville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+MCPHERSON,Bonaville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000020
+MCPHERSON,Bonaville Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000020
+MCPHERSON,Canton Township,United States House of Representatives,1,independent,"LaPolice, Alan",86,000030
+MCPHERSON,Canton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+MCPHERSON,Canton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000030
+MCPHERSON,Canton Township,United States House of Representatives,1,Republican,"Marshall, Roger",269,000030
+MCPHERSON,Castle Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000040
+MCPHERSON,Castle Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+MCPHERSON,Castle Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000040
+MCPHERSON,Castle Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000040
+MCPHERSON,Delmore Township,United States House of Representatives,1,independent,"LaPolice, Alan",25,000050
+MCPHERSON,Delmore Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+MCPHERSON,Delmore Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000050
+MCPHERSON,Delmore Township,United States House of Representatives,1,Republican,"Marshall, Roger",58,000050
+MCPHERSON,Empire Township,United States House of Representatives,1,independent,"LaPolice, Alan",115,000060
+MCPHERSON,Empire Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+MCPHERSON,Empire Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000060
+MCPHERSON,Empire Township,United States House of Representatives,1,Republican,"Marshall, Roger",360,000060
+MCPHERSON,Groveland Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000070
+MCPHERSON,Groveland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+MCPHERSON,Groveland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000070
+MCPHERSON,Groveland Township,United States House of Representatives,1,Republican,"Marshall, Roger",75,000070
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000080
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000080
+MCPHERSON,Gypsum Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",70,000080
+MCPHERSON,Harper Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000090
+MCPHERSON,Harper Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+MCPHERSON,Harper Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000090
+MCPHERSON,Harper Township,United States House of Representatives,1,Republican,"Marshall, Roger",49,000090
+MCPHERSON,Hayes Township,United States House of Representatives,1,independent,"LaPolice, Alan",33,000100
+MCPHERSON,Hayes Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+MCPHERSON,Hayes Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000100
+MCPHERSON,Hayes Township,United States House of Representatives,1,Republican,"Marshall, Roger",75,000100
+MCPHERSON,Jackson Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000110
+MCPHERSON,Jackson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+MCPHERSON,Jackson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000110
+MCPHERSON,Jackson Township,United States House of Representatives,1,Republican,"Marshall, Roger",70,000110
+MCPHERSON,King City Township,United States House of Representatives,1,independent,"LaPolice, Alan",70,000120
+MCPHERSON,King City Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+MCPHERSON,King City Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000120
+MCPHERSON,King City Township,United States House of Representatives,1,Republican,"Marshall, Roger",183,000120
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",161,000130
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000130
+MCPHERSON,Lindsborg Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",170,000130
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",216,000140
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000140
+MCPHERSON,Lindsborg Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",241,000140
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",149,000150
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,000150
+MCPHERSON,Lindsborg Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",198,000150
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",181,000160
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,000160
+MCPHERSON,Lindsborg Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",173,000160
+MCPHERSON,Little Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",39,000170
+MCPHERSON,Little Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+MCPHERSON,Little Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000170
+MCPHERSON,Little Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",153,000170
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000180
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000180
+MCPHERSON,Lone Tree Township,United States House of Representatives,1,Republican,"Marshall, Roger",67,000180
+MCPHERSON,Marquette Township,United States House of Representatives,1,independent,"LaPolice, Alan",119,000190
+MCPHERSON,Marquette Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+MCPHERSON,Marquette Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000190
+MCPHERSON,Marquette Township,United States House of Representatives,1,Republican,"Marshall, Roger",223,000190
+MCPHERSON,McPherson Township,United States House of Representatives,1,independent,"LaPolice, Alan",74,000200
+MCPHERSON,McPherson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+MCPHERSON,McPherson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000200
+MCPHERSON,McPherson Township,United States House of Representatives,1,Republican,"Marshall, Roger",187,000200
+MCPHERSON,Meridian Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000290
+MCPHERSON,Meridian Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+MCPHERSON,Meridian Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000290
+MCPHERSON,Meridian Township,United States House of Representatives,1,Republican,"Marshall, Roger",82,000290
+MCPHERSON,Mound Township,United States House of Representatives,1,independent,"LaPolice, Alan",222,000300
+MCPHERSON,Mound Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000300
+MCPHERSON,Mound Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",56,000300
+MCPHERSON,Mound Township,United States House of Representatives,1,Republican,"Marshall, Roger",540,000300
+MCPHERSON,New Gottland Township,United States House of Representatives,1,independent,"LaPolice, Alan",58,000310
+MCPHERSON,New Gottland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+MCPHERSON,New Gottland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000310
+MCPHERSON,New Gottland Township,United States House of Representatives,1,Republican,"Marshall, Roger",190,000310
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,independent,"LaPolice, Alan",57,000320
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000320
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000320
+MCPHERSON,Smoky Hill Township,United States House of Representatives,1,Republican,"Marshall, Roger",113,000320
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000330
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000330
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000330
+MCPHERSON,South Sharps Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000330
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000340
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000340
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000340
+MCPHERSON,Spring Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",115,000340
+MCPHERSON,Superior Township,United States House of Representatives,1,independent,"LaPolice, Alan",131,000350
+MCPHERSON,Superior Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000350
+MCPHERSON,Superior Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",43,000350
+MCPHERSON,Superior Township,United States House of Representatives,1,Republican,"Marshall, Roger",561,000350
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000360
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000360
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000360
+MCPHERSON,Turkey Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",100,000360
+MCPHERSON,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",25,000370
+MCPHERSON,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000370
+MCPHERSON,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000370
+MCPHERSON,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",69,000370
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",206,900020
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",62,900020
+MCPHERSON,McPherson Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",645,900020
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",138,900030
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,900030
+MCPHERSON,McPherson Ward 3 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",353,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",257,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",88,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",812,900040
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",740,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",74,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",197,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",1987,900050
+MCPHERSON,Battle Hill Township,United States Senate,,write - in,"Smith, DJ",0,000010
+MCPHERSON,Battle Hill Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000010
+MCPHERSON,Battle Hill Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000010
+MCPHERSON,Battle Hill Township,United States Senate,,Republican,"Moran, Jerry",38,000010
+MCPHERSON,Bonaville Township,United States Senate,,write - in,"Smith, DJ",0,000020
+MCPHERSON,Bonaville Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+MCPHERSON,Bonaville Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+MCPHERSON,Bonaville Township,United States Senate,,Republican,"Moran, Jerry",39,000020
+MCPHERSON,Canton Township,United States Senate,,write - in,"Smith, DJ",0,000030
+MCPHERSON,Canton Township,United States Senate,,Democratic,"Wiesner, Patrick",59,000030
+MCPHERSON,Canton Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000030
+MCPHERSON,Canton Township,United States Senate,,Republican,"Moran, Jerry",304,000030
+MCPHERSON,Castle Township,United States Senate,,write - in,"Smith, DJ",0,000040
+MCPHERSON,Castle Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000040
+MCPHERSON,Castle Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000040
+MCPHERSON,Castle Township,United States Senate,,Republican,"Moran, Jerry",57,000040
+MCPHERSON,Delmore Township,United States Senate,,write - in,"Smith, DJ",0,000050
+MCPHERSON,Delmore Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000050
+MCPHERSON,Delmore Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000050
+MCPHERSON,Delmore Township,United States Senate,,Republican,"Moran, Jerry",69,000050
+MCPHERSON,Empire Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MCPHERSON,Empire Township,United States Senate,,Democratic,"Wiesner, Patrick",62,000060
+MCPHERSON,Empire Township,United States Senate,,Libertarian,"Garrard, Robert D.",29,000060
+MCPHERSON,Empire Township,United States Senate,,Republican,"Moran, Jerry",422,000060
+MCPHERSON,Groveland Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MCPHERSON,Groveland Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000070
+MCPHERSON,Groveland Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000070
+MCPHERSON,Groveland Township,United States Senate,,Republican,"Moran, Jerry",79,000070
+MCPHERSON,Gypsum Creek Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MCPHERSON,Gypsum Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000080
+MCPHERSON,Gypsum Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000080
+MCPHERSON,Gypsum Creek Township,United States Senate,,Republican,"Moran, Jerry",79,000080
+MCPHERSON,Harper Township,United States Senate,,write - in,"Smith, DJ",0,000090
+MCPHERSON,Harper Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000090
+MCPHERSON,Harper Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000090
+MCPHERSON,Harper Township,United States Senate,,Republican,"Moran, Jerry",65,000090
+MCPHERSON,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000100
+MCPHERSON,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000100
+MCPHERSON,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000100
+MCPHERSON,Hayes Township,United States Senate,,Republican,"Moran, Jerry",98,000100
+MCPHERSON,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000110
+MCPHERSON,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000110
+MCPHERSON,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000110
+MCPHERSON,Jackson Township,United States Senate,,Republican,"Moran, Jerry",81,000110
+MCPHERSON,King City Township,United States Senate,,write - in,"Smith, DJ",0,000120
+MCPHERSON,King City Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000120
+MCPHERSON,King City Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000120
+MCPHERSON,King City Township,United States Senate,,Republican,"Moran, Jerry",224,000120
+MCPHERSON,Lindsborg Ward 1,United States Senate,,write - in,"Smith, DJ",0,000130
+MCPHERSON,Lindsborg Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",113,000130
+MCPHERSON,Lindsborg Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",10,000130
+MCPHERSON,Lindsborg Ward 1,United States Senate,,Republican,"Moran, Jerry",223,000130
+MCPHERSON,Lindsborg Ward 2,United States Senate,,write - in,"Smith, DJ",0,000140
+MCPHERSON,Lindsborg Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",161,000140
+MCPHERSON,Lindsborg Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,000140
+MCPHERSON,Lindsborg Ward 2,United States Senate,,Republican,"Moran, Jerry",314,000140
+MCPHERSON,Lindsborg Ward 3,United States Senate,,write - in,"Smith, DJ",0,000150
+MCPHERSON,Lindsborg Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",112,000150
+MCPHERSON,Lindsborg Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",22,000150
+MCPHERSON,Lindsborg Ward 3,United States Senate,,Republican,"Moran, Jerry",252,000150
+MCPHERSON,Lindsborg Ward 4,United States Senate,,write - in,"Smith, DJ",0,000160
+MCPHERSON,Lindsborg Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",135,000160
+MCPHERSON,Lindsborg Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",28,000160
+MCPHERSON,Lindsborg Ward 4,United States Senate,,Republican,"Moran, Jerry",232,000160
+MCPHERSON,Little Valley Township,United States Senate,,write - in,"Smith, DJ",0,000170
+MCPHERSON,Little Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000170
+MCPHERSON,Little Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000170
+MCPHERSON,Little Valley Township,United States Senate,,Republican,"Moran, Jerry",185,000170
+MCPHERSON,Lone Tree Township,United States Senate,,write - in,"Smith, DJ",0,000180
+MCPHERSON,Lone Tree Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000180
+MCPHERSON,Lone Tree Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000180
+MCPHERSON,Lone Tree Township,United States Senate,,Republican,"Moran, Jerry",76,000180
+MCPHERSON,Marquette Township,United States Senate,,write - in,"Smith, DJ",0,000190
+MCPHERSON,Marquette Township,United States Senate,,Democratic,"Wiesner, Patrick",83,000190
+MCPHERSON,Marquette Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000190
+MCPHERSON,Marquette Township,United States Senate,,Republican,"Moran, Jerry",260,000190
+MCPHERSON,McPherson Township,United States Senate,,write - in,"Smith, DJ",0,000200
+MCPHERSON,McPherson Township,United States Senate,,Democratic,"Wiesner, Patrick",49,000200
+MCPHERSON,McPherson Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000200
+MCPHERSON,McPherson Township,United States Senate,,Republican,"Moran, Jerry",220,000200
+MCPHERSON,Meridian Township,United States Senate,,write - in,"Smith, DJ",0,000290
+MCPHERSON,Meridian Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000290
+MCPHERSON,Meridian Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000290
+MCPHERSON,Meridian Township,United States Senate,,Republican,"Moran, Jerry",106,000290
+MCPHERSON,Mound Township,United States Senate,,write - in,"Smith, DJ",0,000300
+MCPHERSON,Mound Township,United States Senate,,Democratic,"Wiesner, Patrick",185,000300
+MCPHERSON,Mound Township,United States Senate,,Libertarian,"Garrard, Robert D.",41,000300
+MCPHERSON,Mound Township,United States Senate,,Republican,"Moran, Jerry",625,000300
+MCPHERSON,New Gottland Township,United States Senate,,write - in,"Smith, DJ",0,000310
+MCPHERSON,New Gottland Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000310
+MCPHERSON,New Gottland Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000310
+MCPHERSON,New Gottland Township,United States Senate,,Republican,"Moran, Jerry",219,000310
+MCPHERSON,Smoky Hill Township,United States Senate,,write - in,"Smith, DJ",0,000320
+MCPHERSON,Smoky Hill Township,United States Senate,,Democratic,"Wiesner, Patrick",35,000320
+MCPHERSON,Smoky Hill Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000320
+MCPHERSON,Smoky Hill Township,United States Senate,,Republican,"Moran, Jerry",142,000320
+MCPHERSON,South Sharps Creek Township,United States Senate,,write - in,"Smith, DJ",0,000330
+MCPHERSON,South Sharps Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000330
+MCPHERSON,South Sharps Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000330
+MCPHERSON,South Sharps Creek Township,United States Senate,,Republican,"Moran, Jerry",37,000330
+MCPHERSON,Spring Valley Township,United States Senate,,write - in,"Smith, DJ",0,000340
+MCPHERSON,Spring Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000340
+MCPHERSON,Spring Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000340
+MCPHERSON,Spring Valley Township,United States Senate,,Republican,"Moran, Jerry",130,000340
+MCPHERSON,Superior Township,United States Senate,,write - in,"Smith, DJ",0,000350
+MCPHERSON,Superior Township,United States Senate,,Democratic,"Wiesner, Patrick",91,000350
+MCPHERSON,Superior Township,United States Senate,,Libertarian,"Garrard, Robert D.",34,000350
+MCPHERSON,Superior Township,United States Senate,,Republican,"Moran, Jerry",620,000350
+MCPHERSON,Turkey Creek Township,United States Senate,,write - in,"Smith, DJ",0,000360
+MCPHERSON,Turkey Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000360
+MCPHERSON,Turkey Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000360
+MCPHERSON,Turkey Creek Township,United States Senate,,Republican,"Moran, Jerry",112,000360
+MCPHERSON,Union Township,United States Senate,,write - in,"Smith, DJ",0,000370
+MCPHERSON,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000370
+MCPHERSON,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000370
+MCPHERSON,Union Township,United States Senate,,Republican,"Moran, Jerry",80,000370
+MCPHERSON,McPherson Ward 2,United States Senate,,write - in,"Smith, DJ",0,900020
+MCPHERSON,McPherson Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",178,900020
+MCPHERSON,McPherson Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",44,900020
+MCPHERSON,McPherson Ward 2,United States Senate,,Republican,"Moran, Jerry",713,900020
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,write - in,"Smith, DJ",0,900030
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,Democratic,"Wiesner, Patrick",101,900030
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",32,900030
+MCPHERSON,McPherson Ward 3 Part A,United States Senate,,Republican,"Moran, Jerry",403,900030
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,write - in,"Smith, DJ",0,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,Democratic,"Wiesner, Patrick",214,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",68,900040
+MCPHERSON,McPherson Ward 4 Precinct 1 Part A,United States Senate,,Republican,"Moran, Jerry",905,900040
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",655,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",124,900050
+MCPHERSON,McPherson Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",2228,900050

--- a/2016/20161108__ks__general__meade__precinct.csv
+++ b/2016/20161108__ks__general__meade__precinct.csv
@@ -1,121 +1,325 @@
-county,precinct,office,district,party,candidate,votes
-Meade,Cimarron,President,,REP,Trump/Pence,24
-Meade,Cimarron,President,,DEM,Clinton/Kaine,6
-Meade,Cimarron,President,,LIB,Johnson/Weld,0
-Meade,Cimarron,President,,IND,Stein/Baraka,0
-Meade,Cimarron,U.S. Senate,,REP,Jerry Moran,25
-Meade,Cimarron,U.S. Senate,,DEM,Patrick Wiesner,3
-Meade,Cimarron,U.S. Senate,,LIB,Robert D. Garrard,1
-Meade,Cimarron,U.S. House,1,REP,Roger Marshall,20
-Meade,Cimarron,U.S. House,1,IND,Alan LaPolice,7
-Meade,Cimarron,U.S. House,1,LIB,Kerry Burt,1
-Meade,Cimarron,U.S. House,1,,Tim Huelskamp,1
-Meade,Cimarron,State Senate,38,REP,Bud Estes,24
-Meade,Cimarron,State Senate,38,DEM,Miguel Angel Rodriguez,7
-Meade,Cimarron,State House,115,REP,Boyd Orr,26
-Meade,Crooked Creek,President,,REP,Trump/Pence,44
-Meade,Crooked Creek,President,,DEM,Clinton/Kaine,4
-Meade,Crooked Creek,President,,LIB,Johnson/Weld,2
-Meade,Crooked Creek,President,,IND,Stein/Baraka,0
-Meade,Crooked Creek,President,,,Evan McMullin,2
-Meade,Crooked Creek,President,,,Darrell Castle,1
-Meade,Crooked Creek,U.S. Senate,,REP,Jerry Moran,49
-Meade,Crooked Creek,U.S. Senate,,DEM,Patrick Wiesner,3
-Meade,Crooked Creek,U.S. Senate,,LIB,Robert D. Garrard,1
-Meade,Crooked Creek,U.S. House,1,REP,Roger Marshall,32
-Meade,Crooked Creek,U.S. House,1,IND,Alan LaPolice,13
-Meade,Crooked Creek,U.S. House,1,LIB,Kerry Burt,1
-Meade,Crooked Creek,U.S. House,1,,Tim Huelskamp,5
-Meade,Crooked Creek,State Senate,38,REP,Bud Estes,47
-Meade,Crooked Creek,State Senate,38,DEM,Miguel Angel Rodriguez,4
-Meade,Crooked Creek,State House,115,REP,Boyd Orr,49
-Meade,Fowler,President,,REP,Trump/Pence,221
-Meade,Fowler,President,,DEM,Clinton/Kaine,38
-Meade,Fowler,President,,LIB,Johnson/Weld,4
-Meade,Fowler,President,,IND,Stein/Baraka,2
-Meade,Fowler,President,,,Evan McMullin,1
-Meade,Fowler,U.S. Senate,,REP,Jerry Moran,225
-Meade,Fowler,U.S. Senate,,DEM,Patrick Wiesner,28
-Meade,Fowler,U.S. Senate,,LIB,Robert D. Garrard,9
-Meade,Fowler,U.S. House,1,REP,Roger Marshall,155
-Meade,Fowler,U.S. House,1,IND,Alan LaPolice,72
-Meade,Fowler,U.S. House,1,LIB,Kerry Burt,18
-Meade,Fowler,U.S. House,1,,Tim Huelskamp,5
-Meade,Fowler,State Senate,38,REP,Bud Estes,220
-Meade,Fowler,State Senate,38,DEM,Miguel Angel Rodriguez,36
-Meade,Fowler,State House,115,REP,Boyd Orr,253
-Meade,Logan,President,,REP,Trump/Pence,48
-Meade,Logan,President,,DEM,Clinton/Kaine,6
-Meade,Logan,President,,LIB,Johnson/Weld,4
-Meade,Logan,President,,IND,Stein/Baraka,0
-Meade,Logan,U.S. Senate,,REP,Jerry Moran,51
-Meade,Logan,U.S. Senate,,DEM,Patrick Wiesner,6
-Meade,Logan,U.S. Senate,,LIB,Robert D. Garrard,2
-Meade,Logan,U.S. House,1,REP,Roger Marshall,36
-Meade,Logan,U.S. House,1,IND,Alan LaPolice,12
-Meade,Logan,U.S. House,1,LIB,Kerry Burt,7
-Meade,Logan,U.S. House,1,,Tim Huelskamp,2
-Meade,Logan,State Senate,38,REP,Bud Estes,49
-Meade,Logan,State Senate,38,DEM,Miguel Angel Rodriguez,8
-Meade,Logan,State House,115,REP,Boyd Orr,49
-Meade,Meade Center,President,,REP,Trump/Pence,716
-Meade,Meade Center,President,,DEM,Clinton/Kaine,90
-Meade,Meade Center,President,,LIB,Johnson/Weld,31
-Meade,Meade Center,President,,IND,Stein/Baraka,9
-Meade,Meade Center,President,,,Evan McMullin,4
-Meade,Meade Center,President,,,Tom Hoefling,4
-Meade,Meade Center,U.S. Senate,,REP,Jerry Moran,753
-Meade,Meade Center,U.S. Senate,,DEM,Patrick Wiesner,65
-Meade,Meade Center,U.S. Senate,,LIB,Robert D. Garrard,37
-Meade,Meade Center,U.S. House,1,REP,Roger Marshall,647
-Meade,Meade Center,U.S. House,1,IND,Alan LaPolice,142
-Meade,Meade Center,U.S. House,1,LIB,Kerry Burt,44
-Meade,Meade Center,U.S. House,1,,Tim Huelskamp,12
-Meade,Meade Center,State Senate,38,REP,Bud Estes,740
-Meade,Meade Center,State Senate,38,DEM,Miguel Angel Rodriguez,102
-Meade,Meade Center,State House,115,REP,Boyd Orr,776
-Meade,Meade Center,State House,115,,Bart Fischer,1
-Meade,Meade Center,State House,115,,Dale Weber,1
-Meade,Meade Center,State House,115,,Tim Huelskamp,2
-Meade,Meade Center,State House,115,,Ron Rykeman,1
-Meade,Meade Center,State House,115,,Brian Lutters,1
-Meade,Mertilla,President,,REP,Trump/Pence,38
-Meade,Mertilla,President,,DEM,Clinton/Kaine,8
-Meade,Mertilla,President,,LIB,Johnson/Weld,2
-Meade,Mertilla,President,,IND,Stein/Baraka,2
-Meade,Mertilla,U.S. Senate,,REP,Jerry Moran,45
-Meade,Mertilla,U.S. Senate,,DEM,Patrick Wiesner,3
-Meade,Mertilla,U.S. Senate,,LIB,Robert D. Garrard,1
-Meade,Mertilla,U.S. House,1,REP,Roger Marshall,36
-Meade,Mertilla,U.S. House,1,IND,Alan LaPolice,11
-Meade,Mertilla,U.S. House,1,LIB,Kerry Burt,1
-Meade,Mertilla,State Senate,38,REP,Bud Estes,46
-Meade,Mertilla,State Senate,38,DEM,Miguel Angel Rodriguez,3
-Meade,Mertilla,State House,115,REP,Boyd Orr,47
-Meade,Odee,President,,REP,Trump/Pence,14
-Meade,Odee,President,,DEM,Clinton/Kaine,1
-Meade,Odee,President,,LIB,Johnson/Weld,0
-Meade,Odee,President,,IND,Stein/Baraka,1
-Meade,Odee,U.S. Senate,,REP,Jerry Moran,15
-Meade,Odee,U.S. Senate,,DEM,Patrick Wiesner,0
-Meade,Odee,U.S. Senate,,LIB,Robert D. Garrard,0
-Meade,Odee,U.S. House,1,REP,Roger Marshall,7
-Meade,Odee,U.S. House,1,IND,Alan LaPolice,8
-Meade,Odee,U.S. House,1,LIB,Kerry Burt,0
-Meade,Odee,State Senate,38,REP,Bud Estes,14
-Meade,Odee,State Senate,38,DEM,Miguel Angel Rodriguez,1
-Meade,Odee,State House,115,REP,Boyd Orr,14
-Meade,Sand Creek,President,,REP,Trump/Pence,20
-Meade,Sand Creek,President,,DEM,Clinton/Kaine,0
-Meade,Sand Creek,President,,LIB,Johnson/Weld,0
-Meade,Sand Creek,President,,IND,Stein/Baraka,0
-Meade,Sand Creek,U.S. Senate,,REP,Jerry Moran,20
-Meade,Sand Creek,U.S. Senate,,DEM,Patrick Wiesner,0
-Meade,Sand Creek,U.S. Senate,,LIB,Robert D. Garrard,0
-Meade,Sand Creek,U.S. House,1,REP,Roger Marshall,14
-Meade,Sand Creek,U.S. House,1,IND,Alan LaPolice,4
-Meade,Sand Creek,U.S. House,1,LIB,Kerry Burt,0
-Meade,Sand Creek,U.S. House,1,,Tim Huelskamp,2
-Meade,Sand Creek,State Senate,38,REP,Bud Estes,20
-Meade,Sand Creek,State Senate,38,DEM,Miguel Angel Rodriguez,0
-Meade,Sand Creek,State House,115,REP,Boyd Orr,20
+county,precinct,office,district,party,candidate,votes,vtd
+MEADE,Cimarron Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",26,000010
+MEADE,Crooked Creek Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",49,000020
+MEADE,Fowler Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",253,000030
+MEADE,Logan Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",49,000040
+MEADE,Meade Center Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",776,000050
+MEADE,Mertilla Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",47,000060
+MEADE,Odee Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",14,000070
+MEADE,Sand Creek Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",20,000080
+MEADE,West Plains Township,Kansas House of Representatives,115,Republican,"Orr, Boyd",346,000090
+MEADE,Cimarron Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000010
+MEADE,Cimarron Township,Kansas Senate,38,Republican,"Estes, Bud",24,000010
+MEADE,Crooked Creek Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",4,000020
+MEADE,Crooked Creek Township,Kansas Senate,38,Republican,"Estes, Bud",47,000020
+MEADE,Fowler Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",36,000030
+MEADE,Fowler Township,Kansas Senate,38,Republican,"Estes, Bud",220,000030
+MEADE,Logan Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",8,000040
+MEADE,Logan Township,Kansas Senate,38,Republican,"Estes, Bud",49,000040
+MEADE,Meade Center Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",102,000050
+MEADE,Meade Center Township,Kansas Senate,38,Republican,"Estes, Bud",740,000050
+MEADE,Mertilla Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",3,000060
+MEADE,Mertilla Township,Kansas Senate,38,Republican,"Estes, Bud",46,000060
+MEADE,Odee Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",1,000070
+MEADE,Odee Township,Kansas Senate,38,Republican,"Estes, Bud",14,000070
+MEADE,Sand Creek Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,000080
+MEADE,Sand Creek Township,Kansas Senate,38,Republican,"Estes, Bud",20,000080
+MEADE,West Plains Township,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",72,000090
+MEADE,West Plains Township,Kansas Senate,38,Republican,"Estes, Bud",291,000090
+MEADE,Cimarron Township,President / Vice President,,independent,"Stein, Jill",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MEADE,Cimarron Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MEADE,Cimarron Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000010
+MEADE,Cimarron Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+MEADE,Cimarron Township,President / Vice President,,Republican,"Trump, Donald J.",24,000010
+MEADE,Crooked Creek Township,President / Vice President,,independent,"Stein, Jill",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Castle, Darrell L",1,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"McMullin, Evan",2,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MEADE,Crooked Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000020
+MEADE,Crooked Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+MEADE,Crooked Creek Township,President / Vice President,,Republican,"Trump, Donald J.",44,000020
+MEADE,Fowler Township,President / Vice President,,independent,"Stein, Jill",2,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"McMullin, Evan",1,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MEADE,Fowler Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MEADE,Fowler Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000030
+MEADE,Fowler Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+MEADE,Fowler Township,President / Vice President,,Republican,"Trump, Donald J.",221,000030
+MEADE,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MEADE,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MEADE,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000040
+MEADE,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+MEADE,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",48,000040
+MEADE,Meade Center Township,President / Vice President,,independent,"Stein, Jill",9,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Hoefling, Tom",4,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"McMullin, Evan",4,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MEADE,Meade Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MEADE,Meade Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",90,000050
+MEADE,Meade Center Township,President / Vice President,,Libertarian,"Johnson, Gary",31,000050
+MEADE,Meade Center Township,President / Vice President,,Republican,"Trump, Donald J.",716,000050
+MEADE,Mertilla Township,President / Vice President,,independent,"Stein, Jill",2,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MEADE,Mertilla Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MEADE,Mertilla Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000060
+MEADE,Mertilla Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+MEADE,Mertilla Township,President / Vice President,,Republican,"Trump, Donald J.",38,000060
+MEADE,Odee Township,President / Vice President,,independent,"Stein, Jill",1,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MEADE,Odee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MEADE,Odee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000070
+MEADE,Odee Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MEADE,Odee Township,President / Vice President,,Republican,"Trump, Donald J.",14,000070
+MEADE,Sand Creek Township,President / Vice President,,independent,"Stein, Jill",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MEADE,Sand Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MEADE,Sand Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+MEADE,Sand Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+MEADE,Sand Creek Township,President / Vice President,,Republican,"Trump, Donald J.",20,000080
+MEADE,West Plains Township,President / Vice President,,independent,"Stein, Jill",4,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"McMullin, Evan",3,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MEADE,West Plains Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MEADE,West Plains Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000090
+MEADE,West Plains Township,President / Vice President,,Libertarian,"Johnson, Gary",19,000090
+MEADE,West Plains Township,President / Vice President,,Republican,"Trump, Donald J.",290,000090
+MEADE,Cimarron Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000010
+MEADE,Cimarron Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+MEADE,Cimarron Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+MEADE,Cimarron Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000010
+MEADE,Crooked Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000020
+MEADE,Crooked Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,000020
+MEADE,Crooked Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000020
+MEADE,Crooked Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000020
+MEADE,Fowler Township,United States House of Representatives,1,independent,"LaPolice, Alan",72,000030
+MEADE,Fowler Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,000030
+MEADE,Fowler Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000030
+MEADE,Fowler Township,United States House of Representatives,1,Republican,"Marshall, Roger",155,000030
+MEADE,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000040
+MEADE,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000040
+MEADE,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000040
+MEADE,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000040
+MEADE,Meade Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",142,000050
+MEADE,Meade Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",12,000050
+MEADE,Meade Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",44,000050
+MEADE,Meade Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",647,000050
+MEADE,Mertilla Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000060
+MEADE,Mertilla Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+MEADE,Mertilla Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+MEADE,Mertilla Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000060
+MEADE,Odee Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000070
+MEADE,Odee Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+MEADE,Odee Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000070
+MEADE,Odee Township,United States House of Representatives,1,Republican,"Marshall, Roger",7,000070
+MEADE,Sand Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000080
+MEADE,Sand Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000080
+MEADE,Sand Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+MEADE,Sand Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000080
+MEADE,West Plains Township,United States House of Representatives,1,independent,"LaPolice, Alan",70,000090
+MEADE,West Plains Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+MEADE,West Plains Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000090
+MEADE,West Plains Township,United States House of Representatives,1,Republican,"Marshall, Roger",265,000090
+MEADE,Cimarron Township,United States Senate,,write - in,"Smith, DJ",0,000010
+MEADE,Cimarron Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000010
+MEADE,Cimarron Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+MEADE,Cimarron Township,United States Senate,,Republican,"Moran, Jerry",25,000010
+MEADE,Crooked Creek Township,United States Senate,,write - in,"Smith, DJ",0,000020
+MEADE,Crooked Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+MEADE,Crooked Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+MEADE,Crooked Creek Township,United States Senate,,Republican,"Moran, Jerry",49,000020
+MEADE,Fowler Township,United States Senate,,write - in,"Smith, DJ",0,000030
+MEADE,Fowler Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000030
+MEADE,Fowler Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000030
+MEADE,Fowler Township,United States Senate,,Republican,"Moran, Jerry",225,000030
+MEADE,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000040
+MEADE,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000040
+MEADE,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000040
+MEADE,Logan Township,United States Senate,,Republican,"Moran, Jerry",51,000040
+MEADE,Meade Center Township,United States Senate,,write - in,"Smith, DJ",0,000050
+MEADE,Meade Center Township,United States Senate,,Democratic,"Wiesner, Patrick",65,000050
+MEADE,Meade Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",37,000050
+MEADE,Meade Center Township,United States Senate,,Republican,"Moran, Jerry",753,000050
+MEADE,Mertilla Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MEADE,Mertilla Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+MEADE,Mertilla Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+MEADE,Mertilla Township,United States Senate,,Republican,"Moran, Jerry",45,000060
+MEADE,Odee Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MEADE,Odee Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000070
+MEADE,Odee Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+MEADE,Odee Township,United States Senate,,Republican,"Moran, Jerry",15,000070
+MEADE,Sand Creek Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MEADE,Sand Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000080
+MEADE,Sand Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+MEADE,Sand Creek Township,United States Senate,,Republican,"Moran, Jerry",20,000080
+MEADE,West Plains Township,United States Senate,,write - in,"Smith, DJ",0,000090
+MEADE,West Plains Township,United States Senate,,Democratic,"Wiesner, Patrick",50,000090
+MEADE,West Plains Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000090
+MEADE,West Plains Township,United States Senate,,Republican,"Moran, Jerry",308,000090

--- a/2016/20161108__ks__general__miami__precinct.csv
+++ b/2016/20161108__ks__general__miami__precinct.csv
@@ -1,1030 +1,1444 @@
-county,precinct,office,district,party,candidate,votes
-Miami,EMC (2),Voters,,,Registration,183
-Miami,EMC (3),Voters,,,Registration,623
-Miami,EV,Voters,,,Registration,309
-Miami,FC,Voters,,,Registration,105
-Miami,LC 01,Voters,,,Registration,578
-Miami,LC 02,Voters,,,Registration,755
-Miami,LC 03,Voters,,,Registration,772
-Miami,LC 04,Voters,,,Registration,729
-Miami,MI,Voters,,,Registration,297
-Miami,MND,Voters,,,Registration,501
-Miami,NMV (2),Voters,,,Registration,205
-Miami,NMV (3),Voters,,,Registration,590
-Miami,NP W,Voters,,,Registration,335
-Miami,NP E Prt 1,Voters,,,Registration,15
-Miami,NP E Prt 2,Voters,,,Registration,114
-Miami,NW,Voters,,,Registration,38
-Miami,OSAGE,Voters,,,Registration,316
-Miami,OC 01,Voters,,,Registration,493
-Miami,OC 02,Voters,,,Registration,639
-Miami,OC 03,Voters,,,Registration,625
-Miami,OC 04,Voters,,,Registration,495
-Miami,OSA TWP,Voters,,,Registration,497
-Miami,PC 01,Voters,,,Registration,903
-Miami,PC 02,Voters,,,Registration,870
-Miami,PC 03,Voters,,,Registration,871
-Miami,PC 04,Voters,,,Registration,1013
-Miami,RICH,Voters,,,Registration,1488
-Miami,SMV (3),Voters,,,Registration,21
-Miami,SMV (2),Voters,,,Registration,998
-Miami,SP E Prt 2,Voters,,,Registration,141
-Miami,SP W,Voters,,,Registration,210
-Miami,SW,Voters,,,Registration,1047
-Miami,SH 01,Voters,,,Registration,1174
-Miami,SH 02,Voters,,,Registration,307
-Miami,SH 03,Voters,,,Registration,90
-Miami,STAN 368,Voters,,,Registration,447
-Miami,STAN 367,Voters,,,Registration,196
-Miami,SC,Voters,,,Registration,57
-Miami,TM,Voters,,,Registration,376
-Miami,WMC 416,Voters,,,Registration,146
-Miami,WMC 368,Voters,,,Registration,428
-Miami,WV (6),Voters,,,Registration,183
-Miami,WV (12) 368,Voters,,,Registration,110
-Miami,WV (12) 367,Voters,,,Registration,192
-Miami,WV (5),Voters,,,Registration,196
-Miami,TM 416,Voters,,,Registration,678
-Miami,SC 416,Voters,,,Registration,293
-Miami,NW 416,Voters,,,Registration,469
-Miami,MI 416,Voters,,,Registration,95
-Miami,EMC (2),Voters,,,Ballots Cast,136
-Miami,EMC (3),Voters,,,Ballots Cast,482
-Miami,EV,Voters,,,Ballots Cast,231
-Miami,FC,Voters,,,Ballots Cast,64
-Miami,LC 01,Voters,,,Ballots Cast,378
-Miami,LC 02,Voters,,,Ballots Cast,542
-Miami,LC 03,Voters,,,Ballots Cast,551
-Miami,LC 04,Voters,,,Ballots Cast,508
-Miami,MI,Voters,,,Ballots Cast,214
-Miami,MND,Voters,,,Ballots Cast,343
-Miami,NMV (2),Voters,,,Ballots Cast,151
-Miami,NMV (3),Voters,,,Ballots Cast,440
-Miami,NP W,Voters,,,Ballots Cast,234
-Miami,NP E Prt 1,Voters,,,Ballots Cast,13
-Miami,NP E Prt 2,Voters,,,Ballots Cast,88
-Miami,NW,Voters,,,Ballots Cast,37
-Miami,OSAGE,Voters,,,Ballots Cast,231
-Miami,OC 01,Voters,,,Ballots Cast,236
-Miami,OC 02,Voters,,,Ballots Cast,387
-Miami,OC 03,Voters,,,Ballots Cast,377
-Miami,OC 04,Voters,,,Ballots Cast,240
-Miami,OSA TWP,Voters,,,Ballots Cast,339
-Miami,PC 01,Voters,,,Ballots Cast,586
-Miami,PC 02,Voters,,,Ballots Cast,498
-Miami,PC 03,Voters,,,Ballots Cast,541
-Miami,PC 04,Voters,,,Ballots Cast,661
-Miami,RICH,Voters,,,Ballots Cast,1113
-Miami,SMV (3),Voters,,,Ballots Cast,17
-Miami,SMV (2),Voters,,,Ballots Cast,722
-Miami,SP E Prt 2,Voters,,,Ballots Cast,103
-Miami,SP W,Voters,,,Ballots Cast,142
-Miami,SW,Voters,,,Ballots Cast,779
-Miami,SH 01,Voters,,,Ballots Cast,800
-Miami,SH 02,Voters,,,Ballots Cast,208
-Miami,SH 03,Voters,,,Ballots Cast,64
-Miami,STAN 368,Voters,,,Ballots Cast,308
-Miami,STAN 367,Voters,,,Ballots Cast,142
-Miami,SC,Voters,,,Ballots Cast,45
-Miami,TM,Voters,,,Ballots Cast,295
-Miami,WMC 416,Voters,,,Ballots Cast,105
-Miami,WMC 368,Voters,,,Ballots Cast,310
-Miami,WV (6),Voters,,,Ballots Cast,137
-Miami,WV (12) 368,Voters,,,Ballots Cast,80
-Miami,WV (12) 367,Voters,,,Ballots Cast,144
-Miami,WV (5),Voters,,,Ballots Cast,132
-Miami,TM 416,Voters,,,Ballots Cast,520
-Miami,SC 416,Voters,,,Ballots Cast,201
-Miami,NW 416,Voters,,,Ballots Cast,336
-Miami,MI 416,Voters,,,Ballots Cast,73
-Miami,EMC (2),President,,IND,Jill Stein,4
-Miami,EMC (3),President,,IND,Jill Stein,10
-Miami,EV,President,,IND,Jill Stein,8
-Miami,FC,President,,IND,Jill Stein,0
-Miami,LC 01,President,,IND,Jill Stein,8
-Miami,LC 02,President,,IND,Jill Stein,8
-Miami,LC 03,President,,IND,Jill Stein,3
-Miami,LC 04,President,,IND,Jill Stein,9
-Miami,MI,President,,IND,Jill Stein,5
-Miami,MND,President,,IND,Jill Stein,8
-Miami,NMV (2),President,,IND,Jill Stein,1
-Miami,NMV (3),President,,IND,Jill Stein,5
-Miami,NP W,President,,IND,Jill Stein,3
-Miami,NP E Prt 1,President,,IND,Jill Stein,0
-Miami,NP E Prt 2,President,,IND,Jill Stein,2
-Miami,NW,President,,IND,Jill Stein,1
-Miami,OSAGE,President,,IND,Jill Stein,2
-Miami,OC 01,President,,IND,Jill Stein,4
-Miami,OC 02,President,,IND,Jill Stein,10
-Miami,OC 03,President,,IND,Jill Stein,10
-Miami,OC 04,President,,IND,Jill Stein,10
-Miami,OSA TWP,President,,IND,Jill Stein,3
-Miami,PC 01,President,,IND,Jill Stein,13
-Miami,PC 02,President,,IND,Jill Stein,9
-Miami,PC 03,President,,IND,Jill Stein,9
-Miami,PC 04,President,,IND,Jill Stein,15
-Miami,RICH,President,,IND,Jill Stein,17
-Miami,SMV (3),President,,IND,Jill Stein,2
-Miami,SMV (2),President,,IND,Jill Stein,11
-Miami,SP E Prt 2,President,,IND,Jill Stein,1
-Miami,SP W,President,,IND,Jill Stein,0
-Miami,SW,President,,IND,Jill Stein,7
-Miami,SH 01,President,,IND,Jill Stein,18
-Miami,SH 02,President,,IND,Jill Stein,1
-Miami,SH 03,President,,IND,Jill Stein,2
-Miami,STAN 368,President,,IND,Jill Stein,5
-Miami,STAN 367,President,,IND,Jill Stein,0
-Miami,SC,President,,IND,Jill Stein,1
-Miami,TM,President,,IND,Jill Stein,3
-Miami,WMC 416,President,,IND,Jill Stein,2
-Miami,WMC 368,President,,IND,Jill Stein,5
-Miami,WV (6),President,,IND,Jill Stein,2
-Miami,WV (12) 368,President,,IND,Jill Stein,1
-Miami,WV (12) 367,President,,IND,Jill Stein,3
-Miami,WV (5),President,,IND,Jill Stein,5
-Miami,TM 416,President,,IND,Jill Stein,7
-Miami,SC 416,President,,IND,Jill Stein,2
-Miami,NW 416,President,,IND,Jill Stein,4
-Miami,MI 416,President,,IND,Jill Stein,0
-Miami,EMC (2),President,,R,Donald Trump,85
-Miami,EMC (3),President,,R,Donald Trump,342
-Miami,EV,President,,R,Donald Trump,152
-Miami,FC,President,,R,Donald Trump,41
-Miami,LC 01,President,,R,Donald Trump,221
-Miami,LC 02,President,,R,Donald Trump,354
-Miami,LC 03,President,,R,Donald Trump,366
-Miami,LC 04,President,,R,Donald Trump,351
-Miami,MI,President,,R,Donald Trump,138
-Miami,MND,President,,R,Donald Trump,210
-Miami,NMV (2),President,,R,Donald Trump,111
-Miami,NMV (3),President,,R,Donald Trump,282
-Miami,NP W,President,,R,Donald Trump,148
-Miami,NP E Prt 1,President,,R,Donald Trump,8
-Miami,NP E Prt 2,President,,R,Donald Trump,63
-Miami,NW,President,,R,Donald Trump,24
-Miami,OSAGE,President,,R,Donald Trump,140
-Miami,OC 01,President,,R,Donald Trump,138
-Miami,OC 02,President,,R,Donald Trump,226
-Miami,OC 03,President,,R,Donald Trump,214
-Miami,OC 04,President,,R,Donald Trump,145
-Miami,OSA TWP,President,,R,Donald Trump,234
-Miami,PC 01,President,,R,Donald Trump,350
-Miami,PC 02,President,,R,Donald Trump,293
-Miami,PC 03,President,,R,Donald Trump,314
-Miami,PC 04,President,,R,Donald Trump,390
-Miami,RICH,President,,R,Donald Trump,800
-Miami,SMV (3),President,,R,Donald Trump,9
-Miami,SMV (2),President,,R,Donald Trump,489
-Miami,SP E Prt 2,President,,R,Donald Trump,61
-Miami,SP W,President,,R,Donald Trump,98
-Miami,SW,President,,R,Donald Trump,585
-Miami,SH 01,President,,R,Donald Trump,519
-Miami,SH 02,President,,R,Donald Trump,119
-Miami,SH 03,President,,R,Donald Trump,39
-Miami,STAN 368,President,,R,Donald Trump,214
-Miami,STAN 367,President,,R,Donald Trump,93
-Miami,SC,President,,R,Donald Trump,39
-Miami,TM,President,,R,Donald Trump,209
-Miami,WMC 416,President,,R,Donald Trump,71
-Miami,WMC 368,President,,R,Donald Trump,212
-Miami,WV (6),President,,R,Donald Trump,84
-Miami,WV (12) 368,President,,R,Donald Trump,53
-Miami,WV (12) 367,President,,R,Donald Trump,90
-Miami,WV (5),President,,R,Donald Trump,91
-Miami,TM 416,President,,R,Donald Trump,358
-Miami,SC 416,President,,R,Donald Trump,155
-Miami,NW 416,President,,R,Donald Trump,230
-Miami,MI 416,President,,R,Donald Trump,45
-Miami,EMC (2),President,,D,Hillary Clinton,33
-Miami,EMC (3),President,,D,Hillary Clinton,106
-Miami,EV,President,,D,Hillary Clinton,61
-Miami,FC,President,,D,Hillary Clinton,16
-Miami,LC 01,President,,D,Hillary Clinton,126
-Miami,LC 02,President,,D,Hillary Clinton,140
-Miami,LC 03,President,,D,Hillary Clinton,157
-Miami,LC 04,President,,D,Hillary Clinton,113
-Miami,MI,President,,D,Hillary Clinton,55
-Miami,MND,President,,D,Hillary Clinton,97
-Miami,NMV (2),President,,D,Hillary Clinton,29
-Miami,NMV (3),President,,D,Hillary Clinton,128
-Miami,NP W,President,,D,Hillary Clinton,64
-Miami,NP E Prt 1,President,,D,Hillary Clinton,3
-Miami,NP E Prt 2,President,,D,Hillary Clinton,20
-Miami,NW,President,,D,Hillary Clinton,9
-Miami,OSAGE,President,,D,Hillary Clinton,73
-Miami,OC 01,President,,D,Hillary Clinton,82
-Miami,OC 02,President,,D,Hillary Clinton,122
-Miami,OC 03,President,,D,Hillary Clinton,123
-Miami,OC 04,President,,D,Hillary Clinton,66
-Miami,OSA TWP,President,,D,Hillary Clinton,86
-Miami,PC 01,President,,D,Hillary Clinton,177
-Miami,PC 02,President,,D,Hillary Clinton,154
-Miami,PC 03,President,,D,Hillary Clinton,176
-Miami,PC 04,President,,D,Hillary Clinton,221
-Miami,RICH,President,,D,Hillary Clinton,238
-Miami,SMV (3),President,,D,Hillary Clinton,6
-Miami,SMV (2),President,,D,Hillary Clinton,168
-Miami,SP E Prt 2,President,,D,Hillary Clinton,31
-Miami,SP W,President,,D,Hillary Clinton,38
-Miami,SW,President,,D,Hillary Clinton,145
-Miami,SH 01,President,,D,Hillary Clinton,202
-Miami,SH 02,President,,D,Hillary Clinton,62
-Miami,SH 03,President,,D,Hillary Clinton,17
-Miami,STAN 368,President,,D,Hillary Clinton,64
-Miami,STAN 367,President,,D,Hillary Clinton,43
-Miami,SC,President,,D,Hillary Clinton,5
-Miami,TM,President,,D,Hillary Clinton,68
-Miami,WMC 416,President,,D,Hillary Clinton,25
-Miami,WMC 368,President,,D,Hillary Clinton,64
-Miami,WV (6),President,,D,Hillary Clinton,41
-Miami,WV (12) 368,President,,D,Hillary Clinton,21
-Miami,WV (12) 367,President,,D,Hillary Clinton,36
-Miami,WV (5),President,,D,Hillary Clinton,27
-Miami,TM 416,President,,D,Hillary Clinton,121
-Miami,SC 416,President,,D,Hillary Clinton,27
-Miami,NW 416,President,,D,Hillary Clinton,81
-Miami,MI 416,President,,D,Hillary Clinton,24
-Miami,EMC (2),President,,LBT,Gary Johnson,11
-Miami,EMC (3),President,,LBT,Gary Johnson,13
-Miami,EV,President,,LBT,Gary Johnson,8
-Miami,FC,President,,LBT,Gary Johnson,6
-Miami,LC 01,President,,LBT,Gary Johnson,17
-Miami,LC 02,President,,LBT,Gary Johnson,29
-Miami,LC 03,President,,LBT,Gary Johnson,16
-Miami,LC 04,President,,LBT,Gary Johnson,27
-Miami,MI,President,,LBT,Gary Johnson,9
-Miami,MND,President,,LBT,Gary Johnson,20
-Miami,NMV (2),President,,LBT,Gary Johnson,4
-Miami,NMV (3),President,,LBT,Gary Johnson,13
-Miami,NP W,President,,LBT,Gary Johnson,17
-Miami,NP E Prt 1,President,,LBT,Gary Johnson,2
-Miami,NP E Prt 2,President,,LBT,Gary Johnson,3
-Miami,NW,President,,LBT,Gary Johnson,1
-Miami,OSAGE,President,,LBT,Gary Johnson,8
-Miami,OC 01,President,,LBT,Gary Johnson,7
-Miami,OC 02,President,,LBT,Gary Johnson,20
-Miami,OC 03,President,,LBT,Gary Johnson,19
-Miami,OC 04,President,,LBT,Gary Johnson,14
-Miami,OSA TWP,President,,LBT,Gary Johnson,13
-Miami,PC 01,President,,LBT,Gary Johnson,24
-Miami,PC 02,President,,LBT,Gary Johnson,36
-Miami,PC 03,President,,LBT,Gary Johnson,29
-Miami,PC 04,President,,LBT,Gary Johnson,20
-Miami,RICH,President,,LBT,Gary Johnson,38
-Miami,SMV (3),President,,LBT,Gary Johnson,0
-Miami,SMV (2),President,,LBT,Gary Johnson,36
-Miami,SP E Prt 2,President,,LBT,Gary Johnson,7
-Miami,SP W,President,,LBT,Gary Johnson,3
-Miami,SW,President,,LBT,Gary Johnson,23
-Miami,SH 01,President,,LBT,Gary Johnson,45
-Miami,SH 02,President,,LBT,Gary Johnson,22
-Miami,SH 03,President,,LBT,Gary Johnson,5
-Miami,STAN 368,President,,LBT,Gary Johnson,19
-Miami,STAN 367,President,,LBT,Gary Johnson,3
-Miami,SC,President,,LBT,Gary Johnson,0
-Miami,TM,President,,LBT,Gary Johnson,2
-Miami,WMC 416,President,,LBT,Gary Johnson,1
-Miami,WMC 368,President,,LBT,Gary Johnson,15
-Miami,WV (6),President,,LBT,Gary Johnson,8
-Miami,WV (12) 368,President,,LBT,Gary Johnson,4
-Miami,WV (12) 367,President,,LBT,Gary Johnson,12
-Miami,WV (5),President,,LBT,Gary Johnson,6
-Miami,TM 416,President,,LBT,Gary Johnson,20
-Miami,SC 416,President,,LBT,Gary Johnson,12
-Miami,NW 416,President,,LBT,Gary Johnson,13
-Miami,MI 416,President,,LBT,Gary Johnson,3
-Miami,EMC (2),President,,,Write-ins,2
-Miami,EMC (3),President,,,Write-ins,9
-Miami,EV,President,,,Write-ins,2
-Miami,FC,President,,,Write-ins,0
-Miami,LC 01,President,,,Write-ins,1
-Miami,LC 02,President,,,Write-ins,7
-Miami,LC 03,President,,,Write-ins,8
-Miami,LC 04,President,,,Write-ins,4
-Miami,MI,President,,,Write-ins,7
-Miami,MND,President,,,Write-ins,6
-Miami,NMV (2),President,,,Write-ins,4
-Miami,NMV (3),President,,,Write-ins,9
-Miami,NP W,President,,,Write-ins,1
-Miami,NP E Prt 1,President,,,Write-ins,0
-Miami,NP E Prt 2,President,,,Write-ins,0
-Miami,NW,President,,,Write-ins,2
-Miami,OSAGE,President,,,Write-ins,6
-Miami,OC 01,President,,,Write-ins,2
-Miami,OC 02,President,,,Write-ins,7
-Miami,OC 03,President,,,Write-ins,5
-Miami,OC 04,President,,,Write-ins,3
-Miami,OSA TWP,President,,,Write-ins,2
-Miami,PC 01,President,,,Write-ins,16
-Miami,PC 02,President,,,Write-ins,3
-Miami,PC 03,President,,,Write-ins,9
-Miami,PC 04,President,,,Write-ins,13
-Miami,RICH,President,,,Write-ins,18
-Miami,SMV (3),President,,,Write-ins,0
-Miami,SMV (2),President,,,Write-ins,14
-Miami,SP E Prt 2,President,,,Write-ins,0
-Miami,SP W,President,,,Write-ins,1
-Miami,SW,President,,,Write-ins,15
-Miami,SH 01,President,,,Write-ins,15
-Miami,SH 02,President,,,Write-ins,3
-Miami,SH 03,President,,,Write-ins,1
-Miami,STAN 368,President,,,Write-ins,3
-Miami,STAN 367,President,,,Write-ins,2
-Miami,SC,President,,,Write-ins,0
-Miami,TM,President,,,Write-ins,7
-Miami,WMC 416,President,,,Write-ins,0
-Miami,WMC 368,President,,,Write-ins,11
-Miami,WV (6),President,,,Write-ins,2
-Miami,WV (12) 368,President,,,Write-ins,1
-Miami,WV (12) 367,President,,,Write-ins,2
-Miami,WV (5),President,,,Write-ins,3
-Miami,TM 416,President,,,Write-ins,6
-Miami,SC 416,President,,,Write-ins,2
-Miami,NW 416,President,,,Write-ins,5
-Miami,MI 416,President,,,Write-ins,0
-Miami,EMC (2),U.S. Senate,,R,Jerry Moran,89
-Miami,EMC (3),U.S. Senate,,R,Jerry Moran,355
-Miami,EV,U.S. Senate,,R,Jerry Moran,157
-Miami,FC,U.S. Senate,,R,Jerry Moran,41
-Miami,LC 01,U.S. Senate,,R,Jerry Moran,226
-Miami,LC 02,U.S. Senate,,R,Jerry Moran,363
-Miami,LC 03,U.S. Senate,,R,Jerry Moran,378
-Miami,LC 04,U.S. Senate,,R,Jerry Moran,348
-Miami,MI,U.S. Senate,,R,Jerry Moran,141
-Miami,MND,U.S. Senate,,R,Jerry Moran,218
-Miami,NMV (2),U.S. Senate,,R,Jerry Moran,121
-Miami,NMV (3),U.S. Senate,,R,Jerry Moran,300
-Miami,NP W,U.S. Senate,,R,Jerry Moran,148
-Miami,NP E Prt 1,U.S. Senate,,R,Jerry Moran,11
-Miami,NP E Prt 2,U.S. Senate,,R,Jerry Moran,61
-Miami,NW,U.S. Senate,,R,Jerry Moran,27
-Miami,OSAGE,U.S. Senate,,R,Jerry Moran,145
-Miami,OC 01,U.S. Senate,,R,Jerry Moran,137
-Miami,OC 02,U.S. Senate,,R,Jerry Moran,241
-Miami,OC 03,U.S. Senate,,R,Jerry Moran,223
-Miami,OC 04,U.S. Senate,,R,Jerry Moran,145
-Miami,OSA TWP,U.S. Senate,,R,Jerry Moran,229
-Miami,PC 01,U.S. Senate,,R,Jerry Moran,367
-Miami,PC 02,U.S. Senate,,R,Jerry Moran,309
-Miami,PC 03,U.S. Senate,,R,Jerry Moran,335
-Miami,PC 04,U.S. Senate,,R,Jerry Moran,433
-Miami,RICH,U.S. Senate,,R,Jerry Moran,817
-Miami,SMV (3),U.S. Senate,,R,Jerry Moran,12
-Miami,SMV (2),U.S. Senate,,R,Jerry Moran,508
-Miami,SP E Prt 2,U.S. Senate,,R,Jerry Moran,67
-Miami,SP W,U.S. Senate,,R,Jerry Moran,103
-Miami,SW,U.S. Senate,,R,Jerry Moran,611
-Miami,SH 01,U.S. Senate,,R,Jerry Moran,541
-Miami,SH 02,U.S. Senate,,R,Jerry Moran,135
-Miami,SH 03,U.S. Senate,,R,Jerry Moran,47
-Miami,STAN 368,U.S. Senate,,R,Jerry Moran,229
-Miami,STAN 367,U.S. Senate,,R,Jerry Moran,93
-Miami,SC,U.S. Senate,,R,Jerry Moran,41
-Miami,TM,U.S. Senate,,R,Jerry Moran,225
-Miami,WMC 416,U.S. Senate,,R,Jerry Moran,82
-Miami,WMC 368,U.S. Senate,,R,Jerry Moran,232
-Miami,WV (6),U.S. Senate,,R,Jerry Moran,91
-Miami,WV (12) 368,U.S. Senate,,R,Jerry Moran,58
-Miami,WV (12) 367,U.S. Senate,,R,Jerry Moran,89
-Miami,WV (5),U.S. Senate,,R,Jerry Moran,91
-Miami,TM 416,U.S. Senate,,R,Jerry Moran,376
-Miami,SC 416,U.S. Senate,,R,Jerry Moran,156
-Miami,NW 416,U.S. Senate,,R,Jerry Moran,249
-Miami,MI 416,U.S. Senate,,R,Jerry Moran,47
-Miami,EMC (2),U.S. Senate,,D,Patrick Wiesner,36
-Miami,EMC (3),U.S. Senate,,D,Patrick Wiesner,100
-Miami,EV,U.S. Senate,,D,Patrick Wiesner,54
-Miami,FC,U.S. Senate,,D,Patrick Wiesner,17
-Miami,LC 01,U.S. Senate,,D,Patrick Wiesner,121
-Miami,LC 02,U.S. Senate,,D,Patrick Wiesner,140
-Miami,LC 03,U.S. Senate,,D,Patrick Wiesner,132
-Miami,LC 04,U.S. Senate,,D,Patrick Wiesner,117
-Miami,MI,U.S. Senate,,D,Patrick Wiesner,53
-Miami,MND,U.S. Senate,,D,Patrick Wiesner,104
-Miami,NMV (2),U.S. Senate,,D,Patrick Wiesner,22
-Miami,NMV (3),U.S. Senate,,D,Patrick Wiesner,118
-Miami,NP W,U.S. Senate,,D,Patrick Wiesner,64
-Miami,NP E Prt 1,U.S. Senate,,D,Patrick Wiesner,1
-Miami,NP E Prt 2,U.S. Senate,,D,Patrick Wiesner,15
-Miami,NW,U.S. Senate,,D,Patrick Wiesner,10
-Miami,OSAGE,U.S. Senate,,D,Patrick Wiesner,70
-Miami,OC 01,U.S. Senate,,D,Patrick Wiesner,77
-Miami,OC 02,U.S. Senate,,D,Patrick Wiesner,119
-Miami,OC 03,U.S. Senate,,D,Patrick Wiesner,119
-Miami,OC 04,U.S. Senate,,D,Patrick Wiesner,68
-Miami,OSA TWP,U.S. Senate,,D,Patrick Wiesner,86
-Miami,PC 01,U.S. Senate,,D,Patrick Wiesner,174
-Miami,PC 02,U.S. Senate,,D,Patrick Wiesner,134
-Miami,PC 03,U.S. Senate,,D,Patrick Wiesner,163
-Miami,PC 04,U.S. Senate,,D,Patrick Wiesner,198
-Miami,RICH,U.S. Senate,,D,Patrick Wiesner,235
-Miami,SMV (3),U.S. Senate,,D,Patrick Wiesner,4
-Miami,SMV (2),U.S. Senate,,D,Patrick Wiesner,168
-Miami,SP E Prt 2,U.S. Senate,,D,Patrick Wiesner,26
-Miami,SP W,U.S. Senate,,D,Patrick Wiesner,31
-Miami,SW,U.S. Senate,,D,Patrick Wiesner,123
-Miami,SH 01,U.S. Senate,,D,Patrick Wiesner,193
-Miami,SH 02,U.S. Senate,,D,Patrick Wiesner,47
-Miami,SH 03,U.S. Senate,,D,Patrick Wiesner,15
-Miami,STAN 368,U.S. Senate,,D,Patrick Wiesner,58
-Miami,STAN 367,U.S. Senate,,D,Patrick Wiesner,40
-Miami,SC,U.S. Senate,,D,Patrick Wiesner,4
-Miami,TM,U.S. Senate,,D,Patrick Wiesner,58
-Miami,WMC 416,U.S. Senate,,D,Patrick Wiesner,19
-Miami,WMC 368,U.S. Senate,,D,Patrick Wiesner,68
-Miami,WV (6),U.S. Senate,,D,Patrick Wiesner,40
-Miami,WV (12) 368,U.S. Senate,,D,Patrick Wiesner,17
-Miami,WV (12) 367,U.S. Senate,,D,Patrick Wiesner,45
-Miami,WV (5),U.S. Senate,,D,Patrick Wiesner,34
-Miami,TM 416,U.S. Senate,,D,Patrick Wiesner,114
-Miami,SC 416,U.S. Senate,,D,Patrick Wiesner,32
-Miami,NW 416,U.S. Senate,,D,Patrick Wiesner,71
-Miami,MI 416,U.S. Senate,,D,Patrick Wiesner,19
-Miami,EMC (2),U.S. Senate,,LBT,Robert Garrard,10
-Miami,EMC (3),U.S. Senate,,LBT,Robert Garrard,16
-Miami,EV,U.S. Senate,,LBT,Robert Garrard,14
-Miami,FC,U.S. Senate,,LBT,Robert Garrard,6
-Miami,LC 01,U.S. Senate,,LBT,Robert Garrard,24
-Miami,LC 02,U.S. Senate,,LBT,Robert Garrard,24
-Miami,LC 03,U.S. Senate,,LBT,Robert Garrard,27
-Miami,LC 04,U.S. Senate,,LBT,Robert Garrard,31
-Miami,MI,U.S. Senate,,LBT,Robert Garrard,12
-Miami,MND,U.S. Senate,,LBT,Robert Garrard,13
-Miami,NMV (2),U.S. Senate,,LBT,Robert Garrard,6
-Miami,NMV (3),U.S. Senate,,LBT,Robert Garrard,13
-Miami,NP W,U.S. Senate,,LBT,Robert Garrard,18
-Miami,NP E Prt 1,U.S. Senate,,LBT,Robert Garrard,1
-Miami,NP E Prt 2,U.S. Senate,,LBT,Robert Garrard,10
-Miami,NW,U.S. Senate,,LBT,Robert Garrard,0
-Miami,OSAGE,U.S. Senate,,LBT,Robert Garrard,10
-Miami,OC 01,U.S. Senate,,LBT,Robert Garrard,14
-Miami,OC 02,U.S. Senate,,LBT,Robert Garrard,17
-Miami,OC 03,U.S. Senate,,LBT,Robert Garrard,20
-Miami,OC 04,U.S. Senate,,LBT,Robert Garrard,21
-Miami,OSA TWP,U.S. Senate,,LBT,Robert Garrard,13
-Miami,PC 01,U.S. Senate,,LBT,Robert Garrard,27
-Miami,PC 02,U.S. Senate,,LBT,Robert Garrard,43
-Miami,PC 03,U.S. Senate,,LBT,Robert Garrard,25
-Miami,PC 04,U.S. Senate,,LBT,Robert Garrard,20
-Miami,RICH,U.S. Senate,,LBT,Robert Garrard,42
-Miami,SMV (3),U.S. Senate,,LBT,Robert Garrard,0
-Miami,SMV (2),U.S. Senate,,LBT,Robert Garrard,35
-Miami,SP E Prt 2,U.S. Senate,,LBT,Robert Garrard,6
-Miami,SP W,U.S. Senate,,LBT,Robert Garrard,3
-Miami,SW,U.S. Senate,,LBT,Robert Garrard,28
-Miami,SH 01,U.S. Senate,,LBT,Robert Garrard,48
-Miami,SH 02,U.S. Senate,,LBT,Robert Garrard,13
-Miami,SH 03,U.S. Senate,,LBT,Robert Garrard,2
-Miami,STAN 368,U.S. Senate,,LBT,Robert Garrard,13
-Miami,STAN 367,U.S. Senate,,LBT,Robert Garrard,8
-Miami,SC,U.S. Senate,,LBT,Robert Garrard,0
-Miami,TM,U.S. Senate,,LBT,Robert Garrard,7
-Miami,WMC 416,U.S. Senate,,LBT,Robert Garrard,2
-Miami,WMC 368,U.S. Senate,,LBT,Robert Garrard,7
-Miami,WV (6),U.S. Senate,,LBT,Robert Garrard,6
-Miami,WV (12) 368,U.S. Senate,,LBT,Robert Garrard,5
-Miami,WV (12) 367,U.S. Senate,,LBT,Robert Garrard,8
-Miami,WV (5),U.S. Senate,,LBT,Robert Garrard,5
-Miami,TM 416,U.S. Senate,,LBT,Robert Garrard,16
-Miami,SC 416,U.S. Senate,,LBT,Robert Garrard,9
-Miami,NW 416,U.S. Senate,,LBT,Robert Garrard,11
-Miami,MI 416,U.S. Senate,,LBT,Robert Garrard,6
-Miami,EMC (2),U.S. Senate,,,Write-ins,0
-Miami,EMC (3),U.S. Senate,,,Write-ins,0
-Miami,EV,U.S. Senate,,,Write-ins,1
-Miami,FC,U.S. Senate,,,Write-ins,0
-Miami,LC 01,U.S. Senate,,,Write-ins,0
-Miami,LC 02,U.S. Senate,,,Write-ins,0
-Miami,LC 03,U.S. Senate,,,Write-ins,0
-Miami,LC 04,U.S. Senate,,,Write-ins,0
-Miami,MI,U.S. Senate,,,Write-ins,0
-Miami,MND,U.S. Senate,,,Write-ins,0
-Miami,NMV (2),U.S. Senate,,,Write-ins,0
-Miami,NMV (3),U.S. Senate,,,Write-ins,0
-Miami,NP W,U.S. Senate,,,Write-ins,0
-Miami,NP E Prt 1,U.S. Senate,,,Write-ins,0
-Miami,NP E Prt 2,U.S. Senate,,,Write-ins,0
-Miami,NW,U.S. Senate,,,Write-ins,0
-Miami,OSAGE,U.S. Senate,,,Write-ins,0
-Miami,OC 01,U.S. Senate,,,Write-ins,4
-Miami,OC 02,U.S. Senate,,,Write-ins,0
-Miami,OC 03,U.S. Senate,,,Write-ins,0
-Miami,OC 04,U.S. Senate,,,Write-ins,0
-Miami,OSA TWP,U.S. Senate,,,Write-ins,1
-Miami,PC 01,U.S. Senate,,,Write-ins,1
-Miami,PC 02,U.S. Senate,,,Write-ins,1
-Miami,PC 03,U.S. Senate,,,Write-ins,1
-Miami,PC 04,U.S. Senate,,,Write-ins,1
-Miami,RICH,U.S. Senate,,,Write-ins,2
-Miami,SMV (3),U.S. Senate,,,Write-ins,0
-Miami,SMV (2),U.S. Senate,,,Write-ins,0
-Miami,SP E Prt 2,U.S. Senate,,,Write-ins,0
-Miami,SP W,U.S. Senate,,,Write-ins,1
-Miami,SW,U.S. Senate,,,Write-ins,0
-Miami,SH 01,U.S. Senate,,,Write-ins,1
-Miami,SH 02,U.S. Senate,,,Write-ins,0
-Miami,SH 03,U.S. Senate,,,Write-ins,0
-Miami,STAN 368,U.S. Senate,,,Write-ins,1
-Miami,STAN 367,U.S. Senate,,,Write-ins,0
-Miami,SC,U.S. Senate,,,Write-ins,0
-Miami,TM,U.S. Senate,,,Write-ins,0
-Miami,WMC 416,U.S. Senate,,,Write-ins,0
-Miami,WMC 368,U.S. Senate,,,Write-ins,0
-Miami,WV (6),U.S. Senate,,,Write-ins,0
-Miami,WV (12) 368,U.S. Senate,,,Write-ins,0
-Miami,WV (12) 367,U.S. Senate,,,Write-ins,0
-Miami,WV (5),U.S. Senate,,,Write-ins,0
-Miami,TM 416,U.S. Senate,,,Write-ins,0
-Miami,SC 416,U.S. Senate,,,Write-ins,0
-Miami,NW 416,U.S. Senate,,,Write-ins,0
-Miami,MI 416,U.S. Senate,,,Write-ins,0
-Miami,EMC (2),U.S. House,2,D,Britani Potter,32
-Miami,EV,U.S. House,2,D,Britani Potter,53
-Miami,FC,U.S. House,2,D,Britani Potter,15
-Miami,MI,U.S. House,2,D,Britani Potter,52
-Miami,MND,U.S. House,2,D,Britani Potter,91
-Miami,NMV (2),U.S. House,2,D,Britani Potter,19
-Miami,NP W,U.S. House,2,D,Britani Potter,53
-Miami,NP E Prt 1,U.S. House,2,D,Britani Potter,0
-Miami,NP E Prt 2,U.S. House,2,D,Britani Potter,19
-Miami,OSAGE,U.S. House,2,D,Britani Potter,68
-Miami,OC 01,U.S. House,2,D,Britani Potter,76
-Miami,OC 02,U.S. House,2,D,Britani Potter,111
-Miami,OC 03,U.S. House,2,D,Britani Potter,112
-Miami,OC 04,U.S. House,2,D,Britani Potter,67
-Miami,OSA TWP,U.S. House,2,D,Britani Potter,86
-Miami,PC 01,U.S. House,2,D,Britani Potter,156
-Miami,PC 02,U.S. House,2,D,Britani Potter,120
-Miami,PC 03,U.S. House,2,D,Britani Potter,150
-Miami,PC 04,U.S. House,2,D,Britani Potter,189
-Miami,RICH,U.S. House,2,D,Britani Potter,220
-Miami,SMV (2),U.S. House,2,D,Britani Potter,144
-Miami,SP E Prt 2,U.S. House,2,D,Britani Potter,29
-Miami,SP W,U.S. House,2,D,Britani Potter,30
-Miami,STAN 368,U.S. House,2,D,Britani Potter,54
-Miami,STAN 367,U.S. House,2,D,Britani Potter,36
-Miami,SC,U.S. House,2,D,Britani Potter,4
-Miami,WMC 416,U.S. House,2,D,Britani Potter,15
-Miami,WMC 368,U.S. House,2,D,Britani Potter,63
-Miami,WV (6),U.S. House,2,D,Britani Potter,37
-Miami,WV (12) 368,U.S. House,2,D,Britani Potter,16
-Miami,WV (12) 367,U.S. House,2,D,Britani Potter,35
-Miami,WV (5),U.S. House,2,D,Britani Potter,29
-Miami,SC 416,U.S. House,2,D,Britani Potter,31
-Miami,MI 416,U.S. House,2,D,Britani Potter,18
-Miami,EMC (2),U.S. House,2,LBT,James Bales,11
-Miami,EV,U.S. House,2,LBT,James Bales,9
-Miami,FC,U.S. House,2,LBT,James Bales,3
-Miami,MI,U.S. House,2,LBT,James Bales,11
-Miami,MND,U.S. House,2,LBT,James Bales,15
-Miami,NMV (2),U.S. House,2,LBT,James Bales,10
-Miami,NP W,U.S. House,2,LBT,James Bales,13
-Miami,NP E Prt 1,U.S. House,2,LBT,James Bales,1
-Miami,NP E Prt 2,U.S. House,2,LBT,James Bales,2
-Miami,OSAGE,U.S. House,2,LBT,James Bales,8
-Miami,OC 01,U.S. House,2,LBT,James Bales,13
-Miami,OC 02,U.S. House,2,LBT,James Bales,21
-Miami,OC 03,U.S. House,2,LBT,James Bales,17
-Miami,OC 04,U.S. House,2,LBT,James Bales,23
-Miami,OSA TWP,U.S. House,2,LBT,James Bales,12
-Miami,PC 01,U.S. House,2,LBT,James Bales,17
-Miami,PC 02,U.S. House,2,LBT,James Bales,37
-Miami,PC 03,U.S. House,2,LBT,James Bales,19
-Miami,PC 04,U.S. House,2,LBT,James Bales,24
-Miami,RICH,U.S. House,2,LBT,James Bales,42
-Miami,SMV (2),U.S. House,2,LBT,James Bales,37
-Miami,SP E Prt 2,U.S. House,2,LBT,James Bales,5
-Miami,SP W,U.S. House,2,LBT,James Bales,3
-Miami,STAN 368,U.S. House,2,LBT,James Bales,15
-Miami,STAN 367,U.S. House,2,LBT,James Bales,7
-Miami,SC,U.S. House,2,LBT,James Bales,0
-Miami,WMC 416,U.S. House,2,LBT,James Bales,1
-Miami,WMC 368,U.S. House,2,LBT,James Bales,8
-Miami,WV (6),U.S. House,2,LBT,James Bales,4
-Miami,WV (12) 368,U.S. House,2,LBT,James Bales,6
-Miami,WV (12) 367,U.S. House,2,LBT,James Bales,6
-Miami,WV (5),U.S. House,2,LBT,James Bales,5
-Miami,SC 416,U.S. House,2,LBT,James Bales,10
-Miami,MI 416,U.S. House,2,LBT,James Bales,8
-Miami,EMC (2),U.S. House,2,R,Lynn Jenkins,92
-Miami,EV,U.S. House,2,R,Lynn Jenkins,167
-Miami,FC,U.S. House,2,R,Lynn Jenkins,45
-Miami,MI,U.S. House,2,R,Lynn Jenkins,146
-Miami,MND,U.S. House,2,R,Lynn Jenkins,230
-Miami,NMV (2),U.S. House,2,R,Lynn Jenkins,119
-Miami,NP W,U.S. House,2,R,Lynn Jenkins,165
-Miami,NP E Prt 1,U.S. House,2,R,Lynn Jenkins,12
-Miami,NP E Prt 2,U.S. House,2,R,Lynn Jenkins,66
-Miami,OSAGE,U.S. House,2,R,Lynn Jenkins,151
-Miami,OC 01,U.S. House,2,R,Lynn Jenkins,139
-Miami,OC 02,U.S. House,2,R,Lynn Jenkins,247
-Miami,OC 03,U.S. House,2,R,Lynn Jenkins,231
-Miami,OC 04,U.S. House,2,R,Lynn Jenkins,147
-Miami,OSA TWP,U.S. House,2,R,Lynn Jenkins,233
-Miami,PC 01,U.S. House,2,R,Lynn Jenkins,395
-Miami,PC 02,U.S. House,2,R,Lynn Jenkins,325
-Miami,PC 03,U.S. House,2,R,Lynn Jenkins,361
-Miami,PC 04,U.S. House,2,R,Lynn Jenkins,435
-Miami,RICH,U.S. House,2,R,Lynn Jenkins,832
-Miami,SMV (2),U.S. House,2,R,Lynn Jenkins,529
-Miami,SP E Prt 2,U.S. House,2,R,Lynn Jenkins,65
-Miami,SP W,U.S. House,2,R,Lynn Jenkins,104
-Miami,STAN 368,U.S. House,2,R,Lynn Jenkins,232
-Miami,STAN 367,U.S. House,2,R,Lynn Jenkins,96
-Miami,SC,U.S. House,2,R,Lynn Jenkins,40
-Miami,WMC 416,U.S. House,2,R,Lynn Jenkins,83
-Miami,WMC 368,U.S. House,2,R,Lynn Jenkins,236
-Miami,WV (6),U.S. House,2,R,Lynn Jenkins,95
-Miami,WV (12) 368,U.S. House,2,R,Lynn Jenkins,58
-Miami,WV (12) 367,U.S. House,2,R,Lynn Jenkins,98
-Miami,WV (5),U.S. House,2,R,Lynn Jenkins,96
-Miami,SC 416,U.S. House,2,R,Lynn Jenkins,153
-Miami,MI 416,U.S. House,2,R,Lynn Jenkins,46
-Miami,EMC (2),U.S. House,2,,Write-ins,0
-Miami,EV,U.S. House,2,,Write-ins,1
-Miami,FC,U.S. House,2,,Write-ins,0
-Miami,MI,U.S. House,2,,Write-ins,0
-Miami,MND,U.S. House,2,,Write-ins,0
-Miami,NMV (2),U.S. House,2,,Write-ins,0
-Miami,NP W,U.S. House,2,,Write-ins,0
-Miami,NP E Prt 1,U.S. House,2,,Write-ins,0
-Miami,NP E Prt 2,U.S. House,2,,Write-ins,0
-Miami,OSAGE,U.S. House,2,,Write-ins,0
-Miami,OC 01,U.S. House,2,,Write-ins,1
-Miami,OC 02,U.S. House,2,,Write-ins,0
-Miami,OC 03,U.S. House,2,,Write-ins,1
-Miami,OC 04,U.S. House,2,,Write-ins,0
-Miami,OSA TWP,U.S. House,2,,Write-ins,1
-Miami,PC 01,U.S. House,2,,Write-ins,2
-Miami,PC 02,U.S. House,2,,Write-ins,2
-Miami,PC 03,U.S. House,2,,Write-ins,1
-Miami,PC 04,U.S. House,2,,Write-ins,0
-Miami,RICH,U.S. House,2,,Write-ins,1
-Miami,SMV (2),U.S. House,2,,Write-ins,0
-Miami,SP E Prt 2,U.S. House,2,,Write-ins,0
-Miami,SP W,U.S. House,2,,Write-ins,0
-Miami,STAN 368,U.S. House,2,,Write-ins,0
-Miami,STAN 367,U.S. House,2,,Write-ins,1
-Miami,SC,U.S. House,2,,Write-ins,0
-Miami,WMC 416,U.S. House,2,,Write-ins,0
-Miami,WMC 368,U.S. House,2,,Write-ins,0
-Miami,WV (6),U.S. House,2,,Write-ins,0
-Miami,WV (12) 368,U.S. House,2,,Write-ins,0
-Miami,WV (12) 367,U.S. House,2,,Write-ins,0
-Miami,WV (5),U.S. House,2,,Write-ins,0
-Miami,SC 416,U.S. House,2,,Write-ins,0
-Miami,MI 416,U.S. House,2,,Write-ins,0
-Miami,EMC (3),U.S. House,3,LBT,Steven Hohe,30
-Miami,LC 01,U.S. House,3,LBT,Steven Hohe,33
-Miami,LC 02,U.S. House,3,LBT,Steven Hohe,39
-Miami,LC 03,U.S. House,3,LBT,Steven Hohe,39
-Miami,LC 04,U.S. House,3,LBT,Steven Hohe,41
-Miami,NMV (3),U.S. House,3,LBT,Steven Hohe,27
-Miami,NW,U.S. House,3,LBT,Steven Hohe,0
-Miami,SMV (3),U.S. House,3,LBT,Steven Hohe,3
-Miami,SW,U.S. House,3,LBT,Steven Hohe,33
-Miami,SH 01,U.S. House,3,LBT,Steven Hohe,52
-Miami,SH 02,U.S. House,3,LBT,Steven Hohe,20
-Miami,SH 03,U.S. House,3,LBT,Steven Hohe,2
-Miami,TM,U.S. House,3,LBT,Steven Hohe,16
-Miami,TM 416,U.S. House,3,LBT,Steven Hohe,41
-Miami,NW 416,U.S. House,3,LBT,Steven Hohe,17
-Miami,EMC (3),U.S. House,3,D,Jay Sidie,112
-Miami,LC 01,U.S. House,3,D,Jay Sidie,122
-Miami,LC 02,U.S. House,3,D,Jay Sidie,152
-Miami,LC 03,U.S. House,3,D,Jay Sidie,142
-Miami,LC 04,U.S. House,3,D,Jay Sidie,122
-Miami,NMV (3),U.S. House,3,D,Jay Sidie,128
-Miami,NW,U.S. House,3,D,Jay Sidie,10
-Miami,SMV (3),U.S. House,3,D,Jay Sidie,4
-Miami,SW,U.S. House,3,D,Jay Sidie,133
-Miami,SH 01,U.S. House,3,D,Jay Sidie,194
-Miami,SH 02,U.S. House,3,D,Jay Sidie,61
-Miami,SH 03,U.S. House,3,D,Jay Sidie,13
-Miami,TM,U.S. House,3,D,Jay Sidie,58
-Miami,TM 416,U.S. House,3,D,Jay Sidie,111
-Miami,NW 416,U.S. House,3,D,Jay Sidie,79
-Miami,EMC (3),U.S. House,3,R,Kevin Yoder,330
-Miami,LC 01,U.S. House,3,R,Kevin Yoder,214
-Miami,LC 02,U.S. House,3,R,Kevin Yoder,338
-Miami,LC 03,U.S. House,3,R,Kevin Yoder,354
-Miami,LC 04,U.S. House,3,R,Kevin Yoder,332
-Miami,NMV (3),U.S. House,3,R,Kevin Yoder,278
-Miami,NW,U.S. House,3,R,Kevin Yoder,27
-Miami,SMV (3),U.S. House,3,R,Kevin Yoder,9
-Miami,SW,U.S. House,3,R,Kevin Yoder,595
-Miami,SH 01,U.S. House,3,R,Kevin Yoder,534
-Miami,SH 02,U.S. House,3,R,Kevin Yoder,113
-Miami,SH 03,U.S. House,3,R,Kevin Yoder,48
-Miami,TM,U.S. House,3,R,Kevin Yoder,215
-Miami,TM 416,U.S. House,3,R,Kevin Yoder,358
-Miami,NW 416,U.S. House,3,R,Kevin Yoder,234
-Miami,EMC (3),U.S. House,3,,Write-ins,1
-Miami,LC 01,U.S. House,3,,Write-ins,0
-Miami,LC 02,U.S. House,3,,Write-ins,0
-Miami,LC 03,U.S. House,3,,Write-ins,0
-Miami,LC 04,U.S. House,3,,Write-ins,0
-Miami,NMV (3),U.S. House,3,,Write-ins,0
-Miami,NW,U.S. House,3,,Write-ins,0
-Miami,SMV (3),U.S. House,3,,Write-ins,0
-Miami,SW,U.S. House,3,,Write-ins,2
-Miami,SH 01,U.S. House,3,,Write-ins,3
-Miami,SH 02,U.S. House,3,,Write-ins,0
-Miami,SH 03,U.S. House,3,,Write-ins,0
-Miami,TM,U.S. House,3,,Write-ins,0
-Miami,TM 416,U.S. House,3,,Write-ins,1
-Miami,NW 416,U.S. House,3,,Write-ins,0
-Miami,EV,State Senate,12,R,Caryn Tyson,162
-Miami,FC,State Senate,12,R,Caryn Tyson,41
-Miami,MI,State Senate,12,R,Caryn Tyson,135
-Miami,MND,State Senate,12,R,Caryn Tyson,217
-Miami,OSAGE,State Senate,12,R,Caryn Tyson,145
-Miami,OC 01,State Senate,12,R,Caryn Tyson,142
-Miami,OC 02,State Senate,12,R,Caryn Tyson,232
-Miami,OC 03,State Senate,12,R,Caryn Tyson,207
-Miami,OC 04,State Senate,12,R,Caryn Tyson,148
-Miami,OSA TWP,State Senate,12,R,Caryn Tyson,224
-Miami,SC,State Senate,12,R,Caryn Tyson,38
-Miami,WV (12) 368,State Senate,12,R,Caryn Tyson,55
-Miami,WV (12) 367,State Senate,12,R,Caryn Tyson,89
-Miami,SC 416,State Senate,12,R,Caryn Tyson,150
-Miami,MI 416,State Senate,12,R,Caryn Tyson,51
-Miami,EV,State Senate,12,D,Christopher Johnston,60
-Miami,FC,State Senate,12,D,Christopher Johnston,15
-Miami,MI,State Senate,12,D,Christopher Johnston,56
-Miami,MND,State Senate,12,D,Christopher Johnston,93
-Miami,OSAGE,State Senate,12,D,Christopher Johnston,71
-Miami,OC 01,State Senate,12,D,Christopher Johnston,78
-Miami,OC 02,State Senate,12,D,Christopher Johnston,103
-Miami,OC 03,State Senate,12,D,Christopher Johnston,124
-Miami,OC 04,State Senate,12,D,Christopher Johnston,80
-Miami,OSA TWP,State Senate,12,D,Christopher Johnston,79
-Miami,SC,State Senate,12,D,Christopher Johnston,4
-Miami,WV (12) 368,State Senate,12,D,Christopher Johnston,22
-Miami,WV (12) 367,State Senate,12,D,Christopher Johnston,48
-Miami,SC 416,State Senate,12,D,Christopher Johnston,42
-Miami,MI 416,State Senate,12,D,Christopher Johnston,18
-Miami,EV,State Senate,12,,Write-ins,3
-Miami,FC,State Senate,12,,Write-ins,5
-Miami,MI,State Senate,12,,Write-ins,10
-Miami,MND,State Senate,12,,Write-ins,19
-Miami,OSAGE,State Senate,12,,Write-ins,9
-Miami,OC 01,State Senate,12,,Write-ins,8
-Miami,OC 02,State Senate,12,,Write-ins,44
-Miami,OC 03,State Senate,12,,Write-ins,28
-Miami,OC 04,State Senate,12,,Write-ins,6
-Miami,OSA TWP,State Senate,12,,Write-ins,23
-Miami,SC,State Senate,12,,Write-ins,0
-Miami,WV (12) 368,State Senate,12,,Write-ins,1
-Miami,WV (12) 367,State Senate,12,,Write-ins,4
-Miami,SC 416,State Senate,12,,Write-ins,1
-Miami,MI 416,State Senate,12,,Write-ins,2
-Miami,EMC (2),State Senate,37,R,Molly Baumgardner,99
-Miami,EMC (3),State Senate,37,R,Molly Baumgardner,363
-Miami,LC 01,State Senate,37,R,Molly Baumgardner,258
-Miami,LC 02,State Senate,37,R,Molly Baumgardner,374
-Miami,LC 03,State Senate,37,R,Molly Baumgardner,391
-Miami,LC 04,State Senate,37,R,Molly Baumgardner,388
-Miami,NMV (2),State Senate,37,R,Molly Baumgardner,116
-Miami,NMV (3),State Senate,37,R,Molly Baumgardner,287
-Miami,NP W,State Senate,37,R,Molly Baumgardner,170
-Miami,NP E Prt 1,State Senate,37,R,Molly Baumgardner,13
-Miami,NP E Prt 2,State Senate,37,R,Molly Baumgardner,69
-Miami,NW,State Senate,37,R,Molly Baumgardner,29
-Miami,PC 01,State Senate,37,R,Molly Baumgardner,379
-Miami,PC 02,State Senate,37,R,Molly Baumgardner,315
-Miami,PC 03,State Senate,37,R,Molly Baumgardner,359
-Miami,PC 04,State Senate,37,R,Molly Baumgardner,428
-Miami,RICH,State Senate,37,R,Molly Baumgardner,814
-Miami,SMV (3),State Senate,37,R,Molly Baumgardner,10
-Miami,SMV (2),State Senate,37,R,Molly Baumgardner,519
-Miami,SP E Prt 2,State Senate,37,R,Molly Baumgardner,66
-Miami,SP W,State Senate,37,R,Molly Baumgardner,102
-Miami,SW,State Senate,37,R,Molly Baumgardner,627
-Miami,SH 01,State Senate,37,R,Molly Baumgardner,551
-Miami,SH 02,State Senate,37,R,Molly Baumgardner,130
-Miami,SH 03,State Senate,37,R,Molly Baumgardner,48
-Miami,STAN 368,State Senate,37,R,Molly Baumgardner,227
-Miami,STAN 367,State Senate,37,R,Molly Baumgardner,89
-Miami,TM,State Senate,37,R,Molly Baumgardner,224
-Miami,WMC 416,State Senate,37,R,Molly Baumgardner,77
-Miami,WMC 368,State Senate,37,R,Molly Baumgardner,237
-Miami,WV (6),State Senate,37,R,Molly Baumgardner,90
-Miami,WV (5),State Senate,37,R,Molly Baumgardner,94
-Miami,TM 416,State Senate,37,R,Molly Baumgardner,382
-Miami,NW 416,State Senate,37,R,Molly Baumgardner,259
-Miami,EMC (2),State Senate,37,D,Kevin King,34
-Miami,EMC (3),State Senate,37,D,Kevin King,109
-Miami,LC 01,State Senate,37,D,Kevin King,109
-Miami,LC 02,State Senate,37,D,Kevin King,140
-Miami,LC 03,State Senate,37,D,Kevin King,134
-Miami,LC 04,State Senate,37,D,Kevin King,107
-Miami,NMV (2),State Senate,37,D,Kevin King,32
-Miami,NMV (3),State Senate,37,D,Kevin King,139
-Miami,NP W,State Senate,37,D,Kevin King,58
-Miami,NP E Prt 1,State Senate,37,D,Kevin King,0
-Miami,NP E Prt 2,State Senate,37,D,Kevin King,18
-Miami,NW,State Senate,37,D,Kevin King,8
-Miami,PC 01,State Senate,37,D,Kevin King,178
-Miami,PC 02,State Senate,37,D,Kevin King,162
-Miami,PC 03,State Senate,37,D,Kevin King,159
-Miami,PC 04,State Senate,37,D,Kevin King,215
-Miami,RICH,State Senate,37,D,Kevin King,267
-Miami,SMV (3),State Senate,37,D,Kevin King,5
-Miami,SMV (2),State Senate,37,D,Kevin King,185
-Miami,SP E Prt 2,State Senate,37,D,Kevin King,30
-Miami,SP W,State Senate,37,D,Kevin King,31
-Miami,SW,State Senate,37,D,Kevin King,125
-Miami,SH 01,State Senate,37,D,Kevin King,214
-Miami,SH 02,State Senate,37,D,Kevin King,64
-Miami,SH 03,State Senate,37,D,Kevin King,15
-Miami,STAN 368,State Senate,37,D,Kevin King,72
-Miami,STAN 367,State Senate,37,D,Kevin King,46
-Miami,TM,State Senate,37,D,Kevin King,62
-Miami,WMC 416,State Senate,37,D,Kevin King,21
-Miami,WMC 368,State Senate,37,D,Kevin King,67
-Miami,WV (6),State Senate,37,D,Kevin King,45
-Miami,WV (5),State Senate,37,D,Kevin King,33
-Miami,TM 416,State Senate,37,D,Kevin King,122
-Miami,NW 416,State Senate,37,D,Kevin King,68
-Miami,EMC (2),State Senate,37,,Write-ins,2
-Miami,EMC (3),State Senate,37,,Write-ins,1
-Miami,LC 01,State Senate,37,,Write-ins,1
-Miami,LC 02,State Senate,37,,Write-ins,2
-Miami,LC 03,State Senate,37,,Write-ins,0
-Miami,LC 04,State Senate,37,,Write-ins,2
-Miami,NMV (2),State Senate,37,,Write-ins,0
-Miami,NMV (3),State Senate,37,,Write-ins,0
-Miami,NP W,State Senate,37,,Write-ins,0
-Miami,NP E Prt 1,State Senate,37,,Write-ins,0
-Miami,NP E Prt 2,State Senate,37,,Write-ins,0
-Miami,NW,State Senate,37,,Write-ins,0
-Miami,PC 01,State Senate,37,,Write-ins,4
-Miami,PC 02,State Senate,37,,Write-ins,1
-Miami,PC 03,State Senate,37,,Write-ins,0
-Miami,PC 04,State Senate,37,,Write-ins,0
-Miami,RICH,State Senate,37,,Write-ins,3
-Miami,SMV (3),State Senate,37,,Write-ins,0
-Miami,SMV (2),State Senate,37,,Write-ins,0
-Miami,SP E Prt 2,State Senate,37,,Write-ins,0
-Miami,SP W,State Senate,37,,Write-ins,1
-Miami,SW,State Senate,37,,Write-ins,1
-Miami,SH 01,State Senate,37,,Write-ins,1
-Miami,SH 02,State Senate,37,,Write-ins,1
-Miami,SH 03,State Senate,37,,Write-ins,0
-Miami,STAN 368,State Senate,37,,Write-ins,1
-Miami,STAN 367,State Senate,37,,Write-ins,1
-Miami,TM,State Senate,37,,Write-ins,0
-Miami,WMC 416,State Senate,37,,Write-ins,0
-Miami,WMC 368,State Senate,37,,Write-ins,0
-Miami,WV (6),State Senate,37,,Write-ins,1
-Miami,WV (5),State Senate,37,,Write-ins,0
-Miami,TM 416,State Senate,37,,Write-ins,1
-Miami,NW 416,State Senate,37,,Write-ins,0
-Miami,MND,State House,5,R,Kevin Jones,170
-Miami,OC 01,State House,5,R,Kevin Jones,98
-Miami,OC 02,State House,5,R,Kevin Jones,170
-Miami,OC 03,State House,5,R,Kevin Jones,139
-Miami,OC 04,State House,5,R,Kevin Jones,116
-Miami,OSA TWP,State House,5,R,Kevin Jones,169
-Miami,STAN 368,State House,5,R,Kevin Jones,200
-Miami,STAN 367,State House,5,R,Kevin Jones,77
-Miami,WV (5),State House,5,R,Kevin Jones,72
-Miami,MND,State House,5,D,Doug Walker,160
-Miami,OC 01,State House,5,D,Doug Walker,133
-Miami,OC 02,State House,5,D,Doug Walker,210
-Miami,OC 03,State House,5,D,Doug Walker,231
-Miami,OC 04,State House,5,D,Doug Walker,120
-Miami,OSA TWP,State House,5,D,Doug Walker,161
-Miami,STAN 368,State House,5,D,Doug Walker,94
-Miami,STAN 367,State House,5,D,Doug Walker,61
-Miami,WV (5),State House,5,D,Doug Walker,56
-Miami,MND,State House,5,,Write-ins,0
-Miami,OC 01,State House,5,,Write-ins,0
-Miami,OC 02,State House,5,,Write-ins,1
-Miami,OC 03,State House,5,,Write-ins,0
-Miami,OC 04,State House,5,,Write-ins,0
-Miami,OSA TWP,State House,5,,Write-ins,1
-Miami,STAN 368,State House,5,,Write-ins,0
-Miami,STAN 367,State House,5,,Write-ins,1
-Miami,WV (5),State House,5,,Write-ins,0
-Miami,EMC (2),State House,6,D,Christy Levings,50
-Miami,EMC (3),State House,6,D,Christy Levings,183
-Miami,EV,State House,6,D,Christy Levings,99
-Miami,FC,State House,6,D,Christy Levings,34
-Miami,LC 01,State House,6,D,Christy Levings,178
-Miami,LC 02,State House,6,D,Christy Levings,224
-Miami,LC 03,State House,6,D,Christy Levings,234
-Miami,LC 04,State House,6,D,Christy Levings,198
-Miami,MI,State House,6,D,Christy Levings,82
-Miami,NP W,State House,6,D,Christy Levings,109
-Miami,NP E Prt 1,State House,6,D,Christy Levings,4
-Miami,NP E Prt 2,State House,6,D,Christy Levings,34
-Miami,NW,State House,6,D,Christy Levings,11
-Miami,OSAGE,State House,6,D,Christy Levings,104
-Miami,PC 01,State House,6,D,Christy Levings,304
-Miami,PC 02,State House,6,D,Christy Levings,262
-Miami,PC 03,State House,6,D,Christy Levings,294
-Miami,PC 04,State House,6,D,Christy Levings,348
-Miami,RICH,State House,6,D,Christy Levings,336
-Miami,SMV (3),State House,6,D,Christy Levings,6
-Miami,SMV (2),State House,6,D,Christy Levings,276
-Miami,SP E Prt 2,State House,6,D,Christy Levings,46
-Miami,SP W,State House,6,D,Christy Levings,63
-Miami,SW,State House,6,D,Christy Levings,228
-Miami,SC,State House,6,D,Christy Levings,7
-Miami,TM,State House,6,D,Christy Levings,85
-Miami,WMC 416,State House,6,D,Christy Levings,41
-Miami,WMC 368,State House,6,D,Christy Levings,111
-Miami,WV (6),State House,6,D,Christy Levings,62
-Miami,WV (12) 368,State House,6,D,Christy Levings,32
-Miami,WV (12) 367,State House,6,D,Christy Levings,73
-Miami,TM 416,State House,6,D,Christy Levings,179
-Miami,SC 416,State House,6,D,Christy Levings,63
-Miami,NW 416,State House,6,D,Christy Levings,102
-Miami,MI 416,State House,6,D,Christy Levings,28
-Miami,EMC (2),State House,6,R,Jene Vickrey,86
-Miami,EMC (3),State House,6,R,Jene Vickrey,290
-Miami,EV,State House,6,R,Jene Vickrey,129
-Miami,FC,State House,6,R,Jene Vickrey,29
-Miami,LC 01,State House,6,R,Jene Vickrey,196
-Miami,LC 02,State House,6,R,Jene Vickrey,302
-Miami,LC 03,State House,6,R,Jene Vickrey,306
-Miami,LC 04,State House,6,R,Jene Vickrey,301
-Miami,MI,State House,6,R,Jene Vickrey,122
-Miami,NP W,State House,6,R,Jene Vickrey,121
-Miami,NP E Prt 1,State House,6,R,Jene Vickrey,8
-Miami,NP E Prt 2,State House,6,R,Jene Vickrey,53
-Miami,NW,State House,6,R,Jene Vickrey,26
-Miami,OSAGE,State House,6,R,Jene Vickrey,126
-Miami,PC 01,State House,6,R,Jene Vickrey,270
-Miami,PC 02,State House,6,R,Jene Vickrey,221
-Miami,PC 03,State House,6,R,Jene Vickrey,236
-Miami,PC 04,State House,6,R,Jene Vickrey,302
-Miami,RICH,State House,6,R,Jene Vickrey,754
-Miami,SMV (3),State House,6,R,Jene Vickrey,9
-Miami,SMV (2),State House,6,R,Jene Vickrey,431
-Miami,SP E Prt 2,State House,6,R,Jene Vickrey,53
-Miami,SP W,State House,6,R,Jene Vickrey,75
-Miami,SW,State House,6,R,Jene Vickrey,536
-Miami,SC,State House,6,R,Jene Vickrey,35
-Miami,TM,State House,6,R,Jene Vickrey,203
-Miami,WMC 416,State House,6,R,Jene Vickrey,63
-Miami,WMC 368,State House,6,R,Jene Vickrey,194
-Miami,WV (6),State House,6,R,Jene Vickrey,74
-Miami,WV (12) 368,State House,6,R,Jene Vickrey,47
-Miami,WV (12) 367,State House,6,R,Jene Vickrey,68
-Miami,TM 416,State House,6,R,Jene Vickrey,330
-Miami,SC 416,State House,6,R,Jene Vickrey,131
-Miami,NW 416,State House,6,R,Jene Vickrey,225
-Miami,MI 416,State House,6,R,Jene Vickrey,45
-Miami,EMC (2),State House,6,,Write-ins,0
-Miami,EMC (3),State House,6,,Write-ins,1
-Miami,EV,State House,6,,Write-ins,0
-Miami,FC,State House,6,,Write-ins,0
-Miami,LC 01,State House,6,,Write-ins,1
-Miami,LC 02,State House,6,,Write-ins,1
-Miami,LC 03,State House,6,,Write-ins,1
-Miami,LC 04,State House,6,,Write-ins,0
-Miami,MI,State House,6,,Write-ins,1
-Miami,NP W,State House,6,,Write-ins,0
-Miami,NP E Prt 1,State House,6,,Write-ins,0
-Miami,NP E Prt 2,State House,6,,Write-ins,0
-Miami,NW,State House,6,,Write-ins,0
-Miami,OSAGE,State House,6,,Write-ins,0
-Miami,PC 01,State House,6,,Write-ins,1
-Miami,PC 02,State House,6,,Write-ins,1
-Miami,PC 03,State House,6,,Write-ins,0
-Miami,PC 04,State House,6,,Write-ins,0
-Miami,RICH,State House,6,,Write-ins,0
-Miami,SMV (3),State House,6,,Write-ins,0
-Miami,SMV (2),State House,6,,Write-ins,0
-Miami,SP E Prt 2,State House,6,,Write-ins,0
-Miami,SP W,State House,6,,Write-ins,2
-Miami,SW,State House,6,,Write-ins,1
-Miami,SC,State House,6,,Write-ins,0
-Miami,TM,State House,6,,Write-ins,0
-Miami,WMC 416,State House,6,,Write-ins,0
-Miami,WMC 368,State House,6,,Write-ins,1
-Miami,WV (6),State House,6,,Write-ins,0
-Miami,WV (12) 368,State House,6,,Write-ins,0
-Miami,WV (12) 367,State House,6,,Write-ins,1
-Miami,TM 416,State House,6,,Write-ins,0
-Miami,SC 416,State House,6,,Write-ins,0
-Miami,NW 416,State House,6,,Write-ins,0
-Miami,MI 416,State House,6,,Write-ins,0
-Miami,NMV (2),State House,26,R,Larry Campbell,116
-Miami,NMV (3),State House,26,R,Larry Campbell,286
-Miami,SH 01,State House,26,R,Larry Campbell,559
-Miami,SH 02,State House,26,R,Larry Campbell,128
-Miami,SH 03,State House,26,R,Larry Campbell,48
-Miami,NMV (2),State House,26,D,Cheron Tiffany,30
-Miami,NMV (3),State House,26,D,Cheron Tiffany,132
-Miami,SH 01,State House,26,D,Cheron Tiffany,201
-Miami,SH 02,State House,26,D,Cheron Tiffany,63
-Miami,SH 03,State House,26,D,Cheron Tiffany,15
-Miami,NMV (2),State House,26,,Write-ins,0
-Miami,NMV (3),State House,26,,Write-ins,0
-Miami,SH 01,State House,26,,Write-ins,2
-Miami,SH 02,State House,26,,Write-ins,0
-Miami,SH 03,State House,26,,Write-ins,0
+county,precinct,office,district,party,candidate,votes,vtd
+MIAMI,East Valley Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",99,000020
+MIAMI,East Valley Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",129,000020
+MIAMI,Miami Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",110,000050
+MIAMI,Miami Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",167,000050
+MIAMI,Mound Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",160,000060
+MIAMI,Mound Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",170,000060
+MIAMI,North Wea Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",113,000080
+MIAMI,North Wea Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",251,000080
+MIAMI,Osage Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",138,000090
+MIAMI,Osage Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",155,000090
+MIAMI,Osawatomie Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",161,000100
+MIAMI,Osawatomie Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",169,000100
+MIAMI,Osawatomie Ward 2,Kansas House of Representatives,5,Democratic,"Walker, Doug",210,00012A
+MIAMI,Osawatomie Ward 2,Kansas House of Representatives,5,Republican,"Jones, Kevin",170,00012A
+MIAMI,Osawatomie Ward 3,Kansas House of Representatives,5,Democratic,"Walker, Doug",231,00013A
+MIAMI,Osawatomie Ward 3,Kansas House of Representatives,5,Republican,"Jones, Kevin",139,00013A
+MIAMI,Osawatomie Ward 4,Kansas House of Representatives,5,Democratic,"Walker, Doug",120,000140
+MIAMI,Osawatomie Ward 4,Kansas House of Representatives,5,Republican,"Jones, Kevin",116,000140
+MIAMI,Paola Ward 1,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",304,00016A
+MIAMI,Paola Ward 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",270,00016A
+MIAMI,Paola Ward 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",262,000170
+MIAMI,Paola Ward 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",221,000170
+MIAMI,Paola Ward 3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",294,00018A
+MIAMI,Paola Ward 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",236,00018A
+MIAMI,Paola Ward 4,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",348,00019A
+MIAMI,Paola Ward 4,Kansas House of Representatives,6,Republican,"Vickrey, Jene",302,00019A
+MIAMI,Richland Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",336,000200
+MIAMI,Richland Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",754,000200
+MIAMI,South Wea Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",228,000220
+MIAMI,South Wea Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",536,000220
+MIAMI,Spring Hill City Precinct 01,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",201,00023A
+MIAMI,Spring Hill City Precinct 01,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",559,00023A
+MIAMI,Spring Hill City Exclave B,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",63,00023C
+MIAMI,Spring Hill City Exclave B,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",128,00023C
+MIAMI,Spring Hill City Exclave C,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",147,00023D
+MIAMI,Spring Hill City Exclave C,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",334,00023D
+MIAMI,Stanton Township,Kansas House of Representatives,5,Democratic,"Walker, Doug",155,000240
+MIAMI,Stanton Township,Kansas House of Representatives,5,Republican,"Jones, Kevin",277,000240
+MIAMI,Sugar Creek Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",70,000250
+MIAMI,Sugar Creek Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",166,000250
+MIAMI,Ten Mile Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",264,000260
+MIAMI,Ten Mile Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",533,000260
+MIAMI,West Middle Creek Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",152,000270
+MIAMI,West Middle Creek Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",257,000270
+MIAMI,East Middle Creek Township C2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",50,120020
+MIAMI,East Middle Creek Township C2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",86,120020
+MIAMI,East Middle Creek Township C3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",183,120030
+MIAMI,East Middle Creek Township C3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",290,120030
+MIAMI,North Marysville Township C2,Kansas House of Representatives,26,Democratic,"Tiffany, Cheron",30,120040
+MIAMI,North Marysville Township C2,Kansas House of Representatives,26,Republican,"Campbell, Larry L.",116,120040
+MIAMI,Osawatomie Ward 1 H5,Kansas House of Representatives,5,Democratic,"Walker, Doug",133,120060
+MIAMI,Osawatomie Ward 1 H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",98,120060
+MIAMI,South Marysville Township C2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",276,120080
+MIAMI,South Marysville Township C2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",431,120080
+MIAMI,South Marysville Township C3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",6,120090
+MIAMI,South Marysville Township C3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",9,120090
+MIAMI,West Valley Township H5,Kansas House of Representatives,5,Democratic,"Walker, Doug",56,120100
+MIAMI,West Valley Township H5,Kansas House of Representatives,5,Republican,"Jones, Kevin",72,120100
+MIAMI,West Valley Township H6,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",62,120110
+MIAMI,West Valley Township H6,Kansas House of Representatives,6,Republican,"Vickrey, Jene",74,120110
+MIAMI,Louisburg Ward 1,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",178,140010
+MIAMI,Louisburg Ward 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",196,140010
+MIAMI,Louisburg Ward 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",224,140020
+MIAMI,Louisburg Ward 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",302,140020
+MIAMI,Louisburg Ward 3,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",234,140030
+MIAMI,Louisburg Ward 3,Kansas House of Representatives,6,Republican,"Vickrey, Jene",306,140030
+MIAMI,Louisburg Ward 4,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",198,140040
+MIAMI,Louisburg Ward 4,Kansas House of Representatives,6,Republican,"Vickrey, Jene",301,140040
+MIAMI,North Paola Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",109,200010
+MIAMI,North Paola Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",121,200010
+MIAMI,South Paola Township,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",63,200020
+MIAMI,South Paola Township,Kansas House of Representatives,6,Republican,"Vickrey, Jene",75,200020
+MIAMI,West Valley Township Exclave,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",105,900120
+MIAMI,West Valley Township Exclave,Kansas House of Representatives,6,Republican,"Vickrey, Jene",115,900120
+MIAMI,North Paola Township Part 1,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",4,900140
+MIAMI,North Paola Township Part 1,Kansas House of Representatives,6,Republican,"Vickrey, Jene",8,900140
+MIAMI,North Paola Township Part 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",34,900150
+MIAMI,North Paola Township Part 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",53,900150
+MIAMI,South Paola Township Part 2,Kansas House of Representatives,6,Democratic,"Levings, Christy C.",46,900180
+MIAMI,South Paola Township Part 2,Kansas House of Representatives,6,Republican,"Vickrey, Jene",53,900180
+MIAMI,East Valley Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",60,000020
+MIAMI,East Valley Township,Kansas Senate,12,Republican,"Tyson, Caryn",162,000020
+MIAMI,Miami Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",74,000050
+MIAMI,Miami Township,Kansas Senate,12,Republican,"Tyson, Caryn",186,000050
+MIAMI,Mound Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",93,000060
+MIAMI,Mound Township,Kansas Senate,12,Republican,"Tyson, Caryn",217,000060
+MIAMI,North Wea Township,Kansas Senate,37,Democratic,"King, Kevin",76,000080
+MIAMI,North Wea Township,Kansas Senate,37,Republican,"Baumgardner, Molly",288,000080
+MIAMI,Osage Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",86,000090
+MIAMI,Osage Township,Kansas Senate,12,Republican,"Tyson, Caryn",186,000090
+MIAMI,Osawatomie Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",79,000100
+MIAMI,Osawatomie Township,Kansas Senate,12,Republican,"Tyson, Caryn",224,000100
+MIAMI,Osawatomie Ward 2,Kansas Senate,12,Democratic,"Johnston, Christopher B.",103,00012A
+MIAMI,Osawatomie Ward 2,Kansas Senate,12,Republican,"Tyson, Caryn",232,00012A
+MIAMI,Osawatomie Ward 3,Kansas Senate,12,Democratic,"Johnston, Christopher B.",124,00013A
+MIAMI,Osawatomie Ward 3,Kansas Senate,12,Republican,"Tyson, Caryn",207,00013A
+MIAMI,Osawatomie Ward 4,Kansas Senate,12,Democratic,"Johnston, Christopher B.",80,000140
+MIAMI,Osawatomie Ward 4,Kansas Senate,12,Republican,"Tyson, Caryn",148,000140
+MIAMI,Paola Ward 1,Kansas Senate,37,Democratic,"King, Kevin",178,00016A
+MIAMI,Paola Ward 1,Kansas Senate,37,Republican,"Baumgardner, Molly",379,00016A
+MIAMI,Paola Ward 2,Kansas Senate,37,Democratic,"King, Kevin",162,000170
+MIAMI,Paola Ward 2,Kansas Senate,37,Republican,"Baumgardner, Molly",315,000170
+MIAMI,Paola Ward 3,Kansas Senate,37,Democratic,"King, Kevin",159,00018A
+MIAMI,Paola Ward 3,Kansas Senate,37,Republican,"Baumgardner, Molly",359,00018A
+MIAMI,Paola Ward 4,Kansas Senate,37,Democratic,"King, Kevin",215,00019A
+MIAMI,Paola Ward 4,Kansas Senate,37,Republican,"Baumgardner, Molly",428,00019A
+MIAMI,Richland Township,Kansas Senate,37,Democratic,"King, Kevin",267,000200
+MIAMI,Richland Township,Kansas Senate,37,Republican,"Baumgardner, Molly",814,000200
+MIAMI,South Wea Township,Kansas Senate,37,Democratic,"King, Kevin",125,000220
+MIAMI,South Wea Township,Kansas Senate,37,Republican,"Baumgardner, Molly",627,000220
+MIAMI,Spring Hill City Precinct 01,Kansas Senate,37,Democratic,"King, Kevin",214,00023A
+MIAMI,Spring Hill City Precinct 01,Kansas Senate,37,Republican,"Baumgardner, Molly",551,00023A
+MIAMI,Spring Hill City Exclave B,Kansas Senate,37,Democratic,"King, Kevin",64,00023C
+MIAMI,Spring Hill City Exclave B,Kansas Senate,37,Republican,"Baumgardner, Molly",130,00023C
+MIAMI,Spring Hill City Exclave C,Kansas Senate,37,Democratic,"King, Kevin",154,00023D
+MIAMI,Spring Hill City Exclave C,Kansas Senate,37,Republican,"Baumgardner, Molly",335,00023D
+MIAMI,Stanton Township,Kansas Senate,37,Democratic,"King, Kevin",118,000240
+MIAMI,Stanton Township,Kansas Senate,37,Republican,"Baumgardner, Molly",316,000240
+MIAMI,Sugar Creek Township,Kansas Senate,12,Democratic,"Johnston, Christopher B.",46,000250
+MIAMI,Sugar Creek Township,Kansas Senate,12,Republican,"Tyson, Caryn",188,000250
+MIAMI,Ten Mile Township,Kansas Senate,37,Democratic,"King, Kevin",184,000260
+MIAMI,Ten Mile Township,Kansas Senate,37,Republican,"Baumgardner, Molly",606,000260
+MIAMI,West Middle Creek Township,Kansas Senate,37,Democratic,"King, Kevin",88,000270
+MIAMI,West Middle Creek Township,Kansas Senate,37,Republican,"Baumgardner, Molly",314,000270
+MIAMI,East Middle Creek Township C2,Kansas Senate,37,Democratic,"King, Kevin",34,120020
+MIAMI,East Middle Creek Township C2,Kansas Senate,37,Republican,"Baumgardner, Molly",99,120020
+MIAMI,East Middle Creek Township C3,Kansas Senate,37,Democratic,"King, Kevin",109,120030
+MIAMI,East Middle Creek Township C3,Kansas Senate,37,Republican,"Baumgardner, Molly",363,120030
+MIAMI,North Marysville Township C2,Kansas Senate,37,Democratic,"King, Kevin",32,120040
+MIAMI,North Marysville Township C2,Kansas Senate,37,Republican,"Baumgardner, Molly",116,120040
+MIAMI,Osawatomie Ward 1 H5,Kansas Senate,12,Democratic,"Johnston, Christopher B.",78,120060
+MIAMI,Osawatomie Ward 1 H5,Kansas Senate,12,Republican,"Tyson, Caryn",142,120060
+MIAMI,South Marysville Township C2,Kansas Senate,37,Democratic,"King, Kevin",185,120080
+MIAMI,South Marysville Township C2,Kansas Senate,37,Republican,"Baumgardner, Molly",519,120080
+MIAMI,South Marysville Township C3,Kansas Senate,37,Democratic,"King, Kevin",5,120090
+MIAMI,South Marysville Township C3,Kansas Senate,37,Republican,"Baumgardner, Molly",10,120090
+MIAMI,West Valley Township H5,Kansas Senate,37,Democratic,"King, Kevin",33,120100
+MIAMI,West Valley Township H5,Kansas Senate,37,Republican,"Baumgardner, Molly",94,120100
+MIAMI,West Valley Township H6,Kansas Senate,37,Democratic,"King, Kevin",45,120110
+MIAMI,West Valley Township H6,Kansas Senate,37,Republican,"Baumgardner, Molly",90,120110
+MIAMI,Louisburg Ward 1,Kansas Senate,37,Democratic,"King, Kevin",109,140010
+MIAMI,Louisburg Ward 1,Kansas Senate,37,Republican,"Baumgardner, Molly",258,140010
+MIAMI,Louisburg Ward 2,Kansas Senate,37,Democratic,"King, Kevin",140,140020
+MIAMI,Louisburg Ward 2,Kansas Senate,37,Republican,"Baumgardner, Molly",374,140020
+MIAMI,Louisburg Ward 3,Kansas Senate,37,Democratic,"King, Kevin",134,140030
+MIAMI,Louisburg Ward 3,Kansas Senate,37,Republican,"Baumgardner, Molly",391,140030
+MIAMI,Louisburg Ward 4,Kansas Senate,37,Democratic,"King, Kevin",107,140040
+MIAMI,Louisburg Ward 4,Kansas Senate,37,Republican,"Baumgardner, Molly",388,140040
+MIAMI,North Paola Township,Kansas Senate,37,Democratic,"King, Kevin",58,200010
+MIAMI,North Paola Township,Kansas Senate,37,Republican,"Baumgardner, Molly",170,200010
+MIAMI,South Paola Township,Kansas Senate,37,Democratic,"King, Kevin",31,200020
+MIAMI,South Paola Township,Kansas Senate,37,Republican,"Baumgardner, Molly",102,200020
+MIAMI,West Valley Township Exclave,Kansas Senate,12,Democratic,"Johnston, Christopher B.",70,900120
+MIAMI,West Valley Township Exclave,Kansas Senate,12,Republican,"Tyson, Caryn",144,900120
+MIAMI,North Paola Township Part 1,Kansas Senate,37,Democratic,"King, Kevin",0,900140
+MIAMI,North Paola Township Part 1,Kansas Senate,37,Republican,"Baumgardner, Molly",13,900140
+MIAMI,North Paola Township Part 2,Kansas Senate,37,Democratic,"King, Kevin",18,900150
+MIAMI,North Paola Township Part 2,Kansas Senate,37,Republican,"Baumgardner, Molly",69,900150
+MIAMI,South Paola Township Part 2,Kansas Senate,37,Democratic,"King, Kevin",30,900180
+MIAMI,South Paola Township Part 2,Kansas Senate,37,Republican,"Baumgardner, Molly",66,900180
+MIAMI,East Valley Township,President / Vice President,,independent,"Stein, Jill",8,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"McMullin, Evan",1,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MIAMI,East Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MIAMI,East Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,000020
+MIAMI,East Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000020
+MIAMI,East Valley Township,President / Vice President,,Republican,"Trump, Donald J.",152,000020
+MIAMI,Miami Township,President / Vice President,,independent,"Stein, Jill",5,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"McMullin, Evan",4,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MIAMI,Miami Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MIAMI,Miami Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000050
+MIAMI,Miami Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000050
+MIAMI,Miami Township,President / Vice President,,Republican,"Trump, Donald J.",183,000050
+MIAMI,Mound Township,President / Vice President,,independent,"Stein, Jill",8,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Castle, Darrell L",1,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"McMullin, Evan",3,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MIAMI,Mound Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MIAMI,Mound Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000060
+MIAMI,Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000060
+MIAMI,Mound Township,President / Vice President,,Republican,"Trump, Donald J.",210,000060
+MIAMI,North Wea Township,President / Vice President,,independent,"Stein, Jill",5,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"McMullin, Evan",2,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MIAMI,North Wea Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MIAMI,North Wea Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",90,000080
+MIAMI,North Wea Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000080
+MIAMI,North Wea Township,President / Vice President,,Republican,"Trump, Donald J.",254,000080
+MIAMI,Osage Township,President / Vice President,,independent,"Stein, Jill",2,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"McMullin, Evan",1,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MIAMI,Osage Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MIAMI,Osage Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",89,000090
+MIAMI,Osage Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000090
+MIAMI,Osage Township,President / Vice President,,Republican,"Trump, Donald J.",181,000090
+MIAMI,Osawatomie Township,President / Vice President,,independent,"Stein, Jill",3,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MIAMI,Osawatomie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000100
+MIAMI,Osawatomie Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000100
+MIAMI,Osawatomie Township,President / Vice President,,Republican,"Trump, Donald J.",234,000100
+MIAMI,Osawatomie Ward 2,President / Vice President,,independent,"Stein, Jill",10,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",20,00012A
+MIAMI,Osawatomie Ward 2,President / Vice President,,Republican,"Trump, Donald J.",226,00012A
+MIAMI,Osawatomie Ward 3,President / Vice President,,independent,"Stein, Jill",10,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",19,00013A
+MIAMI,Osawatomie Ward 3,President / Vice President,,Republican,"Trump, Donald J.",214,00013A
+MIAMI,Osawatomie Ward 4,President / Vice President,,independent,"Stein, Jill",10,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",14,000140
+MIAMI,Osawatomie Ward 4,President / Vice President,,Republican,"Trump, Donald J.",145,000140
+MIAMI,Paola Ward 1,President / Vice President,,independent,"Stein, Jill",13,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Hoefling, Tom",1,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"McMullin, Evan",5,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",177,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",24,00016A
+MIAMI,Paola Ward 1,President / Vice President,,Republican,"Trump, Donald J.",350,00016A
+MIAMI,Paola Ward 2,President / Vice President,,independent,"Stein, Jill",9,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+MIAMI,Paola Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",154,000170
+MIAMI,Paola Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",36,000170
+MIAMI,Paola Ward 2,President / Vice President,,Republican,"Trump, Donald J.",293,000170
+MIAMI,Paola Ward 3,President / Vice President,,independent,"Stein, Jill",9,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"McMullin, Evan",4,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",176,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",29,00018A
+MIAMI,Paola Ward 3,President / Vice President,,Republican,"Trump, Donald J.",314,00018A
+MIAMI,Paola Ward 4,President / Vice President,,independent,"Stein, Jill",15,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Castle, Darrell L",1,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"McMullin, Evan",6,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",221,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",20,00019A
+MIAMI,Paola Ward 4,President / Vice President,,Republican,"Trump, Donald J.",390,00019A
+MIAMI,Richland Township,President / Vice President,,independent,"Stein, Jill",17,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",1,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"McMullin, Evan",5,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+MIAMI,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+MIAMI,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",238,000200
+MIAMI,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",38,000200
+MIAMI,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",800,000200
+MIAMI,South Wea Township,President / Vice President,,independent,"Stein, Jill",7,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Castle, Darrell L",1,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"McMullin, Evan",5,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+MIAMI,South Wea Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+MIAMI,South Wea Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",145,000220
+MIAMI,South Wea Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000220
+MIAMI,South Wea Township,President / Vice President,,Republican,"Trump, Donald J.",585,000220
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,independent,"Stein, Jill",18,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"McMullin, Evan",5,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",202,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",45,00023A
+MIAMI,Spring Hill City Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",519,00023A
+MIAMI,Spring Hill City Exclave B,President / Vice President,,independent,"Stein, Jill",1,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"McMullin, Evan",1,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",22,00023C
+MIAMI,Spring Hill City Exclave B,President / Vice President,,Republican,"Trump, Donald J.",119,00023C
+MIAMI,Spring Hill City Exclave C,President / Vice President,,independent,"Stein, Jill",7,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Hedges, James A",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"McMullin, Evan",4,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Perry, Darryl",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Smith, Mike",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Sood, Ajay",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",145,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Libertarian,"Johnson, Gary",18,00023D
+MIAMI,Spring Hill City Exclave C,President / Vice President,,Republican,"Trump, Donald J.",321,00023D
+MIAMI,Stanton Township,President / Vice President,,independent,"Stein, Jill",5,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+MIAMI,Stanton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+MIAMI,Stanton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",107,000240
+MIAMI,Stanton Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000240
+MIAMI,Stanton Township,President / Vice President,,Republican,"Trump, Donald J.",307,000240
+MIAMI,Sugar Creek Township,President / Vice President,,independent,"Stein, Jill",3,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000250
+MIAMI,Sugar Creek Township,President / Vice President,,Republican,"Trump, Donald J.",194,000250
+MIAMI,Ten Mile Township,President / Vice President,,independent,"Stein, Jill",10,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Castle, Darrell L",4,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"McMullin, Evan",4,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+MIAMI,Ten Mile Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",189,000260
+MIAMI,Ten Mile Township,President / Vice President,,Libertarian,"Johnson, Gary",22,000260
+MIAMI,Ten Mile Township,President / Vice President,,Republican,"Trump, Donald J.",567,000260
+MIAMI,West Middle Creek Township,President / Vice President,,independent,"Stein, Jill",7,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"McMullin, Evan",3,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",89,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000270
+MIAMI,West Middle Creek Township,President / Vice President,,Republican,"Trump, Donald J.",283,000270
+MIAMI,East Middle Creek Township C2,President / Vice President,,independent,"Stein, Jill",4,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Hedges, James A",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"McMullin, Evan",2,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Perry, Darryl",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Smith, Mike",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Sood, Ajay",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Libertarian,"Johnson, Gary",11,120020
+MIAMI,East Middle Creek Township C2,President / Vice President,,Republican,"Trump, Donald J.",85,120020
+MIAMI,East Middle Creek Township C3,President / Vice President,,independent,"Stein, Jill",10,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Hedges, James A",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"McMullin, Evan",4,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Perry, Darryl",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Smith, Mike",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Sood, Ajay",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Libertarian,"Johnson, Gary",13,120030
+MIAMI,East Middle Creek Township C3,President / Vice President,,Republican,"Trump, Donald J.",342,120030
+MIAMI,North Marysville Township C2,President / Vice President,,independent,"Stein, Jill",1,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Hedges, James A",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"McMullin, Evan",2,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Perry, Darryl",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Smith, Mike",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Sood, Ajay",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Libertarian,"Johnson, Gary",4,120040
+MIAMI,North Marysville Township C2,President / Vice President,,Republican,"Trump, Donald J.",111,120040
+MIAMI,South Marysville Township C2,President / Vice President,,independent,"Stein, Jill",11,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Hedges, James A",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"McMullin, Evan",5,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Perry, Darryl",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Smith, Mike",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Sood, Ajay",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",168,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Libertarian,"Johnson, Gary",36,120080
+MIAMI,South Marysville Township C2,President / Vice President,,Republican,"Trump, Donald J.",489,120080
+MIAMI,South Marysville Township C3,President / Vice President,,independent,"Stein, Jill",2,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Hedges, James A",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"McMullin, Evan",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Perry, Darryl",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Smith, Mike",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Sood, Ajay",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Libertarian,"Johnson, Gary",0,120090
+MIAMI,South Marysville Township C3,President / Vice President,,Republican,"Trump, Donald J.",9,120090
+MIAMI,West Valley Township H5,President / Vice President,,independent,"Stein, Jill",5,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Basiago, Andrew D.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Castle, Darrell L",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Giordani, Rocky",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Hedges, James A",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Kahn, Lynn",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"La Riva, Gloria",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Levinson, Michael S.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Maturen, Michael A",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"McMullin, Evan",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Moorehead, Monica G.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Perry, Darryl",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Schriner, Joe C",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Smith, Mike",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Sood, Ajay",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Sterling, Shawna",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Valdivia, Anthony J",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120100
+MIAMI,West Valley Township H5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,120100
+MIAMI,West Valley Township H5,President / Vice President,,Libertarian,"Johnson, Gary",6,120100
+MIAMI,West Valley Township H5,President / Vice President,,Republican,"Trump, Donald J.",91,120100
+MIAMI,West Valley Township H6,President / Vice President,,independent,"Stein, Jill",2,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Basiago, Andrew D.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Castle, Darrell L",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Giordani, Rocky",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Hedges, James A",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Kahn, Lynn",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"La Riva, Gloria",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Levinson, Michael S.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Maturen, Michael A",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"McMullin, Evan",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Moorehead, Monica G.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Perry, Darryl",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Schriner, Joe C",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Smith, Mike",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Sood, Ajay",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Sterling, Shawna",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Valdivia, Anthony J",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120110
+MIAMI,West Valley Township H6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,120110
+MIAMI,West Valley Township H6,President / Vice President,,Libertarian,"Johnson, Gary",8,120110
+MIAMI,West Valley Township H6,President / Vice President,,Republican,"Trump, Donald J.",84,120110
+MIAMI,Louisburg Ward 1,President / Vice President,,independent,"Stein, Jill",8,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Hedges, James A",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Smith, Mike",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",126,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",17,140010
+MIAMI,Louisburg Ward 1,President / Vice President,,Republican,"Trump, Donald J.",221,140010
+MIAMI,Louisburg Ward 2,President / Vice President,,independent,"Stein, Jill",8,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Hedges, James A",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Smith, Mike",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",140,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",29,140020
+MIAMI,Louisburg Ward 2,President / Vice President,,Republican,"Trump, Donald J.",354,140020
+MIAMI,Louisburg Ward 3,President / Vice President,,independent,"Stein, Jill",3,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Hedges, James A",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Smith, Mike",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",157,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",16,140030
+MIAMI,Louisburg Ward 3,President / Vice President,,Republican,"Trump, Donald J.",366,140030
+MIAMI,Louisburg Ward 4,President / Vice President,,independent,"Stein, Jill",9,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Hedges, James A",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Smith, Mike",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",113,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",27,140040
+MIAMI,Louisburg Ward 4,President / Vice President,,Republican,"Trump, Donald J.",351,140040
+MIAMI,North Paola Township,President / Vice President,,independent,"Stein, Jill",3,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Castle, Darrell L",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Giordani, Rocky",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Hedges, James A",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Kahn, Lynn",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"La Riva, Gloria",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Levinson, Michael S.",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Maturen, Michael A",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"McMullin, Evan",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Perry, Darryl",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Schriner, Joe C",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Smith, Mike",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Sood, Ajay",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Sterling, Shawna",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200010
+MIAMI,North Paola Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200010
+MIAMI,North Paola Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",64,200010
+MIAMI,North Paola Township,President / Vice President,,Libertarian,"Johnson, Gary",17,200010
+MIAMI,North Paola Township,President / Vice President,,Republican,"Trump, Donald J.",148,200010
+MIAMI,South Paola Township,President / Vice President,,independent,"Stein, Jill",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Castle, Darrell L",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Giordani, Rocky",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Hedges, James A",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Kahn, Lynn",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"La Riva, Gloria",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Levinson, Michael S.",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Maturen, Michael A",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"McMullin, Evan",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Perry, Darryl",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Schriner, Joe C",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Smith, Mike",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Sood, Ajay",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Sterling, Shawna",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200020
+MIAMI,South Paola Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200020
+MIAMI,South Paola Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,200020
+MIAMI,South Paola Township,President / Vice President,,Libertarian,"Johnson, Gary",3,200020
+MIAMI,South Paola Township,President / Vice President,,Republican,"Trump, Donald J.",98,200020
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,independent,"Stein, Jill",4,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"McMullin, Evan",3,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",7,900030
+MIAMI,Osawatomie Ward 1 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",138,900030
+MIAMI,West Valley Township Exclave,President / Vice President,,independent,"Stein, Jill",4,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Hedges, James A",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"McMullin, Evan",1,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Smith, Mike",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Libertarian,"Johnson, Gary",16,900120
+MIAMI,West Valley Township Exclave,President / Vice President,,Republican,"Trump, Donald J.",143,900120
+MIAMI,North Paola Township Part 1,President / Vice President,,independent,"Stein, Jill",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Castle, Darrell L",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Giordani, Rocky",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Hedges, James A",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Hoefling, Tom",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Kahn, Lynn",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"La Riva, Gloria",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Maturen, Michael A",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"McMullin, Evan",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Perry, Darryl",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Schriner, Joe C",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Smith, Mike",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Sood, Ajay",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Sterling, Shawna",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Libertarian,"Johnson, Gary",2,900140
+MIAMI,North Paola Township Part 1,President / Vice President,,Republican,"Trump, Donald J.",8,900140
+MIAMI,North Paola Township Part 2,President / Vice President,,independent,"Stein, Jill",2,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Hedges, James A",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"McMullin, Evan",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Perry, Darryl",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Smith, Mike",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Sood, Ajay",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Libertarian,"Johnson, Gary",3,900150
+MIAMI,North Paola Township Part 2,President / Vice President,,Republican,"Trump, Donald J.",63,900150
+MIAMI,South Paola Township Part 2,President / Vice President,,independent,"Stein, Jill",1,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Castle, Darrell L",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Giordani, Rocky",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Hedges, James A",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Hoefling, Tom",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Kahn, Lynn",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"La Riva, Gloria",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Maturen, Michael A",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"McMullin, Evan",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Perry, Darryl",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Schriner, Joe C",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Smith, Mike",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Sood, Ajay",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Sterling, Shawna",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Libertarian,"Johnson, Gary",7,900180
+MIAMI,South Paola Township Part 2,President / Vice President,,Republican,"Trump, Donald J.",61,900180
+MIAMI,East Valley Township,United States House of Representatives,2,Democratic,"Potter, Britani",53,000020
+MIAMI,East Valley Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000020
+MIAMI,East Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",167,000020
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Democratic,"Sidie, Jay",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",0,00003B
+MIAMI,Louisburg Ward 1 Exclave Park,United States House of Representatives,3,Republican,"Yoder, Kevin",0,00003B
+MIAMI,Miami Township,United States House of Representatives,2,Democratic,"Potter, Britani",70,000050
+MIAMI,Miami Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000050
+MIAMI,Miami Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",192,000050
+MIAMI,Mound Township,United States House of Representatives,2,Democratic,"Potter, Britani",91,000060
+MIAMI,Mound Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000060
+MIAMI,Mound Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,000060
+MIAMI,North Wea Township,United States House of Representatives,3,Democratic,"Sidie, Jay",89,000080
+MIAMI,North Wea Township,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",17,000080
+MIAMI,North Wea Township,United States House of Representatives,3,Republican,"Yoder, Kevin",261,000080
+MIAMI,Osage Township,United States House of Representatives,2,Democratic,"Potter, Britani",83,000090
+MIAMI,Osage Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000090
+MIAMI,Osage Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",196,000090
+MIAMI,Osawatomie Township,United States House of Representatives,2,Democratic,"Potter, Britani",86,000100
+MIAMI,Osawatomie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000100
+MIAMI,Osawatomie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,000100
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",111,00012A
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,00012A
+MIAMI,Osawatomie Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,00012A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",112,00013A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,00013A
+MIAMI,Osawatomie Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",231,00013A
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",67,000140
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000140
+MIAMI,Osawatomie Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",147,000140
+MIAMI,Paola Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",156,00016A
+MIAMI,Paola Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,00016A
+MIAMI,Paola Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",395,00016A
+MIAMI,Paola Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",120,000170
+MIAMI,Paola Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",37,000170
+MIAMI,Paola Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",325,000170
+MIAMI,Paola Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",150,00018A
+MIAMI,Paola Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,00018A
+MIAMI,Paola Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",361,00018A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",189,00019A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,00019A
+MIAMI,Paola Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",435,00019A
+MIAMI,Richland Township,United States House of Representatives,2,Democratic,"Potter, Britani",220,000200
+MIAMI,Richland Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",42,000200
+MIAMI,Richland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",832,000200
+MIAMI,South Wea Township,United States House of Representatives,3,Democratic,"Sidie, Jay",133,000220
+MIAMI,South Wea Township,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",33,000220
+MIAMI,South Wea Township,United States House of Representatives,3,Republican,"Yoder, Kevin",595,000220
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Democratic,"Sidie, Jay",194,00023A
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",52,00023A
+MIAMI,Spring Hill City Precinct 01,United States House of Representatives,3,Republican,"Yoder, Kevin",534,00023A
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Democratic,"Sidie, Jay",61,00023C
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",20,00023C
+MIAMI,Spring Hill City Exclave B,United States House of Representatives,3,Republican,"Yoder, Kevin",113,00023C
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Democratic,"Sidie, Jay",141,00023D
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",29,00023D
+MIAMI,Spring Hill City Exclave C,United States House of Representatives,3,Republican,"Yoder, Kevin",326,00023D
+MIAMI,Stanton Township,United States House of Representatives,2,Democratic,"Potter, Britani",90,000240
+MIAMI,Stanton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,000240
+MIAMI,Stanton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",328,000240
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",35,000250
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000250
+MIAMI,Sugar Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",193,000250
+MIAMI,Ten Mile Township,United States House of Representatives,3,Democratic,"Sidie, Jay",169,000260
+MIAMI,Ten Mile Township,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",57,000260
+MIAMI,Ten Mile Township,United States House of Representatives,3,Republican,"Yoder, Kevin",573,000260
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",78,000270
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000270
+MIAMI,West Middle Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",319,000270
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Democratic,"Potter, Britani",32,120020
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,120020
+MIAMI,East Middle Creek Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,120020
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Democratic,"Sidie, Jay",112,120030
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",30,120030
+MIAMI,East Middle Creek Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",330,120030
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Democratic,"Potter, Britani",19,120040
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,120040
+MIAMI,North Marysville Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",119,120040
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Democratic,"Potter, Britani",144,120080
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Libertarian,"Bales, James Houston",37,120080
+MIAMI,South Marysville Township C2,United States House of Representatives,2,Republican,"Jenkins, Lynn",529,120080
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Democratic,"Sidie, Jay",4,120090
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",3,120090
+MIAMI,South Marysville Township C3,United States House of Representatives,3,Republican,"Yoder, Kevin",9,120090
+MIAMI,West Valley Township H5,United States House of Representatives,2,Democratic,"Potter, Britani",29,120100
+MIAMI,West Valley Township H5,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,120100
+MIAMI,West Valley Township H5,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,120100
+MIAMI,West Valley Township H6,United States House of Representatives,2,Democratic,"Potter, Britani",37,120110
+MIAMI,West Valley Township H6,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,120110
+MIAMI,West Valley Township H6,United States House of Representatives,2,Republican,"Jenkins, Lynn",95,120110
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Democratic,"Sidie, Jay",122,140010
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",33,140010
+MIAMI,Louisburg Ward 1,United States House of Representatives,3,Republican,"Yoder, Kevin",214,140010
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Democratic,"Sidie, Jay",152,140020
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",39,140020
+MIAMI,Louisburg Ward 2,United States House of Representatives,3,Republican,"Yoder, Kevin",338,140020
+MIAMI,Louisburg Ward 3,United States House of Representatives,3,Democratic,"Sidie, Jay",142,140030
+MIAMI,Louisburg Ward 3,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",39,140030
+MIAMI,Louisburg Ward 3,United States House of Representatives,3,Republican,"Yoder, Kevin",354,140030
+MIAMI,Louisburg Ward 4,United States House of Representatives,3,Democratic,"Sidie, Jay",122,140040
+MIAMI,Louisburg Ward 4,United States House of Representatives,3,Libertarian,"Hohe, Steven A.",41,140040
+MIAMI,Louisburg Ward 4,United States House of Representatives,3,Republican,"Yoder, Kevin",332,140040
+MIAMI,North Paola Township,United States House of Representatives,2,Democratic,"Potter, Britani",53,200010
+MIAMI,North Paola Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,200010
+MIAMI,North Paola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",165,200010
+MIAMI,South Paola Township,United States House of Representatives,2,Democratic,"Potter, Britani",30,200020
+MIAMI,South Paola Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,200020
+MIAMI,South Paola Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",104,200020
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",76,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,900030
+MIAMI,Osawatomie Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,900030
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",51,900120
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,900120
+MIAMI,West Valley Township Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,900120
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900140
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,900140
+MIAMI,North Paola Township Part 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",12,900140
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",19,900150
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,900150
+MIAMI,North Paola Township Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,900150
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Democratic,"Potter, Britani",29,900180
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,900180
+MIAMI,South Paola Township Part 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",65,900180
+MIAMI,East Valley Township,United States Senate,,write - in,"Smith, DJ",1,000020
+MIAMI,East Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",54,000020
+MIAMI,East Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000020
+MIAMI,East Valley Township,United States Senate,,Republican,"Moran, Jerry",157,000020
+MIAMI,Miami Township,United States Senate,,write - in,"Smith, DJ",0,000050
+MIAMI,Miami Township,United States Senate,,Democratic,"Wiesner, Patrick",72,000050
+MIAMI,Miami Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000050
+MIAMI,Miami Township,United States Senate,,Republican,"Moran, Jerry",188,000050
+MIAMI,Mound Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MIAMI,Mound Township,United States Senate,,Democratic,"Wiesner, Patrick",104,000060
+MIAMI,Mound Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000060
+MIAMI,Mound Township,United States Senate,,Republican,"Moran, Jerry",218,000060
+MIAMI,North Wea Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MIAMI,North Wea Township,United States Senate,,Democratic,"Wiesner, Patrick",81,000080
+MIAMI,North Wea Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000080
+MIAMI,North Wea Township,United States Senate,,Republican,"Moran, Jerry",276,000080
+MIAMI,Osage Township,United States Senate,,write - in,"Smith, DJ",0,000090
+MIAMI,Osage Township,United States Senate,,Democratic,"Wiesner, Patrick",87,000090
+MIAMI,Osage Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000090
+MIAMI,Osage Township,United States Senate,,Republican,"Moran, Jerry",186,000090
+MIAMI,Osawatomie Township,United States Senate,,write - in,"Smith, DJ",0,000100
+MIAMI,Osawatomie Township,United States Senate,,Democratic,"Wiesner, Patrick",86,000100
+MIAMI,Osawatomie Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000100
+MIAMI,Osawatomie Township,United States Senate,,Republican,"Moran, Jerry",229,000100
+MIAMI,Osawatomie Ward 2,United States Senate,,write - in,"Smith, DJ",0,00012A
+MIAMI,Osawatomie Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",119,00012A
+MIAMI,Osawatomie Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,00012A
+MIAMI,Osawatomie Ward 2,United States Senate,,Republican,"Moran, Jerry",241,00012A
+MIAMI,Osawatomie Ward 3,United States Senate,,write - in,"Smith, DJ",0,00013A
+MIAMI,Osawatomie Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",119,00013A
+MIAMI,Osawatomie Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",20,00013A
+MIAMI,Osawatomie Ward 3,United States Senate,,Republican,"Moran, Jerry",223,00013A
+MIAMI,Osawatomie Ward 4,United States Senate,,write - in,"Smith, DJ",0,000140
+MIAMI,Osawatomie Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",68,000140
+MIAMI,Osawatomie Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",21,000140
+MIAMI,Osawatomie Ward 4,United States Senate,,Republican,"Moran, Jerry",145,000140
+MIAMI,Paola Ward 1,United States Senate,,write - in,"Smith, DJ",0,00016A
+MIAMI,Paola Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",174,00016A
+MIAMI,Paola Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",27,00016A
+MIAMI,Paola Ward 1,United States Senate,,Republican,"Moran, Jerry",367,00016A
+MIAMI,Paola Ward 2,United States Senate,,write - in,"Smith, DJ",0,000170
+MIAMI,Paola Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",134,000170
+MIAMI,Paola Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",43,000170
+MIAMI,Paola Ward 2,United States Senate,,Republican,"Moran, Jerry",309,000170
+MIAMI,Paola Ward 3,United States Senate,,write - in,"Smith, DJ",0,00018A
+MIAMI,Paola Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",163,00018A
+MIAMI,Paola Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",25,00018A
+MIAMI,Paola Ward 3,United States Senate,,Republican,"Moran, Jerry",335,00018A
+MIAMI,Paola Ward 4,United States Senate,,write - in,"Smith, DJ",0,00019A
+MIAMI,Paola Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",198,00019A
+MIAMI,Paola Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",20,00019A
+MIAMI,Paola Ward 4,United States Senate,,Republican,"Moran, Jerry",433,00019A
+MIAMI,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000200
+MIAMI,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",235,000200
+MIAMI,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",42,000200
+MIAMI,Richland Township,United States Senate,,Republican,"Moran, Jerry",817,000200
+MIAMI,South Wea Township,United States Senate,,write - in,"Smith, DJ",0,000220
+MIAMI,South Wea Township,United States Senate,,Democratic,"Wiesner, Patrick",123,000220
+MIAMI,South Wea Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,000220
+MIAMI,South Wea Township,United States Senate,,Republican,"Moran, Jerry",611,000220
+MIAMI,Spring Hill City Exclave A,United States Senate,,write - in,"Smith, DJ",0,00023B
+MIAMI,Spring Hill City Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",193,00023B
+MIAMI,Spring Hill City Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",48,00023B
+MIAMI,Spring Hill City Exclave A,United States Senate,,Republican,"Moran, Jerry",541,00023B
+MIAMI,Spring Hill City Exclave B,United States Senate,,write - in,"Smith, DJ",0,00023C
+MIAMI,Spring Hill City Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",47,00023C
+MIAMI,Spring Hill City Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",13,00023C
+MIAMI,Spring Hill City Exclave B,United States Senate,,Republican,"Moran, Jerry",135,00023C
+MIAMI,Spring Hill City Exclave C,United States Senate,,write - in,"Smith, DJ",0,00023D
+MIAMI,Spring Hill City Exclave C,United States Senate,,Democratic,"Wiesner, Patrick",133,00023D
+MIAMI,Spring Hill City Exclave C,United States Senate,,Libertarian,"Garrard, Robert D.",15,00023D
+MIAMI,Spring Hill City Exclave C,United States Senate,,Republican,"Moran, Jerry",347,00023D
+MIAMI,Stanton Township,United States Senate,,write - in,"Smith, DJ",0,000240
+MIAMI,Stanton Township,United States Senate,,Democratic,"Wiesner, Patrick",98,000240
+MIAMI,Stanton Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000240
+MIAMI,Stanton Township,United States Senate,,Republican,"Moran, Jerry",322,000240
+MIAMI,Sugar Creek Township,United States Senate,,write - in,"Smith, DJ",0,000250
+MIAMI,Sugar Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",36,000250
+MIAMI,Sugar Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000250
+MIAMI,Sugar Creek Township,United States Senate,,Republican,"Moran, Jerry",197,000250
+MIAMI,Ten Mile Township,United States Senate,,write - in,"Smith, DJ",0,000260
+MIAMI,Ten Mile Township,United States Senate,,Democratic,"Wiesner, Patrick",172,000260
+MIAMI,Ten Mile Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,000260
+MIAMI,Ten Mile Township,United States Senate,,Republican,"Moran, Jerry",601,000260
+MIAMI,West Middle Creek Township,United States Senate,,write - in,"Smith, DJ",0,000270
+MIAMI,West Middle Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",87,000270
+MIAMI,West Middle Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000270
+MIAMI,West Middle Creek Township,United States Senate,,Republican,"Moran, Jerry",314,000270
+MIAMI,East Middle Creek Township C2,United States Senate,,write - in,"Smith, DJ",0,120020
+MIAMI,East Middle Creek Township C2,United States Senate,,Democratic,"Wiesner, Patrick",36,120020
+MIAMI,East Middle Creek Township C2,United States Senate,,Libertarian,"Garrard, Robert D.",10,120020
+MIAMI,East Middle Creek Township C2,United States Senate,,Republican,"Moran, Jerry",89,120020
+MIAMI,East Middle Creek Township C3,United States Senate,,write - in,"Smith, DJ",0,120030
+MIAMI,East Middle Creek Township C3,United States Senate,,Democratic,"Wiesner, Patrick",100,120030
+MIAMI,East Middle Creek Township C3,United States Senate,,Libertarian,"Garrard, Robert D.",16,120030
+MIAMI,East Middle Creek Township C3,United States Senate,,Republican,"Moran, Jerry",355,120030
+MIAMI,North Marysville Township C2,United States Senate,,write - in,"Smith, DJ",0,120040
+MIAMI,North Marysville Township C2,United States Senate,,Democratic,"Wiesner, Patrick",22,120040
+MIAMI,North Marysville Township C2,United States Senate,,Libertarian,"Garrard, Robert D.",6,120040
+MIAMI,North Marysville Township C2,United States Senate,,Republican,"Moran, Jerry",121,120040
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,write - in,"Smith, DJ",0,120060
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,Democratic,"Wiesner, Patrick",77,120060
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,Libertarian,"Garrard, Robert D.",14,120060
+MIAMI,Osawatomie Ward 1 H5,United States Senate,,Republican,"Moran, Jerry",137,120060
+MIAMI,South Marysville Township C2,United States Senate,,write - in,"Smith, DJ",0,120080
+MIAMI,South Marysville Township C2,United States Senate,,Democratic,"Wiesner, Patrick",168,120080
+MIAMI,South Marysville Township C2,United States Senate,,Libertarian,"Garrard, Robert D.",35,120080
+MIAMI,South Marysville Township C2,United States Senate,,Republican,"Moran, Jerry",508,120080
+MIAMI,South Marysville Township C3,United States Senate,,write - in,"Smith, DJ",0,120090
+MIAMI,South Marysville Township C3,United States Senate,,Democratic,"Wiesner, Patrick",4,120090
+MIAMI,South Marysville Township C3,United States Senate,,Libertarian,"Garrard, Robert D.",0,120090
+MIAMI,South Marysville Township C3,United States Senate,,Republican,"Moran, Jerry",12,120090
+MIAMI,West Valley Township H5,United States Senate,,write - in,"Smith, DJ",0,120100
+MIAMI,West Valley Township H5,United States Senate,,Democratic,"Wiesner, Patrick",34,120100
+MIAMI,West Valley Township H5,United States Senate,,Libertarian,"Garrard, Robert D.",5,120100
+MIAMI,West Valley Township H5,United States Senate,,Republican,"Moran, Jerry",91,120100
+MIAMI,West Valley Township H6,United States Senate,,write - in,"Smith, DJ",0,120110
+MIAMI,West Valley Township H6,United States Senate,,Democratic,"Wiesner, Patrick",40,120110
+MIAMI,West Valley Township H6,United States Senate,,Libertarian,"Garrard, Robert D.",6,120110
+MIAMI,West Valley Township H6,United States Senate,,Republican,"Moran, Jerry",91,120110
+MIAMI,Louisburg Ward 1,United States Senate,,write - in,"Smith, DJ",0,140010
+MIAMI,Louisburg Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",121,140010
+MIAMI,Louisburg Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,140010
+MIAMI,Louisburg Ward 1,United States Senate,,Republican,"Moran, Jerry",226,140010
+MIAMI,Louisburg Ward 2,United States Senate,,write - in,"Smith, DJ",0,140020
+MIAMI,Louisburg Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",140,140020
+MIAMI,Louisburg Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",24,140020
+MIAMI,Louisburg Ward 2,United States Senate,,Republican,"Moran, Jerry",363,140020
+MIAMI,Louisburg Ward 3,United States Senate,,write - in,"Smith, DJ",0,140030
+MIAMI,Louisburg Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",132,140030
+MIAMI,Louisburg Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",27,140030
+MIAMI,Louisburg Ward 3,United States Senate,,Republican,"Moran, Jerry",378,140030
+MIAMI,Louisburg Ward 4,United States Senate,,write - in,"Smith, DJ",0,140040
+MIAMI,Louisburg Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",117,140040
+MIAMI,Louisburg Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",31,140040
+MIAMI,Louisburg Ward 4,United States Senate,,Republican,"Moran, Jerry",348,140040
+MIAMI,North Paola Township,United States Senate,,write - in,"Smith, DJ",0,200010
+MIAMI,North Paola Township,United States Senate,,Democratic,"Wiesner, Patrick",64,200010
+MIAMI,North Paola Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,200010
+MIAMI,North Paola Township,United States Senate,,Republican,"Moran, Jerry",148,200010
+MIAMI,South Paola Township,United States Senate,,write - in,"Smith, DJ",0,200020
+MIAMI,South Paola Township,United States Senate,,Democratic,"Wiesner, Patrick",31,200020
+MIAMI,South Paola Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,200020
+MIAMI,South Paola Township,United States Senate,,Republican,"Moran, Jerry",103,200020
+MIAMI,West Valley Township Exclave,United States Senate,,write - in,"Smith, DJ",0,900120
+MIAMI,West Valley Township Exclave,United States Senate,,Democratic,"Wiesner, Patrick",62,900120
+MIAMI,West Valley Township Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",13,900120
+MIAMI,West Valley Township Exclave,United States Senate,,Republican,"Moran, Jerry",147,900120
+MIAMI,North Paola Township Part 1,United States Senate,,write - in,"Smith, DJ",0,900140
+MIAMI,North Paola Township Part 1,United States Senate,,Democratic,"Wiesner, Patrick",1,900140
+MIAMI,North Paola Township Part 1,United States Senate,,Libertarian,"Garrard, Robert D.",1,900140
+MIAMI,North Paola Township Part 1,United States Senate,,Republican,"Moran, Jerry",11,900140
+MIAMI,North Paola Township Part 2,United States Senate,,write - in,"Smith, DJ",0,900150
+MIAMI,North Paola Township Part 2,United States Senate,,Democratic,"Wiesner, Patrick",15,900150
+MIAMI,North Paola Township Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",10,900150
+MIAMI,North Paola Township Part 2,United States Senate,,Republican,"Moran, Jerry",61,900150
+MIAMI,South Paola Township Part 2,United States Senate,,write - in,"Smith, DJ",0,900180
+MIAMI,South Paola Township Part 2,United States Senate,,Democratic,"Wiesner, Patrick",26,900180
+MIAMI,South Paola Township Part 2,United States Senate,,Libertarian,"Garrard, Robert D.",6,900180
+MIAMI,South Paola Township Part 2,United States Senate,,Republican,"Moran, Jerry",67,900180

--- a/2016/20161108__ks__general__mitchell__precinct.csv
+++ b/2016/20161108__ks__general__mitchell__precinct.csv
@@ -1,313 +1,1189 @@
-county,precinct,office,district,party,candidate,advance_votes,paper_votes,machine_votes,provisional_votes,votes
-Mitchell,Beloit 1st,President,,REP,Trump/Pence,41,106,47,9,203
-Mitchell,Beloit 2nd,President,,REP,Trump/Pence,75,116,144,7,342
-Mitchell,Beloit 3rd,President,,REP,Trump/Pence,87,117,143,4,351
-Mitchell,Beloit 4th,President,,REP,Trump/Pence,77,72,124,13,286
-Mitchell,Lulu Township,President,,REP,Trump/Pence,12,17,6,1,36
-Mitchell,Asherville Township,President,,REP,Trump/Pence,5,23,7,1,36
-Mitchell,Logan Township,President,,REP,Trump/Pence,8,21,9,,38
-Mitchell,Eureka Township,President,,REP,Trump/Pence,1,4,2,,7
-Mitchell,Plum Creek Township,President,,REP,Trump/Pence,17,33,11,,61
-Mitchell,Beloit Township,President,,REP,Trump/Pence,22,42,27,,91
-Mitchell,Bloomfield Township,President,,REP,Trump/Pence,8,17,8,1,34
-Mitchell,Salt Creek Township,President,,REP,Trump/Pence,1,11,2,,14
-Mitchell,Soloman Rapids Township,President,,REP,Trump/Pence,4,19,5,,28
-Mitchell,Turkey Creek Township,President,,REP,Trump/Pence,8,34,17,,59
-Mitchell,Center Township,President,,REP,Trump/Pence,2,6,5,,13
-Mitchell,Round Springs Township,President,,REP,Trump/Pence,3,9,3,,15
-Mitchell,Glen Elder Township,President,,REP,Trump/Pence,19,164,,17,200
-Mitchell,Walnut Creek Township,President,,REP,Trump/Pence,3,15,,1,19
-Mitchell,Hayes Township,President,,REP,Trump/Pence,2,12,1,,15
-Mitchell,Blue Hill Township,President,,REP,Trump/Pence,2,10,6,,18
-Mitchell,Cawker Township,President,,REP,Trump/Pence,16,137,51,2,206
-Mitchell,Carr Creek Township,President,,REP,Trump/Pence,0,12,,,12
-Mitchell,Pittsburg Township,President,,REP,Trump/Pence,10,109,14,1,134
-Mitchell,Custer Township,President,,REP,Trump/Pence,5,36,47,2,90
-Mitchell,Beloit 1st,President,,DEM,Clinton/Kaine,21,24,6,,51
-Mitchell,Beloit 2nd,President,,DEM,Clinton/Kaine,40,30,35,1,106
-Mitchell,Beloit 3rd,President,,DEM,Clinton/Kaine,16,18,37,1,72
-Mitchell,Beloit 4th,President,,DEM,Clinton/Kaine,32,19,30,5,86
-Mitchell,Lulu Township,President,,DEM,Clinton/Kaine,2,,,,2
-Mitchell,Asherville Township,President,,DEM,Clinton/Kaine,2,5,3,,10
-Mitchell,Logan Township,President,,DEM,Clinton/Kaine,2,3,2,,7
-Mitchell,Eureka Township,President,,DEM,Clinton/Kaine,4,1,2,,7
-Mitchell,Plum Creek Township,President,,DEM,Clinton/Kaine,1,2,2,,5
-Mitchell,Beloit Township,President,,DEM,Clinton/Kaine,4,14,5,,23
-Mitchell,Bloomfield Township,President,,DEM,Clinton/Kaine,3,2,1,,6
-Mitchell,Salt Creek Township,President,,DEM,Clinton/Kaine,,2,,,2
-Mitchell,Soloman Rapids Township,President,,DEM,Clinton/Kaine,3,2,3,,8
-Mitchell,Turkey Creek Township,President,,DEM,Clinton/Kaine,6,1,1,,8
-Mitchell,Center Township,President,,DEM,Clinton/Kaine,,,,,0
-Mitchell,Round Springs Township,President,,DEM,Clinton/Kaine,,,,,0
-Mitchell,Glen Elder Township,President,,DEM,Clinton/Kaine,2,30,,2,34
-Mitchell,Walnut Creek Township,President,,DEM,Clinton/Kaine,2,1,,,3
-Mitchell,Hayes Township,President,,DEM,Clinton/Kaine,,,1,,1
-Mitchell,Blue Hill Township,President,,DEM,Clinton/Kaine,,,,,0
-Mitchell,Cawker Township,President,,DEM,Clinton/Kaine,7,14,3,,24
-Mitchell,Carr Creek Township,President,,DEM,Clinton/Kaine,,,,,0
-Mitchell,Pittsburg Township,President,,DEM,Clinton/Kaine,1,11,1,,13
-Mitchell,Custer Township,President,,DEM,Clinton/Kaine,,7,2,,9
-Mitchell,Beloit 1st,President,,IND,Stein/Baraka,2,1,1,,4
-Mitchell,Beloit 2nd,President,,IND,Stein/Baraka,1,2,1,,4
-Mitchell,Beloit 3rd,President,,IND,Stein/Baraka,2,3,2,,7
-Mitchell,Beloit 4th,President,,IND,Stein/Baraka,4,1,3,1,9
-Mitchell,Lulu Township,President,,IND,Stein/Baraka,0,1,,,1
-Mitchell,Asherville Township,President,,IND,Stein/Baraka,,2,,,2
-Mitchell,Logan Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Eureka Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Plum Creek Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Beloit Township,President,,IND,Stein/Baraka,,,1,,1
-Mitchell,Bloomfield Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Salt Creek Township,President,,IND,Stein/Baraka,,1,,,1
-Mitchell,Soloman Rapids Township,President,,IND,Stein/Baraka,1,1,1,,3
-Mitchell,Turkey Creek Township,President,,IND,Stein/Baraka,1,1,,,2
-Mitchell,Center Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Round Springs Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Glen Elder Township,President,,IND,Stein/Baraka,1,6,,,7
-Mitchell,Walnut Creek Township,President,,IND,Stein/Baraka,,2,,,2
-Mitchell,Hayes Township,President,,IND,Stein/Baraka,1,,,,1
-Mitchell,Blue Hill Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Cawker Township,President,,IND,Stein/Baraka,,4,2,,6
-Mitchell,Carr Creek Township,President,,IND,Stein/Baraka,,,,,0
-Mitchell,Pittsburg Township,President,,IND,Stein/Baraka,,3,,,3
-Mitchell,Custer Township,President,,IND,Stein/Baraka,,2,,,2
-Mitchell,Beloit 1st,President,,LIB,Johnson/Weld,5,4,4,,13
-Mitchell,Beloit 2nd,President,,LIB,Johnson/Weld,6,2,6,1,15
-Mitchell,Beloit 3rd,President,,LIB,Johnson/Weld,3,4,8,1,16
-Mitchell,Beloit 4th,President,,LIB,Johnson/Weld,2,2,7,,11
-Mitchell,Lulu Township,President,,LIB,Johnson/Weld,0,,1,,1
-Mitchell,Asherville Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Logan Township,President,,LIB,Johnson/Weld,,1,1,,2
-Mitchell,Eureka Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Plum Creek Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Beloit Township,President,,LIB,Johnson/Weld,1,,4,,5
-Mitchell,Bloomfield Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Salt Creek Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Soloman Rapids Township,President,,LIB,Johnson/Weld,,1,,,1
-Mitchell,Turkey Creek Township,President,,LIB,Johnson/Weld,,1,,,1
-Mitchell,Center Township,President,,LIB,Johnson/Weld,,1,1,,2
-Mitchell,Round Springs Township,President,,LIB,Johnson/Weld,,,1,,1
-Mitchell,Glen Elder Township,President,,LIB,Johnson/Weld,,8,,,8
-Mitchell,Walnut Creek Township,President,,LIB,Johnson/Weld,,1,,,1
-Mitchell,Hayes Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Blue Hill Township,President,,LIB,Johnson/Weld,,,2,,2
-Mitchell,Cawker Township,President,,LIB,Johnson/Weld,3,4,,,7
-Mitchell,Carr Creek Township,President,,LIB,Johnson/Weld,,,,,0
-Mitchell,Pittsburg Township,President,,LIB,Johnson/Weld,,2,,,2
-Mitchell,Custer Township,President,,LIB,Johnson/Weld,,1,,,1
-Mitchell,Beloit 1st,U.S. Senate,,DEM,Patrick Wiesner,14,15,2,,31
-Mitchell,Beloit 2nd,U.S. Senate,,DEM,Patrick Wiesner,30,25,17,2,74
-Mitchell,Beloit 3rd,U.S. Senate,,DEM,Patrick Wiesner,21,16,25,3,65
-Mitchell,Beloit 4th,U.S. Senate,,DEM,Patrick Wiesner,14,11,20,4,49
-Mitchell,Lulu Township,U.S. Senate,,DEM,Patrick Wiesner,1,,,,1
-Mitchell,Asherville Township,U.S. Senate,,DEM,Patrick Wiesner,,5,2,,7
-Mitchell,Logan Township,U.S. Senate,,DEM,Patrick Wiesner,2,2,1,,5
-Mitchell,Eureka Township,U.S. Senate,,DEM,Patrick Wiesner,,1,1,,2
-Mitchell,Plum Creek Township,U.S. Senate,,DEM,Patrick Wiesner,,3,,,3
-Mitchell,Beloit Township,U.S. Senate,,DEM,Patrick Wiesner,2,7,4,,13
-Mitchell,Bloomfield Township,U.S. Senate,,DEM,Patrick Wiesner,2,1,,,3
-Mitchell,Salt Creek Township,U.S. Senate,,DEM,Patrick Wiesner,,,,,0
-Mitchell,Soloman Rapids Township,U.S. Senate,,DEM,Patrick Wiesner,3,,6,,9
-Mitchell,Turkey Creek Township,U.S. Senate,,DEM,Patrick Wiesner,2,1,,,3
-Mitchell,Center Township,U.S. Senate,,DEM,Patrick Wiesner,,,,,0
-Mitchell,Round Springs Township,U.S. Senate,,DEM,Patrick Wiesner,,,1,,1
-Mitchell,Glen Elder Township,U.S. Senate,,DEM,Patrick Wiesner,1,21,,,22
-Mitchell,Walnut Creek Township,U.S. Senate,,DEM,Patrick Wiesner,2,2,,,4
-Mitchell,Hayes Township,U.S. Senate,,DEM,Patrick Wiesner,1,,,,1
-Mitchell,Blue Hill Township,U.S. Senate,,DEM,Patrick Wiesner,,,,,0
-Mitchell,Cawker Township,U.S. Senate,,DEM,Patrick Wiesner,7,15,5,,27
-Mitchell,Carr Creek Township,U.S. Senate,,DEM,Patrick Wiesner,,,,,0
-Mitchell,Pittsburg Township,U.S. Senate,,DEM,Patrick Wiesner,1,6,1,,8
-Mitchell,Custer Township,U.S. Senate,,DEM,Patrick Wiesner,1,6,1,,8
-Mitchell,Beloit 1st,U.S. Senate,,REP,Jerry Moran,52,113,52,9,226
-Mitchell,Beloit 2nd,U.S. Senate,,REP,Jerry Moran,86,122,168,7,383
-Mitchell,Beloit 3rd,U.S. Senate,,REP,Jerry Moran,86,123,159,1,369
-Mitchell,Beloit 4th,U.S. Senate,,REP,Jerry Moran,93,81,137,15,326
-Mitchell,Lulu Township,U.S. Senate,,REP,Jerry Moran,13,18,7,,38
-Mitchell,Asherville Township,U.S. Senate,,REP,Jerry Moran,6,24,7,,37
-Mitchell,Logan Township,U.S. Senate,,REP,Jerry Moran,7,22,11,,40
-Mitchell,Eureka Township,U.S. Senate,,REP,Jerry Moran,5,5,3,,13
-Mitchell,Plum Creek Township,U.S. Senate,,REP,Jerry Moran,17,31,14,,62
-Mitchell,Beloit Township,U.S. Senate,,REP,Jerry Moran,23,45,33,,101
-Mitchell,Bloomfield Township,U.S. Senate,,REP,Jerry Moran,9,17,9,1,36
-Mitchell,Salt Creek Township,U.S. Senate,,REP,Jerry Moran,2,13,2,,17
-Mitchell,Soloman Rapids Township,U.S. Senate,,REP,Jerry Moran,3,21,3,,27
-Mitchell,Turkey Creek Township,U.S. Senate,,REP,Jerry Moran,15,35,18,,68
-Mitchell,Center Township,U.S. Senate,,REP,Jerry Moran,3,7,6,,16
-Mitchell,Round Springs Township,U.S. Senate,,REP,Jerry Moran,2,9,3,,14
-Mitchell,Glen Elder Township,U.S. Senate,,REP,Jerry Moran,22,182,,17,221
-Mitchell,Walnut Creek Township,U.S. Senate,,REP,Jerry Moran,3,16,,1,20
-Mitchell,Hayes Township,U.S. Senate,,REP,Jerry Moran,1,12,2,,15
-Mitchell,Blue Hill Township,U.S. Senate,,REP,Jerry Moran,2,9,9,,20
-Mitchell,Cawker Township,U.S. Senate,,REP,Jerry Moran,19,138,45,2,204
-Mitchell,Carr Creek Township,U.S. Senate,,REP,Jerry Moran,,13,,,13
-Mitchell,Pittsburg Township,U.S. Senate,,REP,Jerry Moran,10,116,15,,141
-Mitchell,Custer Township,U.S. Senate,,REP,Jerry Moran,3,40,11,2,56
-Mitchell,Beloit 1st,U.S. Senate,,LIB,Robert Garrard,3,8,3,,14
-Mitchell,Beloit 2nd,U.S. Senate,,LIB,Robert Garrard,3,6,4,,13
-Mitchell,Beloit 3rd,U.S. Senate,,LIB,Robert Garrard,5,6,8,2,21
-Mitchell,Beloit 4th,U.S. Senate,,LIB,Robert Garrard,6,1,7,,14
-Mitchell,Lulu Township,U.S. Senate,,LIB,Robert Garrard,0,,,1,1
-Mitchell,Asherville Township,U.S. Senate,,LIB,Robert Garrard,1,3,1,1,6
-Mitchell,Logan Township,U.S. Senate,,LIB,Robert Garrard,1,,,,1
-Mitchell,Eureka Township,U.S. Senate,,LIB,Robert Garrard,,,,,0
-Mitchell,Plum Creek Township,U.S. Senate,,LIB,Robert Garrard,1,2,,,3
-Mitchell,Beloit Township,U.S. Senate,,LIB,Robert Garrard,,3,,,3
-Mitchell,Bloomfield Township,U.S. Senate,,LIB,Robert Garrard,,1,,,1
-Mitchell,Salt Creek Township,U.S. Senate,,LIB,Robert Garrard,,1,,,1
-Mitchell,Soloman Rapids Township,U.S. Senate,,LIB,Robert Garrard,1,1,,,2
-Mitchell,Turkey Creek Township,U.S. Senate,,LIB,Robert Garrard,,1,,,1
-Mitchell,Center Township,U.S. Senate,,LIB,Robert Garrard,,,,,0
-Mitchell,Round Springs Township,U.S. Senate,,LIB,Robert Garrard,,,,,0
-Mitchell,Glen Elder Township,U.S. Senate,,LIB,Robert Garrard,,9,,2,11
-Mitchell,Walnut Creek Township,U.S. Senate,,LIB,Robert Garrard,,1,,,1
-Mitchell,Hayes Township,U.S. Senate,,LIB,Robert Garrard,1,,,,1
-Mitchell,Blue Hill Township,U.S. Senate,,LIB,Robert Garrard,,1,1,,2
-Mitchell,Cawker Township,U.S. Senate,,LIB,Robert Garrard,1,6,3,,10
-Mitchell,Carr Creek Township,U.S. Senate,,LIB,Robert Garrard,,,,,0
-Mitchell,Pittsburg Township,U.S. Senate,,LIB,Robert Garrard,,3,1,1,5
-Mitchell,Custer Township,U.S. Senate,,LIB,Robert Garrard,1,1,1,,3
-Mitchell,Beloit 1st,U.S. House,1,REP,Roger Marshall,41,92,42,7,182
-Mitchell,Beloit 2nd,U.S. House,1,REP,Roger Marshall,76,106,141,8,331
-Mitchell,Beloit 3rd,U.S. House,1,REP,Roger Marshall,82,104,130,5,321
-Mitchell,Beloit 4th,U.S. House,1,REP,Roger Marshall,82,67,115,14,278
-Mitchell,Lulu Township,U.S. House,1,REP,Roger Marshall,9,16,6,1,32
-Mitchell,Asherville Township,U.S. House,1,REP,Roger Marshall,2,21,3,,26
-Mitchell,Logan Township,U.S. House,1,REP,Roger Marshall,5,19,6,,30
-Mitchell,Eureka Township,U.S. House,1,REP,Roger Marshall,3,4,2,,9
-Mitchell,Plum Creek Township,U.S. House,1,REP,Roger Marshall,14,23,14,,51
-Mitchell,Beloit Township,U.S. House,1,REP,Roger Marshall,16,37,32,,85
-Mitchell,Bloomfield Township,U.S. House,1,REP,Roger Marshall,10,15,8,1,34
-Mitchell,Salt Creek Township,U.S. House,1,REP,Roger Marshall,2,12,1,,15
-Mitchell,Soloman Rapids Township,U.S. House,1,REP,Roger Marshall,2,21,4,,27
-Mitchell,Turkey Creek Township,U.S. House,1,REP,Roger Marshall,10,30,14,,54
-Mitchell,Center Township,U.S. House,1,REP,Roger Marshall,,7,6,,13
-Mitchell,Round Springs Township,U.S. House,1,REP,Roger Marshall,3,7,4,,14
-Mitchell,Glen Elder Township,U.S. House,1,REP,Roger Marshall,20,153,,15,188
-Mitchell,Walnut Creek Township,U.S. House,1,REP,Roger Marshall,2,15,,,17
-Mitchell,Hayes Township,U.S. House,1,REP,Roger Marshall,2,11,1,,14
-Mitchell,Blue Hill Township,U.S. House,1,REP,Roger Marshall,2,7,5,,14
-Mitchell,Cawker Township,U.S. House,1,REP,Roger Marshall,17,110,39,2,168
-Mitchell,Carr Creek Township,U.S. House,1,REP,Roger Marshall,,9,,,9
-Mitchell,Pittsburg Township,U.S. House,1,REP,Roger Marshall,10,101,13,1,125
-Mitchell,Custer Township,U.S. House,1,REP,Roger Marshall,5,38,10,2,55
-Mitchell,Beloit 1st,U.S. House,1,LIB,Kerry Burt,1,6,2,1,10
-Mitchell,Beloit 2nd,U.S. House,1,LIB,Kerry Burt,7,2,3,,12
-Mitchell,Beloit 3rd,U.S. House,1,LIB,Kerry Burt,4,7,6,,17
-Mitchell,Beloit 4th,U.S. House,1,LIB,Kerry Burt,2,2,2,3,9
-Mitchell,Lulu Township,U.S. House,1,LIB,Kerry Burt,0,,1,,1
-Mitchell,Asherville Township,U.S. House,1,LIB,Kerry Burt,2,,,,2
-Mitchell,Logan Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Eureka Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Plum Creek Township,U.S. House,1,LIB,Kerry Burt,,2,,,2
-Mitchell,Beloit Township,U.S. House,1,LIB,Kerry Burt,2,5,1,,8
-Mitchell,Bloomfield Township,U.S. House,1,LIB,Kerry Burt,,1,1,,2
-Mitchell,Salt Creek Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Soloman Rapids Township,U.S. House,1,LIB,Kerry Burt,1,,1,,2
-Mitchell,Turkey Creek Township,U.S. House,1,LIB,Kerry Burt,,2,,,2
-Mitchell,Center Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Round Springs Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Glen Elder Township,U.S. House,1,LIB,Kerry Burt,,5,,2,7
-Mitchell,Walnut Creek Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Hayes Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Blue Hill Township,U.S. House,1,LIB,Kerry Burt,,2,,,2
-Mitchell,Cawker Township,U.S. House,1,LIB,Kerry Burt,1,12,3,,16
-Mitchell,Carr Creek Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Pittsburg Township,U.S. House,1,LIB,Kerry Burt,1,5,1,,7
-Mitchell,Custer Township,U.S. House,1,LIB,Kerry Burt,,,,,0
-Mitchell,Beloit 1st,U.S. House,1,IND,Alan LaPolice,23,36,14,1,74
-Mitchell,Beloit 2nd,U.S. House,1,IND,Alan LaPolice,35,44,41,1,121
-Mitchell,Beloit 3rd,U.S. House,1,IND,Alan LaPolice,27,31,52,1,111
-Mitchell,Beloit 4th,U.S. House,1,IND,Alan LaPolice,22,23,42,2,89
-Mitchell,Lulu Township,U.S. House,1,IND,Alan LaPolice,5,2,,,7
-Mitchell,Asherville Township,U.S. House,1,IND,Alan LaPolice,3,11,7,1,22
-Mitchell,Logan Township,U.S. House,1,IND,Alan LaPolice,5,4,5,,14
-Mitchell,Eureka Township,U.S. House,1,IND,Alan LaPolice,2,2,2,,6
-Mitchell,Plum Creek Township,U.S. House,1,IND,Alan LaPolice,4,8,,,12
-Mitchell,Beloit Township,U.S. House,1,IND,Alan LaPolice,6,12,4,,22
-Mitchell,Bloomfield Township,U.S. House,1,IND,Alan LaPolice,2,3,1,,6
-Mitchell,Salt Creek Township,U.S. House,1,IND,Alan LaPolice,,2,1,,3
-Mitchell,Soloman Rapids Township,U.S. House,1,IND,Alan LaPolice,3,1,4,,8
-Mitchell,Turkey Creek Township,U.S. House,1,IND,Alan LaPolice,6,7,4,,17
-Mitchell,Center Township,U.S. House,1,IND,Alan LaPolice,2,0,,,2
-Mitchell,Round Springs Township,U.S. House,1,IND,Alan LaPolice,,1,,,1
-Mitchell,Glen Elder Township,U.S. House,1,IND,Alan LaPolice,3,48,,1,52
-Mitchell,Walnut Creek Township,U.S. House,1,IND,Alan LaPolice,3,4,,1,8
-Mitchell,Hayes Township,U.S. House,1,IND,Alan LaPolice,1,1,1,,3
-Mitchell,Blue Hill Township,U.S. House,1,IND,Alan LaPolice,,1,5,,6
-Mitchell,Cawker Township,U.S. House,1,IND,Alan LaPolice,9,37,11,,57
-Mitchell,Carr Creek Township,U.S. House,1,IND,Alan LaPolice,,4,,,4
-Mitchell,Pittsburg Township,U.S. House,1,IND,Alan LaPolice,,15,3,,18
-Mitchell,Custer Township,U.S. House,1,IND,Alan LaPolice,,5,3,,8
-Mitchell,Beloit 1st,State Senate,36,DEM,Brian Angevine,12,11,2,1,26
-Mitchell,Beloit 2nd,State Senate,36,DEM,Brian Angevine,17,19,14,1,51
-Mitchell,Beloit 3rd,State Senate,36,DEM,Brian Angevine,17,11,19,1,48
-Mitchell,Beloit 4th,State Senate,36,DEM,Brian Angevine,14,4,17,3,38
-Mitchell,Lulu Township,State Senate,36,DEM,Brian Angevine,0,,,,0
-Mitchell,Asherville Township,State Senate,36,DEM,Brian Angevine,,5,1,,6
-Mitchell,Logan Township,State Senate,36,DEM,Brian Angevine,2,1,,,3
-Mitchell,Eureka Township,State Senate,36,DEM,Brian Angevine,1,,1,,2
-Mitchell,Plum Creek Township,State Senate,36,DEM,Brian Angevine,,,,,0
-Mitchell,Beloit Township,State Senate,36,DEM,Brian Angevine,1,3,2,,6
-Mitchell,Bloomfield Township,State Senate,36,DEM,Brian Angevine,2,3,1,,6
-Mitchell,Salt Creek Township,State Senate,36,DEM,Brian Angevine,,2,,,2
-Mitchell,Soloman Rapids Township,State Senate,36,DEM,Brian Angevine,1,1,3,,5
-Mitchell,Turkey Creek Township,State Senate,36,DEM,Brian Angevine,5,2,,,7
-Mitchell,Center Township,State Senate,36,DEM,Brian Angevine,,,,,0
-Mitchell,Round Springs Township,State Senate,36,DEM,Brian Angevine,,,,,0
-Mitchell,Glen Elder Township,State Senate,36,DEM,Brian Angevine,,25,,,25
-Mitchell,Walnut Creek Township,State Senate,36,DEM,Brian Angevine,2,2,,,4
-Mitchell,Hayes Township,State Senate,36,DEM,Brian Angevine,,,1,,1
-Mitchell,Blue Hill Township,State Senate,36,DEM,Brian Angevine,,,2,,2
-Mitchell,Cawker Township,State Senate,36,DEM,Brian Angevine,5,16,5,,26
-Mitchell,Carr Creek Township,State Senate,36,DEM,Brian Angevine,,,,,0
-Mitchell,Pittsburg Township,State Senate,36,DEM,Brian Angevine,1,11,1,,13
-Mitchell,Custer Township,State Senate,36,DEM,Brian Angevine,,7,3,,10
-Mitchell,Beloit 1st,State Senate,36,REP,Elaine Bowers,55,122,53,8,238
-Mitchell,Beloit 2nd,State Senate,36,REP,Elaine Bowers,103,130,173,7,413
-Mitchell,Beloit 3rd,State Senate,36,REP,Elaine Bowers,96,132,173,5,406
-Mitchell,Beloit 4th,State Senate,36,REP,Elaine Bowers,94,90,146,16,346
-Mitchell,Lulu Township,State Senate,36,REP,Elaine Bowers,14,17,7,1,39
-Mitchell,Asherville Township,State Senate,36,REP,Elaine Bowers,7,27,9,1,44
-Mitchell,Logan Township,State Senate,36,REP,Elaine Bowers,7,22,12,,41
-Mitchell,Eureka Township,State Senate,36,REP,Elaine Bowers,4,6,3,,13
-Mitchell,Plum Creek Township,State Senate,36,REP,Elaine Bowers,17,31,14,,62
-Mitchell,Beloit Township,State Senate,36,REP,Elaine Bowers,24,52,35,,111
-Mitchell,Bloomfield Township,State Senate,36,REP,Elaine Bowers,10,16,9,1,36
-Mitchell,Salt Creek Township,State Senate,36,REP,Elaine Bowers,2,12,2,,16
-Mitchell,Soloman Rapids Township,State Senate,36,REP,Elaine Bowers,6,21,6,,33
-Mitchell,Turkey Creek Township,State Senate,36,REP,Elaine Bowers,12,34,18,,64
-Mitchell,Center Township,State Senate,36,REP,Elaine Bowers,3,7,6,,16
-Mitchell,Round Springs Township,State Senate,36,REP,Elaine Bowers,3,9,2,,14
-Mitchell,Glen Elder Township,State Senate,36,REP,Elaine Bowers,23,181,,18,222
-Mitchell,Walnut Creek Township,State Senate,36,REP,Elaine Bowers,3,17,,1,21
-Mitchell,Hayes Township,State Senate,36,REP,Elaine Bowers,3,12,1,,16
-Mitchell,Blue Hill Township,State Senate,36,REP,Elaine Bowers,2,9,8,,19
-Mitchell,Cawker Township,State Senate,36,REP,Elaine Bowers,22,141,49,2,214
-Mitchell,Carr Creek Township,State Senate,36,REP,Elaine Bowers,,13,,,13
-Mitchell,Pittsburg Township,State Senate,36,REP,Elaine Bowers,10,109,16,1,136
-Mitchell,Custer Township,State Senate,36,REP,Elaine Bowers,5,39,10,2,56
-Mitchell,Beloit 1st,State House,107,REP,Susan Concannon,67,124,55,9,255
-Mitchell,Beloit 2nd,State House,107,REP,Susan Concannon,113,137,183,9,442
-Mitchell,Beloit 3rd,State House,107,REP,Susan Concannon,108,132,191,6,437
-Mitchell,Beloit 4th,State House,107,REP,Susan Concannon,101,85,156,19,361
-Mitchell,Lulu Township,State House,107,REP,Susan Concannon,13,16,7,1,37
-Mitchell,Asherville Township,State House,107,REP,Susan Concannon,7,28,10,1,46
-Mitchell,Logan Township,State House,107,REP,Susan Concannon,8,24,12,,44
-Mitchell,Eureka Township,State House,107,REP,Susan Concannon,5,6,4,,15
-Mitchell,Plum Creek Township,State House,107,REP,Susan Concannon,16,33,10,,59
-Mitchell,Beloit Township,State House,107,REP,Susan Concannon,24,53,37,,114
-Mitchell,Bloomfield Township,State House,107,REP,Susan Concannon,11,17,9,1,38
-Mitchell,Salt Creek Township,State House,107,REP,Susan Concannon,2,13,1,,16
-Mitchell,Soloman Rapids Township,State House,107,REP,Susan Concannon,7,21,9,,37
-Mitchell,Turkey Creek Township,State House,107,REP,Susan Concannon,15,34,18,,67
-Mitchell,Center Township,State House,107,REP,Susan Concannon,3,6,4,,13
-Mitchell,Round Springs Township,State House,107,REP,Susan Concannon,2,8,3,,13
-Mitchell,Glen Elder Township,State House,107,REP,Susan Concannon,22,197,,19,238
-Mitchell,Walnut Creek Township,State House,107,REP,Susan Concannon,4,18,,1,23
-Mitchell,Hayes Township,State House,107,REP,Susan Concannon,3,12,2,,17
-Mitchell,Blue Hill Township,State House,107,REP,Susan Concannon,2,8,10,,20
-Mitchell,Cawker Township,State House,107,REP,Susan Concannon,23,142,55,2,222
-Mitchell,Carr Creek Township,State House,107,REP,Susan Concannon,,13,,,13
-Mitchell,Pittsburg Township,State House,107,REP,Susan Concannon,11,118,16,1,146
-Mitchell,Custer Township,State House,107,REP,Susan Concannon,5,44,13,2,64
+county,precinct,office,district,party,candidate,votes,vtd
+MITCHELL,Asherville Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",46,000010
+MITCHELL,Beloit City Ward 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",255,000020
+MITCHELL,Beloit City Ward 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",442,000030
+MITCHELL,Beloit City Ward 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",437,000040
+MITCHELL,Beloit City Ward 4,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",361,000050
+MITCHELL,Beloit Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",114,00006A
+MITCHELL,Beloit Township Enclave A,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006B
+MITCHELL,Beloit Township Enclave B,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006C
+MITCHELL,Beloit Township Enclave C,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00006D
+MITCHELL,Bloomfield Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",38,000070
+MITCHELL,Blue Hill Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",20,000080
+MITCHELL,Carr Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",13,000090
+MITCHELL,Cawker City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000100
+MITCHELL,Cawker Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",222,000110
+MITCHELL,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",13,000120
+MITCHELL,Custer Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",64,000130
+MITCHELL,Eureka Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",15,000140
+MITCHELL,Glen Elder City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000150
+MITCHELL,Glen Elder Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",238,000160
+MITCHELL,Hayes Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",17,000170
+MITCHELL,Hunter City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000180
+MITCHELL,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",44,000190
+MITCHELL,Lulu Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",37,000200
+MITCHELL,Pittsburg Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",146,000210
+MITCHELL,Plum Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",59,000220
+MITCHELL,Round Springs Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",13,000230
+MITCHELL,Salt Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",16,000240
+MITCHELL,Scottsville City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000250
+MITCHELL,Simpson City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000260
+MITCHELL,Solomon Rapids Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",37,000270
+MITCHELL,Tipton City,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,000280
+MITCHELL,Turkey Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",67,000290
+MITCHELL,Walnut Creek Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",23,000300
+MITCHELL,Asherville Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000010
+MITCHELL,Asherville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",44,000010
+MITCHELL,Beloit City Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",26,000020
+MITCHELL,Beloit City Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",238,000020
+MITCHELL,Beloit City Ward 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",51,000030
+MITCHELL,Beloit City Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",413,000030
+MITCHELL,Beloit City Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",48,000040
+MITCHELL,Beloit City Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",406,000040
+MITCHELL,Beloit City Ward 4,Kansas Senate,36,Democratic,"Angevine, Brian G.",38,000050
+MITCHELL,Beloit City Ward 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",346,000050
+MITCHELL,Beloit Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,00006A
+MITCHELL,Beloit Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",111,00006A
+MITCHELL,Beloit Township Enclave A,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00006B
+MITCHELL,Beloit Township Enclave A,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006B
+MITCHELL,Beloit Township Enclave B,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00006C
+MITCHELL,Beloit Township Enclave B,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006C
+MITCHELL,Beloit Township Enclave C,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00006D
+MITCHELL,Beloit Township Enclave C,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006D
+MITCHELL,Bloomfield Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000070
+MITCHELL,Bloomfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000070
+MITCHELL,Blue Hill Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000080
+MITCHELL,Blue Hill Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000080
+MITCHELL,Carr Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000090
+MITCHELL,Carr Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000090
+MITCHELL,Cawker City,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000100
+MITCHELL,Cawker City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000100
+MITCHELL,Cawker Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",26,000110
+MITCHELL,Cawker Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",214,000110
+MITCHELL,Center Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000120
+MITCHELL,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000120
+MITCHELL,Custer Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000130
+MITCHELL,Custer Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",56,000130
+MITCHELL,Eureka Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000140
+MITCHELL,Eureka Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000140
+MITCHELL,Glen Elder City,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000150
+MITCHELL,Glen Elder City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000150
+MITCHELL,Glen Elder Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,000160
+MITCHELL,Glen Elder Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",222,000160
+MITCHELL,Hayes Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000170
+MITCHELL,Hayes Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000170
+MITCHELL,Hunter City,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000180
+MITCHELL,Hunter City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000180
+MITCHELL,Logan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000190
+MITCHELL,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000190
+MITCHELL,Lulu Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000200
+MITCHELL,Lulu Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000200
+MITCHELL,Pittsburg Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",13,000210
+MITCHELL,Pittsburg Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",136,000210
+MITCHELL,Plum Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000220
+MITCHELL,Plum Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",62,000220
+MITCHELL,Round Springs Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000230
+MITCHELL,Round Springs Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",14,000230
+MITCHELL,Salt Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000240
+MITCHELL,Salt Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000240
+MITCHELL,Scottsville City,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000250
+MITCHELL,Scottsville City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000250
+MITCHELL,Simpson City,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000260
+MITCHELL,Simpson City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000260
+MITCHELL,Solomon Rapids Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000270
+MITCHELL,Solomon Rapids Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",33,000270
+MITCHELL,Tipton City,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000280
+MITCHELL,Tipton City,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,000280
+MITCHELL,Turkey Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000290
+MITCHELL,Turkey Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",64,000290
+MITCHELL,Walnut Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000300
+MITCHELL,Walnut Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000300
+MITCHELL,Asherville Township,President / Vice President,,independent,"Stein, Jill",2,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MITCHELL,Asherville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MITCHELL,Asherville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000010
+MITCHELL,Asherville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+MITCHELL,Asherville Township,President / Vice President,,Republican,"Trump, Donald J.",36,000010
+MITCHELL,Beloit City Ward 1,President / Vice President,,independent,"Stein, Jill",4,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000020
+MITCHELL,Beloit City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",203,000020
+MITCHELL,Beloit City Ward 2,President / Vice President,,independent,"Stein, Jill",4,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000030
+MITCHELL,Beloit City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",342,000030
+MITCHELL,Beloit City Ward 3,President / Vice President,,independent,"Stein, Jill",7,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"McMullin, Evan",5,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",72,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",16,000040
+MITCHELL,Beloit City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",351,000040
+MITCHELL,Beloit City Ward 4,President / Vice President,,independent,"Stein, Jill",9,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",11,000050
+MITCHELL,Beloit City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",286,000050
+MITCHELL,Beloit Township,President / Vice President,,independent,"Stein, Jill",1,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Hedges, James A",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"McMullin, Evan",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Smith, Mike",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+MITCHELL,Beloit Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,00006A
+MITCHELL,Beloit Township,President / Vice President,,Libertarian,"Johnson, Gary",5,00006A
+MITCHELL,Beloit Township,President / Vice President,,Republican,"Trump, Donald J.",91,00006A
+MITCHELL,Beloit Township Enclave A,President / Vice President,,independent,"Stein, Jill",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+MITCHELL,Beloit Township Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+MITCHELL,Beloit Township Enclave B,President / Vice President,,independent,"Stein, Jill",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00006C
+MITCHELL,Beloit Township Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00006C
+MITCHELL,Beloit Township Enclave C,President / Vice President,,independent,"Stein, Jill",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Hedges, James A",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"McMullin, Evan",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Perry, Darryl",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Smith, Mike",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Sood, Ajay",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00006D
+MITCHELL,Beloit Township Enclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00006D
+MITCHELL,Bloomfield Township,President / Vice President,,independent,"Stein, Jill",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+MITCHELL,Bloomfield Township,President / Vice President,,Republican,"Trump, Donald J.",34,000070
+MITCHELL,Blue Hill Township,President / Vice President,,independent,"Stein, Jill",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+MITCHELL,Blue Hill Township,President / Vice President,,Republican,"Trump, Donald J.",18,000080
+MITCHELL,Carr Creek Township,President / Vice President,,independent,"Stein, Jill",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+MITCHELL,Carr Creek Township,President / Vice President,,Republican,"Trump, Donald J.",12,000090
+MITCHELL,Cawker City,President / Vice President,,independent,"Stein, Jill",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Hedges, James A",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"McMullin, Evan",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Smith, Mike",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MITCHELL,Cawker City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MITCHELL,Cawker City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000100
+MITCHELL,Cawker City,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+MITCHELL,Cawker City,President / Vice President,,Republican,"Trump, Donald J.",0,000100
+MITCHELL,Cawker Township,President / Vice President,,independent,"Stein, Jill",6,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+MITCHELL,Cawker Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+MITCHELL,Cawker Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000110
+MITCHELL,Cawker Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000110
+MITCHELL,Cawker Township,President / Vice President,,Republican,"Trump, Donald J.",206,000110
+MITCHELL,Center Township,President / Vice President,,independent,"Stein, Jill",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",1,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+MITCHELL,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+MITCHELL,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+MITCHELL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+MITCHELL,Center Township,President / Vice President,,Republican,"Trump, Donald J.",13,000120
+MITCHELL,Custer Township,President / Vice President,,independent,"Stein, Jill",2,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+MITCHELL,Custer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+MITCHELL,Custer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000130
+MITCHELL,Custer Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+MITCHELL,Custer Township,President / Vice President,,Republican,"Trump, Donald J.",90,000130
+MITCHELL,Eureka Township,President / Vice President,,independent,"Stein, Jill",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"McMullin, Evan",1,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MITCHELL,Eureka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MITCHELL,Eureka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000140
+MITCHELL,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+MITCHELL,Eureka Township,President / Vice President,,Republican,"Trump, Donald J.",7,000140
+MITCHELL,Glen Elder City,President / Vice President,,independent,"Stein, Jill",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Hedges, James A",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"McMullin, Evan",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Perry, Darryl",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Smith, Mike",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Sood, Ajay",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+MITCHELL,Glen Elder City,President / Vice President,,Republican,"Trump, Donald J.",0,000150
+MITCHELL,Glen Elder Township,President / Vice President,,independent,"Stein, Jill",7,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"McMullin, Evan",1,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+MITCHELL,Glen Elder Township,President / Vice President,,Republican,"Trump, Donald J.",200,000160
+MITCHELL,Hayes Township,President / Vice President,,independent,"Stein, Jill",1,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+MITCHELL,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+MITCHELL,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000170
+MITCHELL,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+MITCHELL,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",15,000170
+MITCHELL,Hunter City,President / Vice President,,independent,"Stein, Jill",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Hedges, James A",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"McMullin, Evan",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Perry, Darryl",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Smith, Mike",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Sood, Ajay",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+MITCHELL,Hunter City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+MITCHELL,Hunter City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000180
+MITCHELL,Hunter City,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+MITCHELL,Hunter City,President / Vice President,,Republican,"Trump, Donald J.",0,000180
+MITCHELL,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+MITCHELL,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+MITCHELL,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000190
+MITCHELL,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+MITCHELL,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",38,000190
+MITCHELL,Lulu Township,President / Vice President,,independent,"Stein, Jill",1,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+MITCHELL,Lulu Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+MITCHELL,Lulu Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000200
+MITCHELL,Lulu Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+MITCHELL,Lulu Township,President / Vice President,,Republican,"Trump, Donald J.",36,000200
+MITCHELL,Pittsburg Township,President / Vice President,,independent,"Stein, Jill",3,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+MITCHELL,Pittsburg Township,President / Vice President,,Republican,"Trump, Donald J.",134,000210
+MITCHELL,Plum Creek Township,President / Vice President,,independent,"Stein, Jill",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+MITCHELL,Plum Creek Township,President / Vice President,,Republican,"Trump, Donald J.",61,000220
+MITCHELL,Round Springs Township,President / Vice President,,independent,"Stein, Jill",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000230
+MITCHELL,Round Springs Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+MITCHELL,Round Springs Township,President / Vice President,,Republican,"Trump, Donald J.",15,000230
+MITCHELL,Salt Creek Township,President / Vice President,,independent,"Stein, Jill",1,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+MITCHELL,Salt Creek Township,President / Vice President,,Republican,"Trump, Donald J.",14,000240
+MITCHELL,Scottsville City,President / Vice President,,independent,"Stein, Jill",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Hedges, James A",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"McMullin, Evan",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Perry, Darryl",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Smith, Mike",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Sood, Ajay",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+MITCHELL,Scottsville City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+MITCHELL,Scottsville City,President / Vice President,,Republican,"Trump, Donald J.",0,000250
+MITCHELL,Simpson City,President / Vice President,,independent,"Stein, Jill",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Hedges, James A",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"McMullin, Evan",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Perry, Darryl",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Smith, Mike",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Sood, Ajay",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+MITCHELL,Simpson City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+MITCHELL,Simpson City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000260
+MITCHELL,Simpson City,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+MITCHELL,Simpson City,President / Vice President,,Republican,"Trump, Donald J.",0,000260
+MITCHELL,Solomon Rapids Township,President / Vice President,,independent,"Stein, Jill",3,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000270
+MITCHELL,Solomon Rapids Township,President / Vice President,,Republican,"Trump, Donald J.",28,000270
+MITCHELL,Tipton City,President / Vice President,,independent,"Stein, Jill",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Hedges, James A",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"McMullin, Evan",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Perry, Darryl",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Smith, Mike",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Sood, Ajay",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+MITCHELL,Tipton City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+MITCHELL,Tipton City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000280
+MITCHELL,Tipton City,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+MITCHELL,Tipton City,President / Vice President,,Republican,"Trump, Donald J.",0,000280
+MITCHELL,Turkey Creek Township,President / Vice President,,independent,"Stein, Jill",2,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000290
+MITCHELL,Turkey Creek Township,President / Vice President,,Republican,"Trump, Donald J.",59,000290
+MITCHELL,Walnut Creek Township,President / Vice President,,independent,"Stein, Jill",2,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000300
+MITCHELL,Walnut Creek Township,President / Vice President,,Republican,"Trump, Donald J.",19,000300
+MITCHELL,Asherville Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000010
+MITCHELL,Asherville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+MITCHELL,Asherville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+MITCHELL,Asherville Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000010
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",74,000020
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000020
+MITCHELL,Beloit City Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",182,000020
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",121,000030
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000030
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000030
+MITCHELL,Beloit City Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",331,000030
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",111,000040
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000040
+MITCHELL,Beloit City Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",321,000040
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",89,000050
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000050
+MITCHELL,Beloit City Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",278,000050
+MITCHELL,Beloit Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,00006A
+MITCHELL,Beloit Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00006A
+MITCHELL,Beloit Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,00006A
+MITCHELL,Beloit Township,United States House of Representatives,1,Republican,"Marshall, Roger",85,00006A
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006B
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006B
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006B
+MITCHELL,Beloit Township Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006B
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006C
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006C
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006C
+MITCHELL,Beloit Township Enclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006C
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006D
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006D
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006D
+MITCHELL,Beloit Township Enclave C,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006D
+MITCHELL,Bloomfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000070
+MITCHELL,Bloomfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+MITCHELL,Bloomfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000070
+MITCHELL,Bloomfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000070
+MITCHELL,Blue Hill Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000080
+MITCHELL,Blue Hill Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+MITCHELL,Blue Hill Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000080
+MITCHELL,Blue Hill Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000080
+MITCHELL,Carr Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000090
+MITCHELL,Carr Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+MITCHELL,Carr Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+MITCHELL,Carr Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000090
+MITCHELL,Cawker City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000100
+MITCHELL,Cawker City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+MITCHELL,Cawker City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+MITCHELL,Cawker City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000100
+MITCHELL,Cawker Township,United States House of Representatives,1,independent,"LaPolice, Alan",57,000110
+MITCHELL,Cawker Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+MITCHELL,Cawker Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000110
+MITCHELL,Cawker Township,United States House of Representatives,1,Republican,"Marshall, Roger",168,000110
+MITCHELL,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000120
+MITCHELL,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+MITCHELL,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+MITCHELL,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000120
+MITCHELL,Custer Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000130
+MITCHELL,Custer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+MITCHELL,Custer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+MITCHELL,Custer Township,United States House of Representatives,1,Republican,"Marshall, Roger",55,000130
+MITCHELL,Eureka Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000140
+MITCHELL,Eureka Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+MITCHELL,Eureka Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+MITCHELL,Eureka Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000140
+MITCHELL,Glen Elder City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000150
+MITCHELL,Glen Elder City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+MITCHELL,Glen Elder City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000150
+MITCHELL,Glen Elder City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000150
+MITCHELL,Glen Elder Township,United States House of Representatives,1,independent,"LaPolice, Alan",52,000160
+MITCHELL,Glen Elder Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+MITCHELL,Glen Elder Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000160
+MITCHELL,Glen Elder Township,United States House of Representatives,1,Republican,"Marshall, Roger",188,000160
+MITCHELL,Hayes Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000170
+MITCHELL,Hayes Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+MITCHELL,Hayes Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+MITCHELL,Hayes Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000170
+MITCHELL,Hunter City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000180
+MITCHELL,Hunter City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+MITCHELL,Hunter City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000180
+MITCHELL,Hunter City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000180
+MITCHELL,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000190
+MITCHELL,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+MITCHELL,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000190
+MITCHELL,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000190
+MITCHELL,Lulu Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000200
+MITCHELL,Lulu Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+MITCHELL,Lulu Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000200
+MITCHELL,Lulu Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000200
+MITCHELL,Pittsburg Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000210
+MITCHELL,Pittsburg Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000210
+MITCHELL,Pittsburg Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000210
+MITCHELL,Pittsburg Township,United States House of Representatives,1,Republican,"Marshall, Roger",125,000210
+MITCHELL,Plum Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000220
+MITCHELL,Plum Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+MITCHELL,Plum Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000220
+MITCHELL,Plum Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000220
+MITCHELL,Round Springs Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000230
+MITCHELL,Round Springs Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+MITCHELL,Round Springs Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000230
+MITCHELL,Round Springs Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000230
+MITCHELL,Salt Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000240
+MITCHELL,Salt Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+MITCHELL,Salt Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000240
+MITCHELL,Salt Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000240
+MITCHELL,Scottsville City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000250
+MITCHELL,Scottsville City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+MITCHELL,Scottsville City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000250
+MITCHELL,Scottsville City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000250
+MITCHELL,Simpson City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000260
+MITCHELL,Simpson City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+MITCHELL,Simpson City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000260
+MITCHELL,Simpson City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000260
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000270
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000270
+MITCHELL,Solomon Rapids Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000270
+MITCHELL,Tipton City,United States House of Representatives,1,independent,"LaPolice, Alan",0,000280
+MITCHELL,Tipton City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+MITCHELL,Tipton City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000280
+MITCHELL,Tipton City,United States House of Representatives,1,Republican,"Marshall, Roger",0,000280
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",17,000290
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000290
+MITCHELL,Turkey Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000290
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000300
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000300
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000300
+MITCHELL,Walnut Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000300
+MITCHELL,Asherville Township,United States Senate,,write - in,"Smith, DJ",0,000010
+MITCHELL,Asherville Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000010
+MITCHELL,Asherville Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000010
+MITCHELL,Asherville Township,United States Senate,,Republican,"Moran, Jerry",37,000010
+MITCHELL,Beloit City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000020
+MITCHELL,Beloit City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",31,000020
+MITCHELL,Beloit City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000020
+MITCHELL,Beloit City Ward 1,United States Senate,,Republican,"Moran, Jerry",226,000020
+MITCHELL,Beloit City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000030
+MITCHELL,Beloit City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",74,000030
+MITCHELL,Beloit City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",13,000030
+MITCHELL,Beloit City Ward 2,United States Senate,,Republican,"Moran, Jerry",383,000030
+MITCHELL,Beloit City Ward 3,United States Senate,,write - in,"Smith, DJ",0,000040
+MITCHELL,Beloit City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",65,000040
+MITCHELL,Beloit City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",21,000040
+MITCHELL,Beloit City Ward 3,United States Senate,,Republican,"Moran, Jerry",369,000040
+MITCHELL,Beloit City Ward 4,United States Senate,,write - in,"Smith, DJ",0,000050
+MITCHELL,Beloit City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",49,000050
+MITCHELL,Beloit City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",14,000050
+MITCHELL,Beloit City Ward 4,United States Senate,,Republican,"Moran, Jerry",326,000050
+MITCHELL,Beloit Township,United States Senate,,write - in,"Smith, DJ",0,00006A
+MITCHELL,Beloit Township,United States Senate,,Democratic,"Wiesner, Patrick",13,00006A
+MITCHELL,Beloit Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,00006A
+MITCHELL,Beloit Township,United States Senate,,Republican,"Moran, Jerry",101,00006A
+MITCHELL,Beloit Township Enclave A,United States Senate,,write - in,"Smith, DJ",0,00006B
+MITCHELL,Beloit Township Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+MITCHELL,Beloit Township Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+MITCHELL,Beloit Township Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00006B
+MITCHELL,Beloit Township Enclave B,United States Senate,,write - in,"Smith, DJ",0,00006C
+MITCHELL,Beloit Township Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00006C
+MITCHELL,Beloit Township Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006C
+MITCHELL,Beloit Township Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00006C
+MITCHELL,Beloit Township Enclave C,United States Senate,,write - in,"Smith, DJ",0,00006D
+MITCHELL,Beloit Township Enclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00006D
+MITCHELL,Beloit Township Enclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006D
+MITCHELL,Beloit Township Enclave C,United States Senate,,Republican,"Moran, Jerry",0,00006D
+MITCHELL,Bloomfield Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MITCHELL,Bloomfield Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000070
+MITCHELL,Bloomfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+MITCHELL,Bloomfield Township,United States Senate,,Republican,"Moran, Jerry",36,000070
+MITCHELL,Blue Hill Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MITCHELL,Blue Hill Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000080
+MITCHELL,Blue Hill Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+MITCHELL,Blue Hill Township,United States Senate,,Republican,"Moran, Jerry",20,000080
+MITCHELL,Carr Creek Township,United States Senate,,write - in,"Smith, DJ",0,000090
+MITCHELL,Carr Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000090
+MITCHELL,Carr Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+MITCHELL,Carr Creek Township,United States Senate,,Republican,"Moran, Jerry",13,000090
+MITCHELL,Cawker City,United States Senate,,write - in,"Smith, DJ",0,000100
+MITCHELL,Cawker City,United States Senate,,Democratic,"Wiesner, Patrick",0,000100
+MITCHELL,Cawker City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+MITCHELL,Cawker City,United States Senate,,Republican,"Moran, Jerry",0,000100
+MITCHELL,Cawker Township,United States Senate,,write - in,"Smith, DJ",0,000110
+MITCHELL,Cawker Township,United States Senate,,Democratic,"Wiesner, Patrick",27,000110
+MITCHELL,Cawker Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000110
+MITCHELL,Cawker Township,United States Senate,,Republican,"Moran, Jerry",204,000110
+MITCHELL,Center Township,United States Senate,,write - in,"Smith, DJ",0,000120
+MITCHELL,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000120
+MITCHELL,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+MITCHELL,Center Township,United States Senate,,Republican,"Moran, Jerry",16,000120
+MITCHELL,Custer Township,United States Senate,,write - in,"Smith, DJ",0,000130
+MITCHELL,Custer Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000130
+MITCHELL,Custer Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000130
+MITCHELL,Custer Township,United States Senate,,Republican,"Moran, Jerry",56,000130
+MITCHELL,Eureka Township,United States Senate,,write - in,"Smith, DJ",0,000140
+MITCHELL,Eureka Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000140
+MITCHELL,Eureka Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000140
+MITCHELL,Eureka Township,United States Senate,,Republican,"Moran, Jerry",13,000140
+MITCHELL,Glen Elder City,United States Senate,,write - in,"Smith, DJ",0,000150
+MITCHELL,Glen Elder City,United States Senate,,Democratic,"Wiesner, Patrick",0,000150
+MITCHELL,Glen Elder City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+MITCHELL,Glen Elder City,United States Senate,,Republican,"Moran, Jerry",0,000150
+MITCHELL,Glen Elder Township,United States Senate,,write - in,"Smith, DJ",0,000160
+MITCHELL,Glen Elder Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000160
+MITCHELL,Glen Elder Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000160
+MITCHELL,Glen Elder Township,United States Senate,,Republican,"Moran, Jerry",221,000160
+MITCHELL,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000170
+MITCHELL,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000170
+MITCHELL,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000170
+MITCHELL,Hayes Township,United States Senate,,Republican,"Moran, Jerry",15,000170
+MITCHELL,Hunter City,United States Senate,,write - in,"Smith, DJ",0,000180
+MITCHELL,Hunter City,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+MITCHELL,Hunter City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+MITCHELL,Hunter City,United States Senate,,Republican,"Moran, Jerry",0,000180
+MITCHELL,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000190
+MITCHELL,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000190
+MITCHELL,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+MITCHELL,Logan Township,United States Senate,,Republican,"Moran, Jerry",40,000190
+MITCHELL,Lulu Township,United States Senate,,write - in,"Smith, DJ",0,000200
+MITCHELL,Lulu Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000200
+MITCHELL,Lulu Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000200
+MITCHELL,Lulu Township,United States Senate,,Republican,"Moran, Jerry",38,000200
+MITCHELL,Pittsburg Township,United States Senate,,write - in,"Smith, DJ",0,000210
+MITCHELL,Pittsburg Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000210
+MITCHELL,Pittsburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000210
+MITCHELL,Pittsburg Township,United States Senate,,Republican,"Moran, Jerry",141,000210
+MITCHELL,Plum Creek Township,United States Senate,,write - in,"Smith, DJ",0,000220
+MITCHELL,Plum Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000220
+MITCHELL,Plum Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000220
+MITCHELL,Plum Creek Township,United States Senate,,Republican,"Moran, Jerry",62,000220
+MITCHELL,Round Springs Township,United States Senate,,write - in,"Smith, DJ",0,000230
+MITCHELL,Round Springs Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000230
+MITCHELL,Round Springs Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000230
+MITCHELL,Round Springs Township,United States Senate,,Republican,"Moran, Jerry",14,000230
+MITCHELL,Salt Creek Township,United States Senate,,write - in,"Smith, DJ",0,000240
+MITCHELL,Salt Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000240
+MITCHELL,Salt Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+MITCHELL,Salt Creek Township,United States Senate,,Republican,"Moran, Jerry",17,000240
+MITCHELL,Scottsville City,United States Senate,,write - in,"Smith, DJ",0,000250
+MITCHELL,Scottsville City,United States Senate,,Democratic,"Wiesner, Patrick",0,000250
+MITCHELL,Scottsville City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000250
+MITCHELL,Scottsville City,United States Senate,,Republican,"Moran, Jerry",0,000250
+MITCHELL,Simpson City,United States Senate,,write - in,"Smith, DJ",0,000260
+MITCHELL,Simpson City,United States Senate,,Democratic,"Wiesner, Patrick",0,000260
+MITCHELL,Simpson City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000260
+MITCHELL,Simpson City,United States Senate,,Republican,"Moran, Jerry",0,000260
+MITCHELL,Solomon Rapids Township,United States Senate,,write - in,"Smith, DJ",0,000270
+MITCHELL,Solomon Rapids Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000270
+MITCHELL,Solomon Rapids Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000270
+MITCHELL,Solomon Rapids Township,United States Senate,,Republican,"Moran, Jerry",27,000270
+MITCHELL,Tipton City,United States Senate,,write - in,"Smith, DJ",0,000280
+MITCHELL,Tipton City,United States Senate,,Democratic,"Wiesner, Patrick",0,000280
+MITCHELL,Tipton City,United States Senate,,Libertarian,"Garrard, Robert D.",0,000280
+MITCHELL,Tipton City,United States Senate,,Republican,"Moran, Jerry",0,000280
+MITCHELL,Turkey Creek Township,United States Senate,,write - in,"Smith, DJ",0,000290
+MITCHELL,Turkey Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000290
+MITCHELL,Turkey Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000290
+MITCHELL,Turkey Creek Township,United States Senate,,Republican,"Moran, Jerry",68,000290
+MITCHELL,Walnut Creek Township,United States Senate,,write - in,"Smith, DJ",0,000300
+MITCHELL,Walnut Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000300
+MITCHELL,Walnut Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000300
+MITCHELL,Walnut Creek Township,United States Senate,,Republican,"Moran, Jerry",20,000300

--- a/2016/20161108__ks__general__montgomery__precinct.csv
+++ b/2016/20161108__ks__general__montgomery__precinct.csv
@@ -1,1038 +1,2479 @@
-county,precinct,office,district,party,candidate,votes
-Montgomery,Caney FIRST WARD/PRECINCT ONE,President,,D,Hillary Clinton,26
-Montgomery,Caney FIRST WARD/PRECINCT TWO,President,,D,Hillary Clinton,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,President,,D,Hillary Clinton,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,President,,D,Hillary Clinton,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,President,,D,Hillary Clinton,14
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,President,,D,Hillary Clinton,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,President,,D,Hillary Clinton,21
-Montgomery,Caney THIRD WARD/PRECINCT TWO,President,,D,Hillary Clinton,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,President,,D,Hillary Clinton,23
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,President,,D,Hillary Clinton,0
-Montgomery,Caney Total,President,,D,Hillary Clinton,84
-Montgomery,Cherryvale FIRST WARD,President,,D,Hillary Clinton,82
-Montgomery,Cherryvale SECOND WARD,President,,D,Hillary Clinton,54
-Montgomery,Cherryvale Total,President,,D,Hillary Clinton,136
-Montgomery,Coffeyville FIRST PRECINCT,President,,D,Hillary Clinton,46
-Montgomery,Coffeyville SECOND PRECINCT,President,,D,Hillary Clinton,49
-Montgomery,Coffeyville THIRD PRECINCT,President,,D,Hillary Clinton,62
-Montgomery,Coffeyville FOURTH PRECINCT,President,,D,Hillary Clinton,54
-Montgomery,Coffeyville FIFTH PRECINCT,President,,D,Hillary Clinton,73
-Montgomery,Coffeyville SIXTH PRECINCT,President,,D,Hillary Clinton,25
-Montgomery,Coffeyville SEVENTH PRECINCT,President,,D,Hillary Clinton,35
-Montgomery,Coffeyville EIGHTH PRECINCT,President,,D,Hillary Clinton,45
-Montgomery,Coffeyville NINTH PRECINCT,President,,D,Hillary Clinton,16
-Montgomery,Coffeyville TENTH PRECINCT,President,,D,Hillary Clinton,49
-Montgomery,Coffeyville ELEVENTH PRECINCT,President,,D,Hillary Clinton,117
-Montgomery,Coffeyville TWELFTH PRECINCT,President,,D,Hillary Clinton,154
-Montgomery,Coffeyville THIRTEENTH PRECINCT,President,,D,Hillary Clinton,122
-Montgomery,Coffeyville Total,President,,D,Hillary Clinton,847
-Montgomery,Independence FIRST WARD/PRECINCT ONE,President,,D,Hillary Clinton,58
-Montgomery,Independence FIRST WARD/PRECINCT TWO,President,,D,Hillary Clinton,64
-Montgomery,Independence SECOND WARD/PRECINCT ONE,President,,D,Hillary Clinton,19
-Montgomery,Independence SECOND WARD/PRECINCT TWO,President,,D,Hillary Clinton,26
-Montgomery,Independence THIRD WARD/PRECINCT ONE,President,,D,Hillary Clinton,49
-Montgomery,Independence THIRD WARD/PRECINCT TWO,President,,D,Hillary Clinton,32
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,President,,D,Hillary Clinton,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,President,,D,Hillary Clinton,72
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,President,,D,Hillary Clinton,65
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,President,,D,Hillary Clinton,47
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,President,,D,Hillary Clinton,96
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,President,,D,Hillary Clinton,8
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,President,,D,Hillary Clinton,97
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,President,,D,Hillary Clinton,68
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,President,,D,Hillary Clinton,35
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,President,,D,Hillary Clinton,12
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,President,,D,Hillary Clinton,2
-Montgomery,Independence Total,President,,D,Hillary Clinton,750
-Montgomery,Caney Township HAVANA PRECINCT,President,,D,Hillary Clinton,38
-Montgomery,Caney Township TYRO PRECINCT,President,,D,Hillary Clinton,30
-Montgomery,Caney Township Total,President,,D,Hillary Clinton,68
-Montgomery,Cherokee Township ,President,,D,Hillary Clinton,43
-Montgomery,Cherry Township ,President,,D,Hillary Clinton,36
-Montgomery,Drum Creek Township ,President,,D,Hillary Clinton,25
-Montgomery,Fawn Creek Township DEARING PRECINCT,President,,D,Hillary Clinton,114
-Montgomery,Fawn Creek Township TYRO PRECINCT,President,,D,Hillary Clinton,13
-Montgomery,Fawn Creek Township Total,President,,D,Hillary Clinton,127
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,President,,D,Hillary Clinton,0
-Montgomery,Independence Township FIRST PRECINCT H11,President,,D,Hillary Clinton,103
-Montgomery,Independence Township FIRST PRECINCT H12,President,,D,Hillary Clinton,15
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,President,,D,Hillary Clinton,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,President,,D,Hillary Clinton,31
-Montgomery,Independence Township SECOND PRECINCT PART B H12,President,,D,Hillary Clinton,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,President,,D,Hillary Clinton,7
-Montgomery,Independence Township Total,President,,D,Hillary Clinton,156
-Montgomery,Liberty Township ,President,,D,Hillary Clinton,38
-Montgomery,Louisburg Township ,President,,D,Hillary Clinton,27
-Montgomery,Parker Township FIRST PRECINCT,President,,D,Hillary Clinton,22
-Montgomery,Parker Township SECOND PRECINCT,President,,D,Hillary Clinton,101
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,President,,D,Hillary Clinton,4
-Montgomery,Parker Township Total,President,,D,Hillary Clinton,127
-Montgomery,Rutland Township ,President,,D,Hillary Clinton,16
-Montgomery,Sycamore Township ,President,,D,Hillary Clinton,53
-Montgomery,West Cherry Township ,President,,D,Hillary Clinton,24
-Montgomery,Hand Counted,President,,D,Hillary Clinton,24
-Montgomery,Provisional,President,,D,Hillary Clinton,56
-Montgomery,Provisional Hand Count,President,,D,Hillary Clinton,0
-Montgomery,Grand Total,President,,D,Hillary Clinton,2637
-Montgomery,Caney FIRST WARD/PRECINCT ONE,President,,I,Jill Stein,1
-Montgomery,Caney FIRST WARD/PRECINCT TWO,President,,I,Jill Stein,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,President,,I,Jill Stein,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,President,,I,Jill Stein,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,President,,I,Jill Stein,2
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,President,,I,Jill Stein,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,President,,I,Jill Stein,3
-Montgomery,Caney THIRD WARD/PRECINCT TWO,President,,I,Jill Stein,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,President,,I,Jill Stein,2
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,President,,I,Jill Stein,0
-Montgomery,Caney Total,President,,I,Jill Stein,8
-Montgomery,Cherryvale FIRST WARD,President,,I,Jill Stein,15
-Montgomery,Cherryvale SECOND WARD,President,,I,Jill Stein,5
-Montgomery,Cherryvale Total,President,,I,Jill Stein,20
-Montgomery,Coffeyville FIRST PRECINCT,President,,I,Jill Stein,1
-Montgomery,Coffeyville SECOND PRECINCT,President,,I,Jill Stein,1
-Montgomery,Coffeyville THIRD PRECINCT,President,,I,Jill Stein,2
-Montgomery,Coffeyville FOURTH PRECINCT,President,,I,Jill Stein,9
-Montgomery,Coffeyville FIFTH PRECINCT,President,,I,Jill Stein,3
-Montgomery,Coffeyville SIXTH PRECINCT,President,,I,Jill Stein,0
-Montgomery,Coffeyville SEVENTH PRECINCT,President,,I,Jill Stein,2
-Montgomery,Coffeyville EIGHTH PRECINCT,President,,I,Jill Stein,2
-Montgomery,Coffeyville NINTH PRECINCT,President,,I,Jill Stein,0
-Montgomery,Coffeyville TENTH PRECINCT,President,,I,Jill Stein,4
-Montgomery,Coffeyville ELEVENTH PRECINCT,President,,I,Jill Stein,2
-Montgomery,Coffeyville TWELFTH PRECINCT,President,,I,Jill Stein,12
-Montgomery,Coffeyville THIRTEENTH PRECINCT,President,,I,Jill Stein,11
-Montgomery,Coffeyville Total,President,,I,Jill Stein,49
-Montgomery,Independence FIRST WARD/PRECINCT ONE,President,,I,Jill Stein,3
-Montgomery,Independence FIRST WARD/PRECINCT TWO,President,,I,Jill Stein,2
-Montgomery,Independence SECOND WARD/PRECINCT ONE,President,,I,Jill Stein,2
-Montgomery,Independence SECOND WARD/PRECINCT TWO,President,,I,Jill Stein,2
-Montgomery,Independence THIRD WARD/PRECINCT ONE,President,,I,Jill Stein,7
-Montgomery,Independence THIRD WARD/PRECINCT TWO,President,,I,Jill Stein,6
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,President,,I,Jill Stein,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,President,,I,Jill Stein,8
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,President,,I,Jill Stein,6
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,President,,I,Jill Stein,3
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,President,,I,Jill Stein,8
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,President,,I,Jill Stein,1
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,President,,I,Jill Stein,14
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,President,,I,Jill Stein,4
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,President,,I,Jill Stein,0
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,President,,I,Jill Stein,0
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,President,,I,Jill Stein,0
-Montgomery,Independence Total,President,,I,Jill Stein,66
-Montgomery,Caney Township HAVANA PRECINCT,President,,I,Jill Stein,1
-Montgomery,Caney Township TYRO PRECINCT,President,,I,Jill Stein,0
-Montgomery,Caney Township Total,President,,I,Jill Stein,1
-Montgomery,Cherokee Township ,President,,I,Jill Stein,7
-Montgomery,Cherry Township ,President,,I,Jill Stein,2
-Montgomery,Drum Creek Township ,President,,I,Jill Stein,10
-Montgomery,Fawn Creek Township DEARING PRECINCT,President,,I,Jill Stein,13
-Montgomery,Fawn Creek Township TYRO PRECINCT,President,,I,Jill Stein,1
-Montgomery,Fawn Creek Township Total,President,,I,Jill Stein,14
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,President,,I,Jill Stein,0
-Montgomery,Independence Township FIRST PRECINCT H11,President,,I,Jill Stein,5
-Montgomery,Independence Township FIRST PRECINCT H12,President,,I,Jill Stein,2
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,President,,I,Jill Stein,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,President,,I,Jill Stein,2
-Montgomery,Independence Township SECOND PRECINCT PART B H12,President,,I,Jill Stein,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,President,,I,Jill Stein,2
-Montgomery,Independence Township Total,President,,I,Jill Stein,11
-Montgomery,Liberty Township ,President,,I,Jill Stein,4
-Montgomery,Louisburg Township ,President,,I,Jill Stein,6
-Montgomery,Parker Township FIRST PRECINCT,President,,I,Jill Stein,2
-Montgomery,Parker Township SECOND PRECINCT,President,,I,Jill Stein,1
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,President,,I,Jill Stein,0
-Montgomery,Parker Township Total,President,,I,Jill Stein,3
-Montgomery,Rutland Township ,President,,I,Jill Stein,0
-Montgomery,Sycamore Township ,President,,I,Jill Stein,4
-Montgomery,West Cherry Township ,President,,I,Jill Stein,0
-Montgomery,Hand Counted,President,,I,Jill Stein,1
-Montgomery,Provisional,President,,I,Jill Stein,4
-Montgomery,Provisional Hand Count,President,,I,Jill Stein,0
-Montgomery,Grand Total,President,,I,Jill Stein,210
-Montgomery,Caney FIRST WARD/PRECINCT ONE,President,,L,Gary Johnson,5
-Montgomery,Caney FIRST WARD/PRECINCT TWO,President,,L,Gary Johnson,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,President,,L,Gary Johnson,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,President,,L,Gary Johnson,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,President,,L,Gary Johnson,4
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,President,,L,Gary Johnson,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,President,,L,Gary Johnson,9
-Montgomery,Caney THIRD WARD/PRECINCT TWO,President,,L,Gary Johnson,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,President,,L,Gary Johnson,4
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,President,,L,Gary Johnson,0
-Montgomery,Caney Total,President,,L,Gary Johnson,22
-Montgomery,Cherryvale FIRST WARD,President,,L,Gary Johnson,12
-Montgomery,Cherryvale SECOND WARD,President,,L,Gary Johnson,16
-Montgomery,Cherryvale Total,President,,L,Gary Johnson,28
-Montgomery,Coffeyville FIRST PRECINCT,President,,L,Gary Johnson,0
-Montgomery,Coffeyville SECOND PRECINCT,President,,L,Gary Johnson,5
-Montgomery,Coffeyville THIRD PRECINCT,President,,L,Gary Johnson,8
-Montgomery,Coffeyville FOURTH PRECINCT,President,,L,Gary Johnson,12
-Montgomery,Coffeyville FIFTH PRECINCT,President,,L,Gary Johnson,6
-Montgomery,Coffeyville SIXTH PRECINCT,President,,L,Gary Johnson,2
-Montgomery,Coffeyville SEVENTH PRECINCT,President,,L,Gary Johnson,3
-Montgomery,Coffeyville EIGHTH PRECINCT,President,,L,Gary Johnson,2
-Montgomery,Coffeyville NINTH PRECINCT,President,,L,Gary Johnson,3
-Montgomery,Coffeyville TENTH PRECINCT,President,,L,Gary Johnson,10
-Montgomery,Coffeyville ELEVENTH PRECINCT,President,,L,Gary Johnson,14
-Montgomery,Coffeyville TWELFTH PRECINCT,President,,L,Gary Johnson,10
-Montgomery,Coffeyville THIRTEENTH PRECINCT,President,,L,Gary Johnson,16
-Montgomery,Coffeyville Total,President,,L,Gary Johnson,91
-Montgomery,Independence FIRST WARD/PRECINCT ONE,President,,L,Gary Johnson,5
-Montgomery,Independence FIRST WARD/PRECINCT TWO,President,,L,Gary Johnson,6
-Montgomery,Independence SECOND WARD/PRECINCT ONE,President,,L,Gary Johnson,10
-Montgomery,Independence SECOND WARD/PRECINCT TWO,President,,L,Gary Johnson,2
-Montgomery,Independence THIRD WARD/PRECINCT ONE,President,,L,Gary Johnson,11
-Montgomery,Independence THIRD WARD/PRECINCT TWO,President,,L,Gary Johnson,11
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,President,,L,Gary Johnson,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,President,,L,Gary Johnson,6
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,President,,L,Gary Johnson,8
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,President,,L,Gary Johnson,7
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,President,,L,Gary Johnson,12
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,President,,L,Gary Johnson,1
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,President,,L,Gary Johnson,12
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,President,,L,Gary Johnson,7
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,President,,L,Gary Johnson,5
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,President,,L,Gary Johnson,2
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,President,,L,Gary Johnson,2
-Montgomery,Independence Total,President,,L,Gary Johnson,107
-Montgomery,Caney Township HAVANA PRECINCT,President,,L,Gary Johnson,6
-Montgomery,Caney Township TYRO PRECINCT,President,,L,Gary Johnson,10
-Montgomery,Caney Township Total,President,,L,Gary Johnson,16
-Montgomery,Cherokee Township ,President,,L,Gary Johnson,4
-Montgomery,Cherry Township ,President,,L,Gary Johnson,10
-Montgomery,Drum Creek Township ,President,,L,Gary Johnson,4
-Montgomery,Fawn Creek Township DEARING PRECINCT,President,,L,Gary Johnson,22
-Montgomery,Fawn Creek Township TYRO PRECINCT,President,,L,Gary Johnson,3
-Montgomery,Fawn Creek Township Total,President,,L,Gary Johnson,25
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,President,,L,Gary Johnson,0
-Montgomery,Independence Township FIRST PRECINCT H11,President,,L,Gary Johnson,30
-Montgomery,Independence Township FIRST PRECINCT H12,President,,L,Gary Johnson,3
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,President,,L,Gary Johnson,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,President,,L,Gary Johnson,4
-Montgomery,Independence Township SECOND PRECINCT PART B H12,President,,L,Gary Johnson,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,President,,L,Gary Johnson,0
-Montgomery,Independence Township Total,President,,L,Gary Johnson,37
-Montgomery,Liberty Township ,President,,L,Gary Johnson,6
-Montgomery,Louisburg Township ,President,,L,Gary Johnson,5
-Montgomery,Parker Township FIRST PRECINCT,President,,L,Gary Johnson,8
-Montgomery,Parker Township SECOND PRECINCT,President,,L,Gary Johnson,8
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,President,,L,Gary Johnson,0
-Montgomery,Parker Township Total,President,,L,Gary Johnson,16
-Montgomery,Rutland Township ,President,,L,Gary Johnson,4
-Montgomery,Sycamore Township ,President,,L,Gary Johnson,19
-Montgomery,West Cherry Township ,President,,L,Gary Johnson,1
-Montgomery,Hand Counted,President,,L,Gary Johnson,1
-Montgomery,Provisional,President,,L,Gary Johnson,11
-Montgomery,Provisional Hand Count,President,,L,Gary Johnson,0
-Montgomery,Grand Total,President,,L,Gary Johnson,407
-Montgomery,Caney FIRST WARD/PRECINCT ONE,President,,R,Donald J. Trump,137
-Montgomery,Caney FIRST WARD/PRECINCT TWO,President,,R,Donald J. Trump,1
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,President,,R,Donald J. Trump,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,President,,R,Donald J. Trump,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,President,,R,Donald J. Trump,104
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,President,,R,Donald J. Trump,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,President,,R,Donald J. Trump,136
-Montgomery,Caney THIRD WARD/PRECINCT TWO,President,,R,Donald J. Trump,1
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,President,,R,Donald J. Trump,159
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,President,,R,Donald J. Trump,1
-Montgomery,Caney Total,President,,R,Donald J. Trump,539
-Montgomery,Cherryvale FIRST WARD,President,,R,Donald J. Trump,308
-Montgomery,Cherryvale SECOND WARD,President,,R,Donald J. Trump,218
-Montgomery,Cherryvale Total,President,,R,Donald J. Trump,526
-Montgomery,Coffeyville FIRST PRECINCT,President,,R,Donald J. Trump,7
-Montgomery,Coffeyville SECOND PRECINCT,President,,R,Donald J. Trump,67
-Montgomery,Coffeyville THIRD PRECINCT,President,,R,Donald J. Trump,108
-Montgomery,Coffeyville FOURTH PRECINCT,President,,R,Donald J. Trump,124
-Montgomery,Coffeyville FIFTH PRECINCT,President,,R,Donald J. Trump,152
-Montgomery,Coffeyville SIXTH PRECINCT,President,,R,Donald J. Trump,39
-Montgomery,Coffeyville SEVENTH PRECINCT,President,,R,Donald J. Trump,65
-Montgomery,Coffeyville EIGHTH PRECINCT,President,,R,Donald J. Trump,89
-Montgomery,Coffeyville NINTH PRECINCT,President,,R,Donald J. Trump,25
-Montgomery,Coffeyville TENTH PRECINCT,President,,R,Donald J. Trump,110
-Montgomery,Coffeyville ELEVENTH PRECINCT,President,,R,Donald J. Trump,229
-Montgomery,Coffeyville TWELFTH PRECINCT,President,,R,Donald J. Trump,355
-Montgomery,Coffeyville THIRTEENTH PRECINCT,President,,R,Donald J. Trump,262
-Montgomery,Coffeyville Total,President,,R,Donald J. Trump,1632
-Montgomery,Independence FIRST WARD/PRECINCT ONE,President,,R,Donald J. Trump,92
-Montgomery,Independence FIRST WARD/PRECINCT TWO,President,,R,Donald J. Trump,182
-Montgomery,Independence SECOND WARD/PRECINCT ONE,President,,R,Donald J. Trump,67
-Montgomery,Independence SECOND WARD/PRECINCT TWO,President,,R,Donald J. Trump,61
-Montgomery,Independence THIRD WARD/PRECINCT ONE,President,,R,Donald J. Trump,135
-Montgomery,Independence THIRD WARD/PRECINCT TWO,President,,R,Donald J. Trump,82
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,President,,R,Donald J. Trump,1
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,President,,R,Donald J. Trump,142
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,President,,R,Donald J. Trump,104
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,President,,R,Donald J. Trump,108
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,President,,R,Donald J. Trump,179
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,President,,R,Donald J. Trump,20
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,President,,R,Donald J. Trump,282
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,President,,R,Donald J. Trump,213
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,President,,R,Donald J. Trump,77
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,President,,R,Donald J. Trump,71
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,President,,R,Donald J. Trump,8
-Montgomery,Independence Total,President,,R,Donald J. Trump,1824
-Montgomery,Caney Township HAVANA PRECINCT,President,,R,Donald J. Trump,241
-Montgomery,Caney Township TYRO PRECINCT,President,,R,Donald J. Trump,300
-Montgomery,Caney Township Total,President,,R,Donald J. Trump,541
-Montgomery,Cherokee Township ,President,,R,Donald J. Trump,136
-Montgomery,Cherry Township ,President,,R,Donald J. Trump,198
-Montgomery,Drum Creek Township ,President,,R,Donald J. Trump,218
-Montgomery,Fawn Creek Township DEARING PRECINCT,President,,R,Donald J. Trump,529
-Montgomery,Fawn Creek Township TYRO PRECINCT,President,,R,Donald J. Trump,188
-Montgomery,Fawn Creek Township Total,President,,R,Donald J. Trump,717
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,President,,R,Donald J. Trump,0
-Montgomery,Independence Township FIRST PRECINCT H11,President,,R,Donald J. Trump,549
-Montgomery,Independence Township FIRST PRECINCT H12,President,,R,Donald J. Trump,102
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,President,,R,Donald J. Trump,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,President,,R,Donald J. Trump,129
-Montgomery,Independence Township SECOND PRECINCT PART B H12,President,,R,Donald J. Trump,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,President,,R,Donald J. Trump,37
-Montgomery,Independence Township Total,President,,R,Donald J. Trump,817
-Montgomery,Liberty Township ,President,,R,Donald J. Trump,174
-Montgomery,Louisburg Township ,President,,R,Donald J. Trump,200
-Montgomery,Parker Township FIRST PRECINCT,President,,R,Donald J. Trump,94
-Montgomery,Parker Township SECOND PRECINCT,President,,R,Donald J. Trump,287
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,President,,R,Donald J. Trump,6
-Montgomery,Parker Township Total,President,,R,Donald J. Trump,387
-Montgomery,Rutland Township ,President,,R,Donald J. Trump,147
-Montgomery,Sycamore Township ,President,,R,Donald J. Trump,306
-Montgomery,West Cherry Township ,President,,R,Donald J. Trump,104
-Montgomery,Hand Counted,President,,R,Donald J. Trump,24
-Montgomery,Provisional,President,,R,Donald J. Trump,185
-Montgomery,Provisional Hand Count,President,,R,Donald J. Trump,4
-Montgomery,Grand Total,President,,R,Donald J. Trump,8679
-Montgomery,Caney FIRST WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,29
-Montgomery,Caney FIRST WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,21
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,25
-Montgomery,Caney THIRD WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,30
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Caney Total,U.S. Senate,,D,Patrick Wiesner,105
-Montgomery,Cherryvale FIRST WARD,U.S. Senate,,D,Patrick Wiesner,90
-Montgomery,Cherryvale SECOND WARD,U.S. Senate,,D,Patrick Wiesner,65
-Montgomery,Cherryvale Total,U.S. Senate,,D,Patrick Wiesner,155
-Montgomery,Coffeyville FIRST PRECINCT,U.S. Senate,,D,Patrick Wiesner,45
-Montgomery,Coffeyville SECOND PRECINCT,U.S. Senate,,D,Patrick Wiesner,41
-Montgomery,Coffeyville THIRD PRECINCT,U.S. Senate,,D,Patrick Wiesner,70
-Montgomery,Coffeyville FOURTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,57
-Montgomery,Coffeyville FIFTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,81
-Montgomery,Coffeyville SIXTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,25
-Montgomery,Coffeyville SEVENTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,41
-Montgomery,Coffeyville EIGHTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,48
-Montgomery,Coffeyville NINTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,18
-Montgomery,Coffeyville TENTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,60
-Montgomery,Coffeyville ELEVENTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,111
-Montgomery,Coffeyville TWELFTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,150
-Montgomery,Coffeyville THIRTEENTH PRECINCT,U.S. Senate,,D,Patrick Wiesner,131
-Montgomery,Coffeyville Total,U.S. Senate,,D,Patrick Wiesner,878
-Montgomery,Independence FIRST WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,56
-Montgomery,Independence FIRST WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,53
-Montgomery,Independence SECOND WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,21
-Montgomery,Independence SECOND WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,23
-Montgomery,Independence THIRD WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,46
-Montgomery,Independence THIRD WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,38
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,79
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,61
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,U.S. Senate,,D,Patrick Wiesner,46
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,U.S. Senate,,D,Patrick Wiesner,87
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,U.S. Senate,,D,Patrick Wiesner,7
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,U.S. Senate,,D,Patrick Wiesner,97
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,U.S. Senate,,D,Patrick Wiesner,52
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,U.S. Senate,,D,Patrick Wiesner,27
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,U.S. Senate,,D,Patrick Wiesner,14
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,U.S. Senate,,D,Patrick Wiesner,1
-Montgomery,Independence Total,U.S. Senate,,D,Patrick Wiesner,708
-Montgomery,Caney Township HAVANA PRECINCT,U.S. Senate,,D,Patrick Wiesner,41
-Montgomery,Caney Township TYRO PRECINCT,U.S. Senate,,D,Patrick Wiesner,28
-Montgomery,Caney Township Total,U.S. Senate,,D,Patrick Wiesner,69
-Montgomery,Cherokee Township ,U.S. Senate,,D,Patrick Wiesner,45
-Montgomery,Cherry Township ,U.S. Senate,,D,Patrick Wiesner,37
-Montgomery,Drum Creek Township ,U.S. Senate,,D,Patrick Wiesner,27
-Montgomery,Fawn Creek Township DEARING PRECINCT,U.S. Senate,,D,Patrick Wiesner,120
-Montgomery,Fawn Creek Township TYRO PRECINCT,U.S. Senate,,D,Patrick Wiesner,23
-Montgomery,Fawn Creek Township Total,U.S. Senate,,D,Patrick Wiesner,143
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Independence Township FIRST PRECINCT H11,U.S. Senate,,D,Patrick Wiesner,95
-Montgomery,Independence Township FIRST PRECINCT H12,U.S. Senate,,D,Patrick Wiesner,16
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,U.S. Senate,,D,Patrick Wiesner,29
-Montgomery,Independence Township SECOND PRECINCT PART B H12,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,U.S. Senate,,D,Patrick Wiesner,5
-Montgomery,Independence Township Total,U.S. Senate,,D,Patrick Wiesner,145
-Montgomery,Liberty Township ,U.S. Senate,,D,Patrick Wiesner,39
-Montgomery,Louisburg Township ,U.S. Senate,,D,Patrick Wiesner,42
-Montgomery,Parker Township FIRST PRECINCT,U.S. Senate,,D,Patrick Wiesner,22
-Montgomery,Parker Township SECOND PRECINCT,U.S. Senate,,D,Patrick Wiesner,98
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,U.S. Senate,,D,Patrick Wiesner,6
-Montgomery,Parker Township Total,U.S. Senate,,D,Patrick Wiesner,126
-Montgomery,Rutland Township ,U.S. Senate,,D,Patrick Wiesner,17
-Montgomery,Sycamore Township ,U.S. Senate,,D,Patrick Wiesner,55
-Montgomery,West Cherry Township ,U.S. Senate,,D,Patrick Wiesner,19
-Montgomery,Hand Counted,U.S. Senate,,D,Patrick Wiesner,25
-Montgomery,Provisional,U.S. Senate,,D,Patrick Wiesner,67
-Montgomery,Provisional Hand Count,U.S. Senate,,D,Patrick Wiesner,0
-Montgomery,Grand Total,U.S. Senate,,D,Patrick Wiesner,2702
-Montgomery,Caney FIRST WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,12
-Montgomery,Caney FIRST WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,10
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,16
-Montgomery,Caney THIRD WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,12
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Caney Total,U.S. Senate,,L,Robert D. Garrard,50
-Montgomery,Cherryvale FIRST WARD,U.S. Senate,,L,Robert D. Garrard,29
-Montgomery,Cherryvale SECOND WARD,U.S. Senate,,L,Robert D. Garrard,29
-Montgomery,Cherryvale Total,U.S. Senate,,L,Robert D. Garrard,58
-Montgomery,Coffeyville FIRST PRECINCT,U.S. Senate,,L,Robert D. Garrard,1
-Montgomery,Coffeyville SECOND PRECINCT,U.S. Senate,,L,Robert D. Garrard,5
-Montgomery,Coffeyville THIRD PRECINCT,U.S. Senate,,L,Robert D. Garrard,10
-Montgomery,Coffeyville FOURTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,14
-Montgomery,Coffeyville FIFTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,15
-Montgomery,Coffeyville SIXTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,6
-Montgomery,Coffeyville SEVENTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,12
-Montgomery,Coffeyville EIGHTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,13
-Montgomery,Coffeyville NINTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,6
-Montgomery,Coffeyville TENTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,13
-Montgomery,Coffeyville ELEVENTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,31
-Montgomery,Coffeyville TWELFTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,31
-Montgomery,Coffeyville THIRTEENTH PRECINCT,U.S. Senate,,L,Robert D. Garrard,28
-Montgomery,Coffeyville Total,U.S. Senate,,L,Robert D. Garrard,185
-Montgomery,Independence FIRST WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,7
-Montgomery,Independence FIRST WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,19
-Montgomery,Independence SECOND WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,11
-Montgomery,Independence SECOND WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,14
-Montgomery,Independence THIRD WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,16
-Montgomery,Independence THIRD WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,18
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,17
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,20
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,U.S. Senate,,L,Robert D. Garrard,19
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,U.S. Senate,,L,Robert D. Garrard,22
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,U.S. Senate,,L,Robert D. Garrard,3
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,U.S. Senate,,L,Robert D. Garrard,28
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,U.S. Senate,,L,Robert D. Garrard,13
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,U.S. Senate,,L,Robert D. Garrard,9
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,U.S. Senate,,L,Robert D. Garrard,5
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Independence Total,U.S. Senate,,L,Robert D. Garrard,221
-Montgomery,Caney Township HAVANA PRECINCT,U.S. Senate,,L,Robert D. Garrard,14
-Montgomery,Caney Township TYRO PRECINCT,U.S. Senate,,L,Robert D. Garrard,14
-Montgomery,Caney Township Total,U.S. Senate,,L,Robert D. Garrard,28
-Montgomery,Cherokee Township ,U.S. Senate,,L,Robert D. Garrard,21
-Montgomery,Cherry Township ,U.S. Senate,,L,Robert D. Garrard,20
-Montgomery,Drum Creek Township ,U.S. Senate,,L,Robert D. Garrard,16
-Montgomery,Fawn Creek Township DEARING PRECINCT,U.S. Senate,,L,Robert D. Garrard,49
-Montgomery,Fawn Creek Township TYRO PRECINCT,U.S. Senate,,L,Robert D. Garrard,17
-Montgomery,Fawn Creek Township Total,U.S. Senate,,L,Robert D. Garrard,66
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Independence Township FIRST PRECINCT H11,U.S. Senate,,L,Robert D. Garrard,66
-Montgomery,Independence Township FIRST PRECINCT H12,U.S. Senate,,L,Robert D. Garrard,12
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,U.S. Senate,,L,Robert D. Garrard,14
-Montgomery,Independence Township SECOND PRECINCT PART B H12,U.S. Senate,,L,Robert D. Garrard,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,U.S. Senate,,L,Robert D. Garrard,5
-Montgomery,Independence Township Total,U.S. Senate,,L,Robert D. Garrard,97
-Montgomery,Liberty Township ,U.S. Senate,,L,Robert D. Garrard,21
-Montgomery,Louisburg Township ,U.S. Senate,,L,Robert D. Garrard,21
-Montgomery,Parker Township FIRST PRECINCT,U.S. Senate,,L,Robert D. Garrard,10
-Montgomery,Parker Township SECOND PRECINCT,U.S. Senate,,L,Robert D. Garrard,23
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,U.S. Senate,,L,Robert D. Garrard,1
-Montgomery,Parker Township Total,U.S. Senate,,L,Robert D. Garrard,34
-Montgomery,Rutland Township ,U.S. Senate,,L,Robert D. Garrard,5
-Montgomery,Sycamore Township ,U.S. Senate,,L,Robert D. Garrard,37
-Montgomery,West Cherry Township ,U.S. Senate,,L,Robert D. Garrard,5
-Montgomery,Hand Counted,U.S. Senate,,L,Robert D. Garrard,7
-Montgomery,Provisional,U.S. Senate,,L,Robert D. Garrard,26
-Montgomery,Provisional Hand Count,U.S. Senate,,L,Robert D. Garrard,1
-Montgomery,Grand Total,U.S. Senate,,L,Robert D. Garrard,919
-Montgomery,Caney FIRST WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,128
-Montgomery,Caney FIRST WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,1
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,U.S. Senate,,R,Jerry Moran,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,U.S. Senate,,R,Jerry Moran,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,95
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,U.S. Senate,,R,Jerry Moran,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,130
-Montgomery,Caney THIRD WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,2
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,148
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,1
-Montgomery,Caney Total,U.S. Senate,,R,Jerry Moran,505
-Montgomery,Cherryvale FIRST WARD,U.S. Senate,,R,Jerry Moran,304
-Montgomery,Cherryvale SECOND WARD,U.S. Senate,,R,Jerry Moran,190
-Montgomery,Cherryvale Total,U.S. Senate,,R,Jerry Moran,494
-Montgomery,Coffeyville FIRST PRECINCT,U.S. Senate,,R,Jerry Moran,5
-Montgomery,Coffeyville SECOND PRECINCT,U.S. Senate,,R,Jerry Moran,75
-Montgomery,Coffeyville THIRD PRECINCT,U.S. Senate,,R,Jerry Moran,100
-Montgomery,Coffeyville FOURTH PRECINCT,U.S. Senate,,R,Jerry Moran,122
-Montgomery,Coffeyville FIFTH PRECINCT,U.S. Senate,,R,Jerry Moran,137
-Montgomery,Coffeyville SIXTH PRECINCT,U.S. Senate,,R,Jerry Moran,35
-Montgomery,Coffeyville SEVENTH PRECINCT,U.S. Senate,,R,Jerry Moran,51
-Montgomery,Coffeyville EIGHTH PRECINCT,U.S. Senate,,R,Jerry Moran,76
-Montgomery,Coffeyville NINTH PRECINCT,U.S. Senate,,R,Jerry Moran,20
-Montgomery,Coffeyville TENTH PRECINCT,U.S. Senate,,R,Jerry Moran,101
-Montgomery,Coffeyville ELEVENTH PRECINCT,U.S. Senate,,R,Jerry Moran,216
-Montgomery,Coffeyville TWELFTH PRECINCT,U.S. Senate,,R,Jerry Moran,347
-Montgomery,Coffeyville THIRTEENTH PRECINCT,U.S. Senate,,R,Jerry Moran,257
-Montgomery,Coffeyville Total,U.S. Senate,,R,Jerry Moran,1542
-Montgomery,Independence FIRST WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,90
-Montgomery,Independence FIRST WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,183
-Montgomery,Independence SECOND WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,67
-Montgomery,Independence SECOND WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,51
-Montgomery,Independence THIRD WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,134
-Montgomery,Independence THIRD WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,68
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,U.S. Senate,,R,Jerry Moran,1
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,129
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,99
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,U.S. Senate,,R,Jerry Moran,94
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,U.S. Senate,,R,Jerry Moran,185
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,U.S. Senate,,R,Jerry Moran,21
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,U.S. Senate,,R,Jerry Moran,276
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,U.S. Senate,,R,Jerry Moran,224
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,U.S. Senate,,R,Jerry Moran,84
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,U.S. Senate,,R,Jerry Moran,66
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,U.S. Senate,,R,Jerry Moran,12
-Montgomery,Independence Total,U.S. Senate,,R,Jerry Moran,1784
-Montgomery,Caney Township HAVANA PRECINCT,U.S. Senate,,R,Jerry Moran,228
-Montgomery,Caney Township TYRO PRECINCT,U.S. Senate,,R,Jerry Moran,300
-Montgomery,Caney Township Total,U.S. Senate,,R,Jerry Moran,528
-Montgomery,Cherokee Township ,U.S. Senate,,R,Jerry Moran,127
-Montgomery,Cherry Township ,U.S. Senate,,R,Jerry Moran,188
-Montgomery,Drum Creek Township ,U.S. Senate,,R,Jerry Moran,215
-Montgomery,Fawn Creek Township DEARING PRECINCT,U.S. Senate,,R,Jerry Moran,507
-Montgomery,Fawn Creek Township TYRO PRECINCT,U.S. Senate,,R,Jerry Moran,164
-Montgomery,Fawn Creek Township Total,U.S. Senate,,R,Jerry Moran,671
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,U.S. Senate,,R,Jerry Moran,0
-Montgomery,Independence Township FIRST PRECINCT H11,U.S. Senate,,R,Jerry Moran,524
-Montgomery,Independence Township FIRST PRECINCT H12,U.S. Senate,,R,Jerry Moran,95
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,U.S. Senate,,R,Jerry Moran,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,U.S. Senate,,R,Jerry Moran,122
-Montgomery,Independence Township SECOND PRECINCT PART B H12,U.S. Senate,,R,Jerry Moran,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,U.S. Senate,,R,Jerry Moran,36
-Montgomery,Independence Township Total,U.S. Senate,,R,Jerry Moran,777
-Montgomery,Liberty Township ,U.S. Senate,,R,Jerry Moran,168
-Montgomery,Louisburg Township ,U.S. Senate,,R,Jerry Moran,172
-Montgomery,Parker Township FIRST PRECINCT,U.S. Senate,,R,Jerry Moran,91
-Montgomery,Parker Township SECOND PRECINCT,U.S. Senate,,R,Jerry Moran,266
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,U.S. Senate,,R,Jerry Moran,4
-Montgomery,Parker Township Total,U.S. Senate,,R,Jerry Moran,361
-Montgomery,Rutland Township ,U.S. Senate,,R,Jerry Moran,145
-Montgomery,Sycamore Township ,U.S. Senate,,R,Jerry Moran,280
-Montgomery,West Cherry Township ,U.S. Senate,,R,Jerry Moran,97
-Montgomery,Hand Counted,U.S. Senate,,R,Jerry Moran,17
-Montgomery,Provisional,U.S. Senate,,R,Jerry Moran,159
-Montgomery,Provisional Hand Count,U.S. Senate,,R,Jerry Moran,2
-Montgomery,Grand Total,U.S. Senate,,R,Jerry Moran,8232
-Montgomery,Caney FIRST WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,25
-Montgomery,Caney FIRST WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,U.S. House,2,D,Britani Potter,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,U.S. House,2,D,Britani Potter,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,20
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,U.S. House,2,D,Britani Potter,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,24
-Montgomery,Caney THIRD WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,28
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,0
-Montgomery,Caney Total,U.S. House,2,D,Britani Potter,97
-Montgomery,Cherryvale FIRST WARD,U.S. House,2,D,Britani Potter,93
-Montgomery,Cherryvale SECOND WARD,U.S. House,2,D,Britani Potter,57
-Montgomery,Cherryvale Total,U.S. House,2,D,Britani Potter,150
-Montgomery,Coffeyville FIRST PRECINCT,U.S. House,2,D,Britani Potter,42
-Montgomery,Coffeyville SECOND PRECINCT,U.S. House,2,D,Britani Potter,42
-Montgomery,Coffeyville THIRD PRECINCT,U.S. House,2,D,Britani Potter,58
-Montgomery,Coffeyville FOURTH PRECINCT,U.S. House,2,D,Britani Potter,54
-Montgomery,Coffeyville FIFTH PRECINCT,U.S. House,2,D,Britani Potter,81
-Montgomery,Coffeyville SIXTH PRECINCT,U.S. House,2,D,Britani Potter,26
-Montgomery,Coffeyville SEVENTH PRECINCT,U.S. House,2,D,Britani Potter,38
-Montgomery,Coffeyville EIGHTH PRECINCT,U.S. House,2,D,Britani Potter,47
-Montgomery,Coffeyville NINTH PRECINCT,U.S. House,2,D,Britani Potter,17
-Montgomery,Coffeyville TENTH PRECINCT,U.S. House,2,D,Britani Potter,58
-Montgomery,Coffeyville ELEVENTH PRECINCT,U.S. House,2,D,Britani Potter,101
-Montgomery,Coffeyville TWELFTH PRECINCT,U.S. House,2,D,Britani Potter,139
-Montgomery,Coffeyville THIRTEENTH PRECINCT,U.S. House,2,D,Britani Potter,115
-Montgomery,Coffeyville Total,U.S. House,2,D,Britani Potter,818
-Montgomery,Independence FIRST WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,51
-Montgomery,Independence FIRST WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,49
-Montgomery,Independence SECOND WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,22
-Montgomery,Independence SECOND WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,21
-Montgomery,Independence THIRD WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,46
-Montgomery,Independence THIRD WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,37
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,U.S. House,2,D,Britani Potter,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,71
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,62
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,U.S. House,2,D,Britani Potter,42
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,U.S. House,2,D,Britani Potter,71
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,U.S. House,2,D,Britani Potter,8
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,U.S. House,2,D,Britani Potter,88
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,U.S. House,2,D,Britani Potter,48
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,U.S. House,2,D,Britani Potter,21
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,U.S. House,2,D,Britani Potter,15
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,U.S. House,2,D,Britani Potter,2
-Montgomery,Independence Total,U.S. House,2,D,Britani Potter,654
-Montgomery,Caney Township HAVANA PRECINCT,U.S. House,2,D,Britani Potter,32
-Montgomery,Caney Township TYRO PRECINCT,U.S. House,2,D,Britani Potter,24
-Montgomery,Caney Township Total,U.S. House,2,D,Britani Potter,56
-Montgomery,Cherokee Township ,U.S. House,2,D,Britani Potter,43
-Montgomery,Cherry Township ,U.S. House,2,D,Britani Potter,34
-Montgomery,Drum Creek Township ,U.S. House,2,D,Britani Potter,27
-Montgomery,Fawn Creek Township DEARING PRECINCT,U.S. House,2,D,Britani Potter,116
-Montgomery,Fawn Creek Township TYRO PRECINCT,U.S. House,2,D,Britani Potter,16
-Montgomery,Fawn Creek Township Total,U.S. House,2,D,Britani Potter,132
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,U.S. House,2,D,Britani Potter,0
-Montgomery,Independence Township FIRST PRECINCT H11,U.S. House,2,D,Britani Potter,89
-Montgomery,Independence Township FIRST PRECINCT H12,U.S. House,2,D,Britani Potter,15
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,U.S. House,2,D,Britani Potter,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,U.S. House,2,D,Britani Potter,24
-Montgomery,Independence Township SECOND PRECINCT PART B H12,U.S. House,2,D,Britani Potter,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,U.S. House,2,D,Britani Potter,4
-Montgomery,Independence Township Total,U.S. House,2,D,Britani Potter,132
-Montgomery,Liberty Township ,U.S. House,2,D,Britani Potter,37
-Montgomery,Louisburg Township ,U.S. House,2,D,Britani Potter,39
-Montgomery,Parker Township FIRST PRECINCT,U.S. House,2,D,Britani Potter,23
-Montgomery,Parker Township SECOND PRECINCT,U.S. House,2,D,Britani Potter,98
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,U.S. House,2,D,Britani Potter,6
-Montgomery,Parker Township Total,U.S. House,2,D,Britani Potter,127
-Montgomery,Rutland Township ,U.S. House,2,D,Britani Potter,15
-Montgomery,Sycamore Township ,U.S. House,2,D,Britani Potter,47
-Montgomery,West Cherry Township ,U.S. House,2,D,Britani Potter,21
-Montgomery,Hand Counted,U.S. House,2,D,Britani Potter,23
-Montgomery,Provisional,U.S. House,2,D,Britani Potter,59
-Montgomery,Provisional Hand Count,U.S. House,2,D,Britani Potter,0
-Montgomery,Grand Total,U.S. House,2,D,Britani Potter,2511
-Montgomery,Caney FIRST WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,7
-Montgomery,Caney FIRST WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,U.S. House,2,L,James Houston Bales,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,U.S. House,2,L,James Houston Bales,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,8
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,U.S. House,2,L,James Houston Bales,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,11
-Montgomery,Caney THIRD WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,16
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,0
-Montgomery,Caney Total,U.S. House,2,L,James Houston Bales,42
-Montgomery,Cherryvale FIRST WARD,U.S. House,2,L,James Houston Bales,33
-Montgomery,Cherryvale SECOND WARD,U.S. House,2,L,James Houston Bales,23
-Montgomery,Cherryvale Total,U.S. House,2,L,James Houston Bales,56
-Montgomery,Coffeyville FIRST PRECINCT,U.S. House,2,L,James Houston Bales,1
-Montgomery,Coffeyville SECOND PRECINCT,U.S. House,2,L,James Houston Bales,5
-Montgomery,Coffeyville THIRD PRECINCT,U.S. House,2,L,James Houston Bales,11
-Montgomery,Coffeyville FOURTH PRECINCT,U.S. House,2,L,James Houston Bales,20
-Montgomery,Coffeyville FIFTH PRECINCT,U.S. House,2,L,James Houston Bales,13
-Montgomery,Coffeyville SIXTH PRECINCT,U.S. House,2,L,James Houston Bales,2
-Montgomery,Coffeyville SEVENTH PRECINCT,U.S. House,2,L,James Houston Bales,8
-Montgomery,Coffeyville EIGHTH PRECINCT,U.S. House,2,L,James Houston Bales,11
-Montgomery,Coffeyville NINTH PRECINCT,U.S. House,2,L,James Houston Bales,5
-Montgomery,Coffeyville TENTH PRECINCT,U.S. House,2,L,James Houston Bales,17
-Montgomery,Coffeyville ELEVENTH PRECINCT,U.S. House,2,L,James Houston Bales,19
-Montgomery,Coffeyville TWELFTH PRECINCT,U.S. House,2,L,James Houston Bales,23
-Montgomery,Coffeyville THIRTEENTH PRECINCT,U.S. House,2,L,James Houston Bales,20
-Montgomery,Coffeyville Total,U.S. House,2,L,James Houston Bales,155
-Montgomery,Independence FIRST WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,8
-Montgomery,Independence FIRST WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,13
-Montgomery,Independence SECOND WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,8
-Montgomery,Independence SECOND WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,10
-Montgomery,Independence THIRD WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,12
-Montgomery,Independence THIRD WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,13
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,U.S. House,2,L,James Houston Bales,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,14
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,18
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,U.S. House,2,L,James Houston Bales,12
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,U.S. House,2,L,James Houston Bales,19
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,U.S. House,2,L,James Houston Bales,0
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,U.S. House,2,L,James Houston Bales,20
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,U.S. House,2,L,James Houston Bales,11
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,U.S. House,2,L,James Houston Bales,10
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,U.S. House,2,L,James Houston Bales,5
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,U.S. House,2,L,James Houston Bales,0
-Montgomery,Independence Total,U.S. House,2,L,James Houston Bales,173
-Montgomery,Caney Township HAVANA PRECINCT,U.S. House,2,L,James Houston Bales,10
-Montgomery,Caney Township TYRO PRECINCT,U.S. House,2,L,James Houston Bales,12
-Montgomery,Caney Township Total,U.S. House,2,L,James Houston Bales,22
-Montgomery,Cherokee Township ,U.S. House,2,L,James Houston Bales,13
-Montgomery,Cherry Township ,U.S. House,2,L,James Houston Bales,20
-Montgomery,Drum Creek Township ,U.S. House,2,L,James Houston Bales,13
-Montgomery,Fawn Creek Township DEARING PRECINCT,U.S. House,2,L,James Houston Bales,33
-Montgomery,Fawn Creek Township TYRO PRECINCT,U.S. House,2,L,James Houston Bales,13
-Montgomery,Fawn Creek Township Total,U.S. House,2,L,James Houston Bales,46
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,U.S. House,2,L,James Houston Bales,0
-Montgomery,Independence Township FIRST PRECINCT H11,U.S. House,2,L,James Houston Bales,34
-Montgomery,Independence Township FIRST PRECINCT H12,U.S. House,2,L,James Houston Bales,9
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,U.S. House,2,L,James Houston Bales,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,U.S. House,2,L,James Houston Bales,9
-Montgomery,Independence Township SECOND PRECINCT PART B H12,U.S. House,2,L,James Houston Bales,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,U.S. House,2,L,James Houston Bales,5
-Montgomery,Independence Township Total,U.S. House,2,L,James Houston Bales,57
-Montgomery,Liberty Township ,U.S. House,2,L,James Houston Bales,11
-Montgomery,Louisburg Township ,U.S. House,2,L,James Houston Bales,17
-Montgomery,Parker Township FIRST PRECINCT,U.S. House,2,L,James Houston Bales,10
-Montgomery,Parker Township SECOND PRECINCT,U.S. House,2,L,James Houston Bales,19
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,U.S. House,2,L,James Houston Bales,0
-Montgomery,Parker Township Total,U.S. House,2,L,James Houston Bales,29
-Montgomery,Rutland Township ,U.S. House,2,L,James Houston Bales,6
-Montgomery,Sycamore Township ,U.S. House,2,L,James Houston Bales,26
-Montgomery,West Cherry Township ,U.S. House,2,L,James Houston Bales,4
-Montgomery,Hand Counted,U.S. House,2,L,James Houston Bales,4
-Montgomery,Provisional,U.S. House,2,L,James Houston Bales,24
-Montgomery,Provisional Hand Count,U.S. House,2,L,James Houston Bales,1
-Montgomery,Grand Total,U.S. House,2,L,James Houston Bales,719
-Montgomery,Caney FIRST WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,138
-Montgomery,Caney FIRST WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,1
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,U.S. House,2,R,Lynn Jenkins,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,U.S. House,2,R,Lynn Jenkins,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,99
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,U.S. House,2,R,Lynn Jenkins,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,139
-Montgomery,Caney THIRD WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,2
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,147
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,1
-Montgomery,Caney Total,U.S. House,2,R,Lynn Jenkins,527
-Montgomery,Cherryvale FIRST WARD,U.S. House,2,R,Lynn Jenkins,299
-Montgomery,Cherryvale SECOND WARD,U.S. House,2,R,Lynn Jenkins,207
-Montgomery,Cherryvale Total,U.S. House,2,R,Lynn Jenkins,506
-Montgomery,Coffeyville FIRST PRECINCT,U.S. House,2,R,Lynn Jenkins,6
-Montgomery,Coffeyville SECOND PRECINCT,U.S. House,2,R,Lynn Jenkins,74
-Montgomery,Coffeyville THIRD PRECINCT,U.S. House,2,R,Lynn Jenkins,109
-Montgomery,Coffeyville FOURTH PRECINCT,U.S. House,2,R,Lynn Jenkins,124
-Montgomery,Coffeyville FIFTH PRECINCT,U.S. House,2,R,Lynn Jenkins,140
-Montgomery,Coffeyville SIXTH PRECINCT,U.S. House,2,R,Lynn Jenkins,39
-Montgomery,Coffeyville SEVENTH PRECINCT,U.S. House,2,R,Lynn Jenkins,57
-Montgomery,Coffeyville EIGHTH PRECINCT,U.S. House,2,R,Lynn Jenkins,78
-Montgomery,Coffeyville NINTH PRECINCT,U.S. House,2,R,Lynn Jenkins,22
-Montgomery,Coffeyville TENTH PRECINCT,U.S. House,2,R,Lynn Jenkins,102
-Montgomery,Coffeyville ELEVENTH PRECINCT,U.S. House,2,R,Lynn Jenkins,232
-Montgomery,Coffeyville TWELFTH PRECINCT,U.S. House,2,R,Lynn Jenkins,370
-Montgomery,Coffeyville THIRTEENTH PRECINCT,U.S. House,2,R,Lynn Jenkins,277
-Montgomery,Coffeyville Total,U.S. House,2,R,Lynn Jenkins,1630
-Montgomery,Independence FIRST WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,97
-Montgomery,Independence FIRST WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,198
-Montgomery,Independence SECOND WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,69
-Montgomery,Independence SECOND WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,57
-Montgomery,Independence THIRD WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,138
-Montgomery,Independence THIRD WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,76
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,U.S. House,2,R,Lynn Jenkins,1
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,138
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,99
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,U.S. House,2,R,Lynn Jenkins,105
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,U.S. House,2,R,Lynn Jenkins,203
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,U.S. House,2,R,Lynn Jenkins,22
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,U.S. House,2,R,Lynn Jenkins,299
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,U.S. House,2,R,Lynn Jenkins,233
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,U.S. House,2,R,Lynn Jenkins,90
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,U.S. House,2,R,Lynn Jenkins,65
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,U.S. House,2,R,Lynn Jenkins,11
-Montgomery,Independence Total,U.S. House,2,R,Lynn Jenkins,1901
-Montgomery,Caney Township HAVANA PRECINCT,U.S. House,2,R,Lynn Jenkins,246
-Montgomery,Caney Township TYRO PRECINCT,U.S. House,2,R,Lynn Jenkins,309
-Montgomery,Caney Township Total,U.S. House,2,R,Lynn Jenkins,555
-Montgomery,Cherokee Township ,U.S. House,2,R,Lynn Jenkins,136
-Montgomery,Cherry Township ,U.S. House,2,R,Lynn Jenkins,185
-Montgomery,Drum Creek Township ,U.S. House,2,R,Lynn Jenkins,218
-Montgomery,Fawn Creek Township DEARING PRECINCT,U.S. House,2,R,Lynn Jenkins,532
-Montgomery,Fawn Creek Township TYRO PRECINCT,U.S. House,2,R,Lynn Jenkins,174
-Montgomery,Fawn Creek Township Total,U.S. House,2,R,Lynn Jenkins,706
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,U.S. House,2,R,Lynn Jenkins,0
-Montgomery,Independence Township FIRST PRECINCT H11,U.S. House,2,R,Lynn Jenkins,560
-Montgomery,Independence Township FIRST PRECINCT H12,U.S. House,2,R,Lynn Jenkins,98
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,U.S. House,2,R,Lynn Jenkins,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,U.S. House,2,R,Lynn Jenkins,130
-Montgomery,Independence Township SECOND PRECINCT PART B H12,U.S. House,2,R,Lynn Jenkins,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,U.S. House,2,R,Lynn Jenkins,36
-Montgomery,Independence Township Total,U.S. House,2,R,Lynn Jenkins,824
-Montgomery,Liberty Township ,U.S. House,2,R,Lynn Jenkins,179
-Montgomery,Louisburg Township ,U.S. House,2,R,Lynn Jenkins,177
-Montgomery,Parker Township FIRST PRECINCT,U.S. House,2,R,Lynn Jenkins,93
-Montgomery,Parker Township SECOND PRECINCT,U.S. House,2,R,Lynn Jenkins,267
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,U.S. House,2,R,Lynn Jenkins,5
-Montgomery,Parker Township Total,U.S. House,2,R,Lynn Jenkins,365
-Montgomery,Rutland Township ,U.S. House,2,R,Lynn Jenkins,148
-Montgomery,Sycamore Township ,U.S. House,2,R,Lynn Jenkins,306
-Montgomery,West Cherry Township ,U.S. House,2,R,Lynn Jenkins,99
-Montgomery,Hand Counted,U.S. House,2,R,Lynn Jenkins,24
-Montgomery,Provisional,U.S. House,2,R,Lynn Jenkins,170
-Montgomery,Provisional Hand Count,U.S. House,2,R,Lynn Jenkins,2
-Montgomery,Grand Total,U.S. House,2,R,Lynn Jenkins,8658
-Montgomery,Louisburg Township ,State Senate,14,D,Mark Pringle,56
-Montgomery,Hand Counted,State Senate,14,D,Mark Pringle,0
-Montgomery,Provisional,State Senate,14,D,Mark Pringle,1
-Montgomery,Provisional Hand Count,State Senate,14,D,Mark Pringle,0
-Montgomery,Grand Total,State Senate,14,D,Mark Pringle,57
-Montgomery,Louisburg Township ,State Senate,14,R,Bruce Givens,170
-Montgomery,Hand Counted,State Senate,14,R,Bruce Givens,0
-Montgomery,Provisional,State Senate,14,R,Bruce Givens,4
-Montgomery,Provisional Hand Count,State Senate,14,R,Bruce Givens,0
-Montgomery,Grand Total,State Senate,14,R,Bruce Givens,174
-Montgomery,Caney FIRST WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,46
-Montgomery,Caney FIRST WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,1
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,43
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,50
-Montgomery,Caney THIRD WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,67
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Caney Total,State Senate,15,D,Chuck Schmidt,207
-Montgomery,Cherryvale FIRST WARD,State Senate,15,D,Chuck Schmidt,172
-Montgomery,Cherryvale SECOND WARD,State Senate,15,D,Chuck Schmidt,117
-Montgomery,Cherryvale Total,State Senate,15,D,Chuck Schmidt,289
-Montgomery,Coffeyville FIRST PRECINCT,State Senate,15,D,Chuck Schmidt,46
-Montgomery,Coffeyville SECOND PRECINCT,State Senate,15,D,Chuck Schmidt,64
-Montgomery,Coffeyville THIRD PRECINCT,State Senate,15,D,Chuck Schmidt,105
-Montgomery,Coffeyville FOURTH PRECINCT,State Senate,15,D,Chuck Schmidt,86
-Montgomery,Coffeyville FIFTH PRECINCT,State Senate,15,D,Chuck Schmidt,128
-Montgomery,Coffeyville SIXTH PRECINCT,State Senate,15,D,Chuck Schmidt,40
-Montgomery,Coffeyville SEVENTH PRECINCT,State Senate,15,D,Chuck Schmidt,57
-Montgomery,Coffeyville EIGHTH PRECINCT,State Senate,15,D,Chuck Schmidt,79
-Montgomery,Coffeyville NINTH PRECINCT,State Senate,15,D,Chuck Schmidt,24
-Montgomery,Coffeyville TENTH PRECINCT,State Senate,15,D,Chuck Schmidt,84
-Montgomery,Coffeyville ELEVENTH PRECINCT,State Senate,15,D,Chuck Schmidt,150
-Montgomery,Coffeyville TWELFTH PRECINCT,State Senate,15,D,Chuck Schmidt,226
-Montgomery,Coffeyville THIRTEENTH PRECINCT,State Senate,15,D,Chuck Schmidt,194
-Montgomery,Coffeyville Total,State Senate,15,D,Chuck Schmidt,1283
-Montgomery,Independence FIRST WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,72
-Montgomery,Independence FIRST WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,118
-Montgomery,Independence SECOND WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,45
-Montgomery,Independence SECOND WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,43
-Montgomery,Independence THIRD WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,86
-Montgomery,Independence THIRD WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,68
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,State Senate,15,D,Chuck Schmidt,1
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,113
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,93
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,State Senate,15,D,Chuck Schmidt,88
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,State Senate,15,D,Chuck Schmidt,137
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,State Senate,15,D,Chuck Schmidt,15
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,State Senate,15,D,Chuck Schmidt,189
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,State Senate,15,D,Chuck Schmidt,146
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,State Senate,15,D,Chuck Schmidt,60
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,State Senate,15,D,Chuck Schmidt,31
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,State Senate,15,D,Chuck Schmidt,7
-Montgomery,Independence Total,State Senate,15,D,Chuck Schmidt,1312
-Montgomery,Caney Township HAVANA PRECINCT,State Senate,15,D,Chuck Schmidt,82
-Montgomery,Caney Township TYRO PRECINCT,State Senate,15,D,Chuck Schmidt,81
-Montgomery,Caney Township Total,State Senate,15,D,Chuck Schmidt,163
-Montgomery,Cherokee Township ,State Senate,15,D,Chuck Schmidt,75
-Montgomery,Cherry Township ,State Senate,15,D,Chuck Schmidt,70
-Montgomery,Drum Creek Township ,State Senate,15,D,Chuck Schmidt,75
-Montgomery,Fawn Creek Township DEARING PRECINCT,State Senate,15,D,Chuck Schmidt,239
-Montgomery,Fawn Creek Township TYRO PRECINCT,State Senate,15,D,Chuck Schmidt,61
-Montgomery,Fawn Creek Township Total,State Senate,15,D,Chuck Schmidt,300
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Independence Township FIRST PRECINCT H11,State Senate,15,D,Chuck Schmidt,236
-Montgomery,Independence Township FIRST PRECINCT H12,State Senate,15,D,Chuck Schmidt,43
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,State Senate,15,D,Chuck Schmidt,63
-Montgomery,Independence Township SECOND PRECINCT PART B H12,State Senate,15,D,Chuck Schmidt,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,State Senate,15,D,Chuck Schmidt,15
-Montgomery,Independence Township Total,State Senate,15,D,Chuck Schmidt,357
-Montgomery,Liberty Township ,State Senate,15,D,Chuck Schmidt,75
-Montgomery,Parker Township FIRST PRECINCT,State Senate,15,D,Chuck Schmidt,40
-Montgomery,Parker Township SECOND PRECINCT,State Senate,15,D,Chuck Schmidt,156
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,State Senate,15,D,Chuck Schmidt,7
-Montgomery,Parker Township Total,State Senate,15,D,Chuck Schmidt,203
-Montgomery,Rutland Township ,State Senate,15,D,Chuck Schmidt,32
-Montgomery,Sycamore Township ,State Senate,15,D,Chuck Schmidt,121
-Montgomery,West Cherry Township ,State Senate,15,D,Chuck Schmidt,37
-Montgomery,Hand Counted,State Senate,15,D,Chuck Schmidt,30
-Montgomery,Provisional,State Senate,15,D,Chuck Schmidt,102
-Montgomery,Provisional Hand Count,State Senate,15,D,Chuck Schmidt,1
-Montgomery,Grand Total,State Senate,15,D,Chuck Schmidt,4732
-Montgomery,Caney FIRST WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,122
-Montgomery,Caney FIRST WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,State Senate,15,R,Dan Goddard,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,State Senate,15,R,Dan Goddard,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,82
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,State Senate,15,R,Dan Goddard,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,119
-Montgomery,Caney THIRD WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,2
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,122
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,1
-Montgomery,Caney Total,State Senate,15,R,Dan Goddard,448
-Montgomery,Cherryvale FIRST WARD,State Senate,15,R,Dan Goddard,254
-Montgomery,Cherryvale SECOND WARD,State Senate,15,R,Dan Goddard,173
-Montgomery,Cherryvale Total,State Senate,15,R,Dan Goddard,427
-Montgomery,Coffeyville FIRST PRECINCT,State Senate,15,R,Dan Goddard,5
-Montgomery,Coffeyville SECOND PRECINCT,State Senate,15,R,Dan Goddard,56
-Montgomery,Coffeyville THIRD PRECINCT,State Senate,15,R,Dan Goddard,76
-Montgomery,Coffeyville FOURTH PRECINCT,State Senate,15,R,Dan Goddard,109
-Montgomery,Coffeyville FIFTH PRECINCT,State Senate,15,R,Dan Goddard,109
-Montgomery,Coffeyville SIXTH PRECINCT,State Senate,15,R,Dan Goddard,26
-Montgomery,Coffeyville SEVENTH PRECINCT,State Senate,15,R,Dan Goddard,47
-Montgomery,Coffeyville EIGHTH PRECINCT,State Senate,15,R,Dan Goddard,59
-Montgomery,Coffeyville NINTH PRECINCT,State Senate,15,R,Dan Goddard,19
-Montgomery,Coffeyville TENTH PRECINCT,State Senate,15,R,Dan Goddard,92
-Montgomery,Coffeyville ELEVENTH PRECINCT,State Senate,15,R,Dan Goddard,209
-Montgomery,Coffeyville TWELFTH PRECINCT,State Senate,15,R,Dan Goddard,302
-Montgomery,Coffeyville THIRTEENTH PRECINCT,State Senate,15,R,Dan Goddard,218
-Montgomery,Coffeyville Total,State Senate,15,R,Dan Goddard,1327
-Montgomery,Independence FIRST WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,86
-Montgomery,Independence FIRST WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,140
-Montgomery,Independence SECOND WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,56
-Montgomery,Independence SECOND WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,45
-Montgomery,Independence THIRD WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,113
-Montgomery,Independence THIRD WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,59
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,State Senate,15,R,Dan Goddard,0
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,110
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,92
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,State Senate,15,R,Dan Goddard,77
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,State Senate,15,R,Dan Goddard,157
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,State Senate,15,R,Dan Goddard,15
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,State Senate,15,R,Dan Goddard,219
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,State Senate,15,R,Dan Goddard,151
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,State Senate,15,R,Dan Goddard,63
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,State Senate,15,R,Dan Goddard,53
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,State Senate,15,R,Dan Goddard,6
-Montgomery,Independence Total,State Senate,15,R,Dan Goddard,1442
-Montgomery,Caney Township HAVANA PRECINCT,State Senate,15,R,Dan Goddard,205
-Montgomery,Caney Township TYRO PRECINCT,State Senate,15,R,Dan Goddard,260
-Montgomery,Caney Township Total,State Senate,15,R,Dan Goddard,465
-Montgomery,Cherokee Township ,State Senate,15,R,Dan Goddard,114
-Montgomery,Cherry Township ,State Senate,15,R,Dan Goddard,173
-Montgomery,Drum Creek Township ,State Senate,15,R,Dan Goddard,188
-Montgomery,Fawn Creek Township DEARING PRECINCT,State Senate,15,R,Dan Goddard,443
-Montgomery,Fawn Creek Township TYRO PRECINCT,State Senate,15,R,Dan Goddard,140
-Montgomery,Fawn Creek Township Total,State Senate,15,R,Dan Goddard,583
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,State Senate,15,R,Dan Goddard,0
-Montgomery,Independence Township FIRST PRECINCT H11,State Senate,15,R,Dan Goddard,453
-Montgomery,Independence Township FIRST PRECINCT H12,State Senate,15,R,Dan Goddard,80
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,State Senate,15,R,Dan Goddard,0
-Montgomery,Independence Township SECOND PRECINCT PART A H12,State Senate,15,R,Dan Goddard,99
-Montgomery,Independence Township SECOND PRECINCT PART B H12,State Senate,15,R,Dan Goddard,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,State Senate,15,R,Dan Goddard,30
-Montgomery,Independence Township Total,State Senate,15,R,Dan Goddard,662
-Montgomery,Liberty Township ,State Senate,15,R,Dan Goddard,154
-Montgomery,Parker Township FIRST PRECINCT,State Senate,15,R,Dan Goddard,85
-Montgomery,Parker Township SECOND PRECINCT,State Senate,15,R,Dan Goddard,236
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,State Senate,15,R,Dan Goddard,5
-Montgomery,Parker Township Total,State Senate,15,R,Dan Goddard,326
-Montgomery,Rutland Township ,State Senate,15,R,Dan Goddard,134
-Montgomery,Sycamore Township ,State Senate,15,R,Dan Goddard,263
-Montgomery,West Cherry Township ,State Senate,15,R,Dan Goddard,88
-Montgomery,Hand Counted,State Senate,15,R,Dan Goddard,19
-Montgomery,Provisional,State Senate,15,R,Dan Goddard,145
-Montgomery,Provisional Hand Count,State Senate,15,R,Dan Goddard,2
-Montgomery,Grand Total,State Senate,15,R,Dan Goddard,6960
-Montgomery,Cherokee Township ,State House,7,R,Richard J. Proehl,170
-Montgomery,Liberty Township ,State House,7,R,Richard J. Proehl,198
-Montgomery,Parker Township FIRST PRECINCT,State House,7,R,Richard J. Proehl,105
-Montgomery,Parker Township SECOND PRECINCT,State House,7,R,Richard J. Proehl,323
-Montgomery,Hand Counted,State House,7,R,Richard J. Proehl,0
-Montgomery,Provisional,State House,7,R,Richard J. Proehl,11
-Montgomery,Provisional Hand Count,State House,7,R,Richard J. Proehl,0
-Montgomery,Grand Total,State House,7,R,Richard J. Proehl,807
-Montgomery,Cherryvale FIRST WARD,State House,11,R,Jim Kelly,365
-Montgomery,Cherryvale SECOND WARD,State House,11,R,Jim Kelly,258
-Montgomery,Cherryvale Total,State House,11,R,Jim Kelly,623
-Montgomery,Coffeyville FIRST PRECINCT,State House,11,R,Jim Kelly,28
-Montgomery,Coffeyville SECOND PRECINCT,State House,11,R,Jim Kelly,99
-Montgomery,Coffeyville THIRD PRECINCT,State House,11,R,Jim Kelly,159
-Montgomery,Coffeyville FOURTH PRECINCT,State House,11,R,Jim Kelly,172
-Montgomery,Coffeyville FIFTH PRECINCT,State House,11,R,Jim Kelly,189
-Montgomery,Coffeyville SIXTH PRECINCT,State House,11,R,Jim Kelly,53
-Montgomery,Coffeyville SEVENTH PRECINCT,State House,11,R,Jim Kelly,84
-Montgomery,Coffeyville EIGHTH PRECINCT,State House,11,R,Jim Kelly,113
-Montgomery,Coffeyville NINTH PRECINCT,State House,11,R,Jim Kelly,31
-Montgomery,Coffeyville TENTH PRECINCT,State House,11,R,Jim Kelly,150
-Montgomery,Coffeyville ELEVENTH PRECINCT,State House,11,R,Jim Kelly,293
-Montgomery,Coffeyville TWELFTH PRECINCT,State House,11,R,Jim Kelly,457
-Montgomery,Coffeyville THIRTEENTH PRECINCT,State House,11,R,Jim Kelly,353
-Montgomery,Coffeyville Total,State House,11,R,Jim Kelly,2181
-Montgomery,Independence FIRST WARD/PRECINCT ONE,State House,11,R,Jim Kelly,134
-Montgomery,Independence FIRST WARD/PRECINCT TWO,State House,11,R,Jim Kelly,236
-Montgomery,Independence SECOND WARD/PRECINCT ONE,State House,11,R,Jim Kelly,85
-Montgomery,Independence THIRD WARD/PRECINCT ONE,State House,11,R,Jim Kelly,169
-Montgomery,Independence THIRD WARD/PRECINCT TWO EXCLAVE,State House,11,R,Jim Kelly,1
-Montgomery,Independence FOURTH WARD/PRECINCT ONE,State House,11,R,Jim Kelly,192
-Montgomery,Independence FOURTH WARD/PRECINCT TWO,State House,11,R,Jim Kelly,150
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H11,State House,11,R,Jim Kelly,27
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11,State House,11,R,Jim Kelly,275
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H11A,State House,11,R,Jim Kelly,111
-Montgomery,Independence Total,State House,11,R,Jim Kelly,1380
-Montgomery,Cherry Township ,State House,11,R,Jim Kelly,228
-Montgomery,Drum Creek Township ,State House,11,R,Jim Kelly,230
-Montgomery,Fawn Creek Township DEARING PRECINCT,State House,11,R,Jim Kelly,608
-Montgomery,Fawn Creek Township Total,State House,11,R,Jim Kelly,608
-Montgomery,Independence Township FIRST PRECINCT H11,State House,11,R,Jim Kelly,635
-Montgomery,Independence Township FIRST PRECINCT PART A H11 - PARK,State House,11,R,Jim Kelly,0
-Montgomery,Independence Township SECOND PRECINCT PART C H11,State House,11,R,Jim Kelly,40
-Montgomery,Independence Township Total,State House,11,R,Jim Kelly,675
-Montgomery,Parker Township SECOND PRECINCT ENCLAVE H11,State House,11,R,Jim Kelly,10
-Montgomery,Sycamore Township ,State House,11,R,Jim Kelly,344
-Montgomery,West Cherry Township ,State House,11,R,Jim Kelly,116
-Montgomery,Hand Counted,State House,11,R,Jim Kelly,31
-Montgomery,Provisional,State House,11,R,Jim Kelly,141
-Montgomery,Provisional Hand Count,State House,11,R,Jim Kelly,3
-Montgomery,Grand Total,State House,11,R,Jim Kelly,6570
-Montgomery,Caney FIRST WARD/PRECINCT ONE,State House,12,D,Jean Kurtis Schodorf,41
-Montgomery,Caney FIRST WARD/PRECINCT TWO,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,State House,12,D,Jean Kurtis Schodorf,37
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,State House,12,D,Jean Kurtis Schodorf,43
-Montgomery,Caney THIRD WARD/PRECINCT TWO,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,State House,12,D,Jean Kurtis Schodorf,51
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Caney Total,State House,12,D,Jean Kurtis Schodorf,172
-Montgomery,Independence SECOND WARD/PRECINCT TWO,State House,12,D,Jean Kurtis Schodorf,34
-Montgomery,Independence THIRD WARD/PRECINCT TWO,State House,12,D,Jean Kurtis Schodorf,48
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,State House,12,D,Jean Kurtis Schodorf,64
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,State House,12,D,Jean Kurtis Schodorf,121
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,State House,12,D,Jean Kurtis Schodorf,135
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,State House,12,D,Jean Kurtis Schodorf,22
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,State House,12,D,Jean Kurtis Schodorf,4
-Montgomery,Independence Total,State House,12,D,Jean Kurtis Schodorf,428
-Montgomery,Caney Township HAVANA PRECINCT,State House,12,D,Jean Kurtis Schodorf,67
-Montgomery,Caney Township TYRO PRECINCT,State House,12,D,Jean Kurtis Schodorf,58
-Montgomery,Caney Township Total,State House,12,D,Jean Kurtis Schodorf,125
-Montgomery,Fawn Creek Township TYRO PRECINCT,State House,12,D,Jean Kurtis Schodorf,38
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Independence Township FIRST PRECINCT H12,State House,12,D,Jean Kurtis Schodorf,23
-Montgomery,Independence Township SECOND PRECINCT PART A H12,State House,12,D,Jean Kurtis Schodorf,43
-Montgomery,Independence Township SECOND PRECINCT PART B H12,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Louisburg Township ,State House,12,D,Jean Kurtis Schodorf,53
-Montgomery,Rutland Township ,State House,12,D,Jean Kurtis Schodorf,29
-Montgomery,Hand Counted,State House,12,D,Jean Kurtis Schodorf,4
-Montgomery,Provisional,State House,12,D,Jean Kurtis Schodorf,24
-Montgomery,Provisional Hand Count,State House,12,D,Jean Kurtis Schodorf,0
-Montgomery,Grand Total,State House,12,D,Jean Kurtis Schodorf,939
-Montgomery,Caney FIRST WARD/PRECINCT ONE,State House,12,R,Doug Blex,129
-Montgomery,Caney FIRST WARD/PRECINCT TWO,State House,12,R,Doug Blex,1
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC A H12,State House,12,R,Doug Blex,0
-Montgomery,Caney FIRST WARD/PRECINCT TWO EXC B H12,State House,12,R,Doug Blex,0
-Montgomery,Caney SECOND WARD/PRECINCT ONE,State House,12,R,Doug Blex,89
-Montgomery,Caney SECOND WARD/PRECINCT TWO EXC C H12,State House,12,R,Doug Blex,0
-Montgomery,Caney THIRD WARD/PRECINCT ONE,State House,12,R,Doug Blex,126
-Montgomery,Caney THIRD WARD/PRECINCT TWO,State House,12,R,Doug Blex,2
-Montgomery,Caney FOURTH WARD/PRECINCT ONE,State House,12,R,Doug Blex,139
-Montgomery,Caney FOURTH WARD/PRECINCT TWO,State House,12,R,Doug Blex,1
-Montgomery,Caney Total,State House,12,R,Doug Blex,487
-Montgomery,Independence SECOND WARD/PRECINCT TWO,State House,12,R,Doug Blex,55
-Montgomery,Independence THIRD WARD/PRECINCT TWO,State House,12,R,Doug Blex,78
-Montgomery,Independence FIFTH WARD/PRECINCT ONE,State House,12,R,Doug Blex,100
-Montgomery,Independence FIFTH WARD/PRECINCT TWO,State House,12,R,Doug Blex,175
-Montgomery,Independence SIXTH WARD/PRECINCT ONE H12,State House,12,R,Doug Blex,270
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12 ,State House,12,R,Doug Blex,63
-Montgomery,Independence SIXTH WARD/PRECINCT TWO H12A,State House,12,R,Doug Blex,9
-Montgomery,Independence Total,State House,12,R,Doug Blex,750
-Montgomery,Caney Township HAVANA PRECINCT,State House,12,R,Doug Blex,220
-Montgomery,Caney Township TYRO PRECINCT,State House,12,R,Doug Blex,288
-Montgomery,Caney Township Total,State House,12,R,Doug Blex,508
-Montgomery,Fawn Creek Township TYRO PRECINCT,State House,12,R,Doug Blex,173
-Montgomery,Independence Township FIRST PRECINCT ENCLAVE H12,State House,12,R,Doug Blex,0
-Montgomery,Independence Township FIRST PRECINCT H12,State House,12,R,Doug Blex,101
-Montgomery,Independence Township SECOND PRECINCT PART A H12,State House,12,R,Doug Blex,122
-Montgomery,Independence Township SECOND PRECINCT PART B H12,State House,12,R,Doug Blex,0
-Montgomery,Louisburg Township ,State House,12,R,Doug Blex,184
-Montgomery,Rutland Township ,State House,12,R,Doug Blex,142
-Montgomery,Hand Counted,State House,12,R,Doug Blex,6
-Montgomery,Provisional,State House,12,R,Doug Blex,55
-Montgomery,Provisional Hand Count,State House,12,R,Doug Blex,0
-Montgomery,Grand Total,State House,12,R,Doug Blex,2528
+county,precinct,office,district,party,candidate,votes,vtd
+MONTGOMERY,Caney City Ward 1,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",41,00001A
+MONTGOMERY,Caney City Ward 1,Kansas House of Representatives,12,Republican,"Blex, Doug",131,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas House of Representatives,12,Republican,"Blex, Doug",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas House of Representatives,12,Republican,"Blex, Doug",0,00001C
+MONTGOMERY,Caney City Ward 2,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",38,000020
+MONTGOMERY,Caney City Ward 2,Kansas House of Representatives,12,Republican,"Blex, Doug",90,000020
+MONTGOMERY,Caney City Ward 3,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",44,000030
+MONTGOMERY,Caney City Ward 3,Kansas House of Representatives,12,Republican,"Blex, Doug",132,000030
+MONTGOMERY,Caney City Ward 4,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",52,000040
+MONTGOMERY,Caney City Ward 4,Kansas House of Representatives,12,Republican,"Blex, Doug",142,000040
+MONTGOMERY,Caney Township Havana,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",68,000050
+MONTGOMERY,Caney Township Havana,Kansas House of Representatives,12,Republican,"Blex, Doug",223,000050
+MONTGOMERY,Caney Township Tyro,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",59,000060
+MONTGOMERY,Caney Township Tyro,Kansas House of Representatives,12,Republican,"Blex, Doug",291,000060
+MONTGOMERY,Cherokee Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",171,000070
+MONTGOMERY,Cherry Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",230,000080
+MONTGOMERY,Cherryvale Ward 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",371,000090
+MONTGOMERY,Cherryvale Ward 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",268,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas House of Representatives,11,Republican,"Kelly, Jim",30,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas House of Representatives,11,Republican,"Kelly, Jim",104,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas House of Representatives,11,Republican,"Kelly, Jim",163,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas House of Representatives,11,Republican,"Kelly, Jim",174,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas House of Representatives,11,Republican,"Kelly, Jim",191,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas House of Representatives,11,Republican,"Kelly, Jim",55,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas House of Representatives,11,Republican,"Kelly, Jim",85,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas House of Representatives,11,Republican,"Kelly, Jim",118,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas House of Representatives,11,Republican,"Kelly, Jim",35,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas House of Representatives,11,Republican,"Kelly, Jim",154,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas House of Representatives,11,Republican,"Kelly, Jim",298,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas House of Representatives,11,Republican,"Kelly, Jim",466,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas House of Representatives,11,Republican,"Kelly, Jim",365,000230
+MONTGOMERY,Drum Creek Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",235,000240
+MONTGOMERY,Fawn Creek Township Dearing,Kansas House of Representatives,11,Republican,"Kelly, Jim",621,000250
+MONTGOMERY,Fawn Creek Township Tyro,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",40,000260
+MONTGOMERY,Fawn Creek Township Tyro,Kansas House of Representatives,12,Republican,"Blex, Doug",176,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",140,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",246,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",90,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",36,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas House of Representatives,12,Republican,"Blex, Doug",55,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",171,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",51,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas House of Representatives,12,Republican,"Blex, Doug",83,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas House of Representatives,11,Republican,"Kelly, Jim",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas House of Representatives,11,Republican,"Kelly, Jim",199,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas House of Representatives,11,Republican,"Kelly, Jim",155,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",67,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas House of Representatives,12,Republican,"Blex, Doug",106,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",125,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas House of Representatives,12,Republican,"Blex, Doug",185,000360
+MONTGOMERY,Independence Township 2 Part B,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Kansas House of Representatives,12,Republican,"Blex, Doug",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Kansas House of Representatives,11,Republican,"Kelly, Jim",41,00040C
+MONTGOMERY,Liberty Township,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",202,000410
+MONTGOMERY,Louisburg Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",54,000420
+MONTGOMERY,Louisburg Township,Kansas House of Representatives,12,Republican,"Blex, Doug",189,000420
+MONTGOMERY,Parker Township 1,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",107,000430
+MONTGOMERY,Parker Township 2,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",327,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,00044C
+MONTGOMERY,Rutland Township,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",30,000450
+MONTGOMERY,Rutland Township,Kansas House of Representatives,12,Republican,"Blex, Doug",144,000450
+MONTGOMERY,West Cherry Township,Kansas House of Representatives,11,Republican,"Kelly, Jim",126,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",27,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",140,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas House of Representatives,12,Republican,"Blex, Doug",279,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas House of Representatives,11,Republican,"Kelly, Jim",113,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",286,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",5,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas House of Representatives,12,Republican,"Blex, Doug",9,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",22,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas House of Representatives,12,Republican,"Blex, Doug",63,120050
+MONTGOMERY,Independence Township 1 H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",657,120060
+MONTGOMERY,Independence Township 1 H12,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",23,120070
+MONTGOMERY,Independence Township 1 H12,Kansas House of Representatives,12,Republican,"Blex, Doug",105,120070
+MONTGOMERY,Independence Township 2 Part A H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",44,120090
+MONTGOMERY,Independence Township 2 Part A H12,Kansas House of Representatives,12,Republican,"Blex, Doug",125,120090
+MONTGOMERY,Sycamore Township H11,Kansas House of Representatives,11,Republican,"Kelly, Jim",344,120100
+MONTGOMERY,Sycamore Township H12 A,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Kansas House of Representatives,12,Republican,"Blex, Doug",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Kansas House of Representatives,12,Republican,"Blex, Doug",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Kansas House of Representatives,12,Republican,"Blex, Doug",0,12011C
+MONTGOMERY,Sycamore Township H12,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,120110
+MONTGOMERY,Sycamore Township H12,Kansas House of Representatives,12,Republican,"Blex, Doug",0,120110
+MONTGOMERY,Coffeyville Airport,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Kansas House of Representatives,7,Republican,"Proehl, Richard J.",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas House of Representatives,12,Republican,"Blex, Doug",0,900030
+MONTGOMERY,Parker Township 2 Enclave,Kansas House of Representatives,11,Republican,"Kelly, Jim",11,900040
+MONTGOMERY,Independence Township 1 Enclave,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Kansas House of Representatives,12,Republican,"Blex, Doug",0,900050
+MONTGOMERY,Independence Exclave Airport,Kansas House of Representatives,12,Democratic,"Schodorf, Jean Kurtis",0,900060
+MONTGOMERY,Independence Exclave Airport,Kansas House of Representatives,12,Republican,"Blex, Doug",0,900060
+MONTGOMERY,Caney City Ward 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",48,00001A
+MONTGOMERY,Caney City Ward 1,Kansas Senate,15,Republican,"Goddard, Dan",124,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,Kansas Senate,15,Republican,"Goddard, Dan",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,Kansas Senate,15,Republican,"Goddard, Dan",0,00001C
+MONTGOMERY,Caney City Ward 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",43,000020
+MONTGOMERY,Caney City Ward 2,Kansas Senate,15,Republican,"Goddard, Dan",82,000020
+MONTGOMERY,Caney City Ward 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",52,000030
+MONTGOMERY,Caney City Ward 3,Kansas Senate,15,Republican,"Goddard, Dan",124,000030
+MONTGOMERY,Caney City Ward 4,Kansas Senate,15,Democratic,"Schmidt, Chuck",67,000040
+MONTGOMERY,Caney City Ward 4,Kansas Senate,15,Republican,"Goddard, Dan",126,000040
+MONTGOMERY,Caney Township Havana,Kansas Senate,15,Democratic,"Schmidt, Chuck",83,000050
+MONTGOMERY,Caney Township Havana,Kansas Senate,15,Republican,"Goddard, Dan",209,000050
+MONTGOMERY,Caney Township Tyro,Kansas Senate,15,Democratic,"Schmidt, Chuck",82,000060
+MONTGOMERY,Caney Township Tyro,Kansas Senate,15,Republican,"Goddard, Dan",263,000060
+MONTGOMERY,Cherokee Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",75,000070
+MONTGOMERY,Cherokee Township,Kansas Senate,15,Republican,"Goddard, Dan",115,000070
+MONTGOMERY,Cherry Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",71,000080
+MONTGOMERY,Cherry Township,Kansas Senate,15,Republican,"Goddard, Dan",174,000080
+MONTGOMERY,Cherryvale Ward 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",175,000090
+MONTGOMERY,Cherryvale Ward 1,Kansas Senate,15,Republican,"Goddard, Dan",258,000090
+MONTGOMERY,Cherryvale Ward 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",123,000100
+MONTGOMERY,Cherryvale Ward 2,Kansas Senate,15,Republican,"Goddard, Dan",177,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas Senate,15,Democratic,"Schmidt, Chuck",48,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,Kansas Senate,15,Republican,"Goddard, Dan",6,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas Senate,15,Democratic,"Schmidt, Chuck",67,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,Kansas Senate,15,Republican,"Goddard, Dan",58,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas Senate,15,Democratic,"Schmidt, Chuck",108,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,Kansas Senate,15,Republican,"Goddard, Dan",79,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas Senate,15,Democratic,"Schmidt, Chuck",87,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,Kansas Senate,15,Republican,"Goddard, Dan",111,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas Senate,15,Democratic,"Schmidt, Chuck",129,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,Kansas Senate,15,Republican,"Goddard, Dan",110,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas Senate,15,Democratic,"Schmidt, Chuck",41,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,Kansas Senate,15,Republican,"Goddard, Dan",27,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas Senate,15,Democratic,"Schmidt, Chuck",58,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,Kansas Senate,15,Republican,"Goddard, Dan",47,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas Senate,15,Democratic,"Schmidt, Chuck",81,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,Kansas Senate,15,Republican,"Goddard, Dan",64,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas Senate,15,Democratic,"Schmidt, Chuck",25,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,Kansas Senate,15,Republican,"Goddard, Dan",22,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas Senate,15,Democratic,"Schmidt, Chuck",86,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,Kansas Senate,15,Republican,"Goddard, Dan",95,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas Senate,15,Democratic,"Schmidt, Chuck",155,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,Kansas Senate,15,Republican,"Goddard, Dan",211,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas Senate,15,Democratic,"Schmidt, Chuck",233,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,Kansas Senate,15,Republican,"Goddard, Dan",307,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas Senate,15,Democratic,"Schmidt, Chuck",202,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,Kansas Senate,15,Republican,"Goddard, Dan",224,000230
+MONTGOMERY,Drum Creek Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",78,000240
+MONTGOMERY,Drum Creek Township,Kansas Senate,15,Republican,"Goddard, Dan",190,000240
+MONTGOMERY,Fawn Creek Township Dearing,Kansas Senate,15,Democratic,"Schmidt, Chuck",245,000250
+MONTGOMERY,Fawn Creek Township Dearing,Kansas Senate,15,Republican,"Goddard, Dan",451,000250
+MONTGOMERY,Fawn Creek Township Tyro,Kansas Senate,15,Democratic,"Schmidt, Chuck",63,000260
+MONTGOMERY,Fawn Creek Township Tyro,Kansas Senate,15,Republican,"Goddard, Dan",143,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",75,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",89,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",124,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",145,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",49,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",57,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",45,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",45,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",88,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",116,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",71,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",63,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",1,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",119,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",113,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",96,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",95,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",89,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",85,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",142,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",166,000360
+MONTGOMERY,Independence Township 2 Part B,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00040B
+MONTGOMERY,Independence Township 2 Part B,Kansas Senate,15,Republican,"Goddard, Dan",0,00040B
+MONTGOMERY,Independence Township 2 Part C,Kansas Senate,15,Democratic,"Schmidt, Chuck",15,00040C
+MONTGOMERY,Independence Township 2 Part C,Kansas Senate,15,Republican,"Goddard, Dan",31,00040C
+MONTGOMERY,Liberty Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",76,000410
+MONTGOMERY,Liberty Township,Kansas Senate,15,Republican,"Goddard, Dan",158,000410
+MONTGOMERY,Louisburg Township,Kansas Senate,14,Democratic,"Pringle, Mark",57,000420
+MONTGOMERY,Louisburg Township,Kansas Senate,14,Republican,"Givens, Bruce",174,000420
+MONTGOMERY,Parker Township 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",41,000430
+MONTGOMERY,Parker Township 1,Kansas Senate,15,Republican,"Goddard, Dan",87,000430
+MONTGOMERY,Parker Township 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",157,00044A
+MONTGOMERY,Parker Township 2,Kansas Senate,15,Republican,"Goddard, Dan",240,00044A
+MONTGOMERY,Parker Township 2 Enclave A,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,Kansas Senate,15,Republican,"Goddard, Dan",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,Kansas Senate,15,Republican,"Goddard, Dan",0,00044C
+MONTGOMERY,Rutland Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",33,000450
+MONTGOMERY,Rutland Township,Kansas Senate,15,Republican,"Goddard, Dan",136,000450
+MONTGOMERY,West Cherry Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",37,000470
+MONTGOMERY,West Cherry Township,Kansas Senate,15,Republican,"Goddard, Dan",88,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas Senate,15,Democratic,"Schmidt, Chuck",18,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,Kansas Senate,15,Republican,"Goddard, Dan",22,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas Senate,15,Democratic,"Schmidt, Chuck",199,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,Kansas Senate,15,Republican,"Goddard, Dan",224,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas Senate,15,Democratic,"Schmidt, Chuck",60,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,Kansas Senate,15,Republican,"Goddard, Dan",65,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas Senate,15,Democratic,"Schmidt, Chuck",148,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,Kansas Senate,15,Republican,"Goddard, Dan",151,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas Senate,15,Democratic,"Schmidt, Chuck",7,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,Kansas Senate,15,Republican,"Goddard, Dan",6,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas Senate,15,Democratic,"Schmidt, Chuck",32,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,Kansas Senate,15,Republican,"Goddard, Dan",53,120050
+MONTGOMERY,Independence Township 1 H11,Kansas Senate,15,Democratic,"Schmidt, Chuck",244,120060
+MONTGOMERY,Independence Township 1 H11,Kansas Senate,15,Republican,"Goddard, Dan",470,120060
+MONTGOMERY,Independence Township 1 H12,Kansas Senate,15,Democratic,"Schmidt, Chuck",46,120070
+MONTGOMERY,Independence Township 1 H12,Kansas Senate,15,Republican,"Goddard, Dan",81,120070
+MONTGOMERY,Independence Township 2 Part A H11,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,Kansas Senate,15,Republican,"Goddard, Dan",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,Kansas Senate,15,Democratic,"Schmidt, Chuck",64,120090
+MONTGOMERY,Independence Township 2 Part A H12,Kansas Senate,15,Republican,"Goddard, Dan",102,120090
+MONTGOMERY,Sycamore Township H11,Kansas Senate,15,Democratic,"Schmidt, Chuck",124,120100
+MONTGOMERY,Sycamore Township H11,Kansas Senate,15,Republican,"Goddard, Dan",270,120100
+MONTGOMERY,Sycamore Township H12 A,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,12011A
+MONTGOMERY,Sycamore Township H12 A,Kansas Senate,15,Republican,"Goddard, Dan",0,12011A
+MONTGOMERY,Sycamore Township H12 B,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,12011B
+MONTGOMERY,Sycamore Township H12 B,Kansas Senate,15,Republican,"Goddard, Dan",0,12011B
+MONTGOMERY,Sycamore Township H12 C,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,12011C
+MONTGOMERY,Sycamore Township H12 C,Kansas Senate,15,Republican,"Goddard, Dan",0,12011C
+MONTGOMERY,Sycamore Township H12,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,120110
+MONTGOMERY,Sycamore Township H12,Kansas Senate,15,Republican,"Goddard, Dan",0,120110
+MONTGOMERY,Coffeyville Airport,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900010
+MONTGOMERY,Coffeyville Airport,Kansas Senate,15,Republican,"Goddard, Dan",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,900030
+MONTGOMERY,Parker Township 2 Enclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",7,900040
+MONTGOMERY,Parker Township 2 Enclave,Kansas Senate,15,Republican,"Goddard, Dan",5,900040
+MONTGOMERY,Independence Township 1 Enclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900050
+MONTGOMERY,Independence Township 1 Enclave,Kansas Senate,15,Republican,"Goddard, Dan",0,900050
+MONTGOMERY,Independence Exclave Airport,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900060
+MONTGOMERY,Independence Exclave Airport,Kansas Senate,15,Republican,"Goddard, Dan",0,900060
+MONTGOMERY,Caney City Ward 1,President / Vice President,,independent,"Stein, Jill",1,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",5,00001A
+MONTGOMERY,Caney City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",139,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00001C
+MONTGOMERY,Caney City Ward 2,President / Vice President,,independent,"Stein, Jill",2,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000020
+MONTGOMERY,Caney City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",106,000020
+MONTGOMERY,Caney City Ward 3,President / Vice President,,independent,"Stein, Jill",3,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",1,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"McMullin, Evan",5,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",10,000030
+MONTGOMERY,Caney City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",141,000030
+MONTGOMERY,Caney City Ward 4,President / Vice President,,independent,"Stein, Jill",2,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000040
+MONTGOMERY,Caney City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",163,000040
+MONTGOMERY,Caney Township Havana,President / Vice President,,independent,"Stein, Jill",1,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Hedges, James A",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"McMullin, Evan",1,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Smith, Mike",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+MONTGOMERY,Caney Township Havana,President / Vice President,,Republican,"Trump, Donald J.",246,000050
+MONTGOMERY,Caney Township Tyro,President / Vice President,,independent,"Stein, Jill",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Castle, Darrell L",3,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Hedges, James A",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"McMullin, Evan",3,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Smith, Mike",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Libertarian,"Johnson, Gary",10,000060
+MONTGOMERY,Caney Township Tyro,President / Vice President,,Republican,"Trump, Donald J.",304,000060
+MONTGOMERY,Cherokee Township,President / Vice President,,independent,"Stein, Jill",7,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"McMullin, Evan",1,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+MONTGOMERY,Cherokee Township,President / Vice President,,Republican,"Trump, Donald J.",137,000070
+MONTGOMERY,Cherry Township,President / Vice President,,independent,"Stein, Jill",2,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000080
+MONTGOMERY,Cherry Township,President / Vice President,,Republican,"Trump, Donald J.",199,000080
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,independent,"Stein, Jill",16,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000090
+MONTGOMERY,Cherryvale Ward 1,President / Vice President,,Republican,"Trump, Donald J.",313,000090
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,independent,"Stein, Jill",5,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",16,000100
+MONTGOMERY,Cherryvale Ward 2,President / Vice President,,Republican,"Trump, Donald J.",225,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,independent,"Stein, Jill",1,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",8,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,independent,"Stein, Jill",1,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",70,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,independent,"Stein, Jill",2,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",3,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",8,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",112,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,independent,"Stein, Jill",9,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"McMullin, Evan",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",12,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",125,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,independent,"Stein, Jill",3,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"McMullin, Evan",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",6,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",153,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,independent,"Stein, Jill",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"McMullin, Evan",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",40,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,independent,"Stein, Jill",2,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"McMullin, Evan",1,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",66,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,independent,"Stein, Jill",2,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Hedges, James A",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"McMullin, Evan",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Perry, Darryl",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Smith, Mike",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Sood, Ajay",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,President / Vice President,,Republican,"Trump, Donald J.",93,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,independent,"Stein, Jill",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"McMullin, Evan",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",3,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",29,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,independent,"Stein, Jill",4,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"McMullin, Evan",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",10,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",116,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,independent,"Stein, Jill",3,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Hedges, James A",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"McMullin, Evan",3,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Perry, Darryl",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Smith, Mike",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Sood, Ajay",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",121,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",15,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,President / Vice President,,Republican,"Trump, Donald J.",230,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,independent,"Stein, Jill",12,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Hedges, James A",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"McMullin, Evan",5,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Perry, Darryl",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Smith, Mike",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Sood, Ajay",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",161,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",10,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,President / Vice President,,Republican,"Trump, Donald J.",361,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,independent,"Stein, Jill",11,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Hedges, James A",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"McMullin, Evan",3,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Perry, Darryl",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Smith, Mike",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Sood, Ajay",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",129,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",16,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,President / Vice President,,Republican,"Trump, Donald J.",268,000230
+MONTGOMERY,Drum Creek Township,President / Vice President,,independent,"Stein, Jill",10,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Castle, Darrell L",4,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000240
+MONTGOMERY,Drum Creek Township,President / Vice President,,Republican,"Trump, Donald J.",221,000240
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,independent,"Stein, Jill",13,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Hedges, James A",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"McMullin, Evan",4,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Perry, Darryl",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Smith, Mike",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Sood, Ajay",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Democratic,"Clinton, Hillary Rodham",114,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Libertarian,"Johnson, Gary",23,000250
+MONTGOMERY,Fawn Creek Township Dearing,President / Vice President,,Republican,"Trump, Donald J.",542,000250
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,independent,"Stein, Jill",1,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Hedges, James A",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"McMullin, Evan",2,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Perry, Darryl",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Smith, Mike",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Sood, Ajay",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Libertarian,"Johnson, Gary",3,000260
+MONTGOMERY,Fawn Creek Township Tyro,President / Vice President,,Republican,"Trump, Donald J.",191,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",95,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",3,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",186,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",3,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",71,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",62,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",7,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",11,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",138,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",6,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",86,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",8,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",149,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",6,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",8,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",107,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,independent,"Stein, Jill",3,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",1,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",113,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",100,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",188,000360
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,independent,"Stein, Jill",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Hedges, James A",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"McMullin, Evan",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Perry, Darryl",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Smith, Mike",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Sood, Ajay",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Libertarian,"Johnson, Gary",0,00040B
+MONTGOMERY,Independence Township 2 Part B,President / Vice President,,Republican,"Trump, Donald J.",0,00040B
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,independent,"Stein, Jill",2,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Castle, Darrell L",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Giordani, Rocky",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Hedges, James A",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Kahn, Lynn",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"La Riva, Gloria",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Levinson, Michael S.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Maturen, Michael A",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"McMullin, Evan",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Perry, Darryl",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Schriner, Joe C",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Smith, Mike",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Sood, Ajay",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Sterling, Shawna",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,00040C
+MONTGOMERY,Independence Township 2 Part C,President / Vice President,,Republican,"Trump, Donald J.",38,00040C
+MONTGOMERY,Liberty Township,President / Vice President,,independent,"Stein, Jill",4,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",4,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000410
+MONTGOMERY,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",179,000410
+MONTGOMERY,Louisburg Township,President / Vice President,,independent,"Stein, Jill",6,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Hedges, James A",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"McMullin, Evan",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Smith, Mike",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000420
+MONTGOMERY,Louisburg Township,President / Vice President,,Republican,"Trump, Donald J.",207,000420
+MONTGOMERY,Parker Township 1,President / Vice President,,independent,"Stein, Jill",2,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Hedges, James A",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"McMullin, Evan",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Perry, Darryl",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Smith, Mike",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Sood, Ajay",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000430
+MONTGOMERY,Parker Township 1,President / Vice President,,Republican,"Trump, Donald J.",96,000430
+MONTGOMERY,Parker Township 2,President / Vice President,,independent,"Stein, Jill",1,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Castle, Darrell L",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Hedges, James A",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"McMullin, Evan",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Perry, Darryl",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Smith, Mike",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Sood, Ajay",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Libertarian,"Johnson, Gary",8,00044A
+MONTGOMERY,Parker Township 2,President / Vice President,,Republican,"Trump, Donald J.",292,00044A
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,independent,"Stein, Jill",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,independent,"Stein, Jill",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00044C
+MONTGOMERY,Rutland Township,President / Vice President,,independent,"Stein, Jill",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Basiago, Andrew D.",1,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Castle, Darrell L",1,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Hedges, James A",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"McMullin, Evan",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Perry, Darryl",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Smith, Mike",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Sood, Ajay",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000450
+MONTGOMERY,Rutland Township,President / Vice President,,Republican,"Trump, Donald J.",150,000450
+MONTGOMERY,West Cherry Township,President / Vice President,,independent,"Stein, Jill",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Hedges, James A",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"McMullin, Evan",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Perry, Darryl",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Smith, Mike",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Sood, Ajay",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000470
+MONTGOMERY,West Cherry Township,President / Vice President,,Republican,"Trump, Donald J.",104,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,independent,"Stein, Jill",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Hedges, James A",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"McMullin, Evan",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Perry, Darryl",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Smith, Mike",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Sood, Ajay",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,President / Vice President,,Republican,"Trump, Donald J.",20,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,independent,"Stein, Jill",14,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Castle, Darrell L",2,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Hedges, James A",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"McMullin, Evan",1,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Perry, Darryl",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Smith, Mike",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Sood, Ajay",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Libertarian,"Johnson, Gary",13,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,President / Vice President,,Republican,"Trump, Donald J.",287,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,independent,"Stein, Jill",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Castle, Darrell L",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Giordani, Rocky",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Hedges, James A",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Hoefling, Tom",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Kahn, Lynn",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"La Riva, Gloria",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Maturen, Michael A",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"McMullin, Evan",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Perry, Darryl",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Schriner, Joe C",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Smith, Mike",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Sood, Ajay",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Sterling, Shawna",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Libertarian,"Johnson, Gary",5,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,President / Vice President,,Republican,"Trump, Donald J.",79,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,independent,"Stein, Jill",4,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Hedges, James A",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"McMullin, Evan",1,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Perry, Darryl",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Smith, Mike",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Sood, Ajay",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Libertarian,"Johnson, Gary",7,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,President / Vice President,,Republican,"Trump, Donald J.",224,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,independent,"Stein, Jill",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Castle, Darrell L",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Giordani, Rocky",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Hedges, James A",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Hoefling, Tom",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Kahn, Lynn",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"La Riva, Gloria",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Maturen, Michael A",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"McMullin, Evan",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Perry, Darryl",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Schriner, Joe C",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Smith, Mike",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Sood, Ajay",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Sterling, Shawna",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Libertarian,"Johnson, Gary",2,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,President / Vice President,,Republican,"Trump, Donald J.",8,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,independent,"Stein, Jill",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Hedges, James A",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"McMullin, Evan",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Perry, Darryl",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Smith, Mike",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Sood, Ajay",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Libertarian,"Johnson, Gary",2,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,President / Vice President,,Republican,"Trump, Donald J.",72,120050
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,independent,"Stein, Jill",5,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Hedges, James A",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"McMullin, Evan",6,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Perry, Darryl",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Smith, Mike",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Sood, Ajay",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",105,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Libertarian,"Johnson, Gary",31,120060
+MONTGOMERY,Independence Township 1 H11,President / Vice President,,Republican,"Trump, Donald J.",570,120060
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,independent,"Stein, Jill",2,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Hedges, James A",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"McMullin, Evan",1,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Perry, Darryl",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Smith, Mike",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Sood, Ajay",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Libertarian,"Johnson, Gary",3,120070
+MONTGOMERY,Independence Township 1 H12,President / Vice President,,Republican,"Trump, Donald J.",105,120070
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,independent,"Stein, Jill",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Hedges, James A",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"McMullin, Evan",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Perry, Darryl",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Smith, Mike",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Sood, Ajay",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Libertarian,"Johnson, Gary",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,President / Vice President,,Republican,"Trump, Donald J.",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,independent,"Stein, Jill",2,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Basiago, Andrew D.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Castle, Darrell L",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Giordani, Rocky",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Hedges, James A",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Hoefling, Tom",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Kahn, Lynn",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"La Riva, Gloria",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Levinson, Michael S.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Maturen, Michael A",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"McMullin, Evan",2,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Moorehead, Monica G.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Perry, Darryl",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Schriner, Joe C",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Smith, Mike",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Sood, Ajay",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Sterling, Shawna",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Valdivia, Anthony J",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Libertarian,"Johnson, Gary",4,120090
+MONTGOMERY,Independence Township 2 Part A H12,President / Vice President,,Republican,"Trump, Donald J.",133,120090
+MONTGOMERY,Sycamore Township H11,President / Vice President,,independent,"Stein, Jill",4,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Basiago, Andrew D.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Castle, Darrell L",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Giordani, Rocky",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Hedges, James A",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Hoefling, Tom",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Kahn, Lynn",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"La Riva, Gloria",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Levinson, Michael S.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Maturen, Michael A",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"McMullin, Evan",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Moorehead, Monica G.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Perry, Darryl",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Schriner, Joe C",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Smith, Mike",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Sood, Ajay",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Sterling, Shawna",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Valdivia, Anthony J",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Libertarian,"Johnson, Gary",20,120100
+MONTGOMERY,Sycamore Township H11,President / Vice President,,Republican,"Trump, Donald J.",314,120100
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,independent,"Stein, Jill",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Castle, Darrell L",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Giordani, Rocky",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Hedges, James A",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Hoefling, Tom",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Kahn, Lynn",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"La Riva, Gloria",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Maturen, Michael A",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"McMullin, Evan",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Perry, Darryl",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Schriner, Joe C",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Smith, Mike",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Sood, Ajay",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Sterling, Shawna",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12011A
+MONTGOMERY,Sycamore Township H12 A,President / Vice President,,Republican,"Trump, Donald J.",0,12011A
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,independent,"Stein, Jill",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Basiago, Andrew D.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Castle, Darrell L",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Giordani, Rocky",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Hedges, James A",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Hoefling, Tom",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Kahn, Lynn",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"La Riva, Gloria",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Levinson, Michael S.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Maturen, Michael A",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"McMullin, Evan",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Moorehead, Monica G.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Perry, Darryl",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Schriner, Joe C",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Smith, Mike",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Sood, Ajay",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Sterling, Shawna",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Valdivia, Anthony J",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Libertarian,"Johnson, Gary",0,12011B
+MONTGOMERY,Sycamore Township H12 B,President / Vice President,,Republican,"Trump, Donald J.",0,12011B
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,independent,"Stein, Jill",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Basiago, Andrew D.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Castle, Darrell L",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Giordani, Rocky",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Hedges, James A",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Hoefling, Tom",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Kahn, Lynn",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"La Riva, Gloria",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Levinson, Michael S.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Maturen, Michael A",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"McMullin, Evan",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Moorehead, Monica G.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Perry, Darryl",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Schriner, Joe C",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Smith, Mike",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Sood, Ajay",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Sterling, Shawna",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Valdivia, Anthony J",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Libertarian,"Johnson, Gary",0,12011C
+MONTGOMERY,Sycamore Township H12 C,President / Vice President,,Republican,"Trump, Donald J.",0,12011C
+MONTGOMERY,Sycamore Township H12,President / Vice President,,independent,"Stein, Jill",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Basiago, Andrew D.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Castle, Darrell L",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Giordani, Rocky",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Hedges, James A",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Hoefling, Tom",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Kahn, Lynn",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"La Riva, Gloria",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Levinson, Michael S.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Maturen, Michael A",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"McMullin, Evan",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Moorehead, Monica G.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Perry, Darryl",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Schriner, Joe C",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Smith, Mike",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Sood, Ajay",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Sterling, Shawna",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Valdivia, Anthony J",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Libertarian,"Johnson, Gary",0,120110
+MONTGOMERY,Sycamore Township H12,President / Vice President,,Republican,"Trump, Donald J.",0,120110
+MONTGOMERY,Coffeyville Airport,President / Vice President,,independent,"Stein, Jill",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Hedges, James A",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"McMullin, Evan",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Perry, Darryl",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Smith, Mike",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Sood, Ajay",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+MONTGOMERY,Coffeyville Airport,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,independent,"Stein, Jill",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Hedges, James A",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Smith, Mike",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+MONTGOMERY,Parker Township 2 Enclave,President / Vice President,,Republican,"Trump, Donald J.",7,900040
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,independent,"Stein, Jill",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Hedges, James A",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Smith, Mike",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+MONTGOMERY,Independence Township 1 Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,900050
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,independent,"Stein, Jill",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Hedges, James A",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"McMullin, Evan",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Perry, Darryl",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Smith, Mike",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Sood, Ajay",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+MONTGOMERY,Independence Exclave Airport,President / Vice President,,Republican,"Trump, Donald J.",0,900060
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",25,00001A
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,00001A
+MONTGOMERY,Caney City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00001C
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",21,000020
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000020
+MONTGOMERY,Caney City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000020
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",24,000030
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000030
+MONTGOMERY,Caney City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",145,000030
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",28,000040
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000040
+MONTGOMERY,Caney City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",151,000040
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Democratic,"Potter, Britani",33,000050
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000050
+MONTGOMERY,Caney Township Havana,United States House of Representatives,2,Republican,"Jenkins, Lynn",250,000050
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Democratic,"Potter, Britani",24,000060
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000060
+MONTGOMERY,Caney Township Tyro,United States House of Representatives,2,Republican,"Jenkins, Lynn",313,000060
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Democratic,"Potter, Britani",43,000070
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000070
+MONTGOMERY,Cherokee Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",137,000070
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Democratic,"Potter, Britani",36,000080
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000080
+MONTGOMERY,Cherry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000080
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",95,000090
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",33,000090
+MONTGOMERY,Cherryvale Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",304,000090
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",61,000100
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",23,000100
+MONTGOMERY,Cherryvale Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",213,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Democratic,"Potter, Britani",44,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States House of Representatives,2,Republican,"Jenkins, Lynn",7,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Democratic,"Potter, Britani",44,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Democratic,"Potter, Britani",61,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States House of Representatives,2,Republican,"Jenkins, Lynn",110,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Democratic,"Potter, Britani",56,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States House of Representatives,2,Republican,"Jenkins, Lynn",124,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Democratic,"Potter, Britani",82,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States House of Representatives,2,Republican,"Jenkins, Lynn",141,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Democratic,"Potter, Britani",27,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Democratic,"Potter, Britani",38,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Democratic,"Potter, Britani",49,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Democratic,"Potter, Britani",18,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States House of Representatives,2,Republican,"Jenkins, Lynn",25,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Democratic,"Potter, Britani",59,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States House of Representatives,2,Republican,"Jenkins, Lynn",106,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Democratic,"Potter, Britani",105,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States House of Representatives,2,Republican,"Jenkins, Lynn",234,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Democratic,"Potter, Britani",144,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States House of Representatives,2,Republican,"Jenkins, Lynn",375,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Democratic,"Potter, Britani",122,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States House of Representatives,2,Republican,"Jenkins, Lynn",283,000230
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",29,000240
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000240
+MONTGOMERY,Drum Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",221,000240
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Democratic,"Potter, Britani",117,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Libertarian,"Bales, James Houston",34,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States House of Representatives,2,Republican,"Jenkins, Lynn",545,000250
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Democratic,"Potter, Britani",18,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",51,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",53,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",202,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",24,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",21,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",47,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",141,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",39,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",82,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",75,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",143,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",64,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",45,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",111,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",74,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000360
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00040B
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Democratic,"Potter, Britani",4,00040C
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,00040C
+MONTGOMERY,Independence Township 2 Part C,United States House of Representatives,2,Republican,"Jenkins, Lynn",37,00040C
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Democratic,"Potter, Britani",37,000410
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000410
+MONTGOMERY,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",184,000410
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Democratic,"Potter, Britani",40,000420
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000420
+MONTGOMERY,Louisburg Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,000420
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Democratic,"Potter, Britani",23,000430
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000430
+MONTGOMERY,Parker Township 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",96,000430
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Democratic,"Potter, Britani",98,00044A
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,00044A
+MONTGOMERY,Parker Township 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",272,00044A
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00044C
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Democratic,"Potter, Britani",15,000450
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000450
+MONTGOMERY,Rutland Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",150,000450
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Democratic,"Potter, Britani",21,000470
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000470
+MONTGOMERY,West Cherry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",99,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Democratic,"Potter, Britani",8,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",31,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Democratic,"Potter, Britani",96,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Libertarian,"Bales, James Houston",22,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",304,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Democratic,"Potter, Britani",21,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Democratic,"Potter, Britani",48,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",235,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Democratic,"Potter, Britani",2,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",11,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Democratic,"Potter, Britani",15,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",66,120050
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Democratic,"Potter, Britani",92,120060
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Libertarian,"Bales, James Houston",38,120060
+MONTGOMERY,Independence Township 1 H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",578,120060
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Democratic,"Potter, Britani",16,120070
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,120070
+MONTGOMERY,Independence Township 1 H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",100,120070
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Democratic,"Potter, Britani",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Democratic,"Potter, Britani",25,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,120090
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Democratic,"Potter, Britani",48,120100
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Libertarian,"Bales, James Houston",26,120100
+MONTGOMERY,Sycamore Township H11,United States House of Representatives,2,Republican,"Jenkins, Lynn",315,120100
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Democratic,"Potter, Britani",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011A
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Democratic,"Potter, Britani",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011B
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Democratic,"Potter, Britani",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,12011C
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Democratic,"Potter, Britani",0,120110
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120110
+MONTGOMERY,Sycamore Township H12,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120110
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+MONTGOMERY,Coffeyville Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",6,900040
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900040
+MONTGOMERY,Parker Township 2 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",5,900040
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900050
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Democratic,"Potter, Britani",0,900060
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900060
+MONTGOMERY,Independence Exclave Airport,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900060
+MONTGOMERY,Caney City Ward 1,United States Senate,,write - in,"Smith, DJ",0,00001A
+MONTGOMERY,Caney City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",29,00001A
+MONTGOMERY,Caney City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",12,00001A
+MONTGOMERY,Caney City Ward 1,United States Senate,,Republican,"Moran, Jerry",130,00001A
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00001B
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00001C
+MONTGOMERY,Caney City Ward 1 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00001C
+MONTGOMERY,Caney City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000020
+MONTGOMERY,Caney City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",21,000020
+MONTGOMERY,Caney City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,000020
+MONTGOMERY,Caney City Ward 2,United States Senate,,Republican,"Moran, Jerry",96,000020
+MONTGOMERY,Caney City Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+MONTGOMERY,Caney City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",25,000030
+MONTGOMERY,Caney City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",17,000030
+MONTGOMERY,Caney City Ward 3,United States Senate,,Republican,"Moran, Jerry",136,000030
+MONTGOMERY,Caney City Ward 4,United States Senate,,write - in,"Smith, DJ",0,000040
+MONTGOMERY,Caney City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",31,000040
+MONTGOMERY,Caney City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",12,000040
+MONTGOMERY,Caney City Ward 4,United States Senate,,Republican,"Moran, Jerry",152,000040
+MONTGOMERY,Caney Township Havana,United States Senate,,write - in,"Smith, DJ",0,000050
+MONTGOMERY,Caney Township Havana,United States Senate,,Democratic,"Wiesner, Patrick",43,000050
+MONTGOMERY,Caney Township Havana,United States Senate,,Libertarian,"Garrard, Robert D.",14,000050
+MONTGOMERY,Caney Township Havana,United States Senate,,Republican,"Moran, Jerry",231,000050
+MONTGOMERY,Caney Township Tyro,United States Senate,,write - in,"Smith, DJ",0,000060
+MONTGOMERY,Caney Township Tyro,United States Senate,,Democratic,"Wiesner, Patrick",28,000060
+MONTGOMERY,Caney Township Tyro,United States Senate,,Libertarian,"Garrard, Robert D.",14,000060
+MONTGOMERY,Caney Township Tyro,United States Senate,,Republican,"Moran, Jerry",304,000060
+MONTGOMERY,Cherokee Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MONTGOMERY,Cherokee Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000070
+MONTGOMERY,Cherokee Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000070
+MONTGOMERY,Cherokee Township,United States Senate,,Republican,"Moran, Jerry",128,000070
+MONTGOMERY,Cherry Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MONTGOMERY,Cherry Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000080
+MONTGOMERY,Cherry Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000080
+MONTGOMERY,Cherry Township,United States Senate,,Republican,"Moran, Jerry",188,000080
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,write - in,"Smith, DJ",0,000090
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",92,000090
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",29,000090
+MONTGOMERY,Cherryvale Ward 1,United States Senate,,Republican,"Moran, Jerry",309,000090
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,write - in,"Smith, DJ",0,000100
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",69,000100
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",29,000100
+MONTGOMERY,Cherryvale Ward 2,United States Senate,,Republican,"Moran, Jerry",196,000100
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",47,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 01,United States Senate,,Republican,"Moran, Jerry",6,000110
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",43,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",5,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 02,United States Senate,,Republican,"Moran, Jerry",78,000120
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",73,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",12,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 03,United States Senate,,Republican,"Moran, Jerry",102,000130
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,write - in,"Smith, DJ",0,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",59,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",15,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 04,United States Senate,,Republican,"Moran, Jerry",122,000140
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,write - in,"Smith, DJ",0,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",82,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",15,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 05,United States Senate,,Republican,"Moran, Jerry",138,000150
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,write - in,"Smith, DJ",0,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",26,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",7,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 06,United States Senate,,Republican,"Moran, Jerry",36,000160
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,write - in,"Smith, DJ",0,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",41,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",12,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 07,United States Senate,,Republican,"Moran, Jerry",52,000170
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,write - in,"Smith, DJ",0,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,Democratic,"Wiesner, Patrick",51,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,Libertarian,"Garrard, Robert D.",14,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 08,United States Senate,,Republican,"Moran, Jerry",79,000180
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,write - in,"Smith, DJ",0,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",19,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",6,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 09,United States Senate,,Republican,"Moran, Jerry",23,000190
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,write - in,"Smith, DJ",0,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",61,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",14,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 10,United States Senate,,Republican,"Moran, Jerry",104,000200
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,write - in,"Smith, DJ",0,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,Democratic,"Wiesner, Patrick",116,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,Libertarian,"Garrard, Robert D.",32,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 11,United States Senate,,Republican,"Moran, Jerry",217,000210
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,write - in,"Smith, DJ",0,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,Democratic,"Wiesner, Patrick",157,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,Libertarian,"Garrard, Robert D.",32,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 12,United States Senate,,Republican,"Moran, Jerry",351,000220
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,write - in,"Smith, DJ",0,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,Democratic,"Wiesner, Patrick",138,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,Libertarian,"Garrard, Robert D.",28,000230
+MONTGOMERY,Coffeyville Ward 1 Precinct 13,United States Senate,,Republican,"Moran, Jerry",262,000230
+MONTGOMERY,Drum Creek Township,United States Senate,,write - in,"Smith, DJ",0,000240
+MONTGOMERY,Drum Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000240
+MONTGOMERY,Drum Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000240
+MONTGOMERY,Drum Creek Township,United States Senate,,Republican,"Moran, Jerry",218,000240
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,write - in,"Smith, DJ",0,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,Democratic,"Wiesner, Patrick",121,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,Libertarian,"Garrard, Robert D.",53,000250
+MONTGOMERY,Fawn Creek Township Dearing,United States Senate,,Republican,"Moran, Jerry",515,000250
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,write - in,"Smith, DJ",0,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,Democratic,"Wiesner, Patrick",24,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,Libertarian,"Garrard, Robert D.",18,000260
+MONTGOMERY,Fawn Creek Township Tyro,United States Senate,,Republican,"Moran, Jerry",167,000260
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",58,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",8,000270
+MONTGOMERY,Independence City Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",93,000270
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",57,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,000280
+MONTGOMERY,Independence City Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",186,000280
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",22,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",13,000290
+MONTGOMERY,Independence City Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",70,000290
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",23,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000300
+MONTGOMERY,Independence City Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",51,000300
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",47,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,000310
+MONTGOMERY,Independence City Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",138,000310
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",42,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",72,00032A
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00032B
+MONTGOMERY,Independence City Ward 3 Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",1,00032B
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",83,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000330
+MONTGOMERY,Independence City Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",134,000330
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",64,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",20,000340
+MONTGOMERY,Independence City Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",102,000340
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",49,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000350
+MONTGOMERY,Independence City Ward 5 Precinct 1,United States Senate,,Republican,"Moran, Jerry",100,000350
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",90,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,000360
+MONTGOMERY,Independence City Ward 5 Precinct 2,United States Senate,,Republican,"Moran, Jerry",194,000360
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,write - in,"Smith, DJ",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,Democratic,"Wiesner, Patrick",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00040B
+MONTGOMERY,Independence Township 2 Part B,United States Senate,,Republican,"Moran, Jerry",0,00040B
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,write - in,"Smith, DJ",0,00040C
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,Democratic,"Wiesner, Patrick",5,00040C
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,Libertarian,"Garrard, Robert D.",5,00040C
+MONTGOMERY,Independence Township 2 Part C,United States Senate,,Republican,"Moran, Jerry",37,00040C
+MONTGOMERY,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000410
+MONTGOMERY,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000410
+MONTGOMERY,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000410
+MONTGOMERY,Liberty Township,United States Senate,,Republican,"Moran, Jerry",173,000410
+MONTGOMERY,Louisburg Township,United States Senate,,write - in,"Smith, DJ",0,000420
+MONTGOMERY,Louisburg Township,United States Senate,,Democratic,"Wiesner, Patrick",42,000420
+MONTGOMERY,Louisburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",22,000420
+MONTGOMERY,Louisburg Township,United States Senate,,Republican,"Moran, Jerry",178,000420
+MONTGOMERY,Parker Township 1,United States Senate,,write - in,"Smith, DJ",0,000430
+MONTGOMERY,Parker Township 1,United States Senate,,Democratic,"Wiesner, Patrick",22,000430
+MONTGOMERY,Parker Township 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000430
+MONTGOMERY,Parker Township 1,United States Senate,,Republican,"Moran, Jerry",93,000430
+MONTGOMERY,Parker Township 2,United States Senate,,write - in,"Smith, DJ",0,00044A
+MONTGOMERY,Parker Township 2,United States Senate,,Democratic,"Wiesner, Patrick",98,00044A
+MONTGOMERY,Parker Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",25,00044A
+MONTGOMERY,Parker Township 2,United States Senate,,Republican,"Moran, Jerry",268,00044A
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,write - in,"Smith, DJ",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00044B
+MONTGOMERY,Parker Township 2 Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00044B
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,write - in,"Smith, DJ",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00044C
+MONTGOMERY,Parker Township 2 Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00044C
+MONTGOMERY,Rutland Township,United States Senate,,write - in,"Smith, DJ",0,000450
+MONTGOMERY,Rutland Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000450
+MONTGOMERY,Rutland Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000450
+MONTGOMERY,Rutland Township,United States Senate,,Republican,"Moran, Jerry",147,000450
+MONTGOMERY,West Cherry Township,United States Senate,,write - in,"Smith, DJ",0,000470
+MONTGOMERY,West Cherry Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000470
+MONTGOMERY,West Cherry Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000470
+MONTGOMERY,West Cherry Township,United States Senate,,Republican,"Moran, Jerry",97,000470
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,write - in,"Smith, DJ",0,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,Democratic,"Wiesner, Patrick",7,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,Libertarian,"Garrard, Robert D.",3,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H11,United States Senate,,Republican,"Moran, Jerry",31,120020
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,write - in,"Smith, DJ",0,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,Democratic,"Wiesner, Patrick",106,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,Libertarian,"Garrard, Robert D.",30,120030
+MONTGOMERY,Independence City Ward 6 Precinct 1 H12,United States Senate,,Republican,"Moran, Jerry",280,120030
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,write - in,"Smith, DJ",0,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,Democratic,"Wiesner, Patrick",27,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,Libertarian,"Garrard, Robert D.",10,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11 A,United States Senate,,Republican,"Moran, Jerry",85,12004A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,write - in,"Smith, DJ",0,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,Democratic,"Wiesner, Patrick",52,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,Libertarian,"Garrard, Robert D.",13,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H11,United States Senate,,Republican,"Moran, Jerry",226,120040
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,write - in,"Smith, DJ",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,Democratic,"Wiesner, Patrick",1,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12 A,United States Senate,,Republican,"Moran, Jerry",12,12005A
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,write - in,"Smith, DJ",0,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,Democratic,"Wiesner, Patrick",14,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,Libertarian,"Garrard, Robert D.",5,120050
+MONTGOMERY,Independence City Ward 6 Precinct 2 H12,United States Senate,,Republican,"Moran, Jerry",67,120050
+MONTGOMERY,Independence Township 1 H11,United States Senate,,write - in,"Smith, DJ",0,120060
+MONTGOMERY,Independence Township 1 H11,United States Senate,,Democratic,"Wiesner, Patrick",100,120060
+MONTGOMERY,Independence Township 1 H11,United States Senate,,Libertarian,"Garrard, Robert D.",68,120060
+MONTGOMERY,Independence Township 1 H11,United States Senate,,Republican,"Moran, Jerry",541,120060
+MONTGOMERY,Independence Township 1 H12,United States Senate,,write - in,"Smith, DJ",0,120070
+MONTGOMERY,Independence Township 1 H12,United States Senate,,Democratic,"Wiesner, Patrick",17,120070
+MONTGOMERY,Independence Township 1 H12,United States Senate,,Libertarian,"Garrard, Robert D.",12,120070
+MONTGOMERY,Independence Township 1 H12,United States Senate,,Republican,"Moran, Jerry",98,120070
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,write - in,"Smith, DJ",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,Democratic,"Wiesner, Patrick",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,Libertarian,"Garrard, Robert D.",0,120080
+MONTGOMERY,Independence Township 2 Part A H11,United States Senate,,Republican,"Moran, Jerry",0,120080
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,write - in,"Smith, DJ",0,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,Democratic,"Wiesner, Patrick",30,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,Libertarian,"Garrard, Robert D.",14,120090
+MONTGOMERY,Independence Township 2 Part A H12,United States Senate,,Republican,"Moran, Jerry",125,120090
+MONTGOMERY,Sycamore Township H11,United States Senate,,write - in,"Smith, DJ",0,120100
+MONTGOMERY,Sycamore Township H11,United States Senate,,Democratic,"Wiesner, Patrick",56,120100
+MONTGOMERY,Sycamore Township H11,United States Senate,,Libertarian,"Garrard, Robert D.",37,120100
+MONTGOMERY,Sycamore Township H11,United States Senate,,Republican,"Moran, Jerry",289,120100
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,write - in,"Smith, DJ",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12011A
+MONTGOMERY,Sycamore Township H12 A,United States Senate,,Republican,"Moran, Jerry",0,12011A
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,write - in,"Smith, DJ",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,Democratic,"Wiesner, Patrick",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,Libertarian,"Garrard, Robert D.",0,12011B
+MONTGOMERY,Sycamore Township H12 B,United States Senate,,Republican,"Moran, Jerry",0,12011B
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,write - in,"Smith, DJ",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,Democratic,"Wiesner, Patrick",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,Libertarian,"Garrard, Robert D.",0,12011C
+MONTGOMERY,Sycamore Township H12 C,United States Senate,,Republican,"Moran, Jerry",0,12011C
+MONTGOMERY,Sycamore Township H12,United States Senate,,write - in,"Smith, DJ",0,120110
+MONTGOMERY,Sycamore Township H12,United States Senate,,Democratic,"Wiesner, Patrick",0,120110
+MONTGOMERY,Sycamore Township H12,United States Senate,,Libertarian,"Garrard, Robert D.",0,120110
+MONTGOMERY,Sycamore Township H12,United States Senate,,Republican,"Moran, Jerry",0,120110
+MONTGOMERY,Coffeyville Airport,United States Senate,,write - in,"Smith, DJ",0,900010
+MONTGOMERY,Coffeyville Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+MONTGOMERY,Coffeyville Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+MONTGOMERY,Coffeyville Airport,United States Senate,,Republican,"Moran, Jerry",0,900010
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+MONTGOMERY,Coffeyville Ward 1 Precinct 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900020
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+MONTGOMERY,Caney City Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900030
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,write - in,"Smith, DJ",0,900040
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,Democratic,"Wiesner, Patrick",6,900040
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",1,900040
+MONTGOMERY,Parker Township 2 Enclave,United States Senate,,Republican,"Moran, Jerry",4,900040
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,write - in,"Smith, DJ",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+MONTGOMERY,Independence Township 1 Enclave,United States Senate,,Republican,"Moran, Jerry",0,900050
+MONTGOMERY,Independence Exclave Airport,United States Senate,,write - in,"Smith, DJ",0,900060
+MONTGOMERY,Independence Exclave Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+MONTGOMERY,Independence Exclave Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+MONTGOMERY,Independence Exclave Airport,United States Senate,,Republican,"Moran, Jerry",0,900060

--- a/2016/20161108__ks__general__morris__precinct.csv
+++ b/2016/20161108__ks__general__morris__precinct.csv
@@ -1,214 +1,704 @@
-county,precinct,office,district,party,candidate,votes
-Morris,Ward 1,President,,D,Clinton/Kaine,72
-Morris,Ward 2,President,,D,Clinton/Kaine,54
-Morris,Ward 3,President,,D,Clinton/Kaine,129
-Morris,Twp 1 Pct 1,President,,D,Clinton/Kaine,33
-Morris,Twp 1 Pct 2,President,,D,Clinton/Kaine,19
-Morris,Twp 2,President,,D,Clinton/Kaine,120
-Morris,Twp 3,President,,D,Clinton/Kaine,43
-Morris,Twp 4,President,,D,Clinton/Kaine,16
-Morris,Twp 5,President,,D,Clinton/Kaine,33
-Morris,Twp 6,President,,D,Clinton/Kaine,6
-Morris,Twp 7,President,,D,Clinton/Kaine,24
-Morris,Twp 8,President,,D,Clinton/Kaine,18
-Morris,Twp 9,President,,D,Clinton/Kaine,20
-Morris,Highland,President,,D,Clinton/Kaine,6
-Morris,Overland,President,,D,Clinton/Kaine,8
-Morris,Ward 1,President,,R,Trump/Pence,167
-Morris,Ward 2,President,,R,Trump/Pence,132
-Morris,Ward 3,President,,R,Trump/Pence,236
-Morris,Twp 1 Pct 1,President,,R,Trump/Pence,122
-Morris,Twp 1 Pct 2,President,,R,Trump/Pence,53
-Morris,Twp 2,President,,R,Trump/Pence,238
-Morris,Twp 3,President,,R,Trump/Pence,150
-Morris,Twp 4,President,,R,Trump/Pence,90
-Morris,Twp 5,President,,R,Trump/Pence,240
-Morris,Twp 6,President,,R,Trump/Pence,37
-Morris,Twp 7,President,,R,Trump/Pence,91
-Morris,Twp 8,President,,R,Trump/Pence,68
-Morris,Twp 9,President,,R,Trump/Pence,122
-Morris,Highland,President,,R,Trump/Pence,50
-Morris,Overland,President,,R,Trump/Pence,24
-Morris,Ward 1,President,,Lib,Johnson/Weld,7
-Morris,Ward 2,President,,Lib,Johnson/Weld,14
-Morris,Ward 3,President,,Lib,Johnson/Weld,33
-Morris,Twp 1 Pct 1,President,,Lib,Johnson/Weld,14
-Morris,Twp 1 Pct 2,President,,Lib,Johnson/Weld,6
-Morris,Twp 2,President,,Lib,Johnson/Weld,17
-Morris,Twp 3,President,,Lib,Johnson/Weld,4
-Morris,Twp 4,President,,Lib,Johnson/Weld,5
-Morris,Twp 5,President,,Lib,Johnson/Weld,7
-Morris,Twp 6,President,,Lib,Johnson/Weld,2
-Morris,Twp 7,President,,Lib,Johnson/Weld,4
-Morris,Twp 8,President,,Lib,Johnson/Weld,8
-Morris,Twp 9,President,,Lib,Johnson/Weld,11
-Morris,Highland,President,,Lib,Johnson/Weld,2
-Morris,Overland,President,,Lib,Johnson/Weld,4
-Morris,Ward 1,President,,Ind,Stein/Baraka,5
-Morris,Ward 2,President,,Ind,Stein/Baraka,11
-Morris,Ward 3,President,,Ind,Stein/Baraka,12
-Morris,Twp 1 Pct 1,President,,Ind,Stein/Baraka,3
-Morris,Twp 1 Pct 2,President,,Ind,Stein/Baraka,2
-Morris,Twp 2,President,,Ind,Stein/Baraka,5
-Morris,Twp 3,President,,Ind,Stein/Baraka,4
-Morris,Twp 4,President,,Ind,Stein/Baraka,4
-Morris,Twp 5,President,,Ind,Stein/Baraka,7
-Morris,Twp 6,President,,Ind,Stein/Baraka,0
-Morris,Twp 7,President,,Ind,Stein/Baraka,2
-Morris,Twp 8,President,,Ind,Stein/Baraka,2
-Morris,Twp 9,President,,Ind,Stein/Baraka,4
-Morris,Highland,President,,Ind,Stein/Baraka,1
-Morris,Overland,President,,Ind,Stein/Baraka,0
-Morris,Ward 3,President,,,Castle/Bradley,1
-Morris,Twp 3,President,,,McMullin/Johnson,1
-Morris,Twp 9,President,,,McMullin/Johnson,1
-Morris,Ward 1,U.S. Senate,,R,Jerry Moran,192
-Morris,Ward 2,U.S. Senate,,R,Jerry Moran,155
-Morris,Ward 3,U.S. Senate,,R,Jerry Moran,314
-Morris,Twp 1 Pct 1,U.S. Senate,,R,Jerry Moran,143
-Morris,Twp 1 Pct 2,U.S. Senate,,R,Jerry Moran,67
-Morris,Twp 2,U.S. Senate,,R,Jerry Moran,293
-Morris,Twp 3,U.S. Senate,,R,Jerry Moran,159
-Morris,Twp 4,U.S. Senate,,R,Jerry Moran,93
-Morris,Twp 5,U.S. Senate,,R,Jerry Moran,243
-Morris,Twp 6,U.S. Senate,,R,Jerry Moran,37
-Morris,Twp 7,U.S. Senate,,R,Jerry Moran,106
-Morris,Twp 8,U.S. Senate,,R,Jerry Moran,83
-Morris,Twp 9,U.S. Senate,,R,Jerry Moran,122
-Morris,Highland,U.S. Senate,,R,Jerry Moran,51
-Morris,Overland,U.S. Senate,,R,Jerry Moran,29
-Morris,Ward 1,U.S. Senate,,D,Patrick Wiesner,50
-Morris,Ward 2,U.S. Senate,,D,Patrick Wiesner,43
-Morris,Ward 3,U.S. Senate,,D,Patrick Wiesner,90
-Morris,Twp 1 Pct 1,U.S. Senate,,D,Patrick Wiesner,24
-Morris,Twp 1 Pct 2,U.S. Senate,,D,Patrick Wiesner,12
-Morris,Twp 2,U.S. Senate,,D,Patrick Wiesner,64
-Morris,Twp 3,U.S. Senate,,D,Patrick Wiesner,34
-Morris,Twp 4,U.S. Senate,,D,Patrick Wiesner,10
-Morris,Twp 5,U.S. Senate,,D,Patrick Wiesner,29
-Morris,Twp 6,U.S. Senate,,D,Patrick Wiesner,6
-Morris,Twp 7,U.S. Senate,,D,Patrick Wiesner,14
-Morris,Twp 8,U.S. Senate,,D,Patrick Wiesner,11
-Morris,Twp 9,U.S. Senate,,D,Patrick Wiesner,23
-Morris,Highland,U.S. Senate,,D,Patrick Wiesner,5
-Morris,Overland,U.S. Senate,,D,Patrick Wiesner,5
-Morris,Ward 1,U.S. Senate,,Lib,Robert D Garrard,16
-Morris,Ward 2,U.S. Senate,,Lib,Robert D Garrard,10
-Morris,Ward 3,U.S. Senate,,Lib,Robert D Garrard,15
-Morris,Twp 1 Pct 1,U.S. Senate,,Lib,Robert D Garrard,7
-Morris,Twp 1 Pct 2,U.S. Senate,,Lib,Robert D Garrard,3
-Morris,Twp 2,U.S. Senate,,Lib,Robert D Garrard,18
-Morris,Twp 3,U.S. Senate,,Lib,Robert D Garrard,5
-Morris,Twp 4,U.S. Senate,,Lib,Robert D Garrard,12
-Morris,Twp 5,U.S. Senate,,Lib,Robert D Garrard,15
-Morris,Twp 6,U.S. Senate,,Lib,Robert D Garrard,3
-Morris,Twp 7,U.S. Senate,,Lib,Robert D Garrard,4
-Morris,Twp 8,U.S. Senate,,Lib,Robert D Garrard,4
-Morris,Twp 9,U.S. Senate,,Lib,Robert D Garrard,14
-Morris,Highland,U.S. Senate,,Lib,Robert D Garrard,2
-Morris,Overland,U.S. Senate,,Lib,Robert D Garrard,1
-Morris,Ward 1,U.S. House,1,R,Roger Marshall,162
-Morris,Ward 2,U.S. House,1,R,Roger Marshall,139
-Morris,Ward 3,U.S. House,1,R,Roger Marshall,286
-Morris,Twp 1 Pct 1,U.S. House,1,R,Roger Marshall,125
-Morris,Twp 1 Pct 2,U.S. House,1,R,Roger Marshall,65
-Morris,Twp 2,U.S. House,1,R,Roger Marshall,265
-Morris,Twp 3,U.S. House,1,R,Roger Marshall,144
-Morris,Twp 4,U.S. House,1,R,Roger Marshall,89
-Morris,Twp 5,U.S. House,1,R,Roger Marshall,220
-Morris,Twp 6,U.S. House,1,R,Roger Marshall,30
-Morris,Twp 7,U.S. House,1,R,Roger Marshall,91
-Morris,Twp 8,U.S. House,1,R,Roger Marshall,68
-Morris,Twp 9,U.S. House,1,R,Roger Marshall,116
-Morris,Highland,U.S. House,1,R,Roger Marshall,48
-Morris,Overland,U.S. House,1,R,Roger Marshall,20
-Morris,Ward 1,U.S. House,1,Lib,Kerry Burt,29
-Morris,Ward 2,U.S. House,1,Lib,Kerry Burt,19
-Morris,Ward 3,U.S. House,1,Lib,Kerry Burt,35
-Morris,Twp 1 Pct 1,U.S. House,1,Lib,Kerry Burt,14
-Morris,Twp 1 Pct 2,U.S. House,1,Lib,Kerry Burt,3
-Morris,Twp 2,U.S. House,1,Lib,Kerry Burt,30
-Morris,Twp 3,U.S. House,1,Lib,Kerry Burt,10
-Morris,Twp 4,U.S. House,1,Lib,Kerry Burt,9
-Morris,Twp 5,U.S. House,1,Lib,Kerry Burt,21
-Morris,Twp 6,U.S. House,1,Lib,Kerry Burt,1
-Morris,Twp 7,U.S. House,1,Lib,Kerry Burt,6
-Morris,Twp 8,U.S. House,1,Lib,Kerry Burt,10
-Morris,Twp 9,U.S. House,1,Lib,Kerry Burt,12
-Morris,Highland,U.S. House,1,Lib,Kerry Burt,2
-Morris,Overland,U.S. House,1,Lib,Kerry Burt,3
-Morris,Ward 1,U.S. House,1,Ind,Alan LaPolice,56
-Morris,Ward 2,U.S. House,1,Ind,Alan LaPolice,36
-Morris,Ward 3,U.S. House,1,Ind,Alan LaPolice,77
-Morris,Twp 1 Pct 1,U.S. House,1,Ind,Alan LaPolice,30
-Morris,Twp 1 Pct 2,U.S. House,1,Ind,Alan LaPolice,12
-Morris,Twp 2,U.S. House,1,Ind,Alan LaPolice,55
-Morris,Twp 3,U.S. House,1,Ind,Alan LaPolice,40
-Morris,Twp 4,U.S. House,1,Ind,Alan LaPolice,16
-Morris,Twp 5,U.S. House,1,Ind,Alan LaPolice,38
-Morris,Twp 6,U.S. House,1,Ind,Alan LaPolice,12
-Morris,Twp 7,U.S. House,1,Ind,Alan LaPolice,20
-Morris,Twp 8,U.S. House,1,Ind,Alan LaPolice,14
-Morris,Twp 9,U.S. House,1,Ind,Alan LaPolice,24
-Morris,Highland,U.S. House,1,Ind,Alan LaPolice,6
-Morris,Overland,U.S. House,1,Ind,Alan LaPolice,11
-Morris,Ward 1,State Senate,35,R,Richard Wilborn,147
-Morris,Ward 2,State Senate,35,R,Richard Wilborn,122
-Morris,Ward 3,State Senate,35,R,Richard Wilborn,234
-Morris,Twp 1 Pct 1,State Senate,35,R,Richard Wilborn,117
-Morris,Twp 1 Pct 2,State Senate,35,R,Richard Wilborn,57
-Morris,Twp 2,State Senate,35,R,Richard Wilborn,223
-Morris,Twp 3,State Senate,35,R,Richard Wilborn,134
-Morris,Twp 4,State Senate,35,R,Richard Wilborn,85
-Morris,Twp 5,State Senate,35,R,Richard Wilborn,220
-Morris,Twp 6,State Senate,35,R,Richard Wilborn,32
-Morris,Twp 7,State Senate,35,R,Richard Wilborn,87
-Morris,Twp 8,State Senate,35,R,Richard Wilborn,75
-Morris,Twp 9,State Senate,35,R,Richard Wilborn,97
-Morris,Highland,State Senate,35,R,Richard Wilborn,48
-Morris,Overland,State Senate,35,R,Richard Wilborn,21
-Morris,Ward 1,State Senate,35,D,Levi Morris,104
-Morris,Ward 2,State Senate,35,D,Levi Morris,76
-Morris,Ward 3,State Senate,35,D,Levi Morris,172
-Morris,Twp 1 Pct 1,State Senate,35,D,Levi Morris,52
-Morris,Twp 1 Pct 2,State Senate,35,D,Levi Morris,23
-Morris,Twp 2,State Senate,35,D,Levi Morris,141
-Morris,Twp 3,State Senate,35,D,Levi Morris,57
-Morris,Twp 4,State Senate,35,D,Levi Morris,27
-Morris,Twp 5,State Senate,35,D,Levi Morris,54
-Morris,Twp 6,State Senate,35,D,Levi Morris,11
-Morris,Twp 7,State Senate,35,D,Levi Morris,33
-Morris,Twp 8,State Senate,35,D,Levi Morris,22
-Morris,Twp 9,State Senate,35,D,Levi Morris,56
-Morris,Highland,State Senate,35,D,Levi Morris,9
-Morris,Overland,State Senate,35,D,Levi Morris,10
-Morris,Ward 1,State House,68,R,Dave Baker,195
-Morris,Ward 2,State House,68,R,Dave Baker,165
-Morris,Ward 3,State House,68,R,Dave Baker,331
-Morris,Twp 1 Pct 1,State House,68,R,Dave Baker,146
-Morris,Twp 1 Pct 2,State House,68,R,Dave Baker,64
-Morris,Twp 2,State House,68,R,Dave Baker,325
-Morris,Twp 3,State House,68,R,Dave Baker,152
-Morris,Twp 4,State House,68,R,Dave Baker,90
-Morris,Twp 5,State House,68,R,Dave Baker,209
-Morris,Twp 6,State House,68,R,Dave Baker,34
-Morris,Twp 7,State House,68,R,Dave Baker,97
-Morris,Twp 8,State House,68,R,Dave Baker,89
-Morris,Twp 9,State House,68,R,Dave Baker,138
-Morris,Highland,State House,68,R,Dave Baker,50
-Morris,Overland,State House,68,R,Dave Baker,22
-Morris,Ward 1,State House,68,D,Laura Blevins,60
-Morris,Ward 2,State House,68,D,Laura Blevins,45
-Morris,Ward 3,State House,68,D,Laura Blevins,88
-Morris,Twp 1 Pct 1,State House,68,D,Laura Blevins,27
-Morris,Twp 1 Pct 2,State House,68,D,Laura Blevins,17
-Morris,Twp 2,State House,68,D,Laura Blevins,53
-Morris,Twp 3,State House,68,D,Laura Blevins,46
-Morris,Twp 4,State House,68,D,Laura Blevins,21
-Morris,Twp 5,State House,68,D,Laura Blevins,71
-Morris,Twp 6,State House,68,D,Laura Blevins,10
-Morris,Twp 7,State House,68,D,Laura Blevins,24
-Morris,Twp 8,State House,68,D,Laura Blevins,10
-Morris,Twp 9,State House,68,D,Laura Blevins,23
-Morris,Highland,State House,68,D,Laura Blevins,9
-Morris,Overland,State House,68,D,Laura Blevins,13
+county,precinct,office,district,party,candidate,votes,vtd
+MORRIS,Council Grove Ward 1,Kansas House of Representatives,68,Democratic,"Blevins, Laura",60,000010
+MORRIS,Council Grove Ward 1,Kansas House of Representatives,68,Republican,"Baker, Dave",195,000010
+MORRIS,Council Grove Ward 2,Kansas House of Representatives,68,Democratic,"Blevins, Laura",45,000020
+MORRIS,Council Grove Ward 2,Kansas House of Representatives,68,Republican,"Baker, Dave",165,000020
+MORRIS,Council Grove Ward 3,Kansas House of Representatives,68,Democratic,"Blevins, Laura",88,000030
+MORRIS,Council Grove Ward 3,Kansas House of Representatives,68,Republican,"Baker, Dave",331,000030
+MORRIS,Herington Ward 1 Exclave A,Kansas House of Representatives,68,Democratic,"Blevins, Laura",0,000040
+MORRIS,Herington Ward 1 Exclave A,Kansas House of Representatives,68,Republican,"Baker, Dave",0,000040
+MORRIS,Herington Ward 1 Exclave B,Kansas House of Representatives,68,Democratic,"Blevins, Laura",0,000050
+MORRIS,Herington Ward 1 Exclave B,Kansas House of Representatives,68,Republican,"Baker, Dave",0,000050
+MORRIS,Highland Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",9,000060
+MORRIS,Highland Township,Kansas House of Representatives,68,Republican,"Baker, Dave",50,000060
+MORRIS,Overland Township,Kansas House of Representatives,68,Democratic,"Blevins, Laura",13,000070
+MORRIS,Overland Township,Kansas House of Representatives,68,Republican,"Baker, Dave",22,000070
+MORRIS,Township 1 Precinct 1,Kansas House of Representatives,68,Democratic,"Blevins, Laura",27,000080
+MORRIS,Township 1 Precinct 1,Kansas House of Representatives,68,Republican,"Baker, Dave",146,000080
+MORRIS,Township 1 Precinct 2,Kansas House of Representatives,68,Democratic,"Blevins, Laura",17,000090
+MORRIS,Township 1 Precinct 2,Kansas House of Representatives,68,Republican,"Baker, Dave",64,000090
+MORRIS,Township 2,Kansas House of Representatives,68,Democratic,"Blevins, Laura",53,000100
+MORRIS,Township 2,Kansas House of Representatives,68,Republican,"Baker, Dave",325,000100
+MORRIS,Township 3,Kansas House of Representatives,68,Democratic,"Blevins, Laura",46,000110
+MORRIS,Township 3,Kansas House of Representatives,68,Republican,"Baker, Dave",152,000110
+MORRIS,Township 4,Kansas House of Representatives,68,Democratic,"Blevins, Laura",21,000120
+MORRIS,Township 4,Kansas House of Representatives,68,Republican,"Baker, Dave",90,000120
+MORRIS,Township 5,Kansas House of Representatives,68,Democratic,"Blevins, Laura",71,000130
+MORRIS,Township 5,Kansas House of Representatives,68,Republican,"Baker, Dave",209,000130
+MORRIS,Township 6,Kansas House of Representatives,68,Democratic,"Blevins, Laura",10,000140
+MORRIS,Township 6,Kansas House of Representatives,68,Republican,"Baker, Dave",34,000140
+MORRIS,Township 7,Kansas House of Representatives,68,Democratic,"Blevins, Laura",24,000150
+MORRIS,Township 7,Kansas House of Representatives,68,Republican,"Baker, Dave",97,000150
+MORRIS,Township 8,Kansas House of Representatives,68,Democratic,"Blevins, Laura",10,000160
+MORRIS,Township 8,Kansas House of Representatives,68,Republican,"Baker, Dave",89,000160
+MORRIS,Township 9,Kansas House of Representatives,68,Democratic,"Blevins, Laura",23,000170
+MORRIS,Township 9,Kansas House of Representatives,68,Republican,"Baker, Dave",138,000170
+MORRIS,Council Grove Ward 3 Exclave,Kansas House of Representatives,68,Democratic,"Blevins, Laura",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Kansas House of Representatives,68,Republican,"Baker, Dave",0,900010
+MORRIS,Herington Exclave C Airport,Kansas House of Representatives,68,Democratic,"Blevins, Laura",0,900020
+MORRIS,Herington Exclave C Airport,Kansas House of Representatives,68,Republican,"Baker, Dave",0,900020
+MORRIS,Council Grove Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",104,000010
+MORRIS,Council Grove Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",147,000010
+MORRIS,Council Grove Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",76,000020
+MORRIS,Council Grove Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",122,000020
+MORRIS,Council Grove Ward 3,Kansas Senate,35,Democratic,"Morris, Levi",172,000030
+MORRIS,Council Grove Ward 3,Kansas Senate,35,Republican,"Wilborn, Richard",234,000030
+MORRIS,Herington Ward 1 Exclave A,Kansas Senate,35,Democratic,"Morris, Levi",0,000040
+MORRIS,Herington Ward 1 Exclave A,Kansas Senate,35,Republican,"Wilborn, Richard",0,000040
+MORRIS,Herington Ward 1 Exclave B,Kansas Senate,35,Democratic,"Morris, Levi",0,000050
+MORRIS,Herington Ward 1 Exclave B,Kansas Senate,35,Republican,"Wilborn, Richard",0,000050
+MORRIS,Highland Township,Kansas Senate,35,Democratic,"Morris, Levi",9,000060
+MORRIS,Highland Township,Kansas Senate,35,Republican,"Wilborn, Richard",48,000060
+MORRIS,Overland Township,Kansas Senate,35,Democratic,"Morris, Levi",10,000070
+MORRIS,Overland Township,Kansas Senate,35,Republican,"Wilborn, Richard",21,000070
+MORRIS,Township 1 Precinct 1,Kansas Senate,35,Democratic,"Morris, Levi",52,000080
+MORRIS,Township 1 Precinct 1,Kansas Senate,35,Republican,"Wilborn, Richard",117,000080
+MORRIS,Township 1 Precinct 2,Kansas Senate,35,Democratic,"Morris, Levi",23,000090
+MORRIS,Township 1 Precinct 2,Kansas Senate,35,Republican,"Wilborn, Richard",57,000090
+MORRIS,Township 2,Kansas Senate,35,Democratic,"Morris, Levi",141,000100
+MORRIS,Township 2,Kansas Senate,35,Republican,"Wilborn, Richard",223,000100
+MORRIS,Township 3,Kansas Senate,35,Democratic,"Morris, Levi",57,000110
+MORRIS,Township 3,Kansas Senate,35,Republican,"Wilborn, Richard",134,000110
+MORRIS,Township 4,Kansas Senate,35,Democratic,"Morris, Levi",27,000120
+MORRIS,Township 4,Kansas Senate,35,Republican,"Wilborn, Richard",85,000120
+MORRIS,Township 5,Kansas Senate,35,Democratic,"Morris, Levi",54,000130
+MORRIS,Township 5,Kansas Senate,35,Republican,"Wilborn, Richard",220,000130
+MORRIS,Township 6,Kansas Senate,35,Democratic,"Morris, Levi",11,000140
+MORRIS,Township 6,Kansas Senate,35,Republican,"Wilborn, Richard",32,000140
+MORRIS,Township 7,Kansas Senate,35,Democratic,"Morris, Levi",33,000150
+MORRIS,Township 7,Kansas Senate,35,Republican,"Wilborn, Richard",87,000150
+MORRIS,Township 8,Kansas Senate,35,Democratic,"Morris, Levi",22,000160
+MORRIS,Township 8,Kansas Senate,35,Republican,"Wilborn, Richard",75,000160
+MORRIS,Township 9,Kansas Senate,35,Democratic,"Morris, Levi",56,000170
+MORRIS,Township 9,Kansas Senate,35,Republican,"Wilborn, Richard",97,000170
+MORRIS,Council Grove Ward 3 Exclave,Kansas Senate,35,Democratic,"Morris, Levi",0,900010
+MORRIS,Council Grove Ward 3 Exclave,Kansas Senate,35,Republican,"Wilborn, Richard",0,900010
+MORRIS,Herington Exclave C Airport,Kansas Senate,35,Democratic,"Morris, Levi",0,900020
+MORRIS,Herington Exclave C Airport,Kansas Senate,35,Republican,"Wilborn, Richard",0,900020
+MORRIS,Council Grove Ward 1,President / Vice President,,independent,"Stein, Jill",5,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",72,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+MORRIS,Council Grove Ward 1,President / Vice President,,Republican,"Trump, Donald J.",167,000010
+MORRIS,Council Grove Ward 2,President / Vice President,,independent,"Stein, Jill",11,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000020
+MORRIS,Council Grove Ward 2,President / Vice President,,Republican,"Trump, Donald J.",132,000020
+MORRIS,Council Grove Ward 3,President / Vice President,,independent,"Stein, Jill",12,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Castle, Darrell L",1,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",129,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",33,000030
+MORRIS,Council Grove Ward 3,President / Vice President,,Republican,"Trump, Donald J.",236,000030
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,independent,"Stein, Jill",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+MORRIS,Herington Ward 1 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,000040
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,independent,"Stein, Jill",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+MORRIS,Herington Ward 1 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,000050
+MORRIS,Highland Township,President / Vice President,,independent,"Stein, Jill",1,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MORRIS,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MORRIS,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000060
+MORRIS,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+MORRIS,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",50,000060
+MORRIS,Overland Township,President / Vice President,,independent,"Stein, Jill",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MORRIS,Overland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MORRIS,Overland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000070
+MORRIS,Overland Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+MORRIS,Overland Township,President / Vice President,,Republican,"Trump, Donald J.",24,000070
+MORRIS,Township 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",3,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",14,000080
+MORRIS,Township 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",122,000080
+MORRIS,Township 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+MORRIS,Township 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",53,000090
+MORRIS,Township 2,President / Vice President,,independent,"Stein, Jill",5,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Hedges, James A",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"McMullin, Evan",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Smith, Mike",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MORRIS,Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MORRIS,Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000100
+MORRIS,Township 2,President / Vice President,,Libertarian,"Johnson, Gary",17,000100
+MORRIS,Township 2,President / Vice President,,Republican,"Trump, Donald J.",238,000100
+MORRIS,Township 3,President / Vice President,,independent,"Stein, Jill",4,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Hedges, James A",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"McMullin, Evan",1,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Perry, Darryl",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Smith, Mike",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Sood, Ajay",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+MORRIS,Township 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+MORRIS,Township 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000110
+MORRIS,Township 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000110
+MORRIS,Township 3,President / Vice President,,Republican,"Trump, Donald J.",150,000110
+MORRIS,Township 4,President / Vice President,,independent,"Stein, Jill",4,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Hedges, James A",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"McMullin, Evan",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Perry, Darryl",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Smith, Mike",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Sood, Ajay",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+MORRIS,Township 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+MORRIS,Township 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000120
+MORRIS,Township 4,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+MORRIS,Township 4,President / Vice President,,Republican,"Trump, Donald J.",90,000120
+MORRIS,Township 5,President / Vice President,,independent,"Stein, Jill",7,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Hedges, James A",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"McMullin, Evan",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Perry, Darryl",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Smith, Mike",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Sood, Ajay",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+MORRIS,Township 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+MORRIS,Township 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000130
+MORRIS,Township 5,President / Vice President,,Libertarian,"Johnson, Gary",7,000130
+MORRIS,Township 5,President / Vice President,,Republican,"Trump, Donald J.",240,000130
+MORRIS,Township 6,President / Vice President,,independent,"Stein, Jill",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Hedges, James A",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"McMullin, Evan",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Perry, Darryl",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Smith, Mike",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Sood, Ajay",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+MORRIS,Township 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+MORRIS,Township 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000140
+MORRIS,Township 6,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+MORRIS,Township 6,President / Vice President,,Republican,"Trump, Donald J.",37,000140
+MORRIS,Township 7,President / Vice President,,independent,"Stein, Jill",2,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Hedges, James A",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"McMullin, Evan",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Perry, Darryl",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Smith, Mike",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Sood, Ajay",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+MORRIS,Township 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+MORRIS,Township 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000150
+MORRIS,Township 7,President / Vice President,,Libertarian,"Johnson, Gary",4,000150
+MORRIS,Township 7,President / Vice President,,Republican,"Trump, Donald J.",91,000150
+MORRIS,Township 8,President / Vice President,,independent,"Stein, Jill",2,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Hedges, James A",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"McMullin, Evan",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Perry, Darryl",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Smith, Mike",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Sood, Ajay",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+MORRIS,Township 8,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+MORRIS,Township 8,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000160
+MORRIS,Township 8,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+MORRIS,Township 8,President / Vice President,,Republican,"Trump, Donald J.",68,000160
+MORRIS,Township 9,President / Vice President,,independent,"Stein, Jill",4,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Hedges, James A",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"McMullin, Evan",1,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Perry, Darryl",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Smith, Mike",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Sood, Ajay",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+MORRIS,Township 9,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+MORRIS,Township 9,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000170
+MORRIS,Township 9,President / Vice President,,Libertarian,"Johnson, Gary",11,000170
+MORRIS,Township 9,President / Vice President,,Republican,"Trump, Donald J.",122,000170
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+MORRIS,Council Grove Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+MORRIS,Herington Exclave C Airport,President / Vice President,,independent,"Stein, Jill",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Hedges, James A",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"McMullin, Evan",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Perry, Darryl",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Smith, Mike",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Sood, Ajay",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+MORRIS,Herington Exclave C Airport,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",56,000010
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000010
+MORRIS,Council Grove Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",162,000010
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",36,000020
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000020
+MORRIS,Council Grove Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",139,000020
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",77,000030
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000030
+MORRIS,Council Grove Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",286,000030
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,000040
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,000050
+MORRIS,Highland Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000060
+MORRIS,Highland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+MORRIS,Highland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000060
+MORRIS,Highland Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000060
+MORRIS,Overland Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000070
+MORRIS,Overland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+MORRIS,Overland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000070
+MORRIS,Overland Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000070
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",30,000080
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000080
+MORRIS,Township 1 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",125,000080
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",12,000090
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000090
+MORRIS,Township 1 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",65,000090
+MORRIS,Township 2,United States House of Representatives,1,independent,"LaPolice, Alan",55,000100
+MORRIS,Township 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+MORRIS,Township 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,000100
+MORRIS,Township 2,United States House of Representatives,1,Republican,"Marshall, Roger",265,000100
+MORRIS,Township 3,United States House of Representatives,1,independent,"LaPolice, Alan",40,000110
+MORRIS,Township 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+MORRIS,Township 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000110
+MORRIS,Township 3,United States House of Representatives,1,Republican,"Marshall, Roger",144,000110
+MORRIS,Township 4,United States House of Representatives,1,independent,"LaPolice, Alan",16,000120
+MORRIS,Township 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+MORRIS,Township 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000120
+MORRIS,Township 4,United States House of Representatives,1,Republican,"Marshall, Roger",89,000120
+MORRIS,Township 5,United States House of Representatives,1,independent,"LaPolice, Alan",38,000130
+MORRIS,Township 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+MORRIS,Township 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,000130
+MORRIS,Township 5,United States House of Representatives,1,Republican,"Marshall, Roger",220,000130
+MORRIS,Township 6,United States House of Representatives,1,independent,"LaPolice, Alan",12,000140
+MORRIS,Township 6,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+MORRIS,Township 6,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000140
+MORRIS,Township 6,United States House of Representatives,1,Republican,"Marshall, Roger",30,000140
+MORRIS,Township 7,United States House of Representatives,1,independent,"LaPolice, Alan",20,000150
+MORRIS,Township 7,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+MORRIS,Township 7,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000150
+MORRIS,Township 7,United States House of Representatives,1,Republican,"Marshall, Roger",91,000150
+MORRIS,Township 8,United States House of Representatives,1,independent,"LaPolice, Alan",14,000160
+MORRIS,Township 8,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+MORRIS,Township 8,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000160
+MORRIS,Township 8,United States House of Representatives,1,Republican,"Marshall, Roger",68,000160
+MORRIS,Township 9,United States House of Representatives,1,independent,"LaPolice, Alan",24,000170
+MORRIS,Township 9,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+MORRIS,Township 9,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000170
+MORRIS,Township 9,United States House of Representatives,1,Republican,"Marshall, Roger",116,000170
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+MORRIS,Herington Exclave C Airport,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+MORRIS,Council Grove Ward 1,United States Senate,,write - in,"Smith, DJ",0,000010
+MORRIS,Council Grove Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",50,000010
+MORRIS,Council Grove Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,000010
+MORRIS,Council Grove Ward 1,United States Senate,,Republican,"Moran, Jerry",192,000010
+MORRIS,Council Grove Ward 2,United States Senate,,write - in,"Smith, DJ",0,000020
+MORRIS,Council Grove Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",43,000020
+MORRIS,Council Grove Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",10,000020
+MORRIS,Council Grove Ward 2,United States Senate,,Republican,"Moran, Jerry",155,000020
+MORRIS,Council Grove Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+MORRIS,Council Grove Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",90,000030
+MORRIS,Council Grove Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",15,000030
+MORRIS,Council Grove Ward 3,United States Senate,,Republican,"Moran, Jerry",314,000030
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,write - in,"Smith, DJ",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+MORRIS,Herington Ward 1 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,000040
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,write - in,"Smith, DJ",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+MORRIS,Herington Ward 1 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,000050
+MORRIS,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MORRIS,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000060
+MORRIS,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000060
+MORRIS,Highland Township,United States Senate,,Republican,"Moran, Jerry",51,000060
+MORRIS,Overland Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MORRIS,Overland Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000070
+MORRIS,Overland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000070
+MORRIS,Overland Township,United States Senate,,Republican,"Moran, Jerry",29,000070
+MORRIS,Township 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000080
+MORRIS,Township 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",24,000080
+MORRIS,Township 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",7,000080
+MORRIS,Township 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",143,000080
+MORRIS,Township 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000090
+MORRIS,Township 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",12,000090
+MORRIS,Township 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+MORRIS,Township 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",67,000090
+MORRIS,Township 2,United States Senate,,write - in,"Smith, DJ",0,000100
+MORRIS,Township 2,United States Senate,,Democratic,"Wiesner, Patrick",64,000100
+MORRIS,Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,000100
+MORRIS,Township 2,United States Senate,,Republican,"Moran, Jerry",293,000100
+MORRIS,Township 3,United States Senate,,write - in,"Smith, DJ",0,000110
+MORRIS,Township 3,United States Senate,,Democratic,"Wiesner, Patrick",34,000110
+MORRIS,Township 3,United States Senate,,Libertarian,"Garrard, Robert D.",5,000110
+MORRIS,Township 3,United States Senate,,Republican,"Moran, Jerry",159,000110
+MORRIS,Township 4,United States Senate,,write - in,"Smith, DJ",0,000120
+MORRIS,Township 4,United States Senate,,Democratic,"Wiesner, Patrick",10,000120
+MORRIS,Township 4,United States Senate,,Libertarian,"Garrard, Robert D.",12,000120
+MORRIS,Township 4,United States Senate,,Republican,"Moran, Jerry",93,000120
+MORRIS,Township 5,United States Senate,,write - in,"Smith, DJ",0,000130
+MORRIS,Township 5,United States Senate,,Democratic,"Wiesner, Patrick",29,000130
+MORRIS,Township 5,United States Senate,,Libertarian,"Garrard, Robert D.",15,000130
+MORRIS,Township 5,United States Senate,,Republican,"Moran, Jerry",243,000130
+MORRIS,Township 6,United States Senate,,write - in,"Smith, DJ",0,000140
+MORRIS,Township 6,United States Senate,,Democratic,"Wiesner, Patrick",6,000140
+MORRIS,Township 6,United States Senate,,Libertarian,"Garrard, Robert D.",3,000140
+MORRIS,Township 6,United States Senate,,Republican,"Moran, Jerry",37,000140
+MORRIS,Township 7,United States Senate,,write - in,"Smith, DJ",0,000150
+MORRIS,Township 7,United States Senate,,Democratic,"Wiesner, Patrick",14,000150
+MORRIS,Township 7,United States Senate,,Libertarian,"Garrard, Robert D.",4,000150
+MORRIS,Township 7,United States Senate,,Republican,"Moran, Jerry",106,000150
+MORRIS,Township 8,United States Senate,,write - in,"Smith, DJ",0,000160
+MORRIS,Township 8,United States Senate,,Democratic,"Wiesner, Patrick",11,000160
+MORRIS,Township 8,United States Senate,,Libertarian,"Garrard, Robert D.",4,000160
+MORRIS,Township 8,United States Senate,,Republican,"Moran, Jerry",83,000160
+MORRIS,Township 9,United States Senate,,write - in,"Smith, DJ",0,000170
+MORRIS,Township 9,United States Senate,,Democratic,"Wiesner, Patrick",23,000170
+MORRIS,Township 9,United States Senate,,Libertarian,"Garrard, Robert D.",14,000170
+MORRIS,Township 9,United States Senate,,Republican,"Moran, Jerry",122,000170
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+MORRIS,Council Grove Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010
+MORRIS,Herington Exclave C Airport,United States Senate,,write - in,"Smith, DJ",0,900020
+MORRIS,Herington Exclave C Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+MORRIS,Herington Exclave C Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+MORRIS,Herington Exclave C Airport,United States Senate,,Republican,"Moran, Jerry",0,900020

--- a/2016/20161108__ks__general__morton__precinct.csv
+++ b/2016/20161108__ks__general__morton__precinct.csv
@@ -1,196 +1,361 @@
-county,precinct,office,district,party,candidate,votes
-Morton,Ward 1,President,,R,Trump and Pence,157
-Morton,Ward 2,President,,R,Trump and Pence,124
-Morton,Ward 3,President,,R,Trump and Pence,131
-Morton,Rolla City,President,,R,Trump and Pence,80
-Morton,Rolla Township,President,,R,Trump and Pence,47
-Morton,Richfield City/West,President,,R,Trump and Pence,27
-Morton,Richfield East,President,,R,Trump and Pence,16
-Morton,Cimarron Township,President,,R,Trump and Pence,19
-Morton,Jones Township,President,,R,Trump and Pence,4
-Morton,Taloga Township,President,,R,Trump and Pence,39
-Morton,Westola Township,President,,R,Trump and Pence,14
-Morton,Advance,President,,R,Trump and Pence,320
-Morton,Provisionals,President,,R,Trump and Pence,17
-Morton,Total,President,,R,Trump and Pence,995
-Morton,Ward 1,President,,D,Clinton and Kaine,25
-Morton,Ward 2,President,,D,Clinton and Kaine,15
-Morton,Ward 3,President,,D,Clinton and Kaine,14
-Morton,Rolla City,President,,D,Clinton and Kaine,20
-Morton,Rolla Township,President,,D,Clinton and Kaine,2
-Morton,Richfield City/West,President,,D,Clinton and Kaine,0
-Morton,Richfield East,President,,D,Clinton and Kaine,6
-Morton,Cimarron Township,President,,D,Clinton and Kaine,0
-Morton,Taloga Township,President,,D,Clinton and Kaine,2
-Morton,Westola Township,President,,D,Clinton and Kaine,0
-Morton,Advance,President,,D,Clinton and Kaine,62
-Morton,Provisionals,President,,D,Clinton and Kaine,1
-Morton,Total,President,,D,Clinton and Kaine,147
-Morton,Ward 1,President,,I,Stein and Baraka,0
-Morton,Ward 2,President,,I,Stein and Baraka,3
-Morton,Ward 3,President,,I,Stein and Baraka,3
-Morton,Rolla City,President,,I,Stein and Baraka,4
-Morton,Rolla Township,President,,I,Stein and Baraka,1
-Morton,Richfield City/West,President,,I,Stein and Baraka,0
-Morton,Richfield East,President,,I,Stein and Baraka,0
-Morton,Cimarron Township,President,,I,Stein and Baraka,1
-Morton,Taloga Township,President,,I,Stein and Baraka,0
-Morton,Westola Township,President,,I,Stein and Baraka,0
-Morton,Advance,President,,I,Stein and Baraka,1
-Morton,Provisionals,President,,I,Stein and Baraka,1
-Morton,Total,President,,I,Stein and Baraka,14
-Morton,Ward 1,President,,L,Johnson and Weld,8
-Morton,Ward 2,President,,L,Johnson and Weld,3
-Morton,Ward 3,President,,L,Johnson and Weld,8
-Morton,Rolla City,President,,L,Johnson and Weld,3
-Morton,Rolla Township,President,,L,Johnson and Weld,0
-Morton,Richfield City/West,President,,L,Johnson and Weld,1
-Morton,Richfield East,President,,L,Johnson and Weld,0
-Morton,Cimarron Township,President,,L,Johnson and Weld,1
-Morton,Taloga Township,President,,L,Johnson and Weld,3
-Morton,Westola Township,President,,L,Johnson and Weld,1
-Morton,Advance,President,,L,Johnson and Weld,4
-Morton,Provisionals,President,,L,Johnson and Weld,1
-Morton,Total,President,,L,Johnson and Weld,33
-Morton,Ward 2,President,,,Write-ins,2
-Morton,Ward 3,President,,,Write-ins,1
-Morton,Rolla City,President,,,Write-ins,2
-Morton,Rolla Township,President,,,Write-ins,1
-Morton,Advance,President,,,Write-ins,5
-Morton,Total,President,,,Write-ins,11
-Morton,Ward 1,U.S. Senate,,R,Jerry Moran,158
-Morton,Ward 2,U.S. Senate,,R,Jerry Moran,125
-Morton,Ward 3,U.S. Senate,,R,Jerry Moran,127
-Morton,Rolla City,U.S. Senate,,R,Jerry Moran,93
-Morton,Rolla Township,U.S. Senate,,R,Jerry Moran,45
-Morton,Richfield City/West,U.S. Senate,,R,Jerry Moran,26
-Morton,Richfield East,U.S. Senate,,R,Jerry Moran,15
-Morton,Cimarron Township,U.S. Senate,,R,Jerry Moran,18
-Morton,Jones Township,U.S. Senate,,R,Jerry Moran,4
-Morton,Taloga Township,U.S. Senate,,R,Jerry Moran,41
-Morton,Westola Township,U.S. Senate,,R,Jerry Moran,14
-Morton,Advance,U.S. Senate,,R,Jerry Moran,327
-Morton,Provisionals,U.S. Senate,,R,Jerry Moran,17
-Morton,Total,U.S. Senate,,R,Jerry Moran,1010
-Morton,Ward 1,U.S. Senate,,D,Patrick Wiesner,20
-Morton,Ward 2,U.S. Senate,,D,Patrick Wiesner,13
-Morton,Ward 3,U.S. Senate,,D,Patrick Wiesner,16
-Morton,Rolla City,U.S. Senate,,D,Patrick Wiesner,9
-Morton,Rolla Township,U.S. Senate,,D,Patrick Wiesner,2
-Morton,Richfield City/West,U.S. Senate,,D,Patrick Wiesner,0
-Morton,Richfield East,U.S. Senate,,D,Patrick Wiesner,5
-Morton,Cimarron Township,U.S. Senate,,D,Patrick Wiesner,2
-Morton,Taloga Township,U.S. Senate,,D,Patrick Wiesner,0
-Morton,Westola Township,U.S. Senate,,D,Patrick Wiesner,0
-Morton,Advance,U.S. Senate,,D,Patrick Wiesner,39
-Morton,Provisionals,U.S. Senate,,D,Patrick Wiesner,2
-Morton,Total,U.S. Senate,,D,Patrick Wiesner,108
-Morton,Ward 1,U.S. Senate,,L,Robert D. Garrard,11
-Morton,Ward 2,U.S. Senate,,L,Robert D. Garrard,11
-Morton,Ward 3,U.S. Senate,,L,Robert D. Garrard,10
-Morton,Rolla City,U.S. Senate,,L,Robert D. Garrard,5
-Morton,Rolla Township,U.S. Senate,,L,Robert D. Garrard,3
-Morton,Richfield City/West,U.S. Senate,,L,Robert D. Garrard,2
-Morton,Richfield East,U.S. Senate,,L,Robert D. Garrard,1
-Morton,Cimarron Township,U.S. Senate,,L,Robert D. Garrard,1
-Morton,Taloga Township,U.S. Senate,,L,Robert D. Garrard,2
-Morton,Westola Township,U.S. Senate,,L,Robert D. Garrard,1
-Morton,Advance,U.S. Senate,,L,Robert D. Garrard,19
-Morton,Provisionals,U.S. Senate,,L,Robert D. Garrard,2
-Morton,Total,U.S. Senate,,L,Robert D. Garrard,68
-Morton,Rolla Township,U.S. Senate,,,Write-ins,1
-Morton,Advance,U.S. Senate,,,Write-ins,1
-Morton,Total,U.S. Senate,,,Write-ins,2
-Morton,Ward 1,U.S. House,1,I,Alan LaPolice,21
-Morton,Ward 2,U.S. House,1,I,Alan LaPolice,15
-Morton,Ward 3,U.S. House,1,I,Alan LaPolice,18
-Morton,Rolla City,U.S. House,1,I,Alan LaPolice,10
-Morton,Rolla Township,U.S. House,1,I,Alan LaPolice,10
-Morton,Richfield City/West,U.S. House,1,I,Alan LaPolice,5
-Morton,Richfield East,U.S. House,1,I,Alan LaPolice,4
-Morton,Cimarron Township,U.S. House,1,I,Alan LaPolice,1
-Morton,Taloga Township,U.S. House,1,I,Alan LaPolice,2
-Morton,Westola Township,U.S. House,1,I,Alan LaPolice,2
-Morton,Advance,U.S. House,1,I,Alan LaPolice,41
-Morton,Provisionals,U.S. House,1,I,Alan LaPolice,2
-Morton,Total,U.S. House,1,I,Alan LaPolice,131
-Morton,Ward 1,U.S. House,1,R,Roger Marshall,151
-Morton,Ward 2,U.S. House,1,R,Roger Marshall,121
-Morton,Ward 3,U.S. House,1,R,Roger Marshall,122
-Morton,Rolla City,U.S. House,1,R,Roger Marshall,82
-Morton,Rolla Township,U.S. House,1,R,Roger Marshall,38
-Morton,Richfield City/West,U.S. House,1,R,Roger Marshall,22
-Morton,Richfield East,U.S. House,1,R,Roger Marshall,13
-Morton,Cimarron Township,U.S. House,1,R,Roger Marshall,18
-Morton,Jones Township,U.S. House,1,R,Roger Marshall,4
-Morton,Taloga Township,U.S. House,1,R,Roger Marshall,41
-Morton,Westola Township,U.S. House,1,R,Roger Marshall,13
-Morton,Advance,U.S. House,1,R,Roger Marshall,304
-Morton,Provisionals,U.S. House,1,R,Roger Marshall,15
-Morton,Total,U.S. House,1,R,Roger Marshall,944
-Morton,Ward 1,U.S. House,1,L,Kerry Burt,12
-Morton,Ward 2,U.S. House,1,L,Kerry Burt,9
-Morton,Ward 3,U.S. House,1,L,Kerry Burt,8
-Morton,Rolla City,U.S. House,1,L,Kerry Burt,8
-Morton,Rolla Township,U.S. House,1,L,Kerry Burt,0
-Morton,Richfield East,U.S. House,1,L,Kerry Burt,1
-Morton,Cimarron Township,U.S. House,1,L,Kerry Burt,1
-Morton,Taloga Township,U.S. House,1,L,Kerry Burt,0
-Morton,Westola Township,U.S. House,1,L,Kerry Burt,0
-Morton,Advance,U.S. House,1,L,Kerry Burt,24
-Morton,Provisionals,U.S. House,1,L,Kerry Burt,3
-Morton,Total,U.S. House,1,L,Kerry Burt,66
-Morton,Ward 1,U.S. House,1,,Write-ins,2
-Morton,Rolla City,U.S. House,1,,Write-ins,3
-Morton,Rolla Township,U.S. House,1,,Write-ins,3
-Morton,Richfield East,U.S. House,1,,Write-ins,1
-Morton,Total,U.S. House,1,,Write-ins,9
-Morton,Ward 1,State Senate,39,R,John Doll,154
-Morton,Ward 2,State Senate,39,R,John Doll,122
-Morton,Ward 3,State Senate,39,R,John Doll,131
-Morton,Rolla City,State Senate,39,R,John Doll,89
-Morton,Rolla Township,State Senate,39,R,John Doll,44
-Morton,Richfield City/West,State Senate,39,R,John Doll,26
-Morton,Richfield East,State Senate,39,R,John Doll,15
-Morton,Cimarron Township,State Senate,39,R,John Doll,16
-Morton,Jones Township,State Senate,39,R,John Doll,4
-Morton,Taloga Township,State Senate,39,R,John Doll,37
-Morton,Westola Township,State Senate,39,R,John Doll,14
-Morton,Advance,State Senate,39,R,John Doll,319
-Morton,Provisionals,State Senate,39,R,John Doll,17
-Morton,Total,State Senate,39,R,John Doll,988
-Morton,Ward 1,State Senate,39,D,A. Zacheria Wolf,29
-Morton,Ward 2,State Senate,39,D,A. Zacheria Wolf,21
-Morton,Ward 3,State Senate,39,D,A. Zacheria Wolf,14
-Morton,Rolla City,State Senate,39,D,A. Zacheria Wolf,10
-Morton,Rolla Township,State Senate,39,D,A. Zacheria Wolf,6
-Morton,Richfield City/West,State Senate,39,D,A. Zacheria Wolf,2
-Morton,Richfield East,State Senate,39,D,A. Zacheria Wolf,5
-Morton,Cimarron Township,State Senate,39,D,A. Zacheria Wolf,3
-Morton,Taloga Township,State Senate,39,D,A. Zacheria Wolf,4
-Morton,Westola Township,State Senate,39,D,A. Zacheria Wolf,0
-Morton,Advance,State Senate,39,D,A. Zacheria Wolf,53
-Morton,Provisionals,State Senate,39,D,A. Zacheria Wolf,2
-Morton,Total,State Senate,39,D,A. Zacheria Wolf,149
-Morton,Ward 1,State Senate,39,,Write-ins,1
-Morton,Rolla City,State Senate,39,,Write-ins,2
-Morton,Total,State Senate,39,,Write-ins,3
-Morton,Ward 1,State House,124,R,J. Stephen Alford,167
-Morton,Ward 2,State House,124,R,J. Stephen Alford,129
-Morton,Ward 3,State House,124,R,J. Stephen Alford,130
-Morton,Rolla City,State House,124,R,J. Stephen Alford,96
-Morton,Rolla Township,State House,124,R,J. Stephen Alford,42
-Morton,Richfield City/West,State House,124,R,J. Stephen Alford,27
-Morton,Richfield East,State House,124,R,J. Stephen Alford,18
-Morton,Cimarron Township,State House,124,R,J. Stephen Alford,18
-Morton,Jones Township,State House,124,R,J. Stephen Alford,4
-Morton,Taloga Township,State House,124,R,J. Stephen Alford,37
-Morton,Westola Township,State House,124,R,J. Stephen Alford,13
-Morton,Advance,State House,124,R,J. Stephen Alford,349
-Morton,Provisionals,State House,124,R,J. Stephen Alford,17
-Morton,Total,State House,124,R,J. Stephen Alford,1047
-Morton,Ward 1,State House,124,,Write-ins,1
-Morton,Ward 3,State House,124,,Write-ins,1
-Morton,Richfield East,State House,124,,Write-ins,1
-Morton,Advance,State House,124,,Write-ins,2
-Morton,Total,State House,124,,Write-ins,5
+county,precinct,office,district,party,candidate,votes,vtd
+MORTON,Cimarron Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",23,000010
+MORTON,East Richfield,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",29,000020
+MORTON,Elkhart Ward 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",239,000030
+MORTON,Elkhart Ward 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",207,000040
+MORTON,Elkhart Ward 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",233,000050
+MORTON,Jones Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",10,000060
+MORTON,Rolla Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",175,000070
+MORTON,Taloga Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",51,000080
+MORTON,West Richfield,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",54,000090
+MORTON,Westola Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",26,000100
+MORTON,Cimarron Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",4,000010
+MORTON,Cimarron Township,Kansas Senate,39,Republican,"Doll, John",21,000010
+MORTON,East Richfield,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",7,000020
+MORTON,East Richfield,Kansas Senate,39,Republican,"Doll, John",28,000020
+MORTON,Elkhart Ward 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",44,000030
+MORTON,Elkhart Ward 1,Kansas Senate,39,Republican,"Doll, John",213,000030
+MORTON,Elkhart Ward 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",28,000040
+MORTON,Elkhart Ward 2,Kansas Senate,39,Republican,"Doll, John",199,000040
+MORTON,Elkhart Ward 3,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",36,000050
+MORTON,Elkhart Ward 3,Kansas Senate,39,Republican,"Doll, John",220,000050
+MORTON,Jones Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,000060
+MORTON,Jones Township,Kansas Senate,39,Republican,"Doll, John",10,000060
+MORTON,Rolla Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",18,000070
+MORTON,Rolla Township,Kansas Senate,39,Republican,"Doll, John",169,000070
+MORTON,Taloga Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",5,000080
+MORTON,Taloga Township,Kansas Senate,39,Republican,"Doll, John",50,000080
+MORTON,West Richfield,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",5,000090
+MORTON,West Richfield,Kansas Senate,39,Republican,"Doll, John",52,000090
+MORTON,Westola Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",2,000100
+MORTON,Westola Township,Kansas Senate,39,Republican,"Doll, John",26,000100
+MORTON,Cimarron Township,President / Vice President,,independent,"Stein, Jill",1,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+MORTON,Cimarron Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+MORTON,Cimarron Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+MORTON,Cimarron Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+MORTON,Cimarron Township,President / Vice President,,Republican,"Trump, Donald J.",24,000010
+MORTON,East Richfield,President / Vice President,,independent,"Stein, Jill",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Hedges, James A",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"McMullin, Evan",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Perry, Darryl",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Smith, Mike",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Sood, Ajay",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+MORTON,East Richfield,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+MORTON,East Richfield,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000020
+MORTON,East Richfield,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+MORTON,East Richfield,President / Vice President,,Republican,"Trump, Donald J.",29,000020
+MORTON,Elkhart Ward 1,President / Vice President,,independent,"Stein, Jill",1,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+MORTON,Elkhart Ward 1,President / Vice President,,Republican,"Trump, Donald J.",217,000030
+MORTON,Elkhart Ward 2,President / Vice President,,independent,"Stein, Jill",4,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+MORTON,Elkhart Ward 2,President / Vice President,,Republican,"Trump, Donald J.",197,000040
+MORTON,Elkhart Ward 3,President / Vice President,,independent,"Stein, Jill",3,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000050
+MORTON,Elkhart Ward 3,President / Vice President,,Republican,"Trump, Donald J.",225,000050
+MORTON,Jones Township,President / Vice President,,independent,"Stein, Jill",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+MORTON,Jones Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+MORTON,Jones Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000060
+MORTON,Jones Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+MORTON,Jones Township,President / Vice President,,Republican,"Trump, Donald J.",10,000060
+MORTON,Rolla Township,President / Vice President,,independent,"Stein, Jill",5,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+MORTON,Rolla Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+MORTON,Rolla Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000070
+MORTON,Rolla Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+MORTON,Rolla Township,President / Vice President,,Republican,"Trump, Donald J.",161,000070
+MORTON,Taloga Township,President / Vice President,,independent,"Stein, Jill",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+MORTON,Taloga Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+MORTON,Taloga Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000080
+MORTON,Taloga Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+MORTON,Taloga Township,President / Vice President,,Republican,"Trump, Donald J.",52,000080
+MORTON,West Richfield,President / Vice President,,independent,"Stein, Jill",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Hedges, James A",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"McMullin, Evan",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Perry, Darryl",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Smith, Mike",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Sood, Ajay",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+MORTON,West Richfield,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+MORTON,West Richfield,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000090
+MORTON,West Richfield,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+MORTON,West Richfield,President / Vice President,,Republican,"Trump, Donald J.",55,000090
+MORTON,Westola Township,President / Vice President,,independent,"Stein, Jill",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+MORTON,Westola Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+MORTON,Westola Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000100
+MORTON,Westola Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+MORTON,Westola Township,President / Vice President,,Republican,"Trump, Donald J.",25,000100
+MORTON,Cimarron Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000010
+MORTON,Cimarron Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+MORTON,Cimarron Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+MORTON,Cimarron Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000010
+MORTON,East Richfield,United States House of Representatives,1,independent,"LaPolice, Alan",6,000020
+MORTON,East Richfield,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+MORTON,East Richfield,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000020
+MORTON,East Richfield,United States House of Representatives,1,Republican,"Marshall, Roger",23,000020
+MORTON,Elkhart Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",27,000030
+MORTON,Elkhart Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+MORTON,Elkhart Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000030
+MORTON,Elkhart Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",210,000030
+MORTON,Elkhart Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",24,000040
+MORTON,Elkhart Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+MORTON,Elkhart Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000040
+MORTON,Elkhart Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",190,000040
+MORTON,Elkhart Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",34,000050
+MORTON,Elkhart Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+MORTON,Elkhart Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000050
+MORTON,Elkhart Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",215,000050
+MORTON,Jones Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000060
+MORTON,Jones Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+MORTON,Jones Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+MORTON,Jones Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000060
+MORTON,Rolla Township,United States House of Representatives,1,independent,"LaPolice, Alan",25,000070
+MORTON,Rolla Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,000070
+MORTON,Rolla Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000070
+MORTON,Rolla Township,United States House of Representatives,1,Republican,"Marshall, Roger",151,000070
+MORTON,Taloga Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000080
+MORTON,Taloga Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+MORTON,Taloga Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+MORTON,Taloga Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000080
+MORTON,West Richfield,United States House of Representatives,1,independent,"LaPolice, Alan",8,000090
+MORTON,West Richfield,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+MORTON,West Richfield,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+MORTON,West Richfield,United States House of Representatives,1,Republican,"Marshall, Roger",46,000090
+MORTON,Westola Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000100
+MORTON,Westola Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+MORTON,Westola Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+MORTON,Westola Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000100
+MORTON,Cimarron Township,United States Senate,,write - in,"Smith, DJ",0,000010
+MORTON,Cimarron Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+MORTON,Cimarron Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+MORTON,Cimarron Township,United States Senate,,Republican,"Moran, Jerry",25,000010
+MORTON,East Richfield,United States Senate,,write - in,"Smith, DJ",0,000020
+MORTON,East Richfield,United States Senate,,Democratic,"Wiesner, Patrick",8,000020
+MORTON,East Richfield,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+MORTON,East Richfield,United States Senate,,Republican,"Moran, Jerry",26,000020
+MORTON,Elkhart Ward 1,United States Senate,,write - in,"Smith, DJ",0,000030
+MORTON,Elkhart Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",32,000030
+MORTON,Elkhart Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000030
+MORTON,Elkhart Ward 1,United States Senate,,Republican,"Moran, Jerry",218,000030
+MORTON,Elkhart Ward 2,United States Senate,,write - in,"Smith, DJ",0,000040
+MORTON,Elkhart Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",17,000040
+MORTON,Elkhart Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",14,000040
+MORTON,Elkhart Ward 2,United States Senate,,Republican,"Moran, Jerry",204,000040
+MORTON,Elkhart Ward 3,United States Senate,,write - in,"Smith, DJ",0,000050
+MORTON,Elkhart Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",34,000050
+MORTON,Elkhart Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",15,000050
+MORTON,Elkhart Ward 3,United States Senate,,Republican,"Moran, Jerry",219,000050
+MORTON,Jones Township,United States Senate,,write - in,"Smith, DJ",0,000060
+MORTON,Jones Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+MORTON,Jones Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+MORTON,Jones Township,United States Senate,,Republican,"Moran, Jerry",10,000060
+MORTON,Rolla Township,United States Senate,,write - in,"Smith, DJ",0,000070
+MORTON,Rolla Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000070
+MORTON,Rolla Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000070
+MORTON,Rolla Township,United States Senate,,Republican,"Moran, Jerry",173,000070
+MORTON,Taloga Township,United States Senate,,write - in,"Smith, DJ",0,000080
+MORTON,Taloga Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000080
+MORTON,Taloga Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+MORTON,Taloga Township,United States Senate,,Republican,"Moran, Jerry",55,000080
+MORTON,West Richfield,United States Senate,,write - in,"Smith, DJ",0,000090
+MORTON,West Richfield,United States Senate,,Democratic,"Wiesner, Patrick",1,000090
+MORTON,West Richfield,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+MORTON,West Richfield,United States Senate,,Republican,"Moran, Jerry",53,000090
+MORTON,Westola Township,United States Senate,,write - in,"Smith, DJ",0,000100
+MORTON,Westola Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000100
+MORTON,Westola Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000100
+MORTON,Westola Township,United States Senate,,Republican,"Moran, Jerry",27,000100

--- a/2016/20161108__ks__general__nemaha__precinct.csv
+++ b/2016/20161108__ks__general__nemaha__precinct.csv
@@ -1,404 +1,1331 @@
-county,precinct,office,district,party,candidate,votes
-Nemaha,Adams,President,,IND,Jill Stein,1
-Nemaha,Adams,President,,REP,Donald J Trump,88
-Nemaha,Adams,President,,DEM,Hillary Clinton,7
-Nemaha,Adams,President,,LIB,Gary Johnson,4
-Nemaha,Berwick,President,,IND,Jill Stein,1
-Nemaha,Berwick,President,,REP,Donald J Trump,190
-Nemaha,Berwick,President,,DEM,Hillary Clinton,13
-Nemaha,Berwick,President,,LIB,Gary Johnson,2
-Nemaha,Capioma,President,,IND,Jill Stein,0
-Nemaha,Capioma,President,,REP,Donald J Trump,65
-Nemaha,Capioma,President,,DEM,Hillary Clinton,8
-Nemaha,Capioma,President,,LIB,Gary Johnson,2
-Nemaha,Center,President,,IND,Jill Stein,2
-Nemaha,Center,President,,REP,Donald J Trump,73
-Nemaha,Center,President,,DEM,Hillary Clinton,10
-Nemaha,Center,President,,LIB,Gary Johnson,3
-Nemaha,Clear Creek,President,,IND,Jill Stein,0
-Nemaha,Clear Creek,President,,REP,Donald J Trump,41
-Nemaha,Clear Creek,President,,DEM,Hillary Clinton,15
-Nemaha,Clear Creek,President,,LIB,Gary Johnson,1
-Nemaha,Gilman,President,,IND,Jill Stein,2
-Nemaha,Gilman,President,,REP,Donald J Trump,79
-Nemaha,Gilman,President,,DEM,Hillary Clinton,19
-Nemaha,Gilman,President,,LIB,Gary Johnson,1
-Nemaha,Granada,President,,IND,Jill Stein,3
-Nemaha,Granada,President,,REP,Donald J Trump,51
-Nemaha,Granada,President,,DEM,Hillary Clinton,10
-Nemaha,Granada,President,,LIB,Gary Johnson,2
-Nemaha,Harrison-Goff,President,,IND,Jill Stein,2
-Nemaha,Harrison-Goff,President,,REP,Donald J Trump,59
-Nemaha,Harrison-Goff,President,,DEM,Hillary Clinton,17
-Nemaha,Harrison-Goff,President,,LIB,Gary Johnson,3
-Nemaha,Harrison-Kelly,President,,IND,Jill Stein,1
-Nemaha,Harrison-Kelly,President,,REP,Donald J Trump,43
-Nemaha,Harrison-Kelly,President,,DEM,Hillary Clinton,10
-Nemaha,Harrison-Kelly,President,,LIB,Gary Johnson,0
-Nemaha,Home,President,,IND,Jill Stein,0
-Nemaha,Home,President,,REP,Donald J Trump,60
-Nemaha,Home,President,,DEM,Hillary Clinton,7
-Nemaha,Home,President,,LIB,Gary Johnson,4
-Nemaha,Illinois,President,,IND,Jill Stein,2
-Nemaha,Illinois,President,,REP,Donald J Trump,200
-Nemaha,Illinois,President,,DEM,Hillary Clinton,27
-Nemaha,Illinois,President,,LIB,Gary Johnson,6
-Nemaha,Marion Township,President,,IND,Jill Stein,3
-Nemaha,Marion Township,President,,REP,Donald J Trump,185
-Nemaha,Marion Township,President,,DEM,Hillary Clinton,31
-Nemaha,Marion Township,President,,LIB,Gary Johnson,10
-Nemaha,Mitchell Township,President,,IND,Jill Stein,2
-Nemaha,Mitchell Township,President,,REP,Donald J Trump,141
-Nemaha,Mitchell Township,President,,DEM,Hillary Clinton,20
-Nemaha,Mitchell Township,President,,LIB,Gary Johnson,5
-Nemaha,Nemaha Township,President,,IND,Jill Stein,0
-Nemaha,Nemaha Township,President,,REP,Donald J Trump,76
-Nemaha,Nemaha Township,President,,DEM,Hillary Clinton,6
-Nemaha,Nemaha Township,President,,LIB,Gary Johnson,0
-Nemaha,Neuchatel,President,,IND,Jill Stein,0
-Nemaha,Neuchatel,President,,REP,Donald J Trump,58
-Nemaha,Neuchatel,President,,DEM,Hillary Clinton,3
-Nemaha,Neuchatel,President,,LIB,Gary Johnson,1
-Nemaha,Red Vermillion,President,,IND,Jill Stein,0
-Nemaha,Red Vermillion,President,,REP,Donald J Trump,52
-Nemaha,Red Vermillion,President,,DEM,Hillary Clinton,6
-Nemaha,Red Vermillion,President,,LIB,Gary Johnson,3
-Nemaha,Reilly,President,,IND,Jill Stein,3
-Nemaha,Reilly,President,,REP,Donald J Trump,51
-Nemaha,Reilly,President,,DEM,Hillary Clinton,5
-Nemaha,Reilly,President,,LIB,Gary Johnson,9
-Nemaha,Richmond Township,President,,IND,Jill Stein,4
-Nemaha,Richmond Township,President,,REP,Donald J Trump,262
-Nemaha,Richmond Township,President,,DEM,Hillary Clinton,16
-Nemaha,Richmond Township,President,,LIB,Gary Johnson,5
-Nemaha,Rock Creek,President,,IND,Jill Stein,5
-Nemaha,Rock Creek,President,,REP,Donald J Trump,185
-Nemaha,Rock Creek,President,,DEM,Hillary Clinton,12
-Nemaha,Rock Creek,President,,LIB,Gary Johnson,6
-Nemaha,Washington,President,,IND,Jill Stein,5
-Nemaha,Washington,President,,REP,Donald J Trump,176
-Nemaha,Washington,President,,DEM,Hillary Clinton,26
-Nemaha,Washington,President,,LIB,Gary Johnson,5
-Nemaha,Wetmore,President,,IND,Jill Stein,3
-Nemaha,Wetmore,President,,REP,Donald J Trump,152
-Nemaha,Wetmore,President,,DEM,Hillary Clinton,35
-Nemaha,Wetmore,President,,LIB,Gary Johnson,6
-Nemaha,Centralia-Home,President,,IND,Jill Stein,4
-Nemaha,Centralia-Home,President,,REP,Donald J Trump,124
-Nemaha,Centralia-Home,President,,DEM,Hillary Clinton,34
-Nemaha,Centralia-Home,President,,LIB,Gary Johnson,11
-Nemaha,Centralia-Illinois,President,,IND,Jill Stein,1
-Nemaha,Centralia-Illinois,President,,REP,Donald J Trump,25
-Nemaha,Centralia-Illinois,President,,DEM,Hillary Clinton,0
-Nemaha,Centralia-Illinois,President,,LIB,Gary Johnson,1
-Nemaha,Sabetha City Ward 1,President,,IND,Jill Stein,5
-Nemaha,Sabetha City Ward 1,President,,REP,Donald J Trump,229
-Nemaha,Sabetha City Ward 1,President,,DEM,Hillary Clinton,53
-Nemaha,Sabetha City Ward 1,President,,LIB,Gary Johnson,10
-Nemaha,Sabetha City Ward 2,President,,IND,Jill Stein,4
-Nemaha,Sabetha City Ward 2,President,,REP,Donald J Trump,257
-Nemaha,Sabetha City Ward 2,President,,DEM,Hillary Clinton,50
-Nemaha,Sabetha City Ward 2,President,,LIB,Gary Johnson,7
-Nemaha,Sabetha City Ward 3,President,,IND,Jill Stein,7
-Nemaha,Sabetha City Ward 3,President,,REP,Donald J Trump,263
-Nemaha,Sabetha City Ward 3,President,,DEM,Hillary Clinton,50
-Nemaha,Sabetha City Ward 3,President,,LIB,Gary Johnson,8
-Nemaha,Sabetha City Ward 4,President,,IND,Jill Stein,3
-Nemaha,Sabetha City Ward 4,President,,REP,Donald J Trump,142
-Nemaha,Sabetha City Ward 4,President,,DEM,Hillary Clinton,37
-Nemaha,Sabetha City Ward 4,President,,LIB,Gary Johnson,7
-Nemaha,Seneca City Ward 1,President,,IND,Jill Stein,6
-Nemaha,Seneca City Ward 1,President,,REP,Donald J Trump,183
-Nemaha,Seneca City Ward 1,President,,DEM,Hillary Clinton,47
-Nemaha,Seneca City Ward 1,President,,LIB,Gary Johnson,11
-Nemaha,Seneca City Ward 2,President,,IND,Jill Stein,6
-Nemaha,Seneca City Ward 2,President,,REP,Donald J Trump,294
-Nemaha,Seneca City Ward 2,President,,DEM,Hillary Clinton,85
-Nemaha,Seneca City Ward 2,President,,LIB,Gary Johnson,14
-Nemaha,Seneca City Ward 3,President,,IND,Jill Stein,7
-Nemaha,Seneca City Ward 3,President,,REP,Donald J Trump,320
-Nemaha,Seneca City Ward 3,President,,DEM,Hillary Clinton,66
-Nemaha,Seneca City Ward 3,President,,LIB,Gary Johnson,17
-Nemaha,Total,President,,IND,Jill Stein,82
-Nemaha,Total,President,,REP,Donald J Trump,4124
-Nemaha,Total,President,,DEM,Hillary Clinton,725
-Nemaha,Total,President,,LIB,Gary Johnson,164
-Nemaha,Adams,U.S. Senate,,DEM,Patrick Wiesner,9
-Nemaha,Adams,U.S. Senate,,LIB,Robert D. Garrard,0
-Nemaha,Adams,U.S. Senate,,REP,Jerry Moran,87
-Nemaha,Adams,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Adams,U.S. House,2,LIB,James Houston Bales,3
-Nemaha,Adams,U.S. House,2,REP,Lynn Jenkins,84
-Nemaha,Berwick,U.S. Senate,,DEM,Patrick Wiesner,10
-Nemaha,Berwick,U.S. Senate,,LIB,Robert D. Garrard,10
-Nemaha,Berwick,U.S. Senate,,REP,Jerry Moran,193
-Nemaha,Berwick,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Berwick,U.S. House,2,LIB,James Houston Bales,11
-Nemaha,Berwick,U.S. House,2,REP,Lynn Jenkins,187
-Nemaha,Capioma,U.S. Senate,,DEM,Patrick Wiesner,7
-Nemaha,Capioma,U.S. Senate,,LIB,Robert D. Garrard,0
-Nemaha,Capioma,U.S. Senate,,REP,Jerry Moran,72
-Nemaha,Capioma,U.S. House,2,DEM,Britani Potter,9
-Nemaha,Capioma,U.S. House,2,LIB,James Houston Bales,0
-Nemaha,Capioma,U.S. House,2,REP,Lynn Jenkins,70
-Nemaha,Center,U.S. Senate,,DEM,Patrick Wiesner,7
-Nemaha,Center,U.S. Senate,,LIB,Robert D. Garrard,0
-Nemaha,Center,U.S. Senate,,REP,Jerry Moran,80
-Nemaha,Center,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Center,U.S. House,2,LIB,James Houston Bales,2
-Nemaha,Center,U.S. House,2,REP,Lynn Jenkins,69
-Nemaha,Clear Creek,U.S. Senate,,DEM,Patrick Wiesner,10
-Nemaha,Clear Creek,U.S. Senate,,LIB,Robert D. Garrard,1
-Nemaha,Clear Creek,U.S. Senate,,REP,Jerry Moran,46
-Nemaha,Clear Creek,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Clear Creek,U.S. House,2,LIB,James Houston Bales,1
-Nemaha,Clear Creek,U.S. House,2,REP,Lynn Jenkins,45
-Nemaha,Gilman,U.S. Senate,,DEM,Patrick Wiesner,11
-Nemaha,Gilman,U.S. Senate,,LIB,Robert D. Garrard,6
-Nemaha,Gilman,U.S. Senate,,REP,Jerry Moran,83
-Nemaha,Gilman,U.S. House,2,DEM,Britani Potter,16
-Nemaha,Gilman,U.S. House,2,LIB,James Houston Bales,2
-Nemaha,Gilman,U.S. House,2,REP,Lynn Jenkins,84
-Nemaha,Granada,U.S. Senate,,DEM,Patrick Wiesner,11
-Nemaha,Granada,U.S. Senate,,LIB,Robert D. Garrard,5
-Nemaha,Granada,U.S. Senate,,REP,Jerry Moran,49
-Nemaha,Granada,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Granada,U.S. House,2,LIB,James Houston Bales,4
-Nemaha,Granada,U.S. House,2,REP,Lynn Jenkins,50
-Nemaha,Harrison-Goff,U.S. Senate,,DEM,Patrick Wiesner,18
-Nemaha,Harrison-Goff,U.S. Senate,,LIB,Robert D. Garrard,4
-Nemaha,Harrison-Goff,U.S. Senate,,REP,Jerry Moran,59
-Nemaha,Harrison-Goff,U.S. House,2,DEM,Britani Potter,18
-Nemaha,Harrison-Goff,U.S. House,2,LIB,James Houston Bales,5
-Nemaha,Harrison-Goff,U.S. House,2,REP,Lynn Jenkins,59
-Nemaha,Harrison-Kelly,U.S. Senate,,DEM,Patrick Wiesner,7
-Nemaha,Harrison-Kelly,U.S. Senate,,LIB,Robert D. Garrard,1
-Nemaha,Harrison-Kelly,U.S. Senate,,REP,Jerry Moran,47
-Nemaha,Harrison-Kelly,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Harrison-Kelly,U.S. House,2,LIB,James Houston Bales,2
-Nemaha,Harrison-Kelly,U.S. House,2,REP,Lynn Jenkins,40
-Nemaha,Home,U.S. Senate,,DEM,Patrick Wiesner,8
-Nemaha,Home,U.S. Senate,,LIB,Robert D. Garrard,3
-Nemaha,Home,U.S. Senate,,REP,Jerry Moran,63
-Nemaha,Home,U.S. House,2,DEM,Britani Potter,12
-Nemaha,Home,U.S. House,2,LIB,James Houston Bales,5
-Nemaha,Home,U.S. House,2,REP,Lynn Jenkins,57
-Nemaha,Illinois,U.S. Senate,,DEM,Patrick Wiesner,37
-Nemaha,Illinois,U.S. Senate,,LIB,Robert D. Garrard,9
-Nemaha,Illinois,U.S. Senate,,REP,Jerry Moran,187
-Nemaha,Illinois,U.S. House,2,DEM,Britani Potter,38
-Nemaha,Illinois,U.S. House,2,LIB,James Houston Bales,6
-Nemaha,Illinois,U.S. House,2,REP,Lynn Jenkins,189
-Nemaha,Marion Township,U.S. Senate,,DEM,Patrick Wiesner,28
-Nemaha,Marion Township,U.S. Senate,,LIB,Robert D. Garrard,3
-Nemaha,Marion Township,U.S. Senate,,REP,Jerry Moran,200
-Nemaha,Marion Township,U.S. House,2,DEM,Britani Potter,31
-Nemaha,Marion Township,U.S. House,2,LIB,James Houston Bales,4
-Nemaha,Marion Township,U.S. House,2,REP,Lynn Jenkins,194
-Nemaha,Mitchell Township,U.S. Senate,,DEM,Patrick Wiesner,11
-Nemaha,Mitchell Township,U.S. Senate,,LIB,Robert D. Garrard,1
-Nemaha,Mitchell Township,U.S. Senate,,REP,Jerry Moran,154
-Nemaha,Mitchell Township,U.S. House,2,DEM,Britani Potter,22
-Nemaha,Mitchell Township,U.S. House,2,LIB,James Houston Bales,4
-Nemaha,Mitchell Township,U.S. House,2,REP,Lynn Jenkins,140
-Nemaha,Nemaha Township,U.S. Senate,,DEM,Patrick Wiesner,3
-Nemaha,Nemaha Township,U.S. Senate,,LIB,Robert D. Garrard,0
-Nemaha,Nemaha Township,U.S. Senate,,REP,Jerry Moran,79
-Nemaha,Nemaha Township,U.S. House,2,DEM,Britani Potter,2
-Nemaha,Nemaha Township,U.S. House,2,LIB,James Houston Bales,1
-Nemaha,Nemaha Township,U.S. House,2,REP,Lynn Jenkins,78
-Nemaha,Neuchatel,U.S. Senate,,DEM,Patrick Wiesner,7
-Nemaha,Neuchatel,U.S. Senate,,LIB,Robert D. Garrard,1
-Nemaha,Neuchatel,U.S. Senate,,REP,Jerry Moran,53
-Nemaha,Neuchatel,U.S. House,2,DEM,Britani Potter,4
-Nemaha,Neuchatel,U.S. House,2,LIB,James Houston Bales,2
-Nemaha,Neuchatel,U.S. House,2,REP,Lynn Jenkins,56
-Nemaha,Red Vermillion,U.S. Senate,,DEM,Patrick Wiesner,11
-Nemaha,Red Vermillion,U.S. Senate,,LIB,Robert D. Garrard,2
-Nemaha,Red Vermillion,U.S. Senate,,REP,Jerry Moran,45
-Nemaha,Red Vermillion,U.S. House,2,DEM,Britani Potter,6
-Nemaha,Red Vermillion,U.S. House,2,LIB,James Houston Bales,3
-Nemaha,Red Vermillion,U.S. House,2,REP,Lynn Jenkins,49
-Nemaha,Reilly,U.S. Senate,,DEM,Patrick Wiesner,7
-Nemaha,Reilly,U.S. Senate,,LIB,Robert D. Garrard,5
-Nemaha,Reilly,U.S. Senate,,REP,Jerry Moran,57
-Nemaha,Reilly,U.S. House,2,DEM,Britani Potter,8
-Nemaha,Reilly,U.S. House,2,LIB,James Houston Bales,4
-Nemaha,Reilly,U.S. House,2,REP,Lynn Jenkins,58
-Nemaha,Richmond Township,U.S. Senate,,DEM,Patrick Wiesner,25
-Nemaha,Richmond Township,U.S. Senate,,LIB,Robert D. Garrard,4
-Nemaha,Richmond Township,U.S. Senate,,REP,Jerry Moran,254
-Nemaha,Richmond Township,U.S. House,2,DEM,Britani Potter,22
-Nemaha,Richmond Township,U.S. House,2,LIB,James Houston Bales,9
-Nemaha,Richmond Township,U.S. House,2,REP,Lynn Jenkins,256
-Nemaha,Rock Creek,U.S. Senate,,DEM,Patrick Wiesner,14
-Nemaha,Rock Creek,U.S. Senate,,LIB,Robert D. Garrard,11
-Nemaha,Rock Creek,U.S. Senate,,REP,Jerry Moran,186
-Nemaha,Rock Creek,U.S. House,2,DEM,Britani Potter,19
-Nemaha,Rock Creek,U.S. House,2,LIB,James Houston Bales,8
-Nemaha,Rock Creek,U.S. House,2,REP,Lynn Jenkins,183
-Nemaha,Washington,U.S. Senate,,DEM,Patrick Wiesner,25
-Nemaha,Washington,U.S. Senate,,LIB,Robert D. Garrard,4
-Nemaha,Washington,U.S. Senate,,REP,Jerry Moran,190
-Nemaha,Washington,U.S. House,2,DEM,Britani Potter,26
-Nemaha,Washington,U.S. House,2,LIB,James Houston Bales,6
-Nemaha,Washington,U.S. House,2,REP,Lynn Jenkins,187
-Nemaha,Wetmore,U.S. Senate,,DEM,Patrick Wiesner,39
-Nemaha,Wetmore,U.S. Senate,,LIB,Robert D. Garrard,15
-Nemaha,Wetmore,U.S. Senate,,REP,Jerry Moran,140
-Nemaha,Wetmore,U.S. House,2,DEM,Britani Potter,40
-Nemaha,Wetmore,U.S. House,2,LIB,James Houston Bales,20
-Nemaha,Wetmore,U.S. House,2,REP,Lynn Jenkins,132
-Nemaha,Centralia-Home,U.S. Senate,,DEM,Patrick Wiesner,35
-Nemaha,Centralia-Home,U.S. Senate,,LIB,Robert D. Garrard,8
-Nemaha,Centralia-Home,U.S. Senate,,REP,Jerry Moran,128
-Nemaha,Centralia-Home,U.S. House,2,DEM,Britani Potter,40
-Nemaha,Centralia-Home,U.S. House,2,LIB,James Houston Bales,8
-Nemaha,Centralia-Home,U.S. House,2,REP,Lynn Jenkins,122
-Nemaha,Centralia-Illinois,U.S. Senate,,DEM,Patrick Wiesner,4
-Nemaha,Centralia-Illinois,U.S. Senate,,LIB,Robert D. Garrard,0
-Nemaha,Centralia-Illinois,U.S. Senate,,REP,Jerry Moran,24
-Nemaha,Centralia-Illinois,U.S. House,2,DEM,Britani Potter,6
-Nemaha,Centralia-Illinois,U.S. House,2,LIB,James Houston Bales,0
-Nemaha,Centralia-Illinois,U.S. House,2,REP,Lynn Jenkins,22
-Nemaha,Sabetha City Ward 1,U.S. Senate,,DEM,Patrick Wiesner,38
-Nemaha,Sabetha City Ward 1,U.S. Senate,,LIB,Robert D. Garrard,10
-Nemaha,Sabetha City Ward 1,U.S. Senate,,REP,Jerry Moran,260
-Nemaha,Sabetha City Ward 1,U.S. House,2,DEM,Britani Potter,49
-Nemaha,Sabetha City Ward 1,U.S. House,2,LIB,James Houston Bales,14
-Nemaha,Sabetha City Ward 1,U.S. House,2,REP,Lynn Jenkins,246
-Nemaha,Sabetha City Ward 2,U.S. Senate,,DEM,Patrick Wiesner,35
-Nemaha,Sabetha City Ward 2,U.S. Senate,,LIB,Robert D. Garrard,13
-Nemaha,Sabetha City Ward 2,U.S. Senate,,REP,Jerry Moran,280
-Nemaha,Sabetha City Ward 2,U.S. House,2,DEM,Britani Potter,36
-Nemaha,Sabetha City Ward 2,U.S. House,2,LIB,James Houston Bales,20
-Nemaha,Sabetha City Ward 2,U.S. House,2,REP,Lynn Jenkins,269
-Nemaha,Sabetha City Ward 3,U.S. Senate,,DEM,Patrick Wiesner,39
-Nemaha,Sabetha City Ward 3,U.S. Senate,,LIB,Robert D. Garrard,11
-Nemaha,Sabetha City Ward 3,U.S. Senate,,REP,Jerry Moran,282
-Nemaha,Sabetha City Ward 3,U.S. House,2,DEM,Britani Potter,47
-Nemaha,Sabetha City Ward 3,U.S. House,2,LIB,James Houston Bales,9
-Nemaha,Sabetha City Ward 3,U.S. House,2,REP,Lynn Jenkins,270
-Nemaha,Sabetha City Ward 4,U.S. Senate,,DEM,Patrick Wiesner,33
-Nemaha,Sabetha City Ward 4,U.S. Senate,,LIB,Robert D. Garrard,7
-Nemaha,Sabetha City Ward 4,U.S. Senate,,REP,Jerry Moran,154
-Nemaha,Sabetha City Ward 4,U.S. House,2,DEM,Britani Potter,34
-Nemaha,Sabetha City Ward 4,U.S. House,2,LIB,James Houston Bales,11
-Nemaha,Sabetha City Ward 4,U.S. House,2,REP,Lynn Jenkins,148
-Nemaha,Seneca City Ward 1,U.S. Senate,,DEM,Patrick Wiesner,52
-Nemaha,Seneca City Ward 1,U.S. Senate,,LIB,Robert D. Garrard,8
-Nemaha,Seneca City Ward 1,U.S. Senate,,REP,Jerry Moran,188
-Nemaha,Seneca City Ward 1,U.S. House,2,DEM,Britani Potter,49
-Nemaha,Seneca City Ward 1,U.S. House,2,LIB,James Houston Bales,7
-Nemaha,Seneca City Ward 1,U.S. House,2,REP,Lynn Jenkins,191
-Nemaha,Seneca City Ward 2,U.S. Senate,,DEM,Patrick Wiesner,71
-Nemaha,Seneca City Ward 2,U.S. Senate,,LIB,Robert D. Garrard,16
-Nemaha,Seneca City Ward 2,U.S. Senate,,REP,Jerry Moran,313
-Nemaha,Seneca City Ward 2,U.S. House,2,DEM,Britani Potter,77
-Nemaha,Seneca City Ward 2,U.S. House,2,LIB,James Houston Bales,15
-Nemaha,Seneca City Ward 2,U.S. House,2,REP,Lynn Jenkins,310
-Nemaha,Seneca City Ward 3,U.S. Senate,,DEM,Patrick Wiesner,55
-Nemaha,Seneca City Ward 3,U.S. Senate,,LIB,Robert D. Garrard,7
-Nemaha,Seneca City Ward 3,U.S. Senate,,REP,Jerry Moran,341
-Nemaha,Seneca City Ward 3,U.S. House,2,DEM,Britani Potter,59
-Nemaha,Seneca City Ward 3,U.S. House,2,LIB,James Houston Bales,13
-Nemaha,Seneca City Ward 3,U.S. House,2,REP,Lynn Jenkins,334
-Nemaha,Total,U.S. Senate,,DEM,Patrick Wiesner,667
-Nemaha,Total,U.S. Senate,,LIB,Robert D. Garrard,165
-Nemaha,Total,U.S. Senate,,REP,Jerry Moran,4294
-Nemaha,Total,U.S. House,2,DEM,Britani Potter,742
-Nemaha,Total,U.S. House,2,LIB,James Houston Bales,199
-Nemaha,Total,U.S. House,2,REP,Lynn Jenkins,4179
-Nemaha,Adams,State Senate,1,REP,Dennis D. Pyle,60
-Nemaha,Adams,State Senate,1,DEM,Jerry Henry,40
-Nemaha,Adams,State House,62,REP,Randy Garber,80
-Nemaha,Berwick,State Senate,1,REP,Dennis D. Pyle,149
-Nemaha,Berwick,State Senate,1,DEM,Jerry Henry,60
-Nemaha,Berwick,State House,62,REP,Randy Garber,190
-Nemaha,Capioma,State Senate,1,REP,Dennis D. Pyle,53
-Nemaha,Capioma,State Senate,1,DEM,Jerry Henry,26
-Nemaha,Capioma,State House,62,REP,Randy Garber,61
-Nemaha,Center,State Senate,1,REP,Dennis D. Pyle,54
-Nemaha,Center,State Senate,1,DEM,Jerry Henry,32
-Nemaha,Center,State House,62,REP,Randy Garber,65
-Nemaha,Clear Creek,State Senate,1,REP,Dennis D. Pyle,27
-Nemaha,Clear Creek,State Senate,1,DEM,Jerry Henry,31
-Nemaha,Clear Creek,State House,62,REP,Randy Garber,44
-Nemaha,Gilman,State Senate,1,REP,Dennis D. Pyle,59
-Nemaha,Gilman,State Senate,1,DEM,Jerry Henry,43
-Nemaha,Gilman,State House,62,REP,Randy Garber,84
-Nemaha,Granada,State Senate,1,REP,Dennis D. Pyle,50
-Nemaha,Granada,State Senate,1,DEM,Jerry Henry,14
-Nemaha,Granada,State House,62,REP,Randy Garber,53
-Nemaha,Harrison-Goff,State Senate,1,REP,Dennis D. Pyle,59
-Nemaha,Harrison-Goff,State Senate,1,DEM,Jerry Henry,23
-Nemaha,Harrison-Goff,State House,62,REP,Randy Garber,65
-Nemaha,Harrison-Kelly,State Senate,1,REP,Dennis D. Pyle,29
-Nemaha,Harrison-Kelly,State Senate,1,DEM,Jerry Henry,25
-Nemaha,Harrison-Kelly,State House,62,REP,Randy Garber,46
-Nemaha,Home,State Senate,1,REP,Dennis D. Pyle,44
-Nemaha,Home,State Senate,1,DEM,Jerry Henry,28
-Nemaha,Home,State House,62,REP,Randy Garber,58
-Nemaha,Illinois,State Senate,1,REP,Dennis D. Pyle,160
-Nemaha,Illinois,State Senate,1,DEM,Jerry Henry,68
-Nemaha,Illinois,State House,62,REP,Randy Garber,191
-Nemaha,Marion Township,State Senate,1,REP,Dennis D. Pyle,120
-Nemaha,Marion Township,State Senate,1,DEM,Jerry Henry,111
-Nemaha,Marion Township,State House,62,REP,Randy Garber,167
-Nemaha,Mitchell Township,State Senate,1,REP,Dennis D. Pyle,104
-Nemaha,Mitchell Township,State Senate,1,DEM,Jerry Henry,59
-Nemaha,Mitchell Township,State House,62,REP,Randy Garber,133
-Nemaha,Nemaha Township,State Senate,1,REP,Dennis D. Pyle,68
-Nemaha,Nemaha Township,State Senate,1,DEM,Jerry Henry,13
-Nemaha,Nemaha Township,State House,62,REP,Randy Garber,68
-Nemaha,Neuchatel,State Senate,1,REP,Dennis D. Pyle,50
-Nemaha,Neuchatel,State Senate,1,DEM,Jerry Henry,11
-Nemaha,Neuchatel,State House,62,REP,Randy Garber,51
-Nemaha,Red Vermillion,State Senate,1,REP,Dennis D. Pyle,44
-Nemaha,Red Vermillion,State Senate,1,DEM,Jerry Henry,14
-Nemaha,Red Vermillion,State House,62,REP,Randy Garber,50
-Nemaha,Reilly,State Senate,1,REP,Dennis D. Pyle,43
-Nemaha,Reilly,State Senate,1,DEM,Jerry Henry,26
-Nemaha,Reilly,State House,62,REP,Randy Garber,62
-Nemaha,Richmond Township,State Senate,1,REP,Dennis D. Pyle,197
-Nemaha,Richmond Township,State Senate,1,DEM,Jerry Henry,88
-Nemaha,Richmond Township,State House,62,REP,Randy Garber,238
-Nemaha,Rock Creek,State Senate,1,REP,Dennis D. Pyle,127
-Nemaha,Rock Creek,State Senate,1,DEM,Jerry Henry,84
-Nemaha,Rock Creek,State House,62,REP,Randy Garber,168
-Nemaha,Washington,State Senate,1,REP,Dennis D. Pyle,161
-Nemaha,Washington,State Senate,1,DEM,Jerry Henry,58
-Nemaha,Washington,State House,62,REP,Randy Garber,184
-Nemaha,Wetmore,State Senate,1,REP,Dennis D. Pyle,128
-Nemaha,Wetmore,State Senate,1,DEM,Jerry Henry,64
-Nemaha,Wetmore,State House,62,REP,Randy Garber,148
-Nemaha,Centralia-Home,State Senate,1,REP,Dennis D. Pyle,106
-Nemaha,Centralia-Home,State Senate,1,DEM,Jerry Henry,65
-Nemaha,Centralia-Home,State House,62,REP,Randy Garber,126
-Nemaha,Centralia-Illinois,State Senate,1,REP,Dennis D. Pyle,17
-Nemaha,Centralia-Illinois,State Senate,1,DEM,Jerry Henry,10
-Nemaha,Centralia-Illinois,State House,62,REP,Randy Garber,19
-Nemaha,Sabetha City Ward 1,State Senate,1,REP,Dennis D. Pyle,171
-Nemaha,Sabetha City Ward 1,State Senate,1,DEM,Jerry Henry,127
-Nemaha,Sabetha City Ward 1,State House,62,REP,Randy Garber,228
-Nemaha,Sabetha City Ward 2,State Senate,1,REP,Dennis D. Pyle,190
-Nemaha,Sabetha City Ward 2,State Senate,1,DEM,Jerry Henry,137
-Nemaha,Sabetha City Ward 2,State House,62,REP,Randy Garber,269
-Nemaha,Sabetha City Ward 3,State Senate,1,REP,Dennis D. Pyle,194
-Nemaha,Sabetha City Ward 3,State Senate,1,DEM,Jerry Henry,131
-Nemaha,Sabetha City Ward 3,State House,62,REP,Randy Garber,261
-Nemaha,Sabetha City Ward 4,State Senate,1,REP,Dennis D. Pyle,112
-Nemaha,Sabetha City Ward 4,State Senate,1,DEM,Jerry Henry,81
-Nemaha,Sabetha City Ward 4,State House,62,REP,Randy Garber,152
-Nemaha,Seneca City Ward 1,State Senate,1,REP,Dennis D. Pyle,149
-Nemaha,Seneca City Ward 1,State Senate,1,DEM,Jerry Henry,104
-Nemaha,Seneca City Ward 1,State House,62,REP,Randy Garber,192
-Nemaha,Seneca City Ward 2,State Senate,1,REP,Dennis D. Pyle,215
-Nemaha,Seneca City Ward 2,State Senate,1,DEM,Jerry Henry,185
-Nemaha,Seneca City Ward 2,State House,62,REP,Randy Garber,285
-Nemaha,Seneca City Ward 3,State Senate,1,REP,Dennis D. Pyle,250
-Nemaha,Seneca City Ward 3,State Senate,1,DEM,Jerry Henry,160
-Nemaha,Seneca City Ward 3,State House,62,REP,Randy Garber,320
-Nemaha,Total,State Senate,1,REP,Dennis D. Pyle,3190
-Nemaha,Total,State Senate,1,DEM,Jerry Henry,1918
-Nemaha,Total,State House,62,REP,Randy Garber,4058
+county,precinct,office,district,party,candidate,votes,vtd
+NEMAHA,Adams Township,Kansas House of Representatives,62,Republican,"Garber, Randy",80,000010
+NEMAHA,Berwick Township,Kansas House of Representatives,62,Republican,"Garber, Randy",190,000020
+NEMAHA,Capioma Township,Kansas House of Representatives,62,Republican,"Garber, Randy",61,000030
+NEMAHA,Center Township,Kansas House of Representatives,62,Republican,"Garber, Randy",65,000040
+NEMAHA,Centralia,Kansas House of Representatives,62,Republican,"Garber, Randy",126,00005A
+NEMAHA,Centralia Illinois A,Kansas House of Representatives,62,Republican,"Garber, Randy",19,00005B
+NEMAHA,Centralia Illinois B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00005C
+NEMAHA,Clear Creek Township,Kansas House of Representatives,62,Republican,"Garber, Randy",44,000060
+NEMAHA,Gilman Township,Kansas House of Representatives,62,Republican,"Garber, Randy",84,000070
+NEMAHA,Granada Township,Kansas House of Representatives,62,Republican,"Garber, Randy",53,000080
+NEMAHA,Harrison - Goff,Kansas House of Representatives,62,Republican,"Garber, Randy",65,000090
+NEMAHA,Harrison - Kelly,Kansas House of Representatives,62,Republican,"Garber, Randy",46,000100
+NEMAHA,Home Township,Kansas House of Representatives,62,Republican,"Garber, Randy",58,000110
+NEMAHA,Illinois Township,Kansas House of Representatives,62,Republican,"Garber, Randy",191,000120
+NEMAHA,Marion Township,Kansas House of Representatives,62,Republican,"Garber, Randy",167,000130
+NEMAHA,Mitchell Township,Kansas House of Representatives,62,Republican,"Garber, Randy",133,000140
+NEMAHA,Nemaha Township,Kansas House of Representatives,62,Republican,"Garber, Randy",68,000150
+NEMAHA,Neuchatel Township,Kansas House of Representatives,62,Republican,"Garber, Randy",51,000160
+NEMAHA,Red Vermillion Township,Kansas House of Representatives,62,Republican,"Garber, Randy",50,000170
+NEMAHA,Reilly Township,Kansas House of Representatives,62,Republican,"Garber, Randy",62,000180
+NEMAHA,Richmond Township,Kansas House of Representatives,62,Republican,"Garber, Randy",238,000190
+NEMAHA,Rock Creek Township,Kansas House of Representatives,62,Republican,"Garber, Randy",168,00020A
+NEMAHA,Rock Creek Township Enclave A,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00020C
+NEMAHA,Sabetha Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",228,000210
+NEMAHA,Sabetha Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",269,000220
+NEMAHA,Sabetha Ward,Kansas House of Representatives,62,Republican,"Garber, Randy",261,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,00023B
+NEMAHA,Sabetha Ward 4,Kansas House of Representatives,62,Republican,"Garber, Randy",152,000240
+NEMAHA,Sabetha Ward 5,Kansas House of Representatives,62,Republican,"Garber, Randy",0,000250
+NEMAHA,Seneca Ward 1,Kansas House of Representatives,62,Republican,"Garber, Randy",192,000260
+NEMAHA,Seneca Ward 2,Kansas House of Representatives,62,Republican,"Garber, Randy",285,000270
+NEMAHA,Seneca Ward 3,Kansas House of Representatives,62,Republican,"Garber, Randy",320,000280
+NEMAHA,Washington Township,Kansas House of Representatives,62,Republican,"Garber, Randy",184,000290
+NEMAHA,Wetmore Township,Kansas House of Representatives,62,Republican,"Garber, Randy",148,000300
+NEMAHA,Richmond Township Enclave 1,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900010
+NEMAHA,Richland Township Enclave 2,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900020
+NEMAHA,Sabetha Ward Exclave,Kansas House of Representatives,62,Republican,"Garber, Randy",0,900030
+NEMAHA,Adams Township,Kansas Senate,1,Democratic,"Henry, Jerry",40,000010
+NEMAHA,Adams Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",60,000010
+NEMAHA,Berwick Township,Kansas Senate,1,Democratic,"Henry, Jerry",60,000020
+NEMAHA,Berwick Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",149,000020
+NEMAHA,Capioma Township,Kansas Senate,1,Democratic,"Henry, Jerry",26,000030
+NEMAHA,Capioma Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",53,000030
+NEMAHA,Center Township,Kansas Senate,1,Democratic,"Henry, Jerry",32,000040
+NEMAHA,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",54,000040
+NEMAHA,Centralia,Kansas Senate,1,Democratic,"Henry, Jerry",65,00005A
+NEMAHA,Centralia,Kansas Senate,1,Republican,"Pyle, Dennis D.",106,00005A
+NEMAHA,Centralia Illinois A,Kansas Senate,1,Democratic,"Henry, Jerry",10,00005B
+NEMAHA,Centralia Illinois A,Kansas Senate,1,Republican,"Pyle, Dennis D.",17,00005B
+NEMAHA,Centralia Illinois B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00005C
+NEMAHA,Centralia Illinois B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00005C
+NEMAHA,Clear Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",31,000060
+NEMAHA,Clear Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",27,000060
+NEMAHA,Gilman Township,Kansas Senate,1,Democratic,"Henry, Jerry",43,000070
+NEMAHA,Gilman Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",59,000070
+NEMAHA,Granada Township,Kansas Senate,1,Democratic,"Henry, Jerry",14,000080
+NEMAHA,Granada Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",50,000080
+NEMAHA,Harrison - Goff,Kansas Senate,1,Democratic,"Henry, Jerry",23,000090
+NEMAHA,Harrison - Goff,Kansas Senate,1,Republican,"Pyle, Dennis D.",59,000090
+NEMAHA,Harrison - Kelly,Kansas Senate,1,Democratic,"Henry, Jerry",25,000100
+NEMAHA,Harrison - Kelly,Kansas Senate,1,Republican,"Pyle, Dennis D.",29,000100
+NEMAHA,Home Township,Kansas Senate,1,Democratic,"Henry, Jerry",28,000110
+NEMAHA,Home Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",44,000110
+NEMAHA,Illinois Township,Kansas Senate,1,Democratic,"Henry, Jerry",68,000120
+NEMAHA,Illinois Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",160,000120
+NEMAHA,Marion Township,Kansas Senate,1,Democratic,"Henry, Jerry",111,000130
+NEMAHA,Marion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",120,000130
+NEMAHA,Mitchell Township,Kansas Senate,1,Democratic,"Henry, Jerry",59,000140
+NEMAHA,Mitchell Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",104,000140
+NEMAHA,Nemaha Township,Kansas Senate,1,Democratic,"Henry, Jerry",13,000150
+NEMAHA,Nemaha Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",68,000150
+NEMAHA,Neuchatel Township,Kansas Senate,1,Democratic,"Henry, Jerry",11,000160
+NEMAHA,Neuchatel Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",50,000160
+NEMAHA,Red Vermillion Township,Kansas Senate,1,Democratic,"Henry, Jerry",14,000170
+NEMAHA,Red Vermillion Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",44,000170
+NEMAHA,Reilly Township,Kansas Senate,1,Democratic,"Henry, Jerry",26,000180
+NEMAHA,Reilly Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",43,000180
+NEMAHA,Richmond Township,Kansas Senate,1,Democratic,"Henry, Jerry",88,000190
+NEMAHA,Richmond Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",197,000190
+NEMAHA,Rock Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",84,00020A
+NEMAHA,Rock Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",127,00020A
+NEMAHA,Rock Creek Township Enclave A,Kansas Senate,1,Democratic,"Henry, Jerry",0,00020B
+NEMAHA,Rock Creek Township Enclave A,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00020B
+NEMAHA,Rock Creek Township Enclave B,Kansas Senate,1,Democratic,"Henry, Jerry",0,00020C
+NEMAHA,Rock Creek Township Enclave B,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00020C
+NEMAHA,Sabetha Ward 1,Kansas Senate,1,Democratic,"Henry, Jerry",127,000210
+NEMAHA,Sabetha Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",171,000210
+NEMAHA,Sabetha Ward 2,Kansas Senate,1,Democratic,"Henry, Jerry",137,000220
+NEMAHA,Sabetha Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",190,000220
+NEMAHA,Sabetha Ward,Kansas Senate,1,Democratic,"Henry, Jerry",131,00023A
+NEMAHA,Sabetha Ward,Kansas Senate,1,Republican,"Pyle, Dennis D.",194,00023A
+NEMAHA,Sabetha Ward 3 Enclave,Kansas Senate,1,Democratic,"Henry, Jerry",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,00023B
+NEMAHA,Sabetha Ward 4,Kansas Senate,1,Democratic,"Henry, Jerry",81,000240
+NEMAHA,Sabetha Ward 4,Kansas Senate,1,Republican,"Pyle, Dennis D.",112,000240
+NEMAHA,Sabetha Ward 5,Kansas Senate,1,Democratic,"Henry, Jerry",0,000250
+NEMAHA,Sabetha Ward 5,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,000250
+NEMAHA,Seneca Ward 1,Kansas Senate,1,Democratic,"Henry, Jerry",104,000260
+NEMAHA,Seneca Ward 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",149,000260
+NEMAHA,Seneca Ward 2,Kansas Senate,1,Democratic,"Henry, Jerry",185,000270
+NEMAHA,Seneca Ward 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",215,000270
+NEMAHA,Seneca Ward 3,Kansas Senate,1,Democratic,"Henry, Jerry",160,000280
+NEMAHA,Seneca Ward 3,Kansas Senate,1,Republican,"Pyle, Dennis D.",250,000280
+NEMAHA,Washington Township,Kansas Senate,1,Democratic,"Henry, Jerry",58,000290
+NEMAHA,Washington Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",161,000290
+NEMAHA,Wetmore Township,Kansas Senate,1,Democratic,"Henry, Jerry",64,000300
+NEMAHA,Wetmore Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",128,000300
+NEMAHA,Richmond Township Enclave 1,Kansas Senate,1,Democratic,"Henry, Jerry",0,900010
+NEMAHA,Richmond Township Enclave 1,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900010
+NEMAHA,Richland Township Enclave 2,Kansas Senate,1,Democratic,"Henry, Jerry",0,900020
+NEMAHA,Richland Township Enclave 2,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900020
+NEMAHA,Sabetha Ward Exclave,Kansas Senate,1,Democratic,"Henry, Jerry",0,900030
+NEMAHA,Sabetha Ward Exclave,Kansas Senate,1,Republican,"Pyle, Dennis D.",0,900030
+NEMAHA,Adams Township,President / Vice President,,independent,"Stein, Jill",1,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+NEMAHA,Adams Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+NEMAHA,Adams Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000010
+NEMAHA,Adams Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000010
+NEMAHA,Adams Township,President / Vice President,,Republican,"Trump, Donald J.",88,000010
+NEMAHA,Berwick Township,President / Vice President,,independent,"Stein, Jill",1,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"McMullin, Evan",2,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+NEMAHA,Berwick Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+NEMAHA,Berwick Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000020
+NEMAHA,Berwick Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+NEMAHA,Berwick Township,President / Vice President,,Republican,"Trump, Donald J.",190,000020
+NEMAHA,Capioma Township,President / Vice President,,independent,"Stein, Jill",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+NEMAHA,Capioma Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+NEMAHA,Capioma Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000030
+NEMAHA,Capioma Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+NEMAHA,Capioma Township,President / Vice President,,Republican,"Trump, Donald J.",65,000030
+NEMAHA,Center Township,President / Vice President,,independent,"Stein, Jill",2,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+NEMAHA,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+NEMAHA,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000040
+NEMAHA,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+NEMAHA,Center Township,President / Vice President,,Republican,"Trump, Donald J.",73,000040
+NEMAHA,Centralia,President / Vice President,,independent,"Stein, Jill",4,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Hedges, James A",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"McMullin, Evan",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Smith, Mike",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+NEMAHA,Centralia,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+NEMAHA,Centralia,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,00005A
+NEMAHA,Centralia,President / Vice President,,Libertarian,"Johnson, Gary",11,00005A
+NEMAHA,Centralia,President / Vice President,,Republican,"Trump, Donald J.",124,00005A
+NEMAHA,Centralia Illinois A,President / Vice President,,independent,"Stein, Jill",1,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Hedges, James A",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"McMullin, Evan",1,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Smith, Mike",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Libertarian,"Johnson, Gary",1,00005B
+NEMAHA,Centralia Illinois A,President / Vice President,,Republican,"Trump, Donald J.",25,00005B
+NEMAHA,Centralia Illinois B,President / Vice President,,independent,"Stein, Jill",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Castle, Darrell L",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Giordani, Rocky",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Hedges, James A",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Hoefling, Tom",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Kahn, Lynn",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"La Riva, Gloria",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Levinson, Michael S.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Maturen, Michael A",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"McMullin, Evan",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Perry, Darryl",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Schriner, Joe C",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Smith, Mike",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Sood, Ajay",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Sterling, Shawna",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Libertarian,"Johnson, Gary",0,00005C
+NEMAHA,Centralia Illinois B,President / Vice President,,Republican,"Trump, Donald J.",0,00005C
+NEMAHA,Clear Creek Township,President / Vice President,,independent,"Stein, Jill",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+NEMAHA,Clear Creek Township,President / Vice President,,Republican,"Trump, Donald J.",41,000060
+NEMAHA,Gilman Township,President / Vice President,,independent,"Stein, Jill",2,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+NEMAHA,Gilman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+NEMAHA,Gilman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000070
+NEMAHA,Gilman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+NEMAHA,Gilman Township,President / Vice President,,Republican,"Trump, Donald J.",79,000070
+NEMAHA,Granada Township,President / Vice President,,independent,"Stein, Jill",3,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+NEMAHA,Granada Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+NEMAHA,Granada Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000080
+NEMAHA,Granada Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+NEMAHA,Granada Township,President / Vice President,,Republican,"Trump, Donald J.",51,000080
+NEMAHA,Harrison - Goff,President / Vice President,,independent,"Stein, Jill",2,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Hedges, James A",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"McMullin, Evan",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Perry, Darryl",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Smith, Mike",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Sood, Ajay",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+NEMAHA,Harrison - Goff,President / Vice President,,Republican,"Trump, Donald J.",59,000090
+NEMAHA,Harrison - Kelly,President / Vice President,,independent,"Stein, Jill",1,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Hedges, James A",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"McMullin, Evan",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Perry, Darryl",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Smith, Mike",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Sood, Ajay",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+NEMAHA,Harrison - Kelly,President / Vice President,,Republican,"Trump, Donald J.",43,000100
+NEMAHA,Home Township,President / Vice President,,independent,"Stein, Jill",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+NEMAHA,Home Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+NEMAHA,Home Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000110
+NEMAHA,Home Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000110
+NEMAHA,Home Township,President / Vice President,,Republican,"Trump, Donald J.",60,000110
+NEMAHA,Illinois Township,President / Vice President,,independent,"Stein, Jill",2,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+NEMAHA,Illinois Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+NEMAHA,Illinois Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000120
+NEMAHA,Illinois Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000120
+NEMAHA,Illinois Township,President / Vice President,,Republican,"Trump, Donald J.",200,000120
+NEMAHA,Marion Township,President / Vice President,,independent,"Stein, Jill",3,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+NEMAHA,Marion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+NEMAHA,Marion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000130
+NEMAHA,Marion Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000130
+NEMAHA,Marion Township,President / Vice President,,Republican,"Trump, Donald J.",185,000130
+NEMAHA,Mitchell Township,President / Vice President,,independent,"Stein, Jill",2,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"McMullin, Evan",1,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+NEMAHA,Mitchell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000140
+NEMAHA,Mitchell Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000140
+NEMAHA,Mitchell Township,President / Vice President,,Republican,"Trump, Donald J.",141,000140
+NEMAHA,Nemaha Township,President / Vice President,,independent,"Stein, Jill",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000150
+NEMAHA,Nemaha Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+NEMAHA,Nemaha Township,President / Vice President,,Republican,"Trump, Donald J.",76,000150
+NEMAHA,Neuchatel Township,President / Vice President,,independent,"Stein, Jill",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Castle, Darrell L",1,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+NEMAHA,Neuchatel Township,President / Vice President,,Republican,"Trump, Donald J.",58,000160
+NEMAHA,Red Vermillion Township,President / Vice President,,independent,"Stein, Jill",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+NEMAHA,Red Vermillion Township,President / Vice President,,Republican,"Trump, Donald J.",52,000170
+NEMAHA,Reilly Township,President / Vice President,,independent,"Stein, Jill",3,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+NEMAHA,Reilly Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+NEMAHA,Reilly Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000180
+NEMAHA,Reilly Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000180
+NEMAHA,Reilly Township,President / Vice President,,Republican,"Trump, Donald J.",51,000180
+NEMAHA,Richmond Township,President / Vice President,,independent,"Stein, Jill",4,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+NEMAHA,Richmond Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+NEMAHA,Richmond Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000190
+NEMAHA,Richmond Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000190
+NEMAHA,Richmond Township,President / Vice President,,Republican,"Trump, Donald J.",262,000190
+NEMAHA,Rock Creek Township,President / Vice President,,independent,"Stein, Jill",5,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Castle, Darrell L",1,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Hedges, James A",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"McMullin, Evan",3,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Smith, Mike",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",6,00020A
+NEMAHA,Rock Creek Township,President / Vice President,,Republican,"Trump, Donald J.",185,00020A
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,independent,"Stein, Jill",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00020B
+NEMAHA,Rock Creek Township Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00020B
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,independent,"Stein, Jill",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00020C
+NEMAHA,Rock Creek Township Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00020C
+NEMAHA,Sabetha Ward 1,President / Vice President,,independent,"Stein, Jill",5,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Castle, Darrell L",2,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"McMullin, Evan",4,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000210
+NEMAHA,Sabetha Ward 1,President / Vice President,,Republican,"Trump, Donald J.",229,000210
+NEMAHA,Sabetha Ward 2,President / Vice President,,independent,"Stein, Jill",4,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000220
+NEMAHA,Sabetha Ward 2,President / Vice President,,Republican,"Trump, Donald J.",257,000220
+NEMAHA,Sabetha Ward,President / Vice President,,independent,"Stein, Jill",7,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Castle, Darrell L",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Giordani, Rocky",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Hedges, James A",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Hoefling, Tom",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Kahn, Lynn",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"La Riva, Gloria",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Levinson, Michael S.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Maturen, Michael A",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"McMullin, Evan",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Perry, Darryl",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Schriner, Joe C",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Smith, Mike",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Sood, Ajay",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Sterling, Shawna",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Libertarian,"Johnson, Gary",8,00023A
+NEMAHA,Sabetha Ward,President / Vice President,,Republican,"Trump, Donald J.",263,00023A
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,independent,"Stein, Jill",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Hedges, James A",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Smith, Mike",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00023B
+NEMAHA,Sabetha Ward 4,President / Vice President,,independent,"Stein, Jill",3,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"McMullin, Evan",7,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",7,000240
+NEMAHA,Sabetha Ward 4,President / Vice President,,Republican,"Trump, Donald J.",142,000240
+NEMAHA,Sabetha Ward 5,President / Vice President,,independent,"Stein, Jill",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Hedges, James A",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Smith, Mike",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+NEMAHA,Sabetha Ward 5,President / Vice President,,Republican,"Trump, Donald J.",0,000250
+NEMAHA,Seneca Ward 1,President / Vice President,,independent,"Stein, Jill",6,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",11,000260
+NEMAHA,Seneca Ward 1,President / Vice President,,Republican,"Trump, Donald J.",183,000260
+NEMAHA,Seneca Ward 2,President / Vice President,,independent,"Stein, Jill",6,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",85,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000270
+NEMAHA,Seneca Ward 2,President / Vice President,,Republican,"Trump, Donald J.",294,000270
+NEMAHA,Seneca Ward 3,President / Vice President,,independent,"Stein, Jill",7,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",17,000280
+NEMAHA,Seneca Ward 3,President / Vice President,,Republican,"Trump, Donald J.",320,000280
+NEMAHA,Washington Township,President / Vice President,,independent,"Stein, Jill",5,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"McMullin, Evan",1,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+NEMAHA,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+NEMAHA,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000290
+NEMAHA,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000290
+NEMAHA,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",176,000290
+NEMAHA,Wetmore Township,President / Vice President,,independent,"Stein, Jill",3,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"McMullin, Evan",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+NEMAHA,Wetmore Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000300
+NEMAHA,Wetmore Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000300
+NEMAHA,Wetmore Township,President / Vice President,,Republican,"Trump, Donald J.",152,000300
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+NEMAHA,Richmond Township Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+NEMAHA,Richland Township Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+NEMAHA,Richland Township Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,independent,"Stein, Jill",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Hedges, James A",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Smith, Mike",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+NEMAHA,Sabetha Ward Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+NEMAHA,Adams Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000010
+NEMAHA,Adams Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000010
+NEMAHA,Adams Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000010
+NEMAHA,Berwick Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000020
+NEMAHA,Berwick Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000020
+NEMAHA,Berwick Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",187,000020
+NEMAHA,Capioma Township,United States House of Representatives,2,Democratic,"Potter, Britani",9,000030
+NEMAHA,Capioma Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000030
+NEMAHA,Capioma Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000030
+NEMAHA,Center Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000040
+NEMAHA,Center Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000040
+NEMAHA,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",69,000040
+NEMAHA,Centralia,United States House of Representatives,2,Democratic,"Potter, Britani",40,00005A
+NEMAHA,Centralia,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,00005A
+NEMAHA,Centralia,United States House of Representatives,2,Republican,"Jenkins, Lynn",122,00005A
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Democratic,"Potter, Britani",6,00005B
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005B
+NEMAHA,Centralia Illinois A,United States House of Representatives,2,Republican,"Jenkins, Lynn",22,00005B
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00005C
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00005C
+NEMAHA,Centralia Illinois B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00005C
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000060
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000060
+NEMAHA,Clear Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",45,000060
+NEMAHA,Gilman Township,United States House of Representatives,2,Democratic,"Potter, Britani",16,000070
+NEMAHA,Gilman Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000070
+NEMAHA,Gilman Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000070
+NEMAHA,Granada Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000080
+NEMAHA,Granada Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000080
+NEMAHA,Granada Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",50,000080
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Democratic,"Potter, Britani",18,000090
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000090
+NEMAHA,Harrison - Goff,United States House of Representatives,2,Republican,"Jenkins, Lynn",59,000090
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Democratic,"Potter, Britani",12,000100
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000100
+NEMAHA,Harrison - Kelly,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000100
+NEMAHA,Home Township,United States House of Representatives,2,Democratic,"Potter, Britani",12,000110
+NEMAHA,Home Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000110
+NEMAHA,Home Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",57,000110
+NEMAHA,Illinois Township,United States House of Representatives,2,Democratic,"Potter, Britani",38,000120
+NEMAHA,Illinois Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000120
+NEMAHA,Illinois Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",189,000120
+NEMAHA,Marion Township,United States House of Representatives,2,Democratic,"Potter, Britani",31,000130
+NEMAHA,Marion Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000130
+NEMAHA,Marion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",194,000130
+NEMAHA,Mitchell Township,United States House of Representatives,2,Democratic,"Potter, Britani",22,000140
+NEMAHA,Mitchell Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000140
+NEMAHA,Mitchell Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",140,000140
+NEMAHA,Nemaha Township,United States House of Representatives,2,Democratic,"Potter, Britani",2,000150
+NEMAHA,Nemaha Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000150
+NEMAHA,Nemaha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",78,000150
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Democratic,"Potter, Britani",4,000160
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000160
+NEMAHA,Neuchatel Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",56,000160
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Democratic,"Potter, Britani",6,000170
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000170
+NEMAHA,Red Vermillion Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",49,000170
+NEMAHA,Reilly Township,United States House of Representatives,2,Democratic,"Potter, Britani",8,000180
+NEMAHA,Reilly Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000180
+NEMAHA,Reilly Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",58,000180
+NEMAHA,Richmond Township,United States House of Representatives,2,Democratic,"Potter, Britani",22,000190
+NEMAHA,Richmond Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000190
+NEMAHA,Richmond Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",256,000190
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,00020A
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,00020A
+NEMAHA,Rock Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",183,00020A
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020B
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00020C
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",49,000210
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000210
+NEMAHA,Sabetha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",246,000210
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",36,000220
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000220
+NEMAHA,Sabetha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",269,000220
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Democratic,"Potter, Britani",47,00023A
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,00023A
+NEMAHA,Sabetha Ward,United States House of Representatives,2,Republican,"Jenkins, Lynn",270,00023A
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00023B
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",34,000240
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000240
+NEMAHA,Sabetha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",148,000240
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Democratic,"Potter, Britani",0,000250
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,000250
+NEMAHA,Sabetha Ward 5,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,000250
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",49,000260
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000260
+NEMAHA,Seneca Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",191,000260
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",77,000270
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000270
+NEMAHA,Seneca Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",310,000270
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",59,000280
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000280
+NEMAHA,Seneca Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",334,000280
+NEMAHA,Washington Township,United States House of Representatives,2,Democratic,"Potter, Britani",26,000290
+NEMAHA,Washington Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000290
+NEMAHA,Washington Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",187,000290
+NEMAHA,Wetmore Township,United States House of Representatives,2,Democratic,"Potter, Britani",40,000300
+NEMAHA,Wetmore Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",20,000300
+NEMAHA,Wetmore Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",132,000300
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+NEMAHA,Richmond Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+NEMAHA,Richland Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+NEMAHA,Sabetha Ward Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+NEMAHA,Adams Township,United States Senate,,write - in,"Smith, DJ",0,000010
+NEMAHA,Adams Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000010
+NEMAHA,Adams Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+NEMAHA,Adams Township,United States Senate,,Republican,"Moran, Jerry",87,000010
+NEMAHA,Berwick Township,United States Senate,,write - in,"Smith, DJ",0,000020
+NEMAHA,Berwick Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000020
+NEMAHA,Berwick Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000020
+NEMAHA,Berwick Township,United States Senate,,Republican,"Moran, Jerry",193,000020
+NEMAHA,Capioma Township,United States Senate,,write - in,"Smith, DJ",0,000030
+NEMAHA,Capioma Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000030
+NEMAHA,Capioma Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+NEMAHA,Capioma Township,United States Senate,,Republican,"Moran, Jerry",72,000030
+NEMAHA,Center Township,United States Senate,,write - in,"Smith, DJ",0,000040
+NEMAHA,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000040
+NEMAHA,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+NEMAHA,Center Township,United States Senate,,Republican,"Moran, Jerry",80,000040
+NEMAHA,Centralia,United States Senate,,write - in,"Smith, DJ",0,00005A
+NEMAHA,Centralia,United States Senate,,Democratic,"Wiesner, Patrick",35,00005A
+NEMAHA,Centralia,United States Senate,,Libertarian,"Garrard, Robert D.",8,00005A
+NEMAHA,Centralia,United States Senate,,Republican,"Moran, Jerry",128,00005A
+NEMAHA,Centralia Illinois A,United States Senate,,write - in,"Smith, DJ",0,00005B
+NEMAHA,Centralia Illinois A,United States Senate,,Democratic,"Wiesner, Patrick",4,00005B
+NEMAHA,Centralia Illinois A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+NEMAHA,Centralia Illinois A,United States Senate,,Republican,"Moran, Jerry",24,00005B
+NEMAHA,Centralia Illinois B,United States Senate,,write - in,"Smith, DJ",0,00005C
+NEMAHA,Centralia Illinois B,United States Senate,,Democratic,"Wiesner, Patrick",0,00005C
+NEMAHA,Centralia Illinois B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005C
+NEMAHA,Centralia Illinois B,United States Senate,,Republican,"Moran, Jerry",0,00005C
+NEMAHA,Clear Creek Township,United States Senate,,write - in,"Smith, DJ",0,000060
+NEMAHA,Clear Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000060
+NEMAHA,Clear Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+NEMAHA,Clear Creek Township,United States Senate,,Republican,"Moran, Jerry",46,000060
+NEMAHA,Gilman Township,United States Senate,,write - in,"Smith, DJ",0,000070
+NEMAHA,Gilman Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000070
+NEMAHA,Gilman Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000070
+NEMAHA,Gilman Township,United States Senate,,Republican,"Moran, Jerry",83,000070
+NEMAHA,Granada Township,United States Senate,,write - in,"Smith, DJ",0,000080
+NEMAHA,Granada Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000080
+NEMAHA,Granada Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000080
+NEMAHA,Granada Township,United States Senate,,Republican,"Moran, Jerry",49,000080
+NEMAHA,Harrison - Goff,United States Senate,,write - in,"Smith, DJ",0,000090
+NEMAHA,Harrison - Goff,United States Senate,,Democratic,"Wiesner, Patrick",18,000090
+NEMAHA,Harrison - Goff,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+NEMAHA,Harrison - Goff,United States Senate,,Republican,"Moran, Jerry",59,000090
+NEMAHA,Harrison - Kelly,United States Senate,,write - in,"Smith, DJ",0,000100
+NEMAHA,Harrison - Kelly,United States Senate,,Democratic,"Wiesner, Patrick",7,000100
+NEMAHA,Harrison - Kelly,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+NEMAHA,Harrison - Kelly,United States Senate,,Republican,"Moran, Jerry",47,000100
+NEMAHA,Home Township,United States Senate,,write - in,"Smith, DJ",0,000110
+NEMAHA,Home Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000110
+NEMAHA,Home Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000110
+NEMAHA,Home Township,United States Senate,,Republican,"Moran, Jerry",63,000110
+NEMAHA,Illinois Township,United States Senate,,write - in,"Smith, DJ",0,000120
+NEMAHA,Illinois Township,United States Senate,,Democratic,"Wiesner, Patrick",37,000120
+NEMAHA,Illinois Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000120
+NEMAHA,Illinois Township,United States Senate,,Republican,"Moran, Jerry",187,000120
+NEMAHA,Marion Township,United States Senate,,write - in,"Smith, DJ",0,000130
+NEMAHA,Marion Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000130
+NEMAHA,Marion Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000130
+NEMAHA,Marion Township,United States Senate,,Republican,"Moran, Jerry",200,000130
+NEMAHA,Mitchell Township,United States Senate,,write - in,"Smith, DJ",0,000140
+NEMAHA,Mitchell Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000140
+NEMAHA,Mitchell Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+NEMAHA,Mitchell Township,United States Senate,,Republican,"Moran, Jerry",154,000140
+NEMAHA,Nemaha Township,United States Senate,,write - in,"Smith, DJ",0,000150
+NEMAHA,Nemaha Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000150
+NEMAHA,Nemaha Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+NEMAHA,Nemaha Township,United States Senate,,Republican,"Moran, Jerry",79,000150
+NEMAHA,Neuchatel Township,United States Senate,,write - in,"Smith, DJ",0,000160
+NEMAHA,Neuchatel Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000160
+NEMAHA,Neuchatel Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+NEMAHA,Neuchatel Township,United States Senate,,Republican,"Moran, Jerry",53,000160
+NEMAHA,Red Vermillion Township,United States Senate,,write - in,"Smith, DJ",0,000170
+NEMAHA,Red Vermillion Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000170
+NEMAHA,Red Vermillion Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000170
+NEMAHA,Red Vermillion Township,United States Senate,,Republican,"Moran, Jerry",45,000170
+NEMAHA,Reilly Township,United States Senate,,write - in,"Smith, DJ",0,000180
+NEMAHA,Reilly Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000180
+NEMAHA,Reilly Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000180
+NEMAHA,Reilly Township,United States Senate,,Republican,"Moran, Jerry",57,000180
+NEMAHA,Richmond Township,United States Senate,,write - in,"Smith, DJ",0,000190
+NEMAHA,Richmond Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000190
+NEMAHA,Richmond Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000190
+NEMAHA,Richmond Township,United States Senate,,Republican,"Moran, Jerry",254,000190
+NEMAHA,Rock Creek Township,United States Senate,,write - in,"Smith, DJ",0,00020A
+NEMAHA,Rock Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",14,00020A
+NEMAHA,Rock Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,00020A
+NEMAHA,Rock Creek Township,United States Senate,,Republican,"Moran, Jerry",186,00020A
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,write - in,"Smith, DJ",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00020B
+NEMAHA,Rock Creek Township Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00020B
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,write - in,"Smith, DJ",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00020C
+NEMAHA,Rock Creek Township Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00020C
+NEMAHA,Sabetha Ward 1,United States Senate,,write - in,"Smith, DJ",0,000210
+NEMAHA,Sabetha Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",38,000210
+NEMAHA,Sabetha Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",10,000210
+NEMAHA,Sabetha Ward 1,United States Senate,,Republican,"Moran, Jerry",260,000210
+NEMAHA,Sabetha Ward 2,United States Senate,,write - in,"Smith, DJ",0,000220
+NEMAHA,Sabetha Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",35,000220
+NEMAHA,Sabetha Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",13,000220
+NEMAHA,Sabetha Ward 2,United States Senate,,Republican,"Moran, Jerry",280,000220
+NEMAHA,Sabetha Ward,United States Senate,,write - in,"Smith, DJ",0,00023A
+NEMAHA,Sabetha Ward,United States Senate,,Democratic,"Wiesner, Patrick",39,00023A
+NEMAHA,Sabetha Ward,United States Senate,,Libertarian,"Garrard, Robert D.",11,00023A
+NEMAHA,Sabetha Ward,United States Senate,,Republican,"Moran, Jerry",282,00023A
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,write - in,"Smith, DJ",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00023B
+NEMAHA,Sabetha Ward 3 Enclave,United States Senate,,Republican,"Moran, Jerry",0,00023B
+NEMAHA,Sabetha Ward 4,United States Senate,,write - in,"Smith, DJ",0,000240
+NEMAHA,Sabetha Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",33,000240
+NEMAHA,Sabetha Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",7,000240
+NEMAHA,Sabetha Ward 4,United States Senate,,Republican,"Moran, Jerry",154,000240
+NEMAHA,Sabetha Ward 5,United States Senate,,write - in,"Smith, DJ",0,000250
+NEMAHA,Sabetha Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",0,000250
+NEMAHA,Sabetha Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,000250
+NEMAHA,Sabetha Ward 5,United States Senate,,Republican,"Moran, Jerry",0,000250
+NEMAHA,Seneca Ward 1,United States Senate,,write - in,"Smith, DJ",0,000260
+NEMAHA,Seneca Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",52,000260
+NEMAHA,Seneca Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",8,000260
+NEMAHA,Seneca Ward 1,United States Senate,,Republican,"Moran, Jerry",188,000260
+NEMAHA,Seneca Ward 2,United States Senate,,write - in,"Smith, DJ",0,000270
+NEMAHA,Seneca Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",71,000270
+NEMAHA,Seneca Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000270
+NEMAHA,Seneca Ward 2,United States Senate,,Republican,"Moran, Jerry",313,000270
+NEMAHA,Seneca Ward 3,United States Senate,,write - in,"Smith, DJ",0,000280
+NEMAHA,Seneca Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",55,000280
+NEMAHA,Seneca Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",7,000280
+NEMAHA,Seneca Ward 3,United States Senate,,Republican,"Moran, Jerry",341,000280
+NEMAHA,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000290
+NEMAHA,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000290
+NEMAHA,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000290
+NEMAHA,Washington Township,United States Senate,,Republican,"Moran, Jerry",190,000290
+NEMAHA,Wetmore Township,United States Senate,,write - in,"Smith, DJ",0,000300
+NEMAHA,Wetmore Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000300
+NEMAHA,Wetmore Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000300
+NEMAHA,Wetmore Township,United States Senate,,Republican,"Moran, Jerry",140,000300
+NEMAHA,Richmond Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+NEMAHA,Richmond Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+NEMAHA,Richmond Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+NEMAHA,Richmond Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010
+NEMAHA,Richland Township Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900020
+NEMAHA,Richland Township Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+NEMAHA,Richland Township Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+NEMAHA,Richland Township Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900020
+NEMAHA,Sabetha Ward Exclave,United States Senate,,write - in,"Smith, DJ",0,900030
+NEMAHA,Sabetha Ward Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+NEMAHA,Sabetha Ward Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+NEMAHA,Sabetha Ward Exclave,United States Senate,,Republican,"Moran, Jerry",0,900030

--- a/2016/20161108__ks__general__neosho__precinct.csv
+++ b/2016/20161108__ks__general__neosho__precinct.csv
@@ -1,1177 +1,1177 @@
-county,precinct,office,district,candidate,party,votes
-Neosho,Big Creek Township,President,,"Stein, Jill  ",independent,4
-Neosho,Big Creek Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Big Creek Township,President,,"Castle, Darrell L ",Write-ins,1
-Neosho,Big Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Big Creek Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Big Creek Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Big Creek Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Big Creek Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Big Creek Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Big Creek Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Big Creek Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Big Creek Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Big Creek Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Big Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,32
-Neosho,Big Creek Township,President,,"Johnson, Gary  ",Libertarian,13
-Neosho,Big Creek Township,President,,"Trump, Donald J. ",Republican,182
-Neosho,Canville Township,President,,"Stein, Jill  ",independent,2
-Neosho,Canville Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Canville Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Canville Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Canville Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Canville Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Canville Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Canville Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Canville Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Canville Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Canville Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Canville Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Canville Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Canville Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Canville Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Canville Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Canville Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Canville Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Canville Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Canville Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Canville Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Canville Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Canville Township,President,,"Clinton, Hillary Rodham ",Democratic,71
-Neosho,Canville Township,President,,"Johnson, Gary  ",Libertarian,12
-Neosho,Canville Township,President,,"Trump, Donald J. ",Republican,210
-Neosho,Centerville Township,President,,"Stein, Jill  ",independent,1
-Neosho,Centerville Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Centerville Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Centerville Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Centerville Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Centerville Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Centerville Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Centerville Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Centerville Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Centerville Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Centerville Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Centerville Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Centerville Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Centerville Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Centerville Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Centerville Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Centerville Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Centerville Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Centerville Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Centerville Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Centerville Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Centerville Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Centerville Township,President,,"Clinton, Hillary Rodham ",Democratic,55
-Neosho,Centerville Township,President,,"Johnson, Gary  ",Libertarian,4
-Neosho,Centerville Township,President,,"Trump, Donald J. ",Republican,185
-Neosho,Chanute Ward 1,President,,"Stein, Jill  ",independent,6
-Neosho,Chanute Ward 1,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,23
-Neosho,Chanute Ward 1,President,,"Johnson, Gary  ",Libertarian,1
-Neosho,Chanute Ward 1,President,,"Trump, Donald J. ",Republican,65
-Neosho,Chanute Ward 2 Precinct 1,President,,"Stein, Jill  ",independent,9
-Neosho,Chanute Ward 2 Precinct 1,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,79
-Neosho,Chanute Ward 2 Precinct 1,President,,"Johnson, Gary  ",Libertarian,15
-Neosho,Chanute Ward 2 Precinct 1,President,,"Trump, Donald J. ",Republican,173
-Neosho,Chanute Ward 2 Precinct 2,President,,"Stein, Jill  ",independent,7
-Neosho,Chanute Ward 2 Precinct 2,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,68
-Neosho,Chanute Ward 2 Precinct 2,President,,"Johnson, Gary  ",Libertarian,12
-Neosho,Chanute Ward 2 Precinct 2,President,,"Trump, Donald J. ",Republican,230
-Neosho,Chanute Ward 3 Precinct 1,President,,"Stein, Jill  ",independent,14
-Neosho,Chanute Ward 3 Precinct 1,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"McMullin, Evan  ",Write-ins,3
-Neosho,Chanute Ward 3 Precinct 1,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,133
-Neosho,Chanute Ward 3 Precinct 1,President,,"Johnson, Gary  ",Libertarian,24
-Neosho,Chanute Ward 3 Precinct 1,President,,"Trump, Donald J. ",Republican,302
-Neosho,Chanute Ward 3 Precinct 2,President,,"Stein, Jill  ",independent,2
-Neosho,Chanute Ward 3 Precinct 2,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"McMullin, Evan  ",Write-ins,3
-Neosho,Chanute Ward 3 Precinct 2,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,101
-Neosho,Chanute Ward 3 Precinct 2,President,,"Johnson, Gary  ",Libertarian,10
-Neosho,Chanute Ward 3 Precinct 2,President,,"Trump, Donald J. ",Republican,205
-Neosho,Chanute Ward 3 Precinct 3,President,,"Stein, Jill  ",independent,11
-Neosho,Chanute Ward 3 Precinct 3,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,President,,"Clinton, Hillary Rodham ",Democratic,188
-Neosho,Chanute Ward 3 Precinct 3,President,,"Johnson, Gary  ",Libertarian,29
-Neosho,Chanute Ward 3 Precinct 3,President,,"Trump, Donald J. ",Republican,390
-Neosho,Chanute Ward 4 Precinct 1,President,,"Stein, Jill  ",independent,7
-Neosho,Chanute Ward 4 Precinct 1,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Castle, Darrell L ",Write-ins,4
-Neosho,Chanute Ward 4 Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"McMullin, Evan  ",Write-ins,1
-Neosho,Chanute Ward 4 Precinct 1,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,123
-Neosho,Chanute Ward 4 Precinct 1,President,,"Johnson, Gary  ",Libertarian,15
-Neosho,Chanute Ward 4 Precinct 1,President,,"Trump, Donald J. ",Republican,207
-Neosho,Chanute Ward 4 Precinct 2,President,,"Stein, Jill  ",independent,4
-Neosho,Chanute Ward 4 Precinct 2,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,86
-Neosho,Chanute Ward 4 Precinct 2,President,,"Johnson, Gary  ",Libertarian,14
-Neosho,Chanute Ward 4 Precinct 2,President,,"Trump, Donald J. ",Republican,172
-Neosho,Chanute Ward 4 Precinct 3,President,,"Stein, Jill  ",independent,7
-Neosho,Chanute Ward 4 Precinct 3,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,President,,"Clinton, Hillary Rodham ",Democratic,49
-Neosho,Chanute Ward 4 Precinct 3,President,,"Johnson, Gary  ",Libertarian,2
-Neosho,Chanute Ward 4 Precinct 3,President,,"Trump, Donald J. ",Republican,151
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Stein, Jill  ",independent,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,President,,"Trump, Donald J. ",Republican,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Stein, Jill  ",independent,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,President,,"Trump, Donald J. ",Republican,0
-Neosho,East Erie,President,,"Stein, Jill  ",independent,7
-Neosho,East Erie,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,East Erie,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,East Erie,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,East Erie,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,East Erie,President,,"Hedges, James A ",Write-ins,0
-Neosho,East Erie,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,East Erie,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,East Erie,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,East Erie,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,East Erie,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,East Erie,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,East Erie,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,East Erie,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,East Erie,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,East Erie,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,East Erie,President,,"Smith, Mike  ",Write-ins,0
-Neosho,East Erie,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,East Erie,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,East Erie,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,East Erie,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,East Erie,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,East Erie,President,,"Clinton, Hillary Rodham ",Democratic,72
-Neosho,East Erie,President,,"Johnson, Gary  ",Libertarian,12
-Neosho,East Erie,President,,"Trump, Donald J. ",Republican,188
-Neosho,Grant Township,President,,"Stein, Jill  ",independent,8
-Neosho,Grant Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Grant Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Grant Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Grant Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Grant Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Grant Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Grant Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Grant Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Grant Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Grant Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Grant Township,President,,"McMullin, Evan  ",Write-ins,2
-Neosho,Grant Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Grant Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Grant Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Grant Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Grant Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Grant Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Grant Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Grant Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Grant Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Grant Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Grant Township,President,,"Clinton, Hillary Rodham ",Democratic,45
-Neosho,Grant Township,President,,"Johnson, Gary  ",Libertarian,8
-Neosho,Grant Township,President,,"Trump, Donald J. ",Republican,122
-Neosho,Ladore Township,President,,"Stein, Jill  ",independent,6
-Neosho,Ladore Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Ladore Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Ladore Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Ladore Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Ladore Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Ladore Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Ladore Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Ladore Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Ladore Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Ladore Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Ladore Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Ladore Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Ladore Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Ladore Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Ladore Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Ladore Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Ladore Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Ladore Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Ladore Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Ladore Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Ladore Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Ladore Township,President,,"Clinton, Hillary Rodham ",Democratic,54
-Neosho,Ladore Township,President,,"Johnson, Gary  ",Libertarian,4
-Neosho,Ladore Township,President,,"Trump, Donald J. ",Republican,109
-Neosho,Lincoln Township,President,,"Stein, Jill  ",independent,2
-Neosho,Lincoln Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Lincoln Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Lincoln Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Lincoln Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Lincoln Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Lincoln Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Lincoln Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Lincoln Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Lincoln Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Lincoln Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Lincoln Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Lincoln Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Lincoln Township,President,,"Clinton, Hillary Rodham ",Democratic,22
-Neosho,Lincoln Township,President,,"Johnson, Gary  ",Libertarian,3
-Neosho,Lincoln Township,President,,"Trump, Donald J. ",Republican,69
-Neosho,Mission Township,President,,"Stein, Jill  ",independent,8
-Neosho,Mission Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Mission Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Mission Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Mission Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Mission Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Mission Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Mission Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Mission Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Mission Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Mission Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Mission Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Mission Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Mission Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Mission Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Mission Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Mission Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Mission Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Mission Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Mission Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Mission Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Mission Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Mission Township,President,,"Clinton, Hillary Rodham ",Democratic,73
-Neosho,Mission Township,President,,"Johnson, Gary  ",Libertarian,14
-Neosho,Mission Township,President,,"Trump, Donald J. ",Republican,317
-Neosho,North Tioga Township,President,,"Stein, Jill  ",independent,1
-Neosho,North Tioga Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,North Tioga Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,North Tioga Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,North Tioga Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,North Tioga Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,North Tioga Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,North Tioga Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,North Tioga Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,North Tioga Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,North Tioga Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,North Tioga Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,North Tioga Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,North Tioga Township,President,,"Clinton, Hillary Rodham ",Democratic,40
-Neosho,North Tioga Township,President,,"Johnson, Gary  ",Libertarian,8
-Neosho,North Tioga Township,President,,"Trump, Donald J. ",Republican,166
-Neosho,Shiloh Township,President,,"Stein, Jill  ",independent,1
-Neosho,Shiloh Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Shiloh Township,President,,"Castle, Darrell L ",Write-ins,1
-Neosho,Shiloh Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Shiloh Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Shiloh Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Shiloh Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Shiloh Township,President,,"McMullin, Evan  ",Write-ins,2
-Neosho,Shiloh Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Shiloh Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Shiloh Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Shiloh Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Shiloh Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Shiloh Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Shiloh Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Neosho,Shiloh Township,President,,"Johnson, Gary  ",Libertarian,3
-Neosho,Shiloh Township,President,,"Trump, Donald J. ",Republican,143
-Neosho,South Tioga East Township,President,,"Stein, Jill  ",independent,0
-Neosho,South Tioga East Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,South Tioga East Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,South Tioga East Township,President,,"McMullin, Evan  ",Write-ins,1
-Neosho,South Tioga East Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,South Tioga East Township,President,,"Clinton, Hillary Rodham ",Democratic,25
-Neosho,South Tioga East Township,President,,"Johnson, Gary  ",Libertarian,6
-Neosho,South Tioga East Township,President,,"Trump, Donald J. ",Republican,83
-Neosho,South Tioga West Township,President,,"Stein, Jill  ",independent,0
-Neosho,South Tioga West Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,South Tioga West Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,South Tioga West Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,South Tioga West Township,President,,"Clinton, Hillary Rodham ",Democratic,13
-Neosho,South Tioga West Township,President,,"Johnson, Gary  ",Libertarian,2
-Neosho,South Tioga West Township,President,,"Trump, Donald J. ",Republican,66
-Neosho,South Tioga West Township Enclave,President,,"Stein, Jill  ",independent,0
-Neosho,South Tioga West Township Enclave,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Hedges, James A ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Smith, Mike  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,South Tioga West Township Enclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,South Tioga West Township Enclave,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,South Tioga West Township Enclave,President,,"Trump, Donald J. ",Republican,0
-Neosho,South Tioga West Township Enclave B,President,,"Stein, Jill  ",independent,0
-Neosho,South Tioga West Township Enclave B,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Hedges, James A ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Smith, Mike  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,South Tioga West Township Enclave B,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,South Tioga West Township Enclave B,President,,"Trump, Donald J. ",Republican,0
-Neosho,South Tioga West Township Enclave C,President,,"Stein, Jill  ",independent,0
-Neosho,South Tioga West Township Enclave C,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Hedges, James A ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Smith, Mike  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,South Tioga West Township Enclave C,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,South Tioga West Township Enclave C,President,,"Trump, Donald J. ",Republican,0
-Neosho,Walnut Grove Township,President,,"Stein, Jill  ",independent,3
-Neosho,Walnut Grove Township,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Hedges, James A ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Walnut Grove Township,President,,"Clinton, Hillary Rodham ",Democratic,31
-Neosho,Walnut Grove Township,President,,"Johnson, Gary  ",Libertarian,10
-Neosho,Walnut Grove Township,President,,"Trump, Donald J. ",Republican,110
-Neosho,West Erie,President,,"Stein, Jill  ",independent,5
-Neosho,West Erie,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,West Erie,President,,"Castle, Darrell L ",Write-ins,2
-Neosho,West Erie,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,West Erie,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,West Erie,President,,"Hedges, James A ",Write-ins,0
-Neosho,West Erie,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,West Erie,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,West Erie,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,West Erie,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,West Erie,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,West Erie,President,,"McMullin, Evan  ",Write-ins,2
-Neosho,West Erie,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,West Erie,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,West Erie,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,West Erie,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,West Erie,President,,"Smith, Mike  ",Write-ins,0
-Neosho,West Erie,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,West Erie,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,West Erie,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,West Erie,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,West Erie,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,West Erie,President,,"Clinton, Hillary Rodham ",Democratic,62
-Neosho,West Erie,President,,"Johnson, Gary  ",Libertarian,9
-Neosho,West Erie,President,,"Trump, Donald J. ",Republican,260
-Neosho,Chetopa Township H13,President,,"Stein, Jill  ",independent,3
-Neosho,Chetopa Township H13,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chetopa Township H13,President,,"Clinton, Hillary Rodham ",Democratic,40
-Neosho,Chetopa Township H13,President,,"Johnson, Gary  ",Libertarian,8
-Neosho,Chetopa Township H13,President,,"Trump, Donald J. ",Republican,236
-Neosho,Chetopa Township H2,President,,"Stein, Jill  ",independent,0
-Neosho,Chetopa Township H2,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chetopa Township H2,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,Chetopa Township H2,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,Chetopa Township H2,President,,"Trump, Donald J. ",Republican,0
-Neosho,Chetopa Township H9,President,,"Stein, Jill  ",independent,2
-Neosho,Chetopa Township H9,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chetopa Township H9,President,,"Clinton, Hillary Rodham ",Democratic,8
-Neosho,Chetopa Township H9,President,,"Johnson, Gary  ",Libertarian,2
-Neosho,Chetopa Township H9,President,,"Trump, Donald J. ",Republican,90
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Stein, Jill  ",independent,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,President,,"Trump, Donald J. ",Republican,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Stein, Jill  ",independent,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Basiago, Andrew D. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Castle, Darrell L ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Giordani, Rocky  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Hedges, James A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Hoefling, Tom  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Kahn, Lynn  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"La Riva, Gloria  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Levinson, Michael S. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Maturen, Michael A ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"McMullin, Evan  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Moorehead, Monica G. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Perry, Darryl  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Schoenke, Marshall R. ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Schriner, Joe C ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Smith, Mike  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Sood, Ajay  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Sterling, Shawna  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Valdivia, Anthony J ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Vogel-Walcutt, J.J.  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Wysinger, Demetra Jefferson ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,President,,"Trump, Donald J. ",Republican,0
-Neosho,Big Creek Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Big Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,28
-Neosho,Big Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,19
-Neosho,Big Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,192
-Neosho,Canville Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Canville Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,64
-Neosho,Canville Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,21
-Neosho,Canville Township,U.S. Senate,,"Moran, Jerry  ",Republican,208
-Neosho,Centerville Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Centerville Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,57
-Neosho,Centerville Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Neosho,Centerville Township,U.S. Senate,,"Moran, Jerry  ",Republican,174
-Neosho,Chanute Ward 1,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,24
-Neosho,Chanute Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Neosho,Chanute Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,61
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,80
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,24
-Neosho,Chanute Ward 2 Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,168
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,74
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,25
-Neosho,Chanute Ward 2 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,211
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,132
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,45
-Neosho,Chanute Ward 3 Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,299
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,84
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,19
-Neosho,Chanute Ward 3 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,210
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,149
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,42
-Neosho,Chanute Ward 3 Precinct 3,U.S. Senate,,"Moran, Jerry  ",Republican,421
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,101
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,34
-Neosho,Chanute Ward 4 Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,220
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,85
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,22
-Neosho,Chanute Ward 4 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,166
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,44
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,18
-Neosho,Chanute Ward 4 Precinct 3,U.S. Senate,,"Moran, Jerry  ",Republican,149
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,East Erie,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,East Erie,U.S. Senate,,"Wiesner, Patrick  ",Democratic,63
-Neosho,East Erie,U.S. Senate,,"Garrard, Robert D. ",Libertarian,20
-Neosho,East Erie,U.S. Senate,,"Moran, Jerry  ",Republican,194
-Neosho,Grant Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Grant Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,39
-Neosho,Grant Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Neosho,Grant Township,U.S. Senate,,"Moran, Jerry  ",Republican,128
-Neosho,Ladore Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Ladore Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,57
-Neosho,Ladore Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,6
-Neosho,Ladore Township,U.S. Senate,,"Moran, Jerry  ",Republican,109
-Neosho,Lincoln Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Lincoln Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,25
-Neosho,Lincoln Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Neosho,Lincoln Township,U.S. Senate,,"Moran, Jerry  ",Republican,60
-Neosho,Mission Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Mission Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,85
-Neosho,Mission Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,19
-Neosho,Mission Township,U.S. Senate,,"Moran, Jerry  ",Republican,301
-Neosho,North Tioga Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,North Tioga Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,39
-Neosho,North Tioga Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,7
-Neosho,North Tioga Township,U.S. Senate,,"Moran, Jerry  ",Republican,168
-Neosho,Shiloh Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Shiloh Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,13
-Neosho,Shiloh Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,11
-Neosho,Shiloh Township,U.S. Senate,,"Moran, Jerry  ",Republican,132
-Neosho,South Tioga East Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,South Tioga East Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,23
-Neosho,South Tioga East Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,10
-Neosho,South Tioga East Township,U.S. Senate,,"Moran, Jerry  ",Republican,78
-Neosho,South Tioga West Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,South Tioga West Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,7
-Neosho,South Tioga West Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Neosho,South Tioga West Township,U.S. Senate,,"Moran, Jerry  ",Republican,68
-Neosho,South Tioga West Township Enclave,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,South Tioga West Township Enclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,South Tioga West Township Enclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,South Tioga West Township Enclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,South Tioga West Township Enclave B,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,South Tioga West Township Enclave B,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,South Tioga West Township Enclave B,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,South Tioga West Township Enclave B,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,South Tioga West Township Enclave C,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,South Tioga West Township Enclave C,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,South Tioga West Township Enclave C,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,South Tioga West Township Enclave C,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,Walnut Grove Township,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Walnut Grove Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,39
-Neosho,Walnut Grove Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-Neosho,Walnut Grove Township,U.S. Senate,,"Moran, Jerry  ",Republican,104
-Neosho,West Erie,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,West Erie,U.S. Senate,,"Wiesner, Patrick  ",Democratic,67
-Neosho,West Erie,U.S. Senate,,"Garrard, Robert D. ",Libertarian,22
-Neosho,West Erie,U.S. Senate,,"Moran, Jerry  ",Republican,249
-Neosho,Chetopa Township H13,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chetopa Township H13,U.S. Senate,,"Wiesner, Patrick  ",Democratic,39
-Neosho,Chetopa Township H13,U.S. Senate,,"Garrard, Robert D. ",Libertarian,21
-Neosho,Chetopa Township H13,U.S. Senate,,"Moran, Jerry  ",Republican,224
-Neosho,Chetopa Township H2,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chetopa Township H2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,Chetopa Township H2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,Chetopa Township H2,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,Chetopa Township H9,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chetopa Township H9,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9
-Neosho,Chetopa Township H9,U.S. Senate,,"Garrard, Robert D. ",Libertarian,6
-Neosho,Chetopa Township H9,U.S. Senate,,"Moran, Jerry  ",Republican,84
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. Senate,,"Smith, DJ  ",Write-ins,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Neosho,Big Creek Township,U.S. House,2,"Potter, Britani  ",Democratic,30
-Neosho,Big Creek Township,U.S. House,2,"Bales, James Houston ",Libertarian,14
-Neosho,Big Creek Township,U.S. House,2,"Jenkins, Lynn  ",Republican,199
-Neosho,Canville Township,U.S. House,2,"Potter, Britani  ",Democratic,56
-Neosho,Canville Township,U.S. House,2,"Bales, James Houston ",Libertarian,13
-Neosho,Canville Township,U.S. House,2,"Jenkins, Lynn  ",Republican,226
-Neosho,Centerville Township,U.S. House,2,"Potter, Britani  ",Democratic,57
-Neosho,Centerville Township,U.S. House,2,"Bales, James Houston ",Libertarian,8
-Neosho,Centerville Township,U.S. House,2,"Jenkins, Lynn  ",Republican,176
-Neosho,Chanute Ward 1,U.S. House,2,"Potter, Britani  ",Democratic,20
-Neosho,Chanute Ward 1,U.S. House,2,"Bales, James Houston ",Libertarian,11
-Neosho,Chanute Ward 1,U.S. House,2,"Jenkins, Lynn  ",Republican,63
-Neosho,Chanute Ward 2 Precinct 1,U.S. House,2,"Potter, Britani  ",Democratic,63
-Neosho,Chanute Ward 2 Precinct 1,U.S. House,2,"Bales, James Houston ",Libertarian,21
-Neosho,Chanute Ward 2 Precinct 1,U.S. House,2,"Jenkins, Lynn  ",Republican,189
-Neosho,Chanute Ward 2 Precinct 2,U.S. House,2,"Potter, Britani  ",Democratic,60
-Neosho,Chanute Ward 2 Precinct 2,U.S. House,2,"Bales, James Houston ",Libertarian,17
-Neosho,Chanute Ward 2 Precinct 2,U.S. House,2,"Jenkins, Lynn  ",Republican,238
-Neosho,Chanute Ward 3 Precinct 1,U.S. House,2,"Potter, Britani  ",Democratic,111
-Neosho,Chanute Ward 3 Precinct 1,U.S. House,2,"Bales, James Houston ",Libertarian,39
-Neosho,Chanute Ward 3 Precinct 1,U.S. House,2,"Jenkins, Lynn  ",Republican,325
-Neosho,Chanute Ward 3 Precinct 2,U.S. House,2,"Potter, Britani  ",Democratic,61
-Neosho,Chanute Ward 3 Precinct 2,U.S. House,2,"Bales, James Houston ",Libertarian,15
-Neosho,Chanute Ward 3 Precinct 2,U.S. House,2,"Jenkins, Lynn  ",Republican,240
-Neosho,Chanute Ward 3 Precinct 3,U.S. House,2,"Potter, Britani  ",Democratic,144
-Neosho,Chanute Ward 3 Precinct 3,U.S. House,2,"Bales, James Houston ",Libertarian,25
-Neosho,Chanute Ward 3 Precinct 3,U.S. House,2,"Jenkins, Lynn  ",Republican,445
-Neosho,Chanute Ward 4 Precinct 1,U.S. House,2,"Potter, Britani  ",Democratic,96
-Neosho,Chanute Ward 4 Precinct 1,U.S. House,2,"Bales, James Houston ",Libertarian,25
-Neosho,Chanute Ward 4 Precinct 1,U.S. House,2,"Jenkins, Lynn  ",Republican,233
-Neosho,Chanute Ward 4 Precinct 2,U.S. House,2,"Potter, Britani  ",Democratic,68
-Neosho,Chanute Ward 4 Precinct 2,U.S. House,2,"Bales, James Houston ",Libertarian,21
-Neosho,Chanute Ward 4 Precinct 2,U.S. House,2,"Jenkins, Lynn  ",Republican,185
-Neosho,Chanute Ward 4 Precinct 3,U.S. House,2,"Potter, Britani  ",Democratic,42
-Neosho,Chanute Ward 4 Precinct 3,U.S. House,2,"Bales, James Houston ",Libertarian,13
-Neosho,Chanute Ward 4 Precinct 3,U.S. House,2,"Jenkins, Lynn  ",Republican,158
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,East Erie,U.S. House,2,"Potter, Britani  ",Democratic,54
-Neosho,East Erie,U.S. House,2,"Bales, James Houston ",Libertarian,24
-Neosho,East Erie,U.S. House,2,"Jenkins, Lynn  ",Republican,200
-Neosho,Grant Township,U.S. House,2,"Potter, Britani  ",Democratic,33
-Neosho,Grant Township,U.S. House,2,"Bales, James Houston ",Libertarian,9
-Neosho,Grant Township,U.S. House,2,"Jenkins, Lynn  ",Republican,141
-Neosho,Ladore Township,U.S. House,2,"Potter, Britani  ",Democratic,54
-Neosho,Ladore Township,U.S. House,2,"Bales, James Houston ",Libertarian,7
-Neosho,Ladore Township,U.S. House,2,"Jenkins, Lynn  ",Republican,113
-Neosho,Lincoln Township,U.S. House,2,"Potter, Britani  ",Democratic,20
-Neosho,Lincoln Township,U.S. House,2,"Bales, James Houston ",Libertarian,4
-Neosho,Lincoln Township,U.S. House,2,"Jenkins, Lynn  ",Republican,74
-Neosho,Mission Township,U.S. House,2,"Potter, Britani  ",Democratic,84
-Neosho,Mission Township,U.S. House,2,"Bales, James Houston ",Libertarian,10
-Neosho,Mission Township,U.S. House,2,"Jenkins, Lynn  ",Republican,317
-Neosho,North Tioga Township,U.S. House,2,"Potter, Britani  ",Democratic,37
-Neosho,North Tioga Township,U.S. House,2,"Bales, James Houston ",Libertarian,10
-Neosho,North Tioga Township,U.S. House,2,"Jenkins, Lynn  ",Republican,169
-Neosho,Shiloh Township,U.S. House,2,"Potter, Britani  ",Democratic,14
-Neosho,Shiloh Township,U.S. House,2,"Bales, James Houston ",Libertarian,8
-Neosho,Shiloh Township,U.S. House,2,"Jenkins, Lynn  ",Republican,139
-Neosho,South Tioga East Township,U.S. House,2,"Potter, Britani  ",Democratic,19
-Neosho,South Tioga East Township,U.S. House,2,"Bales, James Houston ",Libertarian,4
-Neosho,South Tioga East Township,U.S. House,2,"Jenkins, Lynn  ",Republican,86
-Neosho,South Tioga West Township,U.S. House,2,"Potter, Britani  ",Democratic,9
-Neosho,South Tioga West Township,U.S. House,2,"Bales, James Houston ",Libertarian,3
-Neosho,South Tioga West Township,U.S. House,2,"Jenkins, Lynn  ",Republican,71
-Neosho,South Tioga West Township Enclave,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,South Tioga West Township Enclave,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,South Tioga West Township Enclave,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,South Tioga West Township Enclave B,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,South Tioga West Township Enclave B,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,South Tioga West Township Enclave B,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,South Tioga West Township Enclave C,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,South Tioga West Township Enclave C,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,South Tioga West Township Enclave C,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,Walnut Grove Township,U.S. House,2,"Potter, Britani  ",Democratic,33
-Neosho,Walnut Grove Township,U.S. House,2,"Bales, James Houston ",Libertarian,6
-Neosho,Walnut Grove Township,U.S. House,2,"Jenkins, Lynn  ",Republican,113
-Neosho,West Erie,U.S. House,2,"Potter, Britani  ",Democratic,60
-Neosho,West Erie,U.S. House,2,"Bales, James Houston ",Libertarian,15
-Neosho,West Erie,U.S. House,2,"Jenkins, Lynn  ",Republican,257
-Neosho,Chetopa Township H13,U.S. House,2,"Potter, Britani  ",Democratic,39
-Neosho,Chetopa Township H13,U.S. House,2,"Bales, James Houston ",Libertarian,8
-Neosho,Chetopa Township H13,U.S. House,2,"Jenkins, Lynn  ",Republican,236
-Neosho,Chetopa Township H2,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,Chetopa Township H2,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,Chetopa Township H2,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,Chetopa Township H9,U.S. House,2,"Potter, Britani  ",Democratic,8
-Neosho,Chetopa Township H9,U.S. House,2,"Bales, James Houston ",Libertarian,2
-Neosho,Chetopa Township H9,U.S. House,2,"Jenkins, Lynn  ",Republican,92
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. House,2,"Potter, Britani  ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. House,2,"Bales, James Houston ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,U.S. House,2,"Jenkins, Lynn  ",Republican,0
-Neosho,Big Creek Township,State Senate,15,"Schmidt, Chuck  ",Democratic,72
-Neosho,Big Creek Township,State Senate,15,"Goddard, Dan  ",Republican,170
-Neosho,Canville Township,State Senate,15,"Schmidt, Chuck  ",Democratic,103
-Neosho,Canville Township,State Senate,15,"Goddard, Dan  ",Republican,182
-Neosho,Centerville Township,State Senate,15,"Schmidt, Chuck  ",Democratic,79
-Neosho,Centerville Township,State Senate,15,"Goddard, Dan  ",Republican,163
-Neosho,Chanute Ward 1,State Senate,15,"Schmidt, Chuck  ",Democratic,35
-Neosho,Chanute Ward 1,State Senate,15,"Goddard, Dan  ",Republican,59
-Neosho,Chanute Ward 2 Precinct 1,State Senate,15,"Schmidt, Chuck  ",Democratic,125
-Neosho,Chanute Ward 2 Precinct 1,State Senate,15,"Goddard, Dan  ",Republican,148
-Neosho,Chanute Ward 2 Precinct 2,State Senate,15,"Schmidt, Chuck  ",Democratic,123
-Neosho,Chanute Ward 2 Precinct 2,State Senate,15,"Goddard, Dan  ",Republican,187
-Neosho,Chanute Ward 3 Precinct 1,State Senate,15,"Schmidt, Chuck  ",Democratic,227
-Neosho,Chanute Ward 3 Precinct 1,State Senate,15,"Goddard, Dan  ",Republican,246
-Neosho,Chanute Ward 3 Precinct 2,State Senate,15,"Schmidt, Chuck  ",Democratic,134
-Neosho,Chanute Ward 3 Precinct 2,State Senate,15,"Goddard, Dan  ",Republican,183
-Neosho,Chanute Ward 3 Precinct 3,State Senate,15,"Schmidt, Chuck  ",Democratic,235
-Neosho,Chanute Ward 3 Precinct 3,State Senate,15,"Goddard, Dan  ",Republican,374
-Neosho,Chanute Ward 4 Precinct 1,State Senate,15,"Schmidt, Chuck  ",Democratic,145
-Neosho,Chanute Ward 4 Precinct 1,State Senate,15,"Goddard, Dan  ",Republican,204
-Neosho,Chanute Ward 4 Precinct 2,State Senate,15,"Schmidt, Chuck  ",Democratic,138
-Neosho,Chanute Ward 4 Precinct 2,State Senate,15,"Goddard, Dan  ",Republican,137
-Neosho,Chanute Ward 4 Precinct 3,State Senate,15,"Schmidt, Chuck  ",Democratic,70
-Neosho,Chanute Ward 4 Precinct 3,State Senate,15,"Goddard, Dan  ",Republican,137
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,East Erie,State Senate,15,"Schmidt, Chuck  ",Democratic,130
-Neosho,East Erie,State Senate,15,"Goddard, Dan  ",Republican,148
-Neosho,Grant Township,State Senate,15,"Schmidt, Chuck  ",Democratic,66
-Neosho,Grant Township,State Senate,15,"Goddard, Dan  ",Republican,109
-Neosho,Ladore Township,State Senate,15,"Schmidt, Chuck  ",Democratic,80
-Neosho,Ladore Township,State Senate,15,"Goddard, Dan  ",Republican,93
-Neosho,Lincoln Township,State Senate,15,"Schmidt, Chuck  ",Democratic,26
-Neosho,Lincoln Township,State Senate,15,"Goddard, Dan  ",Republican,70
-Neosho,Mission Township,State Senate,15,"Schmidt, Chuck  ",Democratic,143
-Neosho,Mission Township,State Senate,15,"Goddard, Dan  ",Republican,260
-Neosho,North Tioga Township,State Senate,15,"Schmidt, Chuck  ",Democratic,59
-Neosho,North Tioga Township,State Senate,15,"Goddard, Dan  ",Republican,156
-Neosho,Shiloh Township,State Senate,15,"Schmidt, Chuck  ",Democratic,35
-Neosho,Shiloh Township,State Senate,15,"Goddard, Dan  ",Republican,123
-Neosho,South Tioga East Township,State Senate,15,"Schmidt, Chuck  ",Democratic,34
-Neosho,South Tioga East Township,State Senate,15,"Goddard, Dan  ",Republican,76
-Neosho,South Tioga West Township,State Senate,15,"Schmidt, Chuck  ",Democratic,16
-Neosho,South Tioga West Township,State Senate,15,"Goddard, Dan  ",Republican,66
-Neosho,South Tioga West Township Enclave,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,South Tioga West Township Enclave,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,South Tioga West Township Enclave B,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,South Tioga West Township Enclave B,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,South Tioga West Township Enclave C,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,South Tioga West Township Enclave C,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,Walnut Grove Township,State Senate,15,"Schmidt, Chuck  ",Democratic,59
-Neosho,Walnut Grove Township,State Senate,15,"Goddard, Dan  ",Republican,92
-Neosho,West Erie,State Senate,15,"Schmidt, Chuck  ",Democratic,123
-Neosho,West Erie,State Senate,15,"Goddard, Dan  ",Republican,211
-Neosho,Chetopa Township H13,State Senate,15,"Schmidt, Chuck  ",Democratic,79
-Neosho,Chetopa Township H13,State Senate,15,"Goddard, Dan  ",Republican,203
-Neosho,Chetopa Township H2,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,Chetopa Township H2,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,Chetopa Township H9,State Senate,15,"Schmidt, Chuck  ",Democratic,22
-Neosho,Chetopa Township H9,State Senate,15,"Goddard, Dan  ",Republican,75
-Neosho,Chanute Ward 3 Precinct 3 Exclave,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,State Senate,15,"Schmidt, Chuck  ",Democratic,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,State Senate,15,"Goddard, Dan  ",Republican,0
-Neosho,Big Creek Township,State House,2,"Lusker, Adam J. Sr.",Democratic,149
-Neosho,Canville Township,State House,9,"McMurray, Patrick  ",Libertarian,67
-Neosho,Canville Township,State House,9,"Thompson, Kent L. ",Republican,214
-Neosho,Centerville Township,State House,2,"Lusker, Adam J. Sr.",Democratic,156
-Neosho,Chanute Ward 1,State House,9,"McMurray, Patrick  ",Libertarian,27
-Neosho,Chanute Ward 1,State House,9,"Thompson, Kent L. ",Republican,64
-Neosho,Chanute Ward 2 Precinct 1,State House,9,"McMurray, Patrick  ",Libertarian,91
-Neosho,Chanute Ward 2 Precinct 1,State House,9,"Thompson, Kent L. ",Republican,173
-Neosho,Chanute Ward 2 Precinct 2,State House,9,"McMurray, Patrick  ",Libertarian,86
-Neosho,Chanute Ward 2 Precinct 2,State House,9,"Thompson, Kent L. ",Republican,221
-Neosho,Chanute Ward 3 Precinct 1,State House,9,"McMurray, Patrick  ",Libertarian,175
-Neosho,Chanute Ward 3 Precinct 1,State House,9,"Thompson, Kent L. ",Republican,284
-Neosho,Chanute Ward 3 Precinct 2,State House,9,"McMurray, Patrick  ",Libertarian,94
-Neosho,Chanute Ward 3 Precinct 2,State House,9,"Thompson, Kent L. ",Republican,211
-Neosho,Chanute Ward 3 Precinct 3,State House,9,"McMurray, Patrick  ",Libertarian,156
-Neosho,Chanute Ward 3 Precinct 3,State House,9,"Thompson, Kent L. ",Republican,432
-Neosho,Chanute Ward 4 Precinct 1,State House,9,"McMurray, Patrick  ",Libertarian,110
-Neosho,Chanute Ward 4 Precinct 1,State House,9,"Thompson, Kent L. ",Republican,237
-Neosho,Chanute Ward 4 Precinct 2,State House,9,"McMurray, Patrick  ",Libertarian,102
-Neosho,Chanute Ward 4 Precinct 2,State House,9,"Thompson, Kent L. ",Republican,163
-Neosho,Chanute Ward 4 Precinct 3,State House,9,"McMurray, Patrick  ",Libertarian,70
-Neosho,Chanute Ward 4 Precinct 3,State House,9,"Thompson, Kent L. ",Republican,135
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave A,State House,9,"Thompson, Kent L. ",Republican,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,Chanute Ward 4 Precinct 3 Exclave B,State House,9,"Thompson, Kent L. ",Republican,0
-Neosho,East Erie,State House,2,"Lusker, Adam J. Sr.",Democratic,196
-Neosho,Grant Township,State House,2,"Lusker, Adam J. Sr.",Democratic,117
-Neosho,Ladore Township,State House,2,"Lusker, Adam J. Sr.",Democratic,132
-Neosho,Lincoln Township,State House,2,"Lusker, Adam J. Sr.",Democratic,67
-Neosho,Mission Township,State House,2,"Lusker, Adam J. Sr.",Democratic,288
-Neosho,North Tioga Township,State House,9,"McMurray, Patrick  ",Libertarian,42
-Neosho,North Tioga Township,State House,9,"Thompson, Kent L. ",Republican,170
-Neosho,Shiloh Township,State House,13,"Hibbard, Larry P. ",Republican,139
-Neosho,South Tioga East Township,State House,9,"McMurray, Patrick  ",Libertarian,28
-Neosho,South Tioga East Township,State House,9,"Thompson, Kent L. ",Republican,77
-Neosho,South Tioga West Township,State House,9,"McMurray, Patrick  ",Libertarian,13
-Neosho,South Tioga West Township,State House,9,"Thompson, Kent L. ",Republican,69
-Neosho,South Tioga West Township Enclave,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,South Tioga West Township Enclave,State House,9,"Thompson, Kent L. ",Republican,0
-Neosho,South Tioga West Township Enclave B,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,South Tioga West Township Enclave B,State House,9,"Thompson, Kent L. ",Republican,0
-Neosho,South Tioga West Township Enclave C,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,South Tioga West Township Enclave C,State House,9,"Thompson, Kent L. ",Republican,0
-Neosho,Walnut Grove Township,State House,2,"Lusker, Adam J. Sr.",Democratic,107
-Neosho,West Erie,State House,2,"Lusker, Adam J. Sr.",Democratic,218
-Neosho,Chetopa Township H13,State House,13,"Hibbard, Larry P. ",Republican,256
-Neosho,Chetopa Township H2,State House,2,"Lusker, Adam J. Sr.",Democratic,0
-Neosho,Chetopa Township H9,State House,9,"McMurray, Patrick  ",Libertarian,16
-Neosho,Chetopa Township H9,State House,9,"Thompson, Kent L. ",Republican,77
-Neosho,Chanute Ward 3 Precinct 3 Exclave,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 3 Exclave,State House,9,"Thompson, Kent L. ",Republican,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,State House,9,"McMurray, Patrick  ",Libertarian,0
-Neosho,Chanute Ward 3 Precinct 1 Exclave,State House,9,"Thompson, Kent L. ",Republican,0
+county,precinct,office,district,party,candidate,votes,vtd
+NEOSHO,Big Creek Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",149,000010
+NEOSHO,Canville Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",67,00002A
+NEOSHO,Canville Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",214,00002A
+NEOSHO,Centerville Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",156,000030
+NEOSHO,Chanute Ward 1,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",27,000040
+NEOSHO,Chanute Ward 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",64,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",91,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",173,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",86,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",221,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",175,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",284,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",94,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",211,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",156,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",432,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",110,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",237,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",102,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",163,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",70,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",135,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00012C
+NEOSHO,East Erie,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",196,000140
+NEOSHO,Grant Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",117,000150
+NEOSHO,Ladore Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",132,000160
+NEOSHO,Lincoln Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",67,000170
+NEOSHO,Mission Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",288,000180
+NEOSHO,North Tioga Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",42,000190
+NEOSHO,North Tioga Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",170,000190
+NEOSHO,Shiloh Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",139,000200
+NEOSHO,South Tioga East Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",28,000210
+NEOSHO,South Tioga East Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",77,000210
+NEOSHO,South Tioga West Township,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",13,00022A
+NEOSHO,South Tioga West Township,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",69,00022A
+NEOSHO,South Tioga West Township Enclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00022B
+NEOSHO,South Tioga West Township Enclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,00022D
+NEOSHO,Walnut Grove Township,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",107,000230
+NEOSHO,West Erie,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",218,000240
+NEOSHO,Chetopa Township H13,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",256,120020
+NEOSHO,Chetopa Township H2,Kansas House of Representatives,2,Democratic,"Lusker, Adam J. Sr.",0,120030
+NEOSHO,Chetopa Township H9,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",16,120040
+NEOSHO,Chetopa Township H9,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",77,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas House of Representatives,9,Libertarian,"McMurray, Patrick",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas House of Representatives,9,Republican,"Thompson, Kent L.",0,900020
+NEOSHO,Big Creek Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",72,000010
+NEOSHO,Big Creek Township,Kansas Senate,15,Republican,"Goddard, Dan",170,000010
+NEOSHO,Canville Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",103,00002A
+NEOSHO,Canville Township,Kansas Senate,15,Republican,"Goddard, Dan",182,00002A
+NEOSHO,Centerville Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",79,000030
+NEOSHO,Centerville Township,Kansas Senate,15,Republican,"Goddard, Dan",163,000030
+NEOSHO,Chanute Ward 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",35,000040
+NEOSHO,Chanute Ward 1,Kansas Senate,15,Republican,"Goddard, Dan",59,000040
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",125,000050
+NEOSHO,Chanute Ward 2 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",148,000050
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",123,000060
+NEOSHO,Chanute Ward 2 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",187,000060
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",227,000070
+NEOSHO,Chanute Ward 3 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",246,000070
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",134,000080
+NEOSHO,Chanute Ward 3 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",183,000080
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",235,000090
+NEOSHO,Chanute Ward 3 Precinct 3,Kansas Senate,15,Republican,"Goddard, Dan",374,000090
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas Senate,15,Democratic,"Schmidt, Chuck",145,000100
+NEOSHO,Chanute Ward 4 Precinct 1,Kansas Senate,15,Republican,"Goddard, Dan",204,000100
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas Senate,15,Democratic,"Schmidt, Chuck",138,000110
+NEOSHO,Chanute Ward 4 Precinct 2,Kansas Senate,15,Republican,"Goddard, Dan",137,000110
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas Senate,15,Democratic,"Schmidt, Chuck",70,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,Kansas Senate,15,Republican,"Goddard, Dan",137,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,Kansas Senate,15,Republican,"Goddard, Dan",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,Kansas Senate,15,Republican,"Goddard, Dan",0,00012C
+NEOSHO,East Erie,Kansas Senate,15,Democratic,"Schmidt, Chuck",130,000140
+NEOSHO,East Erie,Kansas Senate,15,Republican,"Goddard, Dan",148,000140
+NEOSHO,Grant Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",66,000150
+NEOSHO,Grant Township,Kansas Senate,15,Republican,"Goddard, Dan",109,000150
+NEOSHO,Ladore Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",80,000160
+NEOSHO,Ladore Township,Kansas Senate,15,Republican,"Goddard, Dan",93,000160
+NEOSHO,Lincoln Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",26,000170
+NEOSHO,Lincoln Township,Kansas Senate,15,Republican,"Goddard, Dan",70,000170
+NEOSHO,Mission Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",143,000180
+NEOSHO,Mission Township,Kansas Senate,15,Republican,"Goddard, Dan",260,000180
+NEOSHO,North Tioga Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",59,000190
+NEOSHO,North Tioga Township,Kansas Senate,15,Republican,"Goddard, Dan",156,000190
+NEOSHO,Shiloh Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",35,000200
+NEOSHO,Shiloh Township,Kansas Senate,15,Republican,"Goddard, Dan",123,000200
+NEOSHO,South Tioga East Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",34,000210
+NEOSHO,South Tioga East Township,Kansas Senate,15,Republican,"Goddard, Dan",76,000210
+NEOSHO,South Tioga West Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",16,00022A
+NEOSHO,South Tioga West Township,Kansas Senate,15,Republican,"Goddard, Dan",66,00022A
+NEOSHO,South Tioga West Township Enclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00022B
+NEOSHO,South Tioga West Township Enclave,Kansas Senate,15,Republican,"Goddard, Dan",0,00022B
+NEOSHO,South Tioga West Township Enclave B,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00022C
+NEOSHO,South Tioga West Township Enclave B,Kansas Senate,15,Republican,"Goddard, Dan",0,00022C
+NEOSHO,South Tioga West Township Enclave C,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,00022D
+NEOSHO,South Tioga West Township Enclave C,Kansas Senate,15,Republican,"Goddard, Dan",0,00022D
+NEOSHO,Walnut Grove Township,Kansas Senate,15,Democratic,"Schmidt, Chuck",59,000230
+NEOSHO,Walnut Grove Township,Kansas Senate,15,Republican,"Goddard, Dan",92,000230
+NEOSHO,West Erie,Kansas Senate,15,Democratic,"Schmidt, Chuck",123,000240
+NEOSHO,West Erie,Kansas Senate,15,Republican,"Goddard, Dan",211,000240
+NEOSHO,Chetopa Township H13,Kansas Senate,15,Democratic,"Schmidt, Chuck",79,120020
+NEOSHO,Chetopa Township H13,Kansas Senate,15,Republican,"Goddard, Dan",203,120020
+NEOSHO,Chetopa Township H2,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,120030
+NEOSHO,Chetopa Township H2,Kansas Senate,15,Republican,"Goddard, Dan",0,120030
+NEOSHO,Chetopa Township H9,Kansas Senate,15,Democratic,"Schmidt, Chuck",22,120040
+NEOSHO,Chetopa Township H9,Kansas Senate,15,Republican,"Goddard, Dan",75,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas Senate,15,Democratic,"Schmidt, Chuck",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,Kansas Senate,15,Republican,"Goddard, Dan",0,900020
+NEOSHO,Big Creek Township,President / Vice President,,independent,"Stein, Jill",4,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Castle, Darrell L",1,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+NEOSHO,Big Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000010
+NEOSHO,Big Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000010
+NEOSHO,Big Creek Township,President / Vice President,,Republican,"Trump, Donald J.",182,000010
+NEOSHO,Canville Township,President / Vice President,,independent,"Stein, Jill",2,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Castle, Darrell L",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Hedges, James A",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"McMullin, Evan",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Smith, Mike",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+NEOSHO,Canville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+NEOSHO,Canville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,00002A
+NEOSHO,Canville Township,President / Vice President,,Libertarian,"Johnson, Gary",12,00002A
+NEOSHO,Canville Township,President / Vice President,,Republican,"Trump, Donald J.",210,00002A
+NEOSHO,Centerville Township,President / Vice President,,independent,"Stein, Jill",1,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+NEOSHO,Centerville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+NEOSHO,Centerville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000030
+NEOSHO,Centerville Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+NEOSHO,Centerville Township,President / Vice President,,Republican,"Trump, Donald J.",185,000030
+NEOSHO,Chanute Ward 1,President / Vice President,,independent,"Stein, Jill",6,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+NEOSHO,Chanute Ward 1,President / Vice President,,Republican,"Trump, Donald J.",65,000040
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",9,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000050
+NEOSHO,Chanute Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",173,000050
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",7,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000060
+NEOSHO,Chanute Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",230,000060
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,independent,"Stein, Jill",14,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",3,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",133,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",24,000070
+NEOSHO,Chanute Ward 3 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",302,000070
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",3,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000080
+NEOSHO,Chanute Ward 3 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",205,000080
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,independent,"Stein, Jill",11,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",188,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",29,000090
+NEOSHO,Chanute Ward 3 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",390,000090
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,independent,"Stein, Jill",7,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",4,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,000100
+NEOSHO,Chanute Ward 4 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",207,000100
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,independent,"Stein, Jill",4,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000110
+NEOSHO,Chanute Ward 4 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",172,000110
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,independent,"Stein, Jill",7,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",2,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",151,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,independent,"Stein, Jill",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,independent,"Stein, Jill",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00012C
+NEOSHO,East Erie,President / Vice President,,independent,"Stein, Jill",7,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Hedges, James A",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"McMullin, Evan",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Perry, Darryl",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Smith, Mike",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Sood, Ajay",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+NEOSHO,East Erie,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+NEOSHO,East Erie,President / Vice President,,Democratic,"Clinton, Hillary Rodham",72,000140
+NEOSHO,East Erie,President / Vice President,,Libertarian,"Johnson, Gary",12,000140
+NEOSHO,East Erie,President / Vice President,,Republican,"Trump, Donald J.",188,000140
+NEOSHO,Grant Township,President / Vice President,,independent,"Stein, Jill",8,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"McMullin, Evan",2,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+NEOSHO,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+NEOSHO,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000150
+NEOSHO,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000150
+NEOSHO,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",122,000150
+NEOSHO,Ladore Township,President / Vice President,,independent,"Stein, Jill",6,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+NEOSHO,Ladore Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+NEOSHO,Ladore Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000160
+NEOSHO,Ladore Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000160
+NEOSHO,Ladore Township,President / Vice President,,Republican,"Trump, Donald J.",109,000160
+NEOSHO,Lincoln Township,President / Vice President,,independent,"Stein, Jill",2,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+NEOSHO,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000170
+NEOSHO,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+NEOSHO,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",69,000170
+NEOSHO,Mission Township,President / Vice President,,independent,"Stein, Jill",8,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+NEOSHO,Mission Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+NEOSHO,Mission Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",73,000180
+NEOSHO,Mission Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000180
+NEOSHO,Mission Township,President / Vice President,,Republican,"Trump, Donald J.",317,000180
+NEOSHO,North Tioga Township,President / Vice President,,independent,"Stein, Jill",1,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+NEOSHO,North Tioga Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000190
+NEOSHO,North Tioga Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000190
+NEOSHO,North Tioga Township,President / Vice President,,Republican,"Trump, Donald J.",166,000190
+NEOSHO,Shiloh Township,President / Vice President,,independent,"Stein, Jill",1,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Castle, Darrell L",1,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"McMullin, Evan",2,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+NEOSHO,Shiloh Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000200
+NEOSHO,Shiloh Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000200
+NEOSHO,Shiloh Township,President / Vice President,,Republican,"Trump, Donald J.",143,000200
+NEOSHO,South Tioga East Township,President / Vice President,,independent,"Stein, Jill",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"McMullin, Evan",1,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000210
+NEOSHO,South Tioga East Township,President / Vice President,,Republican,"Trump, Donald J.",83,000210
+NEOSHO,South Tioga West Township,President / Vice President,,independent,"Stein, Jill",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Castle, Darrell L",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Giordani, Rocky",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Hedges, James A",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Kahn, Lynn",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"La Riva, Gloria",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Maturen, Michael A",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"McMullin, Evan",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Perry, Darryl",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Schriner, Joe C",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Smith, Mike",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Sood, Ajay",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Sterling, Shawna",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Libertarian,"Johnson, Gary",2,00022A
+NEOSHO,South Tioga West Township,President / Vice President,,Republican,"Trump, Donald J.",66,00022A
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,independent,"Stein, Jill",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+NEOSHO,South Tioga West Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00022B
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,independent,"Stein, Jill",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00022C
+NEOSHO,South Tioga West Township Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00022C
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,independent,"Stein, Jill",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Castle, Darrell L",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Giordani, Rocky",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Hedges, James A",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Hoefling, Tom",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Kahn, Lynn",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"La Riva, Gloria",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Levinson, Michael S.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Maturen, Michael A",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"McMullin, Evan",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Perry, Darryl",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Schriner, Joe C",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Smith, Mike",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Sood, Ajay",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Sterling, Shawna",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Libertarian,"Johnson, Gary",0,00022D
+NEOSHO,South Tioga West Township Enclave C,President / Vice President,,Republican,"Trump, Donald J.",0,00022D
+NEOSHO,Walnut Grove Township,President / Vice President,,independent,"Stein, Jill",3,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000230
+NEOSHO,Walnut Grove Township,President / Vice President,,Republican,"Trump, Donald J.",110,000230
+NEOSHO,West Erie,President / Vice President,,independent,"Stein, Jill",5,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Castle, Darrell L",2,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Hedges, James A",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"McMullin, Evan",2,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Perry, Darryl",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Smith, Mike",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Sood, Ajay",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+NEOSHO,West Erie,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+NEOSHO,West Erie,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000240
+NEOSHO,West Erie,President / Vice President,,Libertarian,"Johnson, Gary",9,000240
+NEOSHO,West Erie,President / Vice President,,Republican,"Trump, Donald J.",260,000240
+NEOSHO,Chetopa Township H13,President / Vice President,,independent,"Stein, Jill",3,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Hedges, James A",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"McMullin, Evan",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Perry, Darryl",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Smith, Mike",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Sood, Ajay",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Libertarian,"Johnson, Gary",8,120020
+NEOSHO,Chetopa Township H13,President / Vice President,,Republican,"Trump, Donald J.",236,120020
+NEOSHO,Chetopa Township H2,President / Vice President,,independent,"Stein, Jill",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Hedges, James A",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"McMullin, Evan",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Perry, Darryl",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Smith, Mike",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Sood, Ajay",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+NEOSHO,Chetopa Township H2,President / Vice President,,Republican,"Trump, Donald J.",0,120030
+NEOSHO,Chetopa Township H9,President / Vice President,,independent,"Stein, Jill",2,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Hedges, James A",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"McMullin, Evan",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Perry, Darryl",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Smith, Mike",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Sood, Ajay",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Libertarian,"Johnson, Gary",2,120040
+NEOSHO,Chetopa Township H9,President / Vice President,,Republican,"Trump, Donald J.",90,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+NEOSHO,Big Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",30,000010
+NEOSHO,Big Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000010
+NEOSHO,Big Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",199,000010
+NEOSHO,Canville Township,United States House of Representatives,2,Democratic,"Potter, Britani",56,00002A
+NEOSHO,Canville Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,00002A
+NEOSHO,Canville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",226,00002A
+NEOSHO,Centerville Township,United States House of Representatives,2,Democratic,"Potter, Britani",57,000030
+NEOSHO,Centerville Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000030
+NEOSHO,Centerville Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",176,000030
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",20,000040
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000040
+NEOSHO,Chanute Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",63,000040
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",63,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",189,000050
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",60,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",238,000060
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",111,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",39,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",325,000070
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",61,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",240,000080
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",144,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",445,000090
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Democratic,"Potter, Britani",96,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,000100
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Democratic,"Potter, Britani",68,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",21,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",185,000110
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Democratic,"Potter, Britani",42,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",158,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Democratic,"Potter, Britani",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00012C
+NEOSHO,East Erie,United States House of Representatives,2,Democratic,"Potter, Britani",54,000140
+NEOSHO,East Erie,United States House of Representatives,2,Libertarian,"Bales, James Houston",24,000140
+NEOSHO,East Erie,United States House of Representatives,2,Republican,"Jenkins, Lynn",200,000140
+NEOSHO,Grant Township,United States House of Representatives,2,Democratic,"Potter, Britani",33,000150
+NEOSHO,Grant Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000150
+NEOSHO,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",141,000150
+NEOSHO,Ladore Township,United States House of Representatives,2,Democratic,"Potter, Britani",54,000160
+NEOSHO,Ladore Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000160
+NEOSHO,Ladore Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",113,000160
+NEOSHO,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",20,000170
+NEOSHO,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000170
+NEOSHO,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",74,000170
+NEOSHO,Mission Township,United States House of Representatives,2,Democratic,"Potter, Britani",84,000180
+NEOSHO,Mission Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000180
+NEOSHO,Mission Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",317,000180
+NEOSHO,North Tioga Township,United States House of Representatives,2,Democratic,"Potter, Britani",37,000190
+NEOSHO,North Tioga Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000190
+NEOSHO,North Tioga Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",169,000190
+NEOSHO,Shiloh Township,United States House of Representatives,2,Democratic,"Potter, Britani",14,000200
+NEOSHO,Shiloh Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000200
+NEOSHO,Shiloh Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",139,000200
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Democratic,"Potter, Britani",19,000210
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000210
+NEOSHO,South Tioga East Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",86,000210
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Democratic,"Potter, Britani",9,00022A
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,00022A
+NEOSHO,South Tioga West Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",71,00022A
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022B
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Democratic,"Potter, Britani",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022C
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Democratic,"Potter, Britani",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00022D
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Democratic,"Potter, Britani",33,000230
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000230
+NEOSHO,Walnut Grove Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",113,000230
+NEOSHO,West Erie,United States House of Representatives,2,Democratic,"Potter, Britani",60,000240
+NEOSHO,West Erie,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000240
+NEOSHO,West Erie,United States House of Representatives,2,Republican,"Jenkins, Lynn",257,000240
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Democratic,"Potter, Britani",39,120020
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,120020
+NEOSHO,Chetopa Township H13,United States House of Representatives,2,Republican,"Jenkins, Lynn",236,120020
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Democratic,"Potter, Britani",0,120030
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,120030
+NEOSHO,Chetopa Township H2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,120030
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Democratic,"Potter, Britani",8,120040
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,120040
+NEOSHO,Chetopa Township H9,United States House of Representatives,2,Republican,"Jenkins, Lynn",92,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+NEOSHO,Big Creek Township,United States Senate,,write - in,"Smith, DJ",0,000010
+NEOSHO,Big Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000010
+NEOSHO,Big Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000010
+NEOSHO,Big Creek Township,United States Senate,,Republican,"Moran, Jerry",192,000010
+NEOSHO,Canville Township,United States Senate,,write - in,"Smith, DJ",0,00002A
+NEOSHO,Canville Township,United States Senate,,Democratic,"Wiesner, Patrick",64,00002A
+NEOSHO,Canville Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,00002A
+NEOSHO,Canville Township,United States Senate,,Republican,"Moran, Jerry",208,00002A
+NEOSHO,Centerville Township,United States Senate,,write - in,"Smith, DJ",0,000030
+NEOSHO,Centerville Township,United States Senate,,Democratic,"Wiesner, Patrick",57,000030
+NEOSHO,Centerville Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000030
+NEOSHO,Centerville Township,United States Senate,,Republican,"Moran, Jerry",174,000030
+NEOSHO,Chanute Ward 1,United States Senate,,write - in,"Smith, DJ",0,000040
+NEOSHO,Chanute Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",24,000040
+NEOSHO,Chanute Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",9,000040
+NEOSHO,Chanute Ward 1,United States Senate,,Republican,"Moran, Jerry",61,000040
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",80,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,000050
+NEOSHO,Chanute Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",168,000050
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",74,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",25,000060
+NEOSHO,Chanute Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",211,000060
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",132,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",45,000070
+NEOSHO,Chanute Ward 3 Precinct 1,United States Senate,,Republican,"Moran, Jerry",299,000070
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",84,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,000080
+NEOSHO,Chanute Ward 3 Precinct 2,United States Senate,,Republican,"Moran, Jerry",210,000080
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",149,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",42,000090
+NEOSHO,Chanute Ward 3 Precinct 3,United States Senate,,Republican,"Moran, Jerry",421,000090
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",101,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",34,000100
+NEOSHO,Chanute Ward 4 Precinct 1,United States Senate,,Republican,"Moran, Jerry",220,000100
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",85,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,000110
+NEOSHO,Chanute Ward 4 Precinct 2,United States Senate,,Republican,"Moran, Jerry",166,000110
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",44,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",18,00012A
+NEOSHO,Chanute Ward 4 Precinct 3,United States Senate,,Republican,"Moran, Jerry",149,00012A
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,write - in,"Smith, DJ",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00012B
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,write - in,"Smith, DJ",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00012C
+NEOSHO,Chanute Ward 4 Precinct 3 Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00012C
+NEOSHO,East Erie,United States Senate,,write - in,"Smith, DJ",0,000140
+NEOSHO,East Erie,United States Senate,,Democratic,"Wiesner, Patrick",63,000140
+NEOSHO,East Erie,United States Senate,,Libertarian,"Garrard, Robert D.",20,000140
+NEOSHO,East Erie,United States Senate,,Republican,"Moran, Jerry",194,000140
+NEOSHO,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000150
+NEOSHO,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000150
+NEOSHO,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000150
+NEOSHO,Grant Township,United States Senate,,Republican,"Moran, Jerry",128,000150
+NEOSHO,Ladore Township,United States Senate,,write - in,"Smith, DJ",0,000160
+NEOSHO,Ladore Township,United States Senate,,Democratic,"Wiesner, Patrick",57,000160
+NEOSHO,Ladore Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000160
+NEOSHO,Ladore Township,United States Senate,,Republican,"Moran, Jerry",109,000160
+NEOSHO,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000170
+NEOSHO,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000170
+NEOSHO,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000170
+NEOSHO,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",60,000170
+NEOSHO,Mission Township,United States Senate,,write - in,"Smith, DJ",0,000180
+NEOSHO,Mission Township,United States Senate,,Democratic,"Wiesner, Patrick",85,000180
+NEOSHO,Mission Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000180
+NEOSHO,Mission Township,United States Senate,,Republican,"Moran, Jerry",301,000180
+NEOSHO,North Tioga Township,United States Senate,,write - in,"Smith, DJ",0,000190
+NEOSHO,North Tioga Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000190
+NEOSHO,North Tioga Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000190
+NEOSHO,North Tioga Township,United States Senate,,Republican,"Moran, Jerry",168,000190
+NEOSHO,Shiloh Township,United States Senate,,write - in,"Smith, DJ",0,000200
+NEOSHO,Shiloh Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000200
+NEOSHO,Shiloh Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000200
+NEOSHO,Shiloh Township,United States Senate,,Republican,"Moran, Jerry",132,000200
+NEOSHO,South Tioga East Township,United States Senate,,write - in,"Smith, DJ",0,000210
+NEOSHO,South Tioga East Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000210
+NEOSHO,South Tioga East Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000210
+NEOSHO,South Tioga East Township,United States Senate,,Republican,"Moran, Jerry",78,000210
+NEOSHO,South Tioga West Township,United States Senate,,write - in,"Smith, DJ",0,00022A
+NEOSHO,South Tioga West Township,United States Senate,,Democratic,"Wiesner, Patrick",7,00022A
+NEOSHO,South Tioga West Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,00022A
+NEOSHO,South Tioga West Township,United States Senate,,Republican,"Moran, Jerry",68,00022A
+NEOSHO,South Tioga West Township Enclave,United States Senate,,write - in,"Smith, DJ",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022B
+NEOSHO,South Tioga West Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,00022B
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,write - in,"Smith, DJ",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022C
+NEOSHO,South Tioga West Township Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00022C
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,write - in,"Smith, DJ",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,Democratic,"Wiesner, Patrick",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022D
+NEOSHO,South Tioga West Township Enclave C,United States Senate,,Republican,"Moran, Jerry",0,00022D
+NEOSHO,Walnut Grove Township,United States Senate,,write - in,"Smith, DJ",0,000230
+NEOSHO,Walnut Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000230
+NEOSHO,Walnut Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000230
+NEOSHO,Walnut Grove Township,United States Senate,,Republican,"Moran, Jerry",104,000230
+NEOSHO,West Erie,United States Senate,,write - in,"Smith, DJ",0,000240
+NEOSHO,West Erie,United States Senate,,Democratic,"Wiesner, Patrick",67,000240
+NEOSHO,West Erie,United States Senate,,Libertarian,"Garrard, Robert D.",22,000240
+NEOSHO,West Erie,United States Senate,,Republican,"Moran, Jerry",249,000240
+NEOSHO,Chetopa Township H13,United States Senate,,write - in,"Smith, DJ",0,120020
+NEOSHO,Chetopa Township H13,United States Senate,,Democratic,"Wiesner, Patrick",39,120020
+NEOSHO,Chetopa Township H13,United States Senate,,Libertarian,"Garrard, Robert D.",21,120020
+NEOSHO,Chetopa Township H13,United States Senate,,Republican,"Moran, Jerry",224,120020
+NEOSHO,Chetopa Township H2,United States Senate,,write - in,"Smith, DJ",0,120030
+NEOSHO,Chetopa Township H2,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+NEOSHO,Chetopa Township H2,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+NEOSHO,Chetopa Township H2,United States Senate,,Republican,"Moran, Jerry",0,120030
+NEOSHO,Chetopa Township H9,United States Senate,,write - in,"Smith, DJ",0,120040
+NEOSHO,Chetopa Township H9,United States Senate,,Democratic,"Wiesner, Patrick",9,120040
+NEOSHO,Chetopa Township H9,United States Senate,,Libertarian,"Garrard, Robert D.",6,120040
+NEOSHO,Chetopa Township H9,United States Senate,,Republican,"Moran, Jerry",84,120040
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+NEOSHO,Chanute Ward 3 Precinct 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+NEOSHO,Chanute Ward 3 Precinct 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900020

--- a/2016/20161108__ks__general__ness__precinct.csv
+++ b/2016/20161108__ks__general__ness__precinct.csv
@@ -1,397 +1,397 @@
-county,precinct,office,district,candidate,party,votes
-Ness,Bazine Township,President,,"Stein, Jill  ",independent,1
-Ness,Bazine Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Bazine Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Bazine Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Bazine Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Bazine Township,President,,"Hedges, James A ",write - in,0
-Ness,Bazine Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Bazine Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Bazine Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Bazine Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Bazine Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Bazine Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Bazine Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Bazine Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Bazine Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Bazine Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Bazine Township,President,,"Smith, Mike  ",write - in,0
-Ness,Bazine Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Bazine Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Bazine Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Bazine Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Bazine Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Bazine Township,President,,"Clinton, Hillary Rodham ",Democratic,14
-Ness,Bazine Township,President,,"Johnson, Gary  ",Libertarian,6
-Ness,Bazine Township,President,,"Trump, Donald J. ",Republican,159
-Ness,Eden Township,President,,"Stein, Jill  ",independent,1
-Ness,Eden Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Eden Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Eden Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Eden Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Eden Township,President,,"Hedges, James A ",write - in,0
-Ness,Eden Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Eden Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Eden Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Eden Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Eden Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Eden Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Eden Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Eden Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Eden Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Eden Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Eden Township,President,,"Smith, Mike  ",write - in,0
-Ness,Eden Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Eden Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Eden Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Eden Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Eden Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Eden Township,President,,"Clinton, Hillary Rodham ",Democratic,5
-Ness,Eden Township,President,,"Johnson, Gary  ",Libertarian,1
-Ness,Eden Township,President,,"Trump, Donald J. ",Republican,36
-Ness,Forrester Township,President,,"Stein, Jill  ",independent,3
-Ness,Forrester Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Forrester Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Forrester Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Forrester Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Forrester Township,President,,"Hedges, James A ",write - in,0
-Ness,Forrester Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Forrester Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Forrester Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Forrester Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Forrester Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Forrester Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Forrester Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Forrester Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Forrester Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Forrester Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Forrester Township,President,,"Smith, Mike  ",write - in,0
-Ness,Forrester Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Forrester Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Forrester Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Forrester Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Forrester Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Forrester Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Ness,Forrester Township,President,,"Johnson, Gary  ",Libertarian,0
-Ness,Forrester Township,President,,"Trump, Donald J. ",Republican,51
-Ness,Franklin Township,President,,"Stein, Jill  ",independent,1
-Ness,Franklin Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Franklin Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Franklin Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Franklin Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Franklin Township,President,,"Hedges, James A ",write - in,0
-Ness,Franklin Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Franklin Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Franklin Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Franklin Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Franklin Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Franklin Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Franklin Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Franklin Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Franklin Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Franklin Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Franklin Township,President,,"Smith, Mike  ",write - in,0
-Ness,Franklin Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Franklin Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Franklin Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Franklin Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Franklin Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Franklin Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-Ness,Franklin Township,President,,"Johnson, Gary  ",Libertarian,1
-Ness,Franklin Township,President,,"Trump, Donald J. ",Republican,62
-Ness,Highpoint Township,President,,"Stein, Jill  ",independent,0
-Ness,Highpoint Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Highpoint Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Highpoint Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Highpoint Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Highpoint Township,President,,"Hedges, James A ",write - in,0
-Ness,Highpoint Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Highpoint Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Highpoint Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Highpoint Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Highpoint Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Highpoint Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Highpoint Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Highpoint Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Highpoint Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Highpoint Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Highpoint Township,President,,"Smith, Mike  ",write - in,0
-Ness,Highpoint Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Highpoint Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Highpoint Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Highpoint Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Highpoint Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Highpoint Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Ness,Highpoint Township,President,,"Johnson, Gary  ",Libertarian,0
-Ness,Highpoint Township,President,,"Trump, Donald J. ",Republican,31
-Ness,Johnson Township,President,,"Stein, Jill  ",independent,0
-Ness,Johnson Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Johnson Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Johnson Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Johnson Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Johnson Township,President,,"Hedges, James A ",write - in,0
-Ness,Johnson Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Johnson Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Johnson Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Johnson Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Johnson Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Johnson Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Johnson Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Johnson Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Johnson Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Johnson Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Johnson Township,President,,"Smith, Mike  ",write - in,0
-Ness,Johnson Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Johnson Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Johnson Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Johnson Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Johnson Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Johnson Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Ness,Johnson Township,President,,"Johnson, Gary  ",Libertarian,0
-Ness,Johnson Township,President,,"Trump, Donald J. ",Republican,34
-Ness,Nevada Township,President,,"Stein, Jill  ",independent,2
-Ness,Nevada Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Nevada Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Nevada Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Nevada Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Nevada Township,President,,"Hedges, James A ",write - in,0
-Ness,Nevada Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Nevada Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Nevada Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Nevada Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Nevada Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Nevada Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Nevada Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Nevada Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Nevada Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Nevada Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Nevada Township,President,,"Smith, Mike  ",write - in,0
-Ness,Nevada Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Nevada Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Nevada Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Nevada Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Nevada Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Nevada Township,President,,"Clinton, Hillary Rodham ",Democratic,30
-Ness,Nevada Township,President,,"Johnson, Gary  ",Libertarian,10
-Ness,Nevada Township,President,,"Trump, Donald J. ",Republican,162
-Ness,North Center,President,,"Stein, Jill  ",independent,5
-Ness,North Center,President,,"Basiago, Andrew D. ",write - in,0
-Ness,North Center,President,,"Castle, Darrell L ",write - in,0
-Ness,North Center,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,North Center,President,,"Giordani, Rocky  ",write - in,0
-Ness,North Center,President,,"Hedges, James A ",write - in,0
-Ness,North Center,President,,"Hoefling, Tom  ",write - in,0
-Ness,North Center,President,,"Kahn, Lynn  ",write - in,0
-Ness,North Center,President,,"La Riva, Gloria  ",write - in,0
-Ness,North Center,President,,"Levinson, Michael S. ",write - in,0
-Ness,North Center,President,,"Maturen, Michael A ",write - in,0
-Ness,North Center,President,,"McMullin, Evan  ",write - in,1
-Ness,North Center,President,,"Moorehead, Monica G. ",write - in,0
-Ness,North Center,President,,"Perry, Darryl  ",write - in,0
-Ness,North Center,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,North Center,President,,"Schriner, Joe C ",write - in,0
-Ness,North Center,President,,"Smith, Mike  ",write - in,0
-Ness,North Center,President,,"Sood, Ajay  ",write - in,0
-Ness,North Center,President,,"Sterling, Shawna  ",write - in,0
-Ness,North Center,President,,"Valdivia, Anthony J ",write - in,0
-Ness,North Center,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,North Center,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,North Center,President,,"Clinton, Hillary Rodham ",Democratic,51
-Ness,North Center,President,,"Johnson, Gary  ",Libertarian,10
-Ness,North Center,President,,"Trump, Donald J. ",Republican,364
-Ness,Ohio Township,President,,"Stein, Jill  ",independent,2
-Ness,Ohio Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Ohio Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Ohio Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Ohio Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Ohio Township,President,,"Hedges, James A ",write - in,0
-Ness,Ohio Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Ohio Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Ohio Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Ohio Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Ohio Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Ohio Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Ohio Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Ohio Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Ohio Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Ohio Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Ohio Township,President,,"Smith, Mike  ",write - in,0
-Ness,Ohio Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Ohio Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Ohio Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Ohio Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Ohio Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Ohio Township,President,,"Clinton, Hillary Rodham ",Democratic,14
-Ness,Ohio Township,President,,"Johnson, Gary  ",Libertarian,7
-Ness,Ohio Township,President,,"Trump, Donald J. ",Republican,99
-Ness,South Center,President,,"Stein, Jill  ",independent,5
-Ness,South Center,President,,"Basiago, Andrew D. ",write - in,0
-Ness,South Center,President,,"Castle, Darrell L ",write - in,0
-Ness,South Center,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,South Center,President,,"Giordani, Rocky  ",write - in,0
-Ness,South Center,President,,"Hedges, James A ",write - in,0
-Ness,South Center,President,,"Hoefling, Tom  ",write - in,0
-Ness,South Center,President,,"Kahn, Lynn  ",write - in,0
-Ness,South Center,President,,"La Riva, Gloria  ",write - in,0
-Ness,South Center,President,,"Levinson, Michael S. ",write - in,0
-Ness,South Center,President,,"Maturen, Michael A ",write - in,0
-Ness,South Center,President,,"McMullin, Evan  ",write - in,0
-Ness,South Center,President,,"Moorehead, Monica G. ",write - in,0
-Ness,South Center,President,,"Perry, Darryl  ",write - in,0
-Ness,South Center,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,South Center,President,,"Schriner, Joe C ",write - in,0
-Ness,South Center,President,,"Smith, Mike  ",write - in,0
-Ness,South Center,President,,"Sood, Ajay  ",write - in,0
-Ness,South Center,President,,"Sterling, Shawna  ",write - in,0
-Ness,South Center,President,,"Valdivia, Anthony J ",write - in,0
-Ness,South Center,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,South Center,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,South Center,President,,"Clinton, Hillary Rodham ",Democratic,31
-Ness,South Center,President,,"Johnson, Gary  ",Libertarian,4
-Ness,South Center,President,,"Trump, Donald J. ",Republican,191
-Ness,Waring Township,President,,"Stein, Jill  ",independent,1
-Ness,Waring Township,President,,"Basiago, Andrew D. ",write - in,0
-Ness,Waring Township,President,,"Castle, Darrell L ",write - in,0
-Ness,Waring Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Ness,Waring Township,President,,"Giordani, Rocky  ",write - in,0
-Ness,Waring Township,President,,"Hedges, James A ",write - in,0
-Ness,Waring Township,President,,"Hoefling, Tom  ",write - in,0
-Ness,Waring Township,President,,"Kahn, Lynn  ",write - in,0
-Ness,Waring Township,President,,"La Riva, Gloria  ",write - in,0
-Ness,Waring Township,President,,"Levinson, Michael S. ",write - in,0
-Ness,Waring Township,President,,"Maturen, Michael A ",write - in,0
-Ness,Waring Township,President,,"McMullin, Evan  ",write - in,0
-Ness,Waring Township,President,,"Moorehead, Monica G. ",write - in,0
-Ness,Waring Township,President,,"Perry, Darryl  ",write - in,0
-Ness,Waring Township,President,,"Schoenke, Marshall R. ",write - in,0
-Ness,Waring Township,President,,"Schriner, Joe C ",write - in,0
-Ness,Waring Township,President,,"Smith, Mike  ",write - in,0
-Ness,Waring Township,President,,"Sood, Ajay  ",write - in,0
-Ness,Waring Township,President,,"Sterling, Shawna  ",write - in,0
-Ness,Waring Township,President,,"Valdivia, Anthony J ",write - in,0
-Ness,Waring Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Ness,Waring Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Ness,Waring Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Ness,Waring Township,President,,"Johnson, Gary  ",Libertarian,3
-Ness,Waring Township,President,,"Trump, Donald J. ",Republican,39
-Ness,Bazine Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Bazine Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,12
-Ness,Bazine Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Ness,Bazine Township,U.S. Senate,,"Moran, Jerry  ",Republican,158
-Ness,Eden Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Eden Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Ness,Eden Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Ness,Eden Township,U.S. Senate,,"Moran, Jerry  ",Republican,41
-Ness,Forrester Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Forrester Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Ness,Forrester Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Ness,Forrester Township,U.S. Senate,,"Moran, Jerry  ",Republican,54
-Ness,Franklin Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Franklin Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Ness,Franklin Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Ness,Franklin Township,U.S. Senate,,"Moran, Jerry  ",Republican,67
-Ness,Highpoint Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Highpoint Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Ness,Highpoint Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Ness,Highpoint Township,U.S. Senate,,"Moran, Jerry  ",Republican,31
-Ness,Johnson Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Johnson Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Ness,Johnson Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Ness,Johnson Township,U.S. Senate,,"Moran, Jerry  ",Republican,29
-Ness,Nevada Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Nevada Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,22
-Ness,Nevada Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Ness,Nevada Township,U.S. Senate,,"Moran, Jerry  ",Republican,181
-Ness,North Center,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,North Center,U.S. Senate,,"Wiesner, Patrick  ",Democratic,29
-Ness,North Center,U.S. Senate,,"Garrard, Robert D. ",Libertarian,14
-Ness,North Center,U.S. Senate,,"Moran, Jerry  ",Republican,377
-Ness,Ohio Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Ohio Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,12
-Ness,Ohio Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Ness,Ohio Township,U.S. Senate,,"Moran, Jerry  ",Republican,109
-Ness,South Center,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,South Center,U.S. Senate,,"Wiesner, Patrick  ",Democratic,23
-Ness,South Center,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Ness,South Center,U.S. Senate,,"Moran, Jerry  ",Republican,194
-Ness,Waring Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Ness,Waring Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Ness,Waring Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Ness,Waring Township,U.S. Senate,,"Moran, Jerry  ",Republican,49
-Ness,Bazine Township,U.S. House,1,"LaPolice, Alan  ",independent,23
-Ness,Bazine Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Bazine Township,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Ness,Bazine Township,U.S. House,1,"Marshall, Roger  ",Republican,149
-Ness,Eden Township,U.S. House,1,"LaPolice, Alan  ",independent,5
-Ness,Eden Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Eden Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Ness,Eden Township,U.S. House,1,"Marshall, Roger  ",Republican,36
-Ness,Forrester Township,U.S. House,1,"LaPolice, Alan  ",independent,7
-Ness,Forrester Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Forrester Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Ness,Forrester Township,U.S. House,1,"Marshall, Roger  ",Republican,51
-Ness,Franklin Township,U.S. House,1,"LaPolice, Alan  ",independent,6
-Ness,Franklin Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Franklin Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Ness,Franklin Township,U.S. House,1,"Marshall, Roger  ",Republican,59
-Ness,Highpoint Township,U.S. House,1,"LaPolice, Alan  ",independent,4
-Ness,Highpoint Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Highpoint Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Ness,Highpoint Township,U.S. House,1,"Marshall, Roger  ",Republican,27
-Ness,Johnson Township,U.S. House,1,"LaPolice, Alan  ",independent,2
-Ness,Johnson Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Johnson Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Ness,Johnson Township,U.S. House,1,"Marshall, Roger  ",Republican,29
-Ness,Nevada Township,U.S. House,1,"LaPolice, Alan  ",independent,37
-Ness,Nevada Township,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Ness,Nevada Township,U.S. House,1,"Burt, Kerry  ",Libertarian,7
-Ness,Nevada Township,U.S. House,1,"Marshall, Roger  ",Republican,163
-Ness,North Center,U.S. House,1,"LaPolice, Alan  ",independent,71
-Ness,North Center,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,North Center,U.S. House,1,"Burt, Kerry  ",Libertarian,17
-Ness,North Center,U.S. House,1,"Marshall, Roger  ",Republican,326
-Ness,Ohio Township,U.S. House,1,"LaPolice, Alan  ",independent,16
-Ness,Ohio Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,Ohio Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Ness,Ohio Township,U.S. House,1,"Marshall, Roger  ",Republican,103
-Ness,South Center,U.S. House,1,"LaPolice, Alan  ",independent,45
-Ness,South Center,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Ness,South Center,U.S. House,1,"Burt, Kerry  ",Libertarian,6
-Ness,South Center,U.S. House,1,"Marshall, Roger  ",Republican,172
-Ness,Waring Township,U.S. House,1,"LaPolice, Alan  ",independent,10
-Ness,Waring Township,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Ness,Waring Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Ness,Waring Township,U.S. House,1,"Marshall, Roger  ",Republican,39
-Ness,Bazine Township,State Senate,33,"Bristow, Matt  ",Democratic,22
-Ness,Bazine Township,State Senate,33,"Taylor, Mary Jo ",Republican,136
-Ness,Eden Township,State Senate,33,"Bristow, Matt  ",Democratic,8
-Ness,Eden Township,State Senate,33,"Taylor, Mary Jo ",Republican,34
-Ness,Forrester Township,State Senate,33,"Bristow, Matt  ",Democratic,7
-Ness,Forrester Township,State Senate,33,"Taylor, Mary Jo ",Republican,45
-Ness,Franklin Township,State Senate,33,"Bristow, Matt  ",Democratic,9
-Ness,Franklin Township,State Senate,33,"Taylor, Mary Jo ",Republican,54
-Ness,Highpoint Township,State Senate,33,"Bristow, Matt  ",Democratic,3
-Ness,Highpoint Township,State Senate,33,"Taylor, Mary Jo ",Republican,27
-Ness,Johnson Township,State Senate,33,"Bristow, Matt  ",Democratic,2
-Ness,Johnson Township,State Senate,33,"Taylor, Mary Jo ",Republican,30
-Ness,Nevada Township,State Senate,33,"Bristow, Matt  ",Democratic,39
-Ness,Nevada Township,State Senate,33,"Taylor, Mary Jo ",Republican,163
-Ness,North Center,State Senate,33,"Bristow, Matt  ",Democratic,66
-Ness,North Center,State Senate,33,"Taylor, Mary Jo ",Republican,320
-Ness,Ohio Township,State Senate,33,"Bristow, Matt  ",Democratic,16
-Ness,Ohio Township,State Senate,33,"Taylor, Mary Jo ",Republican,101
-Ness,South Center,State Senate,33,"Bristow, Matt  ",Democratic,58
-Ness,South Center,State Senate,33,"Taylor, Mary Jo ",Republican,152
-Ness,Waring Township,State Senate,33,"Bristow, Matt  ",Democratic,7
-Ness,Waring Township,State Senate,33,"Taylor, Mary Jo ",Republican,40
-Ness,Bazine Township,State House,117,"Mastroni, Leonard A. ",Republican,151
-Ness,Eden Township,State House,117,"Mastroni, Leonard A. ",Republican,39
-Ness,Forrester Township,State House,117,"Mastroni, Leonard A. ",Republican,48
-Ness,Franklin Township,State House,117,"Mastroni, Leonard A. ",Republican,62
-Ness,Highpoint Township,State House,117,"Mastroni, Leonard A. ",Republican,28
-Ness,Johnson Township,State House,117,"Mastroni, Leonard A. ",Republican,32
-Ness,Nevada Township,State House,117,"Mastroni, Leonard A. ",Republican,168
-Ness,North Center,State House,117,"Mastroni, Leonard A. ",Republican,366
-Ness,Ohio Township,State House,117,"Mastroni, Leonard A. ",Republican,109
-Ness,South Center,State House,117,"Mastroni, Leonard A. ",Republican,199
-Ness,Waring Township,State House,117,"Mastroni, Leonard A. ",Republican,46
+county,precinct,office,district,party,candidate,votes,vtd
+NESS,Bazine Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",151,000010
+NESS,Eden Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",39,000020
+NESS,Forrester Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",48,000030
+NESS,Franklin Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",62,000040
+NESS,Highpoint Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",28,000050
+NESS,Johnson Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",32,000060
+NESS,Nevada Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",168,000070
+NESS,North Center,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",366,000080
+NESS,Ohio Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",109,000090
+NESS,South Center,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",199,000100
+NESS,Waring Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",46,000110
+NESS,Bazine Township,Kansas Senate,33,Democratic,"Bristow, Matt",22,000010
+NESS,Bazine Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",136,000010
+NESS,Eden Township,Kansas Senate,33,Democratic,"Bristow, Matt",8,000020
+NESS,Eden Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",34,000020
+NESS,Forrester Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000030
+NESS,Forrester Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",45,000030
+NESS,Franklin Township,Kansas Senate,33,Democratic,"Bristow, Matt",9,000040
+NESS,Franklin Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",54,000040
+NESS,Highpoint Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000050
+NESS,Highpoint Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",27,000050
+NESS,Johnson Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000060
+NESS,Johnson Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",30,000060
+NESS,Nevada Township,Kansas Senate,33,Democratic,"Bristow, Matt",39,000070
+NESS,Nevada Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",163,000070
+NESS,North Center,Kansas Senate,33,Democratic,"Bristow, Matt",66,000080
+NESS,North Center,Kansas Senate,33,Republican,"Taylor, Mary Jo",320,000080
+NESS,Ohio Township,Kansas Senate,33,Democratic,"Bristow, Matt",16,000090
+NESS,Ohio Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",101,000090
+NESS,South Center,Kansas Senate,33,Democratic,"Bristow, Matt",58,000100
+NESS,South Center,Kansas Senate,33,Republican,"Taylor, Mary Jo",152,000100
+NESS,Waring Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000110
+NESS,Waring Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",40,000110
+NESS,Bazine Township,President / Vice President,,independent,"Stein, Jill",1,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+NESS,Bazine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+NESS,Bazine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000010
+NESS,Bazine Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+NESS,Bazine Township,President / Vice President,,Republican,"Trump, Donald J.",159,000010
+NESS,Eden Township,President / Vice President,,independent,"Stein, Jill",1,000020
+NESS,Eden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+NESS,Eden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+NESS,Eden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000020
+NESS,Eden Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+NESS,Eden Township,President / Vice President,,Republican,"Trump, Donald J.",36,000020
+NESS,Forrester Township,President / Vice President,,independent,"Stein, Jill",3,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+NESS,Forrester Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+NESS,Forrester Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000030
+NESS,Forrester Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+NESS,Forrester Township,President / Vice President,,Republican,"Trump, Donald J.",51,000030
+NESS,Franklin Township,President / Vice President,,independent,"Stein, Jill",1,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+NESS,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+NESS,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000040
+NESS,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+NESS,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",62,000040
+NESS,Highpoint Township,President / Vice President,,independent,"Stein, Jill",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+NESS,Highpoint Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+NESS,Highpoint Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000050
+NESS,Highpoint Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+NESS,Highpoint Township,President / Vice President,,Republican,"Trump, Donald J.",31,000050
+NESS,Johnson Township,President / Vice President,,independent,"Stein, Jill",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+NESS,Johnson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+NESS,Johnson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000060
+NESS,Johnson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+NESS,Johnson Township,President / Vice President,,Republican,"Trump, Donald J.",34,000060
+NESS,Nevada Township,President / Vice President,,independent,"Stein, Jill",2,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+NESS,Nevada Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+NESS,Nevada Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000070
+NESS,Nevada Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000070
+NESS,Nevada Township,President / Vice President,,Republican,"Trump, Donald J.",162,000070
+NESS,North Center,President / Vice President,,independent,"Stein, Jill",5,000080
+NESS,North Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+NESS,North Center,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+NESS,North Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+NESS,North Center,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+NESS,North Center,President / Vice President,,write - in,"Hedges, James A",0,000080
+NESS,North Center,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NESS,North Center,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+NESS,North Center,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+NESS,North Center,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+NESS,North Center,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+NESS,North Center,President / Vice President,,write - in,"McMullin, Evan",1,000080
+NESS,North Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+NESS,North Center,President / Vice President,,write - in,"Perry, Darryl",0,000080
+NESS,North Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+NESS,North Center,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+NESS,North Center,President / Vice President,,write - in,"Smith, Mike",0,000080
+NESS,North Center,President / Vice President,,write - in,"Sood, Ajay",0,000080
+NESS,North Center,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+NESS,North Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+NESS,North Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+NESS,North Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+NESS,North Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000080
+NESS,North Center,President / Vice President,,Libertarian,"Johnson, Gary",10,000080
+NESS,North Center,President / Vice President,,Republican,"Trump, Donald J.",364,000080
+NESS,Ohio Township,President / Vice President,,independent,"Stein, Jill",2,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+NESS,Ohio Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+NESS,Ohio Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000090
+NESS,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000090
+NESS,Ohio Township,President / Vice President,,Republican,"Trump, Donald J.",99,000090
+NESS,South Center,President / Vice President,,independent,"Stein, Jill",5,000100
+NESS,South Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+NESS,South Center,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+NESS,South Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+NESS,South Center,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+NESS,South Center,President / Vice President,,write - in,"Hedges, James A",0,000100
+NESS,South Center,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NESS,South Center,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+NESS,South Center,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+NESS,South Center,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+NESS,South Center,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+NESS,South Center,President / Vice President,,write - in,"McMullin, Evan",0,000100
+NESS,South Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+NESS,South Center,President / Vice President,,write - in,"Perry, Darryl",0,000100
+NESS,South Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+NESS,South Center,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+NESS,South Center,President / Vice President,,write - in,"Smith, Mike",0,000100
+NESS,South Center,President / Vice President,,write - in,"Sood, Ajay",0,000100
+NESS,South Center,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+NESS,South Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+NESS,South Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+NESS,South Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+NESS,South Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000100
+NESS,South Center,President / Vice President,,Libertarian,"Johnson, Gary",4,000100
+NESS,South Center,President / Vice President,,Republican,"Trump, Donald J.",191,000100
+NESS,Waring Township,President / Vice President,,independent,"Stein, Jill",1,000110
+NESS,Waring Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+NESS,Waring Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+NESS,Waring Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000110
+NESS,Waring Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+NESS,Waring Township,President / Vice President,,Republican,"Trump, Donald J.",39,000110
+NESS,Bazine Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000010
+NESS,Bazine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+NESS,Bazine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000010
+NESS,Bazine Township,United States House of Representatives,1,Republican,"Marshall, Roger",149,000010
+NESS,Eden Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000020
+NESS,Eden Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+NESS,Eden Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000020
+NESS,Eden Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000020
+NESS,Forrester Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000030
+NESS,Forrester Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+NESS,Forrester Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+NESS,Forrester Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000030
+NESS,Franklin Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000040
+NESS,Franklin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+NESS,Franklin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000040
+NESS,Franklin Township,United States House of Representatives,1,Republican,"Marshall, Roger",59,000040
+NESS,Highpoint Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000050
+NESS,Highpoint Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+NESS,Highpoint Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+NESS,Highpoint Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000050
+NESS,Johnson Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000060
+NESS,Johnson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+NESS,Johnson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+NESS,Johnson Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000060
+NESS,Nevada Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000070
+NESS,Nevada Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000070
+NESS,Nevada Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000070
+NESS,Nevada Township,United States House of Representatives,1,Republican,"Marshall, Roger",163,000070
+NESS,North Center,United States House of Representatives,1,independent,"LaPolice, Alan",71,000080
+NESS,North Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+NESS,North Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000080
+NESS,North Center,United States House of Representatives,1,Republican,"Marshall, Roger",326,000080
+NESS,Ohio Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000090
+NESS,Ohio Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+NESS,Ohio Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000090
+NESS,Ohio Township,United States House of Representatives,1,Republican,"Marshall, Roger",103,000090
+NESS,South Center,United States House of Representatives,1,independent,"LaPolice, Alan",45,000100
+NESS,South Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+NESS,South Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000100
+NESS,South Center,United States House of Representatives,1,Republican,"Marshall, Roger",172,000100
+NESS,Waring Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000110
+NESS,Waring Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000110
+NESS,Waring Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+NESS,Waring Township,United States House of Representatives,1,Republican,"Marshall, Roger",39,000110
+NESS,Bazine Township,United States Senate,,write - in,"Smith, DJ",0,000010
+NESS,Bazine Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000010
+NESS,Bazine Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+NESS,Bazine Township,United States Senate,,Republican,"Moran, Jerry",158,000010
+NESS,Eden Township,United States Senate,,write - in,"Smith, DJ",0,000020
+NESS,Eden Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+NESS,Eden Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+NESS,Eden Township,United States Senate,,Republican,"Moran, Jerry",41,000020
+NESS,Forrester Township,United States Senate,,write - in,"Smith, DJ",0,000030
+NESS,Forrester Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000030
+NESS,Forrester Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+NESS,Forrester Township,United States Senate,,Republican,"Moran, Jerry",54,000030
+NESS,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000040
+NESS,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+NESS,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000040
+NESS,Franklin Township,United States Senate,,Republican,"Moran, Jerry",67,000040
+NESS,Highpoint Township,United States Senate,,write - in,"Smith, DJ",0,000050
+NESS,Highpoint Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000050
+NESS,Highpoint Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+NESS,Highpoint Township,United States Senate,,Republican,"Moran, Jerry",31,000050
+NESS,Johnson Township,United States Senate,,write - in,"Smith, DJ",0,000060
+NESS,Johnson Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+NESS,Johnson Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+NESS,Johnson Township,United States Senate,,Republican,"Moran, Jerry",29,000060
+NESS,Nevada Township,United States Senate,,write - in,"Smith, DJ",0,000070
+NESS,Nevada Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000070
+NESS,Nevada Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000070
+NESS,Nevada Township,United States Senate,,Republican,"Moran, Jerry",181,000070
+NESS,North Center,United States Senate,,write - in,"Smith, DJ",0,000080
+NESS,North Center,United States Senate,,Democratic,"Wiesner, Patrick",29,000080
+NESS,North Center,United States Senate,,Libertarian,"Garrard, Robert D.",14,000080
+NESS,North Center,United States Senate,,Republican,"Moran, Jerry",377,000080
+NESS,Ohio Township,United States Senate,,write - in,"Smith, DJ",0,000090
+NESS,Ohio Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000090
+NESS,Ohio Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+NESS,Ohio Township,United States Senate,,Republican,"Moran, Jerry",109,000090
+NESS,South Center,United States Senate,,write - in,"Smith, DJ",0,000100
+NESS,South Center,United States Senate,,Democratic,"Wiesner, Patrick",23,000100
+NESS,South Center,United States Senate,,Libertarian,"Garrard, Robert D.",9,000100
+NESS,South Center,United States Senate,,Republican,"Moran, Jerry",194,000100
+NESS,Waring Township,United States Senate,,write - in,"Smith, DJ",0,000110
+NESS,Waring Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+NESS,Waring Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+NESS,Waring Township,United States Senate,,Republican,"Moran, Jerry",49,000110

--- a/2016/20161108__ks__general__norton__precinct.csv
+++ b/2016/20161108__ks__general__norton__precinct.csv
@@ -1,433 +1,433 @@
-county,precinct,office,district,candidate,party,votes
-Norton,Almena Township,President,,"Stein, Jill  ",independent,5
-Norton,Almena Township,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Almena Township,President,,"Castle, Darrell L ",write - in,0
-Norton,Almena Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Almena Township,President,,"Giordani, Rocky  ",write - in,0
-Norton,Almena Township,President,,"Hedges, James A ",write - in,0
-Norton,Almena Township,President,,"Hoefling, Tom  ",write - in,0
-Norton,Almena Township,President,,"Kahn, Lynn  ",write - in,0
-Norton,Almena Township,President,,"La Riva, Gloria  ",write - in,0
-Norton,Almena Township,President,,"Levinson, Michael S. ",write - in,0
-Norton,Almena Township,President,,"Maturen, Michael A ",write - in,0
-Norton,Almena Township,President,,"McMullin, Evan  ",write - in,1
-Norton,Almena Township,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Almena Township,President,,"Perry, Darryl  ",write - in,0
-Norton,Almena Township,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Almena Township,President,,"Schriner, Joe C ",write - in,0
-Norton,Almena Township,President,,"Smith, Mike  ",write - in,0
-Norton,Almena Township,President,,"Sood, Ajay  ",write - in,0
-Norton,Almena Township,President,,"Sterling, Shawna  ",write - in,0
-Norton,Almena Township,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Almena Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Almena Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Almena Township,President,,"Clinton, Hillary Rodham ",Democratic,19
-Norton,Almena Township,President,,"Johnson, Gary  ",Libertarian,6
-Norton,Almena Township,President,,"Trump, Donald J. ",Republican,198
-Norton,Center Precinct 1,President,,"Stein, Jill  ",independent,4
-Norton,Center Precinct 1,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Center Precinct 1,President,,"Castle, Darrell L ",write - in,0
-Norton,Center Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Center Precinct 1,President,,"Giordani, Rocky  ",write - in,0
-Norton,Center Precinct 1,President,,"Hedges, James A ",write - in,0
-Norton,Center Precinct 1,President,,"Hoefling, Tom  ",write - in,0
-Norton,Center Precinct 1,President,,"Kahn, Lynn  ",write - in,0
-Norton,Center Precinct 1,President,,"La Riva, Gloria  ",write - in,0
-Norton,Center Precinct 1,President,,"Levinson, Michael S. ",write - in,0
-Norton,Center Precinct 1,President,,"Maturen, Michael A ",write - in,0
-Norton,Center Precinct 1,President,,"McMullin, Evan  ",write - in,0
-Norton,Center Precinct 1,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Center Precinct 1,President,,"Perry, Darryl  ",write - in,0
-Norton,Center Precinct 1,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Center Precinct 1,President,,"Schriner, Joe C ",write - in,0
-Norton,Center Precinct 1,President,,"Smith, Mike  ",write - in,0
-Norton,Center Precinct 1,President,,"Sood, Ajay  ",write - in,0
-Norton,Center Precinct 1,President,,"Sterling, Shawna  ",write - in,0
-Norton,Center Precinct 1,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Center Precinct 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Center Precinct 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Center Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,38
-Norton,Center Precinct 1,President,,"Johnson, Gary  ",Libertarian,5
-Norton,Center Precinct 1,President,,"Trump, Donald J. ",Republican,289
-Norton,Center Precinct 2,President,,"Stein, Jill  ",independent,0
-Norton,Center Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Center Precinct 2,President,,"Castle, Darrell L ",write - in,0
-Norton,Center Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Center Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-Norton,Center Precinct 2,President,,"Hedges, James A ",write - in,0
-Norton,Center Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-Norton,Center Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-Norton,Center Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-Norton,Center Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-Norton,Center Precinct 2,President,,"Maturen, Michael A ",write - in,0
-Norton,Center Precinct 2,President,,"McMullin, Evan  ",write - in,0
-Norton,Center Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Center Precinct 2,President,,"Perry, Darryl  ",write - in,0
-Norton,Center Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Center Precinct 2,President,,"Schriner, Joe C ",write - in,0
-Norton,Center Precinct 2,President,,"Smith, Mike  ",write - in,0
-Norton,Center Precinct 2,President,,"Sood, Ajay  ",write - in,0
-Norton,Center Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-Norton,Center Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Center Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Center Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Center Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,6
-Norton,Center Precinct 2,President,,"Johnson, Gary  ",Libertarian,3
-Norton,Center Precinct 2,President,,"Trump, Donald J. ",Republican,68
-Norton,Harrison Township,President,,"Stein, Jill  ",independent,0
-Norton,Harrison Township,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Harrison Township,President,,"Castle, Darrell L ",write - in,0
-Norton,Harrison Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Harrison Township,President,,"Giordani, Rocky  ",write - in,0
-Norton,Harrison Township,President,,"Hedges, James A ",write - in,0
-Norton,Harrison Township,President,,"Hoefling, Tom  ",write - in,0
-Norton,Harrison Township,President,,"Kahn, Lynn  ",write - in,0
-Norton,Harrison Township,President,,"La Riva, Gloria  ",write - in,0
-Norton,Harrison Township,President,,"Levinson, Michael S. ",write - in,0
-Norton,Harrison Township,President,,"Maturen, Michael A ",write - in,0
-Norton,Harrison Township,President,,"McMullin, Evan  ",write - in,0
-Norton,Harrison Township,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Harrison Township,President,,"Perry, Darryl  ",write - in,0
-Norton,Harrison Township,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Harrison Township,President,,"Schriner, Joe C ",write - in,0
-Norton,Harrison Township,President,,"Smith, Mike  ",write - in,0
-Norton,Harrison Township,President,,"Sood, Ajay  ",write - in,0
-Norton,Harrison Township,President,,"Sterling, Shawna  ",write - in,0
-Norton,Harrison Township,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Harrison Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Harrison Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Harrison Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Norton,Harrison Township,President,,"Johnson, Gary  ",Libertarian,0
-Norton,Harrison Township,President,,"Trump, Donald J. ",Republican,0
-Norton,Highland Precinct 1,President,,"Stein, Jill  ",independent,3
-Norton,Highland Precinct 1,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Highland Precinct 1,President,,"Castle, Darrell L ",write - in,0
-Norton,Highland Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Highland Precinct 1,President,,"Giordani, Rocky  ",write - in,0
-Norton,Highland Precinct 1,President,,"Hedges, James A ",write - in,0
-Norton,Highland Precinct 1,President,,"Hoefling, Tom  ",write - in,0
-Norton,Highland Precinct 1,President,,"Kahn, Lynn  ",write - in,0
-Norton,Highland Precinct 1,President,,"La Riva, Gloria  ",write - in,0
-Norton,Highland Precinct 1,President,,"Levinson, Michael S. ",write - in,0
-Norton,Highland Precinct 1,President,,"Maturen, Michael A ",write - in,0
-Norton,Highland Precinct 1,President,,"McMullin, Evan  ",write - in,0
-Norton,Highland Precinct 1,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Highland Precinct 1,President,,"Perry, Darryl  ",write - in,0
-Norton,Highland Precinct 1,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Highland Precinct 1,President,,"Schriner, Joe C ",write - in,0
-Norton,Highland Precinct 1,President,,"Smith, Mike  ",write - in,0
-Norton,Highland Precinct 1,President,,"Sood, Ajay  ",write - in,0
-Norton,Highland Precinct 1,President,,"Sterling, Shawna  ",write - in,0
-Norton,Highland Precinct 1,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Highland Precinct 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Highland Precinct 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Highland Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,33
-Norton,Highland Precinct 1,President,,"Johnson, Gary  ",Libertarian,8
-Norton,Highland Precinct 1,President,,"Trump, Donald J. ",Republican,165
-Norton,Highland Precinct 2,President,,"Stein, Jill  ",independent,2
-Norton,Highland Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Highland Precinct 2,President,,"Castle, Darrell L ",write - in,0
-Norton,Highland Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Highland Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-Norton,Highland Precinct 2,President,,"Hedges, James A ",write - in,0
-Norton,Highland Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-Norton,Highland Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-Norton,Highland Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-Norton,Highland Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-Norton,Highland Precinct 2,President,,"Maturen, Michael A ",write - in,0
-Norton,Highland Precinct 2,President,,"McMullin, Evan  ",write - in,0
-Norton,Highland Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Highland Precinct 2,President,,"Perry, Darryl  ",write - in,0
-Norton,Highland Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Highland Precinct 2,President,,"Schriner, Joe C ",write - in,0
-Norton,Highland Precinct 2,President,,"Smith, Mike  ",write - in,0
-Norton,Highland Precinct 2,President,,"Sood, Ajay  ",write - in,0
-Norton,Highland Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-Norton,Highland Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Highland Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Highland Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Highland Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,3
-Norton,Highland Precinct 2,President,,"Johnson, Gary  ",Libertarian,0
-Norton,Highland Precinct 2,President,,"Trump, Donald J. ",Republican,45
-Norton,Highland Precinct 3,President,,"Stein, Jill  ",independent,0
-Norton,Highland Precinct 3,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Highland Precinct 3,President,,"Castle, Darrell L ",write - in,0
-Norton,Highland Precinct 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Highland Precinct 3,President,,"Giordani, Rocky  ",write - in,0
-Norton,Highland Precinct 3,President,,"Hedges, James A ",write - in,0
-Norton,Highland Precinct 3,President,,"Hoefling, Tom  ",write - in,0
-Norton,Highland Precinct 3,President,,"Kahn, Lynn  ",write - in,0
-Norton,Highland Precinct 3,President,,"La Riva, Gloria  ",write - in,0
-Norton,Highland Precinct 3,President,,"Levinson, Michael S. ",write - in,0
-Norton,Highland Precinct 3,President,,"Maturen, Michael A ",write - in,0
-Norton,Highland Precinct 3,President,,"McMullin, Evan  ",write - in,0
-Norton,Highland Precinct 3,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Highland Precinct 3,President,,"Perry, Darryl  ",write - in,0
-Norton,Highland Precinct 3,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Highland Precinct 3,President,,"Schriner, Joe C ",write - in,0
-Norton,Highland Precinct 3,President,,"Smith, Mike  ",write - in,0
-Norton,Highland Precinct 3,President,,"Sood, Ajay  ",write - in,0
-Norton,Highland Precinct 3,President,,"Sterling, Shawna  ",write - in,0
-Norton,Highland Precinct 3,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Highland Precinct 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Highland Precinct 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Highland Precinct 3,President,,"Clinton, Hillary Rodham ",Democratic,2
-Norton,Highland Precinct 3,President,,"Johnson, Gary  ",Libertarian,0
-Norton,Highland Precinct 3,President,,"Trump, Donald J. ",Republican,49
-Norton,Norton Ward 1,President,,"Stein, Jill  ",independent,12
-Norton,Norton Ward 1,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Norton Ward 1,President,,"Castle, Darrell L ",write - in,0
-Norton,Norton Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Norton Ward 1,President,,"Giordani, Rocky  ",write - in,0
-Norton,Norton Ward 1,President,,"Hedges, James A ",write - in,0
-Norton,Norton Ward 1,President,,"Hoefling, Tom  ",write - in,0
-Norton,Norton Ward 1,President,,"Kahn, Lynn  ",write - in,0
-Norton,Norton Ward 1,President,,"La Riva, Gloria  ",write - in,0
-Norton,Norton Ward 1,President,,"Levinson, Michael S. ",write - in,0
-Norton,Norton Ward 1,President,,"Maturen, Michael A ",write - in,0
-Norton,Norton Ward 1,President,,"McMullin, Evan  ",write - in,1
-Norton,Norton Ward 1,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Norton Ward 1,President,,"Perry, Darryl  ",write - in,0
-Norton,Norton Ward 1,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Norton Ward 1,President,,"Schriner, Joe C ",write - in,0
-Norton,Norton Ward 1,President,,"Smith, Mike  ",write - in,0
-Norton,Norton Ward 1,President,,"Sood, Ajay  ",write - in,0
-Norton,Norton Ward 1,President,,"Sterling, Shawna  ",write - in,0
-Norton,Norton Ward 1,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Norton Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Norton Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Norton Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,48
-Norton,Norton Ward 1,President,,"Johnson, Gary  ",Libertarian,12
-Norton,Norton Ward 1,President,,"Trump, Donald J. ",Republican,287
-Norton,Norton Ward 2,President,,"Stein, Jill  ",independent,11
-Norton,Norton Ward 2,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Norton Ward 2,President,,"Castle, Darrell L ",write - in,0
-Norton,Norton Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Norton Ward 2,President,,"Giordani, Rocky  ",write - in,0
-Norton,Norton Ward 2,President,,"Hedges, James A ",write - in,0
-Norton,Norton Ward 2,President,,"Hoefling, Tom  ",write - in,0
-Norton,Norton Ward 2,President,,"Kahn, Lynn  ",write - in,0
-Norton,Norton Ward 2,President,,"La Riva, Gloria  ",write - in,0
-Norton,Norton Ward 2,President,,"Levinson, Michael S. ",write - in,0
-Norton,Norton Ward 2,President,,"Maturen, Michael A ",write - in,0
-Norton,Norton Ward 2,President,,"McMullin, Evan  ",write - in,2
-Norton,Norton Ward 2,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Norton Ward 2,President,,"Perry, Darryl  ",write - in,0
-Norton,Norton Ward 2,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Norton Ward 2,President,,"Schriner, Joe C ",write - in,0
-Norton,Norton Ward 2,President,,"Smith, Mike  ",write - in,0
-Norton,Norton Ward 2,President,,"Sood, Ajay  ",write - in,0
-Norton,Norton Ward 2,President,,"Sterling, Shawna  ",write - in,0
-Norton,Norton Ward 2,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Norton Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Norton Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Norton Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,77
-Norton,Norton Ward 2,President,,"Johnson, Gary  ",Libertarian,13
-Norton,Norton Ward 2,President,,"Trump, Donald J. ",Republican,350
-Norton,Norton Ward 3,President,,"Stein, Jill  ",independent,4
-Norton,Norton Ward 3,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Norton Ward 3,President,,"Castle, Darrell L ",write - in,0
-Norton,Norton Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Norton Ward 3,President,,"Giordani, Rocky  ",write - in,0
-Norton,Norton Ward 3,President,,"Hedges, James A ",write - in,0
-Norton,Norton Ward 3,President,,"Hoefling, Tom  ",write - in,0
-Norton,Norton Ward 3,President,,"Kahn, Lynn  ",write - in,0
-Norton,Norton Ward 3,President,,"La Riva, Gloria  ",write - in,0
-Norton,Norton Ward 3,President,,"Levinson, Michael S. ",write - in,0
-Norton,Norton Ward 3,President,,"Maturen, Michael A ",write - in,0
-Norton,Norton Ward 3,President,,"McMullin, Evan  ",write - in,1
-Norton,Norton Ward 3,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Norton Ward 3,President,,"Perry, Darryl  ",write - in,0
-Norton,Norton Ward 3,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Norton Ward 3,President,,"Schriner, Joe C ",write - in,0
-Norton,Norton Ward 3,President,,"Smith, Mike  ",write - in,0
-Norton,Norton Ward 3,President,,"Sood, Ajay  ",write - in,0
-Norton,Norton Ward 3,President,,"Sterling, Shawna  ",write - in,0
-Norton,Norton Ward 3,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Norton Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Norton Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Norton Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,53
-Norton,Norton Ward 3,President,,"Johnson, Gary  ",Libertarian,17
-Norton,Norton Ward 3,President,,"Trump, Donald J. ",Republican,308
-Norton,Solomon Precinct 1,President,,"Stein, Jill  ",independent,0
-Norton,Solomon Precinct 1,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Solomon Precinct 1,President,,"Castle, Darrell L ",write - in,0
-Norton,Solomon Precinct 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Giordani, Rocky  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Hedges, James A ",write - in,0
-Norton,Solomon Precinct 1,President,,"Hoefling, Tom  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Kahn, Lynn  ",write - in,0
-Norton,Solomon Precinct 1,President,,"La Riva, Gloria  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Levinson, Michael S. ",write - in,0
-Norton,Solomon Precinct 1,President,,"Maturen, Michael A ",write - in,0
-Norton,Solomon Precinct 1,President,,"McMullin, Evan  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Solomon Precinct 1,President,,"Perry, Darryl  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Solomon Precinct 1,President,,"Schriner, Joe C ",write - in,0
-Norton,Solomon Precinct 1,President,,"Smith, Mike  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Sood, Ajay  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Sterling, Shawna  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Solomon Precinct 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Solomon Precinct 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Solomon Precinct 1,President,,"Clinton, Hillary Rodham ",Democratic,2
-Norton,Solomon Precinct 1,President,,"Johnson, Gary  ",Libertarian,3
-Norton,Solomon Precinct 1,President,,"Trump, Donald J. ",Republican,57
-Norton,Solomon Precinct 2,President,,"Stein, Jill  ",independent,0
-Norton,Solomon Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-Norton,Solomon Precinct 2,President,,"Castle, Darrell L ",write - in,0
-Norton,Solomon Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Hedges, James A ",write - in,0
-Norton,Solomon Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-Norton,Solomon Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-Norton,Solomon Precinct 2,President,,"Maturen, Michael A ",write - in,0
-Norton,Solomon Precinct 2,President,,"McMullin, Evan  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-Norton,Solomon Precinct 2,President,,"Perry, Darryl  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-Norton,Solomon Precinct 2,President,,"Schriner, Joe C ",write - in,0
-Norton,Solomon Precinct 2,President,,"Smith, Mike  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Sood, Ajay  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-Norton,Solomon Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Norton,Solomon Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Norton,Solomon Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,0
-Norton,Solomon Precinct 2,President,,"Johnson, Gary  ",Libertarian,0
-Norton,Solomon Precinct 2,President,,"Trump, Donald J. ",Republican,24
-Norton,Almena Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Almena Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,16
-Norton,Almena Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Norton,Almena Township,U.S. Senate,,"Moran, Jerry  ",Republican,202
-Norton,Center Precinct 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Center Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,25
-Norton,Center Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Norton,Center Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,294
-Norton,Center Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Center Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Norton,Center Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Norton,Center Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,67
-Norton,Harrison Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Harrison Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Norton,Harrison Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Norton,Harrison Township,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Norton,Highland Precinct 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Highland Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,25
-Norton,Highland Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,15
-Norton,Highland Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,166
-Norton,Highland Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Highland Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,6
-Norton,Highland Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Norton,Highland Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,43
-Norton,Highland Precinct 3,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Highland Precinct 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Norton,Highland Precinct 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Norton,Highland Precinct 3,U.S. Senate,,"Moran, Jerry  ",Republican,50
-Norton,Norton Ward 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Norton Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,44
-Norton,Norton Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,24
-Norton,Norton Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,295
-Norton,Norton Ward 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Norton Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,63
-Norton,Norton Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,20
-Norton,Norton Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,379
-Norton,Norton Ward 3,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Norton Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,51
-Norton,Norton Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,21
-Norton,Norton Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,317
-Norton,Solomon Precinct 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Solomon Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Norton,Solomon Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Norton,Solomon Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,59
-Norton,Solomon Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Norton,Solomon Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Norton,Solomon Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Norton,Solomon Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,23
-Norton,Almena Township,U.S. House,1,"LaPolice, Alan  ",independent,33
-Norton,Almena Township,U.S. House,1,"Huelskamp, Tim  ",write - in,2
-Norton,Almena Township,U.S. House,1,"Burt, Kerry  ",Libertarian,8
-Norton,Almena Township,U.S. House,1,"Marshall, Roger  ",Republican,184
-Norton,Center Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,54
-Norton,Center Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Center Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,6
-Norton,Center Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,268
-Norton,Center Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,7
-Norton,Center Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Center Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,5
-Norton,Center Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,61
-Norton,Harrison Township,U.S. House,1,"LaPolice, Alan  ",independent,0
-Norton,Harrison Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Harrison Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Norton,Harrison Township,U.S. House,1,"Marshall, Roger  ",Republican,0
-Norton,Highland Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,30
-Norton,Highland Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Norton,Highland Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,13
-Norton,Highland Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,161
-Norton,Highland Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,9
-Norton,Highland Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Highland Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Norton,Highland Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,38
-Norton,Highland Precinct 3,U.S. House,1,"LaPolice, Alan  ",independent,6
-Norton,Highland Precinct 3,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Highland Precinct 3,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Norton,Highland Precinct 3,U.S. House,1,"Marshall, Roger  ",Republican,45
-Norton,Norton Ward 1,U.S. House,1,"LaPolice, Alan  ",independent,76
-Norton,Norton Ward 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Norton Ward 1,U.S. House,1,"Burt, Kerry  ",Libertarian,24
-Norton,Norton Ward 1,U.S. House,1,"Marshall, Roger  ",Republican,260
-Norton,Norton Ward 2,U.S. House,1,"LaPolice, Alan  ",independent,86
-Norton,Norton Ward 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Norton Ward 2,U.S. House,1,"Burt, Kerry  ",Libertarian,21
-Norton,Norton Ward 2,U.S. House,1,"Marshall, Roger  ",Republican,342
-Norton,Norton Ward 3,U.S. House,1,"LaPolice, Alan  ",independent,63
-Norton,Norton Ward 3,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Norton,Norton Ward 3,U.S. House,1,"Burt, Kerry  ",Libertarian,25
-Norton,Norton Ward 3,U.S. House,1,"Marshall, Roger  ",Republican,294
-Norton,Solomon Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,4
-Norton,Solomon Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Solomon Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Norton,Solomon Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,54
-Norton,Solomon Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,3
-Norton,Solomon Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Norton,Solomon Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Norton,Solomon Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,19
-Norton,Almena Township,State Senate,40,"Herman, Alex  ",Democratic,37
-Norton,Almena Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,188
-Norton,Center Precinct 1,State Senate,40,"Herman, Alex  ",Democratic,53
-Norton,Center Precinct 1,State Senate,40,"Billinger, Richard (Rick)  ",Republican,262
-Norton,Center Precinct 2,State Senate,40,"Herman, Alex  ",Democratic,10
-Norton,Center Precinct 2,State Senate,40,"Billinger, Richard (Rick)  ",Republican,62
-Norton,Harrison Township,State Senate,40,"Herman, Alex  ",Democratic,0
-Norton,Harrison Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,0
-Norton,Highland Precinct 1,State Senate,40,"Herman, Alex  ",Democratic,57
-Norton,Highland Precinct 1,State Senate,40,"Billinger, Richard (Rick)  ",Republican,152
-Norton,Highland Precinct 2,State Senate,40,"Herman, Alex  ",Democratic,6
-Norton,Highland Precinct 2,State Senate,40,"Billinger, Richard (Rick)  ",Republican,41
-Norton,Highland Precinct 3,State Senate,40,"Herman, Alex  ",Democratic,1
-Norton,Highland Precinct 3,State Senate,40,"Billinger, Richard (Rick)  ",Republican,49
-Norton,Norton Ward 1,State Senate,40,"Herman, Alex  ",Democratic,75
-Norton,Norton Ward 1,State Senate,40,"Billinger, Richard (Rick)  ",Republican,342
-Norton,Norton Ward 2,State Senate,40,"Herman, Alex  ",Democratic,109
-Norton,Norton Ward 2,State Senate,40,"Billinger, Richard (Rick)  ",Republican,340
-Norton,Norton Ward 3,State Senate,40,"Herman, Alex  ",Democratic,84
-Norton,Norton Ward 3,State Senate,40,"Billinger, Richard (Rick)  ",Republican,301
-Norton,Solomon Precinct 1,State Senate,40,"Herman, Alex  ",Democratic,3
-Norton,Solomon Precinct 1,State Senate,40,"Billinger, Richard (Rick)  ",Republican,56
-Norton,Solomon Precinct 2,State Senate,40,"Herman, Alex  ",Democratic,1
-Norton,Solomon Precinct 2,State Senate,40,"Billinger, Richard (Rick)  ",Republican,20
-Norton,Almena Township,State House,110,"Rahjes, Ken  ",Republican,220
-Norton,Center Precinct 1,State House,110,"Rahjes, Ken  ",Republican,303
-Norton,Center Precinct 2,State House,110,"Rahjes, Ken  ",Republican,67
-Norton,Harrison Township,State House,110,"Rahjes, Ken  ",Republican,0
-Norton,Highland Precinct 1,State House,110,"Rahjes, Ken  ",Republican,182
-Norton,Highland Precinct 2,State House,110,"Rahjes, Ken  ",Republican,43
-Norton,Highland Precinct 3,State House,110,"Rahjes, Ken  ",Republican,50
-Norton,Norton Ward 1,State House,110,"Rahjes, Ken  ",Republican,328
-Norton,Norton Ward 2,State House,110,"Rahjes, Ken  ",Republican,408
-Norton,Norton Ward 3,State House,110,"Rahjes, Ken  ",Republican,347
-Norton,Solomon Precinct 1,State House,110,"Rahjes, Ken  ",Republican,57
-Norton,Solomon Precinct 2,State House,110,"Rahjes, Ken  ",Republican,22
+county,precinct,office,district,party,candidate,votes,vtd
+NORTON,Almena Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",220,000010
+NORTON,Center Precinct 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",303,000020
+NORTON,Center Precinct 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",67,000030
+NORTON,Harrison Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",0,000040
+NORTON,Highland Precinct 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",182,000050
+NORTON,Highland Precinct 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",43,000060
+NORTON,Highland Precinct 3,Kansas House of Representatives,110,Republican,"Rahjes, Ken",50,000070
+NORTON,Norton Ward 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",328,000080
+NORTON,Norton Ward 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",408,000090
+NORTON,Norton Ward 3,Kansas House of Representatives,110,Republican,"Rahjes, Ken",347,000100
+NORTON,Solomon Precinct 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",57,000110
+NORTON,Solomon Precinct 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",22,000120
+NORTON,Almena Township,Kansas Senate,40,Democratic,"Herman, Alex",37,000010
+NORTON,Almena Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",188,000010
+NORTON,Center Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",53,000020
+NORTON,Center Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",262,000020
+NORTON,Center Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",10,000030
+NORTON,Center Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",62,000030
+NORTON,Harrison Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000040
+NORTON,Harrison Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,000040
+NORTON,Highland Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",57,000050
+NORTON,Highland Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",152,000050
+NORTON,Highland Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",6,000060
+NORTON,Highland Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",41,000060
+NORTON,Highland Precinct 3,Kansas Senate,40,Democratic,"Herman, Alex",1,000070
+NORTON,Highland Precinct 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",49,000070
+NORTON,Norton Ward 1,Kansas Senate,40,Democratic,"Herman, Alex",75,000080
+NORTON,Norton Ward 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",342,000080
+NORTON,Norton Ward 2,Kansas Senate,40,Democratic,"Herman, Alex",109,000090
+NORTON,Norton Ward 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",340,000090
+NORTON,Norton Ward 3,Kansas Senate,40,Democratic,"Herman, Alex",84,000100
+NORTON,Norton Ward 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",301,000100
+NORTON,Solomon Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",3,000110
+NORTON,Solomon Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",56,000110
+NORTON,Solomon Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",1,000120
+NORTON,Solomon Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",20,000120
+NORTON,Almena Township,President / Vice President,,independent,"Stein, Jill",5,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"McMullin, Evan",1,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+NORTON,Almena Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+NORTON,Almena Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000010
+NORTON,Almena Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+NORTON,Almena Township,President / Vice President,,Republican,"Trump, Donald J.",198,000010
+NORTON,Center Precinct 1,President / Vice President,,independent,"Stein, Jill",4,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+NORTON,Center Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+NORTON,Center Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000020
+NORTON,Center Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+NORTON,Center Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",289,000020
+NORTON,Center Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+NORTON,Center Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+NORTON,Center Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000030
+NORTON,Center Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+NORTON,Center Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",68,000030
+NORTON,Harrison Township,President / Vice President,,independent,"Stein, Jill",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+NORTON,Harrison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+NORTON,Harrison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+NORTON,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+NORTON,Harrison Township,President / Vice President,,Republican,"Trump, Donald J.",0,000040
+NORTON,Highland Precinct 1,President / Vice President,,independent,"Stein, Jill",3,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+NORTON,Highland Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000050
+NORTON,Highland Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+NORTON,Highland Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",165,000050
+NORTON,Highland Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000060
+NORTON,Highland Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+NORTON,Highland Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",45,000060
+NORTON,Highland Precinct 3,President / Vice President,,independent,"Stein, Jill",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000070
+NORTON,Highland Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+NORTON,Highland Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",49,000070
+NORTON,Norton Ward 1,President / Vice President,,independent,"Stein, Jill",12,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+NORTON,Norton Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+NORTON,Norton Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,000080
+NORTON,Norton Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",12,000080
+NORTON,Norton Ward 1,President / Vice President,,Republican,"Trump, Donald J.",287,000080
+NORTON,Norton Ward 2,President / Vice President,,independent,"Stein, Jill",11,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+NORTON,Norton Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+NORTON,Norton Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000090
+NORTON,Norton Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",13,000090
+NORTON,Norton Ward 2,President / Vice President,,Republican,"Trump, Donald J.",350,000090
+NORTON,Norton Ward 3,President / Vice President,,independent,"Stein, Jill",4,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+NORTON,Norton Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+NORTON,Norton Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000100
+NORTON,Norton Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",17,000100
+NORTON,Norton Ward 3,President / Vice President,,Republican,"Trump, Donald J.",308,000100
+NORTON,Solomon Precinct 1,President / Vice President,,independent,"Stein, Jill",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+NORTON,Solomon Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",57,000110
+NORTON,Solomon Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+NORTON,Solomon Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",24,000120
+NORTON,Almena Township,United States House of Representatives,1,independent,"LaPolice, Alan",33,000010
+NORTON,Almena Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000010
+NORTON,Almena Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000010
+NORTON,Almena Township,United States House of Representatives,1,Republican,"Marshall, Roger",184,000010
+NORTON,Center Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",54,000020
+NORTON,Center Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+NORTON,Center Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000020
+NORTON,Center Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",268,000020
+NORTON,Center Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",7,000030
+NORTON,Center Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+NORTON,Center Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000030
+NORTON,Center Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",61,000030
+NORTON,Harrison Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000040
+NORTON,Harrison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+NORTON,Harrison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+NORTON,Harrison Township,United States House of Representatives,1,Republican,"Marshall, Roger",0,000040
+NORTON,Highland Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",30,000050
+NORTON,Highland Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+NORTON,Highland Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000050
+NORTON,Highland Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",161,000050
+NORTON,Highland Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",9,000060
+NORTON,Highland Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+NORTON,Highland Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+NORTON,Highland Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",38,000060
+NORTON,Highland Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",6,000070
+NORTON,Highland Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+NORTON,Highland Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000070
+NORTON,Highland Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",45,000070
+NORTON,Norton Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",76,000080
+NORTON,Norton Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+NORTON,Norton Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000080
+NORTON,Norton Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",260,000080
+NORTON,Norton Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",86,000090
+NORTON,Norton Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+NORTON,Norton Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,000090
+NORTON,Norton Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",342,000090
+NORTON,Norton Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",63,000100
+NORTON,Norton Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+NORTON,Norton Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000100
+NORTON,Norton Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",294,000100
+NORTON,Solomon Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",4,000110
+NORTON,Solomon Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+NORTON,Solomon Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000110
+NORTON,Solomon Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",54,000110
+NORTON,Solomon Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",3,000120
+NORTON,Solomon Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+NORTON,Solomon Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000120
+NORTON,Solomon Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",19,000120
+NORTON,Almena Township,United States Senate,,write - in,"Smith, DJ",0,000010
+NORTON,Almena Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000010
+NORTON,Almena Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000010
+NORTON,Almena Township,United States Senate,,Republican,"Moran, Jerry",202,000010
+NORTON,Center Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000020
+NORTON,Center Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",25,000020
+NORTON,Center Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",12,000020
+NORTON,Center Precinct 1,United States Senate,,Republican,"Moran, Jerry",294,000020
+NORTON,Center Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000030
+NORTON,Center Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",5,000030
+NORTON,Center Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",5,000030
+NORTON,Center Precinct 2,United States Senate,,Republican,"Moran, Jerry",67,000030
+NORTON,Harrison Township,United States Senate,,write - in,"Smith, DJ",0,000040
+NORTON,Harrison Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000040
+NORTON,Harrison Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+NORTON,Harrison Township,United States Senate,,Republican,"Moran, Jerry",0,000040
+NORTON,Highland Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000050
+NORTON,Highland Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",25,000050
+NORTON,Highland Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",15,000050
+NORTON,Highland Precinct 1,United States Senate,,Republican,"Moran, Jerry",166,000050
+NORTON,Highland Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000060
+NORTON,Highland Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",6,000060
+NORTON,Highland Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",2,000060
+NORTON,Highland Precinct 2,United States Senate,,Republican,"Moran, Jerry",43,000060
+NORTON,Highland Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000070
+NORTON,Highland Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",1,000070
+NORTON,Highland Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+NORTON,Highland Precinct 3,United States Senate,,Republican,"Moran, Jerry",50,000070
+NORTON,Norton Ward 1,United States Senate,,write - in,"Smith, DJ",0,000080
+NORTON,Norton Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",44,000080
+NORTON,Norton Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,000080
+NORTON,Norton Ward 1,United States Senate,,Republican,"Moran, Jerry",295,000080
+NORTON,Norton Ward 2,United States Senate,,write - in,"Smith, DJ",0,000090
+NORTON,Norton Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",63,000090
+NORTON,Norton Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",20,000090
+NORTON,Norton Ward 2,United States Senate,,Republican,"Moran, Jerry",379,000090
+NORTON,Norton Ward 3,United States Senate,,write - in,"Smith, DJ",0,000100
+NORTON,Norton Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",51,000100
+NORTON,Norton Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",21,000100
+NORTON,Norton Ward 3,United States Senate,,Republican,"Moran, Jerry",317,000100
+NORTON,Solomon Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000110
+NORTON,Solomon Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+NORTON,Solomon Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+NORTON,Solomon Precinct 1,United States Senate,,Republican,"Moran, Jerry",59,000110
+NORTON,Solomon Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000120
+NORTON,Solomon Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",1,000120
+NORTON,Solomon Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+NORTON,Solomon Precinct 2,United States Senate,,Republican,"Moran, Jerry",23,000120

--- a/2016/20161108__ks__general__osage__precinct.csv
+++ b/2016/20161108__ks__general__osage__precinct.csv
@@ -1,452 +1,1004 @@
-county,precinct,office,district,party,candidate,votes
-Osage,0001 AGENCY,President,,DEM,Clinton & Kaine,31
-Osage,0002 ARVONIA,President,,DEM,Clinton & Kaine,18
-Osage,0003 BARCLAY,President,,DEM,Clinton & Kaine,20
-Osage,0004 NORTH BURLINGAME,President,,DEM,Clinton & Kaine,97
-Osage,0005 SOUTH BURLINGAME,President,,DEM,Clinton & Kaine,63
-Osage,0006 DRAGOON,President,,DEM,Clinton & Kaine,28
-Osage,0007 ELK,President,,DEM,Clinton & Kaine,211
-Osage,0008 FAIRFAX,President,,DEM,Clinton & Kaine,79
-Osage,0009 GRANT,President,,DEM,Clinton & Kaine,32
-Osage,0010 MICHIGAN VALLEY,President,,DEM,Clinton & Kaine,65
-Osage,0011 VASSAR,President,,DEM,Clinton & Kaine,86
-Osage,0012 LINCOLN,President,,DEM,Clinton & Kaine,10
-Osage,0013 MELVERN,President,,DEM,Clinton & Kaine,62
-Osage,0014 OLIVET,President,,DEM,Clinton & Kaine,26
-Osage,0015 NORTH RIDGEWAY,President,,DEM,Clinton & Kaine,142
-Osage,0016 SOUTH RIDGEWAY,President,,DEM,Clinton & Kaine,143
-Osage,0017 SCRANTON,President,,DEM,Clinton & Kaine,117
-Osage,0018 SUPERIOR,President,,DEM,Clinton & Kaine,37
-Osage,0019 NORTH VALLEY BROOK,President,,DEM,Clinton & Kaine,111
-Osage,0020 SOUTH VALLEY BROOK,President,,DEM,Clinton & Kaine,44
-Osage,0021 WARD 1,President,,DEM,Clinton & Kaine,108
-Osage,0022 WARD 2,President,,DEM,Clinton & Kaine,59
-Osage,0023 WARD 3,President,,DEM,Clinton & Kaine,76
-Osage,0024 WARD 4,President,,DEM,Clinton & Kaine,88
-Osage,0001 AGENCY,President,,LBT,Johnson & Weld,6
-Osage,0002 ARVONIA,President,,LBT,Johnson & Weld,6
-Osage,0003 BARCLAY,President,,LBT,Johnson & Weld,8
-Osage,0004 NORTH BURLINGAME,President,,LBT,Johnson & Weld,18
-Osage,0005 SOUTH BURLINGAME,President,,LBT,Johnson & Weld,18
-Osage,0006 DRAGOON,President,,LBT,Johnson & Weld,4
-Osage,0007 ELK,President,,LBT,Johnson & Weld,46
-Osage,0008 FAIRFAX,President,,LBT,Johnson & Weld,5
-Osage,0009 GRANT,President,,LBT,Johnson & Weld,5
-Osage,0010 MICHIGAN VALLEY,President,,LBT,Johnson & Weld,16
-Osage,0011 VASSAR,President,,LBT,Johnson & Weld,13
-Osage,0012 LINCOLN,President,,LBT,Johnson & Weld,2
-Osage,0013 MELVERN,President,,LBT,Johnson & Weld,14
-Osage,0014 OLIVET,President,,LBT,Johnson & Weld,2
-Osage,0015 NORTH RIDGEWAY,President,,LBT,Johnson & Weld,19
-Osage,0016 SOUTH RIDGEWAY,President,,LBT,Johnson & Weld,25
-Osage,0017 SCRANTON,President,,LBT,Johnson & Weld,20
-Osage,0018 SUPERIOR,President,,LBT,Johnson & Weld,4
-Osage,0019 NORTH VALLEY BROOK,President,,LBT,Johnson & Weld,26
-Osage,0020 SOUTH VALLEY BROOK,President,,LBT,Johnson & Weld,6
-Osage,0021 WARD 1,President,,LBT,Johnson & Weld,10
-Osage,0022 WARD 2,President,,LBT,Johnson & Weld,6
-Osage,0023 WARD 3,President,,LBT,Johnson & Weld,9
-Osage,0024 WARD 4,President,,LBT,Johnson & Weld,14
-Osage,0001 AGENCY,President,,IND,Stein & Baraka,6
-Osage,0002 ARVONIA,President,,IND,Stein & Baraka,0
-Osage,0003 BARCLAY,President,,IND,Stein & Baraka,2
-Osage,0004 NORTH BURLINGAME,President,,IND,Stein & Baraka,9
-Osage,0005 SOUTH BURLINGAME,President,,IND,Stein & Baraka,17
-Osage,0006 DRAGOON,President,,IND,Stein & Baraka,2
-Osage,0007 ELK,President,,IND,Stein & Baraka,21
-Osage,0008 FAIRFAX,President,,IND,Stein & Baraka,9
-Osage,0009 GRANT,President,,IND,Stein & Baraka,4
-Osage,0010 MICHIGAN VALLEY,President,,IND,Stein & Baraka,4
-Osage,0011 VASSAR,President,,IND,Stein & Baraka,11
-Osage,0012 LINCOLN,President,,IND,Stein & Baraka,0
-Osage,0013 MELVERN,President,,IND,Stein & Baraka,9
-Osage,0014 OLIVET,President,,IND,Stein & Baraka,1
-Osage,0015 NORTH RIDGEWAY,President,,IND,Stein & Baraka,10
-Osage,0016 SOUTH RIDGEWAY,President,,IND,Stein & Baraka,13
-Osage,0017 SCRANTON,President,,IND,Stein & Baraka,6
-Osage,0018 SUPERIOR,President,,IND,Stein & Baraka,3
-Osage,0019 NORTH VALLEY BROOK,President,,IND,Stein & Baraka,12
-Osage,0020 SOUTH VALLEY BROOK,President,,IND,Stein & Baraka,5
-Osage,0021 WARD 1,President,,IND,Stein & Baraka,8
-Osage,0022 WARD 2,President,,IND,Stein & Baraka,3
-Osage,0023 WARD 3,President,,IND,Stein & Baraka,4
-Osage,0024 WARD 4,President,,IND,Stein & Baraka,6
-Osage,0001 AGENCY,President,,REP,Trump & Pence,153
-Osage,0002 ARVONIA,President,,REP,Trump & Pence,32
-Osage,0003 BARCLAY,President,,REP,Trump & Pence,68
-Osage,0004 NORTH BURLINGAME,President,,REP,Trump & Pence,291
-Osage,0005 SOUTH BURLINGAME,President,,REP,Trump & Pence,254
-Osage,0006 DRAGOON,President,,REP,Trump & Pence,82
-Osage,0007 ELK,President,,REP,Trump & Pence,611
-Osage,0008 FAIRFAX,President,,REP,Trump & Pence,192
-Osage,0009 GRANT,President,,REP,Trump & Pence,101
-Osage,0010 MICHIGAN VALLEY,President,,REP,Trump & Pence,167
-Osage,0011 VASSAR,President,,REP,Trump & Pence,247
-Osage,0012 LINCOLN,President,,REP,Trump & Pence,44
-Osage,0013 MELVERN,President,,REP,Trump & Pence,232
-Osage,0014 OLIVET,President,,REP,Trump & Pence,93
-Osage,0015 NORTH RIDGEWAY,President,,REP,Trump & Pence,366
-Osage,0016 SOUTH RIDGEWAY,President,,REP,Trump & Pence,321
-Osage,0017 SCRANTON,President,,REP,Trump & Pence,327
-Osage,0018 SUPERIOR,President,,REP,Trump & Pence,88
-Osage,0019 NORTH VALLEY BROOK,President,,REP,Trump & Pence,317
-Osage,0020 SOUTH VALLEY BROOK,President,,REP,Trump & Pence,153
-Osage,0021 WARD 1,President,,REP,Trump & Pence,203
-Osage,0022 WARD 2,President,,REP,Trump & Pence,122
-Osage,0023 WARD 3,President,,REP,Trump & Pence,155
-Osage,0024 WARD 4,President,,REP,Trump & Pence,207
-Osage,0001 AGENCY,President,,,Write-ins,1
-Osage,0002 ARVONIA,President,,,Write-ins,1
-Osage,0003 BARCLAY,President,,,Write-ins,1
-Osage,0004 NORTH BURLINGAME,President,,,Write-ins,6
-Osage,0005 SOUTH BURLINGAME,President,,,Write-ins,4
-Osage,0006 DRAGOON,President,,,Write-ins,0
-Osage,0007 ELK,President,,,Write-ins,19
-Osage,0008 FAIRFAX,President,,,Write-ins,6
-Osage,0009 GRANT,President,,,Write-ins,1
-Osage,0010 MICHIGAN VALLEY,President,,,Write-ins,2
-Osage,0011 VASSAR,President,,,Write-ins,8
-Osage,0012 LINCOLN,President,,,Write-ins,0
-Osage,0013 MELVERN,President,,,Write-ins,1
-Osage,0014 OLIVET,President,,,Write-ins,2
-Osage,0015 NORTH RIDGEWAY,President,,,Write-ins,12
-Osage,0016 SOUTH RIDGEWAY,President,,,Write-ins,6
-Osage,0017 SCRANTON,President,,,Write-ins,6
-Osage,0018 SUPERIOR,President,,,Write-ins,0
-Osage,0019 NORTH VALLEY BROOK,President,,,Write-ins,5
-Osage,0020 SOUTH VALLEY BROOK,President,,,Write-ins,6
-Osage,0021 WARD 1,President,,,Write-ins,9
-Osage,0022 WARD 2,President,,,Write-ins,5
-Osage,0023 WARD 3,President,,,Write-ins,2
-Osage,0024 WARD 4,President,,,Write-ins,4
-Osage,0015 NORTH RIDGEWAY,State House,54,REP,Ken Corbet,303
-Osage,0016 SOUTH RIDGEWAY,State House,54,REP,Ken Corbet,273
-Osage,0017 SCRANTON,State House,54,REP,Ken Corbet,279
-Osage,0015 NORTH RIDGEWAY,State House,54,DEM,Renae Hansen,238
-Osage,0016 SOUTH RIDGEWAY,State House,54,DEM,Renae Hansen,230
-Osage,0017 SCRANTON,State House,54,DEM,Renae Hansen,164
-Osage,0015 NORTH RIDGEWAY,State House,54,,Write-ins,0
-Osage,0016 SOUTH RIDGEWAY,State House,54,,Write-ins,0
-Osage,0017 SCRANTON,State House,54,,Write-ins,1
-Osage,0010 MICHIGAN VALLEY,State House,59,REP,Blaine Finch ,215
-Osage,0011 VASSAR,State House,59,REP,Blaine Finch ,310
-Osage,0019 NORTH VALLEY BROOK,State House,59,REP,Blaine Finch ,393
-Osage,0020 SOUTH VALLEY BROOK,State House,59,REP,Blaine Finch ,184
-Osage,0010 MICHIGAN VALLEY,State House,59,,Write-ins,5
-Osage,0011 VASSAR,State House,59,,Write-ins,8
-Osage,0019 NORTH VALLEY BROOK,State House,59,,Write-ins,5
-Osage,0020 SOUTH VALLEY BROOK,State House,59,,Write-ins,4
-Osage,0008 FAIRFAX,State House,59,REP,Blaine Finch ,252
-Osage,0001 AGENCY,State House,76,REP,Eric Smith,130
-Osage,0002 ARVONIA,State House,76,REP,Eric Smith,25
-Osage,0003 BARCLAY,State House,76,REP,Eric Smith,52
-Osage,0006 DRAGOON,State House,76,REP,Eric Smith,75
-Osage,0009 GRANT,State House,76,REP,Eric Smith,90
-Osage,0012 LINCOLN,State House,76,REP,Eric Smith,39
-Osage,0013 MELVERN,State House,76,REP,Eric Smith,200
-Osage,0014 OLIVET,State House,76,REP,Eric Smith,83
-Osage,0018 SUPERIOR,State House,76,REP,Eric Smith,64
-Osage,0021 WARD 1,State House,76,REP,Eric Smith,161
-Osage,0022 WARD 2,State House,76,REP,Eric Smith,106
-Osage,0023 WARD 3,State House,76,REP,Eric Smith,122
-Osage,0024 WARD 4,State House,76,REP,Eric Smith,181
-Osage,0004 NORTH BURLINGAME,State House,54,REP,Ken Corbet ,258
-Osage,0005 SOUTH BURLINGAME,State House,54,REP,Ken Corbet ,221
-Osage,0007 ELK,State House,54,REP,Ken Corbet ,497
-Osage,0004 NORTH BURLINGAME,State House,54,DEM,Renae Hansen,153
-Osage,0005 SOUTH BURLINGAME,State House,54,DEM,Renae Hansen,124
-Osage,0007 ELK,State House,54,DEM,Renae Hansen,398
-Osage,0001 AGENCY,State House,76,DEM,Teresa Briggs,64
-Osage,0002 ARVONIA,State House,76,DEM,Teresa Briggs,31
-Osage,0003 BARCLAY,State House,76,DEM,Teresa Briggs,39
-Osage,0006 DRAGOON,State House,76,DEM,Teresa Briggs,37
-Osage,0009 GRANT,State House,76,DEM,Teresa Briggs,50
-Osage,0012 LINCOLN,State House,76,DEM,Teresa Briggs,15
-Osage,0013 MELVERN,State House,76,DEM,Teresa Briggs,122
-Osage,0014 OLIVET,State House,76,DEM,Teresa Briggs,38
-Osage,0018 SUPERIOR,State House,76,DEM,Teresa Briggs,66
-Osage,0021 WARD 1,State House,76,DEM,Teresa Briggs,168
-Osage,0022 WARD 2,State House,76,DEM,Teresa Briggs,84
-Osage,0023 WARD 3,State House,76,DEM,Teresa Briggs,122
-Osage,0024 WARD 4,State House,76,DEM,Teresa Briggs,128
-Osage,0001 AGENCY,State House,76,,Write-ins,1
-Osage,0002 ARVONIA,State House,76,,Write-ins,0
-Osage,0003 BARCLAY,State House,76,,Write-ins,0
-Osage,0004 NORTH BURLINGAME,State House,54,,Write-ins,1
-Osage,0005 SOUTH BURLINGAME,State House,54,,Write-ins,1
-Osage,0006 DRAGOON,State House,76,,Write-ins,0
-Osage,0007 ELK,State House,54,,Write-ins,1
-Osage,0008 FAIRFAX,State House,59,,Write-ins,3
-Osage,0009 GRANT,State House,76,,Write-ins,0
-Osage,0012 LINCOLN,State House,76,,Write-ins,0
-Osage,0013 MELVERN,State House,76,,Write-ins,0
-Osage,0014 OLIVET,State House,76,,Write-ins,0
-Osage,0018 SUPERIOR,State House,76,,Write-ins,0
-Osage,0021 WARD 1,State House,76,,Write-ins,3
-Osage,0022 WARD 2,State House,76,,Write-ins,0
-Osage,0023 WARD 3,State House,76,,Write-ins,0
-Osage,0024 WARD 4,State House,76,,Write-ins,0
-Osage,0021 WARD 1,State Senate,19,DEM,Anthony Hensley,182
-Osage,0022 WARD 2,State Senate,19,DEM,Anthony Hensley,109
-Osage,0023 WARD 3,State Senate,19,DEM,Anthony Hensley,146
-Osage,0024 WARD 4,State Senate,19,DEM,Anthony Hensley,158
-Osage,0021 WARD 1,State Senate,19,,Write-ins,1
-Osage,0022 WARD 2,State Senate,19,,Write-ins,0
-Osage,0023 WARD 3,State Senate,19,,Write-ins,0
-Osage,0024 WARD 4,State Senate,19,,Write-ins,0
-Osage,0021 WARD 1,State Senate,19,REP,Zach Haney,151
-Osage,0022 WARD 2,State Senate,19,REP,Zach Haney,86
-Osage,0023 WARD 3,State Senate,19,REP,Zach Haney,101
-Osage,0024 WARD 4,State Senate,19,REP,Zach Haney,157
-Osage,0001 AGENCY,State Senate,19,DEM,Anthony Hensley,67
-Osage,0002 ARVONIA,State Senate,19,DEM,Anthony Hensley,27
-Osage,0003 BARCLAY,State Senate,19,DEM,Anthony Hensley,40
-Osage,0004 NORTH BURLINGAME,State Senate,19,DEM,Anthony Hensley,182
-Osage,0005 SOUTH BURLINGAME,State Senate,19,DEM,Anthony Hensley,161
-Osage,0006 DRAGOON,State Senate,19,DEM,Anthony Hensley,56
-Osage,0007 ELK,State Senate,19,DEM,Anthony Hensley,427
-Osage,0008 FAIRFAX,State Senate,19,DEM,Anthony Hensley,125
-Osage,0009 GRANT,State Senate,19,DEM,Anthony Hensley,62
-Osage,0010 MICHIGAN VALLEY,State Senate,19,DEM,Anthony Hensley,120
-Osage,0011 VASSAR,State Senate,19,DEM,Anthony Hensley,160
-Osage,0012 LINCOLN,State Senate,19,DEM,Anthony Hensley,15
-Osage,0013 MELVERN,State Senate,19,DEM,Anthony Hensley,136
-Osage,0014 OLIVET,State Senate,19,DEM,Anthony Hensley,45
-Osage,0015 NORTH RIDGEWAY,State Senate,19,DEM,Anthony Hensley,267
-Osage,0016 SOUTH RIDGEWAY,State Senate,19,DEM,Anthony Hensley,259
-Osage,0017 SCRANTON,State Senate,19,DEM,Anthony Hensley,214
-Osage,0018 SUPERIOR,State Senate,19,DEM,Anthony Hensley,66
-Osage,0019 NORTH VALLEY BROOK,State Senate,19,DEM,Anthony Hensley,210
-Osage,0020 SOUTH VALLEY BROOK,State Senate,19,DEM,Anthony Hensley,87
-Osage,0001 AGENCY,State Senate,19,,Write-ins,1
-Osage,0002 ARVONIA,State Senate,19,,Write-ins,0
-Osage,0003 BARCLAY,State Senate,19,,Write-ins,0
-Osage,0004 NORTH BURLINGAME,State Senate,19,,Write-ins,1
-Osage,0005 SOUTH BURLINGAME,State Senate,19,,Write-ins,1
-Osage,0006 DRAGOON,State Senate,19,,Write-ins,0
-Osage,0007 ELK,State Senate,19,,Write-ins,0
-Osage,0008 FAIRFAX,State Senate,19,,Write-ins,1
-Osage,0009 GRANT,State Senate,19,,Write-ins,0
-Osage,0010 MICHIGAN VALLEY,State Senate,19,,Write-ins,0
-Osage,0011 VASSAR,State Senate,19,,Write-ins,1
-Osage,0012 LINCOLN,State Senate,19,,Write-ins,0
-Osage,0013 MELVERN,State Senate,19,,Write-ins,0
-Osage,0014 OLIVET,State Senate,19,,Write-ins,0
-Osage,0015 NORTH RIDGEWAY,State Senate,19,,Write-ins,0
-Osage,0016 SOUTH RIDGEWAY,State Senate,19,,Write-ins,0
-Osage,0017 SCRANTON,State Senate,19,,Write-ins,1
-Osage,0018 SUPERIOR,State Senate,19,,Write-ins,0
-Osage,0019 NORTH VALLEY BROOK,State Senate,19,,Write-ins,0
-Osage,0020 SOUTH VALLEY BROOK,State Senate,19,,Write-ins,2
-Osage,0001 AGENCY,State Senate,19,REP,Zach Haney,127
-Osage,0002 ARVONIA,State Senate,19,REP,Zach Haney,29
-Osage,0003 BARCLAY,State Senate,19,REP,Zach Haney,52
-Osage,0004 NORTH BURLINGAME,State Senate,19,REP,Zach Haney,226
-Osage,0005 SOUTH BURLINGAME,State Senate,19,REP,Zach Haney,186
-Osage,0006 DRAGOON,State Senate,19,REP,Zach Haney,59
-Osage,0007 ELK,State Senate,19,REP,Zach Haney,475
-Osage,0008 FAIRFAX,State Senate,19,REP,Zach Haney,167
-Osage,0009 GRANT,State Senate,19,REP,Zach Haney,80
-Osage,0010 MICHIGAN VALLEY,State Senate,19,REP,Zach Haney,131
-Osage,0011 VASSAR,State Senate,19,REP,Zach Haney,204
-Osage,0012 LINCOLN,State Senate,19,REP,Zach Haney,42
-Osage,0013 MELVERN,State Senate,19,REP,Zach Haney,186
-Osage,0014 OLIVET,State Senate,19,REP,Zach Haney,77
-Osage,0015 NORTH RIDGEWAY,State Senate,19,REP,Zach Haney,275
-Osage,0016 SOUTH RIDGEWAY,State Senate,19,REP,Zach Haney,248
-Osage,0017 SCRANTON,State Senate,19,REP,Zach Haney,237
-Osage,0018 SUPERIOR,State Senate,19,REP,Zach Haney,64
-Osage,0019 NORTH VALLEY BROOK,State Senate,19,REP,Zach Haney,247
-Osage,0020 SOUTH VALLEY BROOK,State Senate,19,REP,Zach Haney,126
-Osage,0001 AGENCY,U.S. House,2,DEM,Britani Potter,32
-Osage,0002 ARVONIA,U.S. House,2,DEM,Britani Potter,15
-Osage,0003 BARCLAY,U.S. House,2,DEM,Britani Potter,21
-Osage,0004 NORTH BURLINGAME,U.S. House,2,DEM,Britani Potter,101
-Osage,0005 SOUTH BURLINGAME,U.S. House,2,DEM,Britani Potter,70
-Osage,0006 DRAGOON,U.S. House,2,DEM,Britani Potter,23
-Osage,0007 ELK,U.S. House,2,DEM,Britani Potter,203
-Osage,0008 FAIRFAX,U.S. House,2,DEM,Britani Potter,66
-Osage,0009 GRANT,U.S. House,2,DEM,Britani Potter,23
-Osage,0010 MICHIGAN VALLEY,U.S. House,2,DEM,Britani Potter,67
-Osage,0011 VASSAR,U.S. House,2,DEM,Britani Potter,102
-Osage,0012 LINCOLN,U.S. House,2,DEM,Britani Potter,11
-Osage,0013 MELVERN,U.S. House,2,DEM,Britani Potter,65
-Osage,0014 OLIVET,U.S. House,2,DEM,Britani Potter,28
-Osage,0015 NORTH RIDGEWAY,U.S. House,2,DEM,Britani Potter,138
-Osage,0016 SOUTH RIDGEWAY,U.S. House,2,DEM,Britani Potter,117
-Osage,0017 SCRANTON,U.S. House,2,DEM,Britani Potter,104
-Osage,0018 SUPERIOR,U.S. House,2,DEM,Britani Potter,25
-Osage,0019 NORTH VALLEY BROOK,U.S. House,2,DEM,Britani Potter,96
-Osage,0020 SOUTH VALLEY BROOK,U.S. House,2,DEM,Britani Potter,40
-Osage,0021 WARD 1,U.S. House,2,DEM,Britani Potter,87
-Osage,0022 WARD 2,U.S. House,2,DEM,Britani Potter,55
-Osage,0023 WARD 3,U.S. House,2,DEM,Britani Potter,73
-Osage,0024 WARD 4,U.S. House,2,DEM,Britani Potter,70
-Osage,0001 AGENCY,U.S. House,2,LBT,James Bales,10
-Osage,0002 ARVONIA,U.S. House,2,LBT,James Bales,1
-Osage,0003 BARCLAY,U.S. House,2,LBT,James Bales,5
-Osage,0004 NORTH BURLINGAME,U.S. House,2,LBT,James Bales,25
-Osage,0005 SOUTH BURLINGAME,U.S. House,2,LBT,James Bales,40
-Osage,0006 DRAGOON,U.S. House,2,LBT,James Bales,8
-Osage,0007 ELK,U.S. House,2,LBT,James Bales,64
-Osage,0008 FAIRFAX,U.S. House,2,LBT,James Bales,13
-Osage,0009 GRANT,U.S. House,2,LBT,James Bales,14
-Osage,0010 MICHIGAN VALLEY,U.S. House,2,LBT,James Bales,14
-Osage,0011 VASSAR,U.S. House,2,LBT,James Bales,17
-Osage,0012 LINCOLN,U.S. House,2,LBT,James Bales,3
-Osage,0013 MELVERN,U.S. House,2,LBT,James Bales,15
-Osage,0014 OLIVET,U.S. House,2,LBT,James Bales,9
-Osage,0015 NORTH RIDGEWAY,U.S. House,2,LBT,James Bales,47
-Osage,0016 SOUTH RIDGEWAY,U.S. House,2,LBT,James Bales,28
-Osage,0017 SCRANTON,U.S. House,2,LBT,James Bales,36
-Osage,0018 SUPERIOR,U.S. House,2,LBT,James Bales,3
-Osage,0019 NORTH VALLEY BROOK,U.S. House,2,LBT,James Bales,28
-Osage,0020 SOUTH VALLEY BROOK,U.S. House,2,LBT,James Bales,19
-Osage,0021 WARD 1,U.S. House,2,LBT,James Bales,18
-Osage,0022 WARD 2,U.S. House,2,LBT,James Bales,9
-Osage,0023 WARD 3,U.S. House,2,LBT,James Bales,7
-Osage,0024 WARD 4,U.S. House,2,LBT,James Bales,17
-Osage,0001 AGENCY,U.S. House,2,REP,Lynn Jenkins,153
-Osage,0002 ARVONIA,U.S. House,2,REP,Lynn Jenkins,41
-Osage,0003 BARCLAY,U.S. House,2,REP,Lynn Jenkins,70
-Osage,0004 NORTH BURLINGAME,U.S. House,2,REP,Lynn Jenkins,289
-Osage,0005 SOUTH BURLINGAME,U.S. House,2,REP,Lynn Jenkins,239
-Osage,0006 DRAGOON,U.S. House,2,REP,Lynn Jenkins,81
-Osage,0007 ELK,U.S. House,2,REP,Lynn Jenkins,638
-Osage,0008 FAIRFAX,U.S. House,2,REP,Lynn Jenkins,214
-Osage,0009 GRANT,U.S. House,2,REP,Lynn Jenkins,105
-Osage,0010 MICHIGAN VALLEY,U.S. House,2,REP,Lynn Jenkins,171
-Osage,0011 VASSAR,U.S. House,2,REP,Lynn Jenkins,247
-Osage,0012 LINCOLN,U.S. House,2,REP,Lynn Jenkins,43
-Osage,0013 MELVERN,U.S. House,2,REP,Lynn Jenkins,239
-Osage,0014 OLIVET,U.S. House,2,REP,Lynn Jenkins,85
-Osage,0015 NORTH RIDGEWAY,U.S. House,2,REP,Lynn Jenkins,359
-Osage,0016 SOUTH RIDGEWAY,U.S. House,2,REP,Lynn Jenkins,361
-Osage,0017 SCRANTON,U.S. House,2,REP,Lynn Jenkins,321
-Osage,0018 SUPERIOR,U.S. House,2,REP,Lynn Jenkins,102
-Osage,0019 NORTH VALLEY BROOK,U.S. House,2,REP,Lynn Jenkins,339
-Osage,0020 SOUTH VALLEY BROOK,U.S. House,2,REP,Lynn Jenkins,156
-Osage,0021 WARD 1,U.S. House,2,REP,Lynn Jenkins,230
-Osage,0022 WARD 2,U.S. House,2,REP,Lynn Jenkins,128
-Osage,0023 WARD 3,U.S. House,2,REP,Lynn Jenkins,166
-Osage,0024 WARD 4,U.S. House,2,REP,Lynn Jenkins,228
-Osage,0001 AGENCY,U.S. House,2,,Write-ins,2
-Osage,0002 ARVONIA,U.S. House,2,,Write-ins,0
-Osage,0003 BARCLAY,U.S. House,2,,Write-ins,0
-Osage,0004 NORTH BURLINGAME,U.S. House,2,,Write-ins,0
-Osage,0005 SOUTH BURLINGAME,U.S. House,2,,Write-ins,3
-Osage,0006 DRAGOON,U.S. House,2,,Write-ins,0
-Osage,0007 ELK,U.S. House,2,,Write-ins,0
-Osage,0008 FAIRFAX,U.S. House,2,,Write-ins,1
-Osage,0009 GRANT,U.S. House,2,,Write-ins,0
-Osage,0010 MICHIGAN VALLEY,U.S. House,2,,Write-ins,1
-Osage,0011 VASSAR,U.S. House,2,,Write-ins,2
-Osage,0012 LINCOLN,U.S. House,2,,Write-ins,0
-Osage,0013 MELVERN,U.S. House,2,,Write-ins,1
-Osage,0014 OLIVET,U.S. House,2,,Write-ins,0
-Osage,0015 NORTH RIDGEWAY,U.S. House,2,,Write-ins,0
-Osage,0016 SOUTH RIDGEWAY,U.S. House,2,,Write-ins,2
-Osage,0017 SCRANTON,U.S. House,2,,Write-ins,1
-Osage,0018 SUPERIOR,U.S. House,2,,Write-ins,0
-Osage,0019 NORTH VALLEY BROOK,U.S. House,2,,Write-ins,0
-Osage,0020 SOUTH VALLEY BROOK,U.S. House,2,,Write-ins,1
-Osage,0021 WARD 1,U.S. House,2,,Write-ins,0
-Osage,0022 WARD 2,U.S. House,2,,Write-ins,0
-Osage,0023 WARD 3,U.S. House,2,,Write-ins,0
-Osage,0024 WARD 4,U.S. House,2,,Write-ins,0
-Osage,0001 AGENCY,U.S. Senate,,REP,Jerry Moran,147
-Osage,0002 ARVONIA,U.S. Senate,,REP,Jerry Moran,39
-Osage,0003 BARCLAY,U.S. Senate,,REP,Jerry Moran,77
-Osage,0004 NORTH BURLINGAME,U.S. Senate,,REP,Jerry Moran,293
-Osage,0005 SOUTH BURLINGAME,U.S. Senate,,REP,Jerry Moran,245
-Osage,0006 DRAGOON,U.S. Senate,,REP,Jerry Moran,78
-Osage,0007 ELK,U.S. Senate,,REP,Jerry Moran,649
-Osage,0008 FAIRFAX,U.S. Senate,,REP,Jerry Moran,225
-Osage,0009 GRANT,U.S. Senate,,REP,Jerry Moran,110
-Osage,0010 MICHIGAN VALLEY,U.S. Senate,,REP,Jerry Moran,168
-Osage,0011 VASSAR,U.S. Senate,,REP,Jerry Moran,250
-Osage,0012 LINCOLN,U.S. Senate,,REP,Jerry Moran,43
-Osage,0013 MELVERN,U.S. Senate,,REP,Jerry Moran,242
-Osage,0014 OLIVET,U.S. Senate,,REP,Jerry Moran,87
-Osage,0015 NORTH RIDGEWAY,U.S. Senate,,REP,Jerry Moran,359
-Osage,0016 SOUTH RIDGEWAY,U.S. Senate,,REP,Jerry Moran,333
-Osage,0017 SCRANTON,U.S. Senate,,REP,Jerry Moran,317
-Osage,0018 SUPERIOR,U.S. Senate,,REP,Jerry Moran,95
-Osage,0019 NORTH VALLEY BROOK,U.S. Senate,,REP,Jerry Moran,331
-Osage,0020 SOUTH VALLEY BROOK,U.S. Senate,,REP,Jerry Moran,149
-Osage,0021 WARD 1,U.S. Senate,,REP,Jerry Moran,221
-Osage,0022 WARD 2,U.S. Senate,,REP,Jerry Moran,126
-Osage,0023 WARD 3,U.S. Senate,,REP,Jerry Moran,170
-Osage,0024 WARD 4,U.S. Senate,,REP,Jerry Moran,223
-Osage,0001 AGENCY,U.S. Senate,,DEM,Patrick Wiesner,32
-Osage,0002 ARVONIA,U.S. Senate,,DEM,Patrick Wiesner,16
-Osage,0003 BARCLAY,U.S. Senate,,DEM,Patrick Wiesner,15
-Osage,0004 NORTH BURLINGAME,U.S. Senate,,DEM,Patrick Wiesner,96
-Osage,0005 SOUTH BURLINGAME,U.S. Senate,,DEM,Patrick Wiesner,70
-Osage,0006 DRAGOON,U.S. Senate,,DEM,Patrick Wiesner,25
-Osage,0007 ELK,U.S. Senate,,DEM,Patrick Wiesner,190
-Osage,0008 FAIRFAX,U.S. Senate,,DEM,Patrick Wiesner,61
-Osage,0009 GRANT,U.S. Senate,,DEM,Patrick Wiesner,21
-Osage,0010 MICHIGAN VALLEY,U.S. Senate,,DEM,Patrick Wiesner,63
-Osage,0011 VASSAR,U.S. Senate,,DEM,Patrick Wiesner,93
-Osage,0012 LINCOLN,U.S. Senate,,DEM,Patrick Wiesner,9
-Osage,0013 MELVERN,U.S. Senate,,DEM,Patrick Wiesner,68
-Osage,0014 OLIVET,U.S. Senate,,DEM,Patrick Wiesner,25
-Osage,0015 NORTH RIDGEWAY,U.S. Senate,,DEM,Patrick Wiesner,139
-Osage,0016 SOUTH RIDGEWAY,U.S. Senate,,DEM,Patrick Wiesner,129
-Osage,0017 SCRANTON,U.S. Senate,,DEM,Patrick Wiesner,115
-Osage,0018 SUPERIOR,U.S. Senate,,DEM,Patrick Wiesner,31
-Osage,0019 NORTH VALLEY BROOK,U.S. Senate,,DEM,Patrick Wiesner,95
-Osage,0020 SOUTH VALLEY BROOK,U.S. Senate,,DEM,Patrick Wiesner,52
-Osage,0021 WARD 1,U.S. Senate,,DEM,Patrick Wiesner,91
-Osage,0022 WARD 2,U.S. Senate,,DEM,Patrick Wiesner,57
-Osage,0023 WARD 3,U.S. Senate,,DEM,Patrick Wiesner,66
-Osage,0024 WARD 4,U.S. Senate,,DEM,Patrick Wiesner,77
-Osage,0001 AGENCY,U.S. Senate,,LBT,Robert Garrard,17
-Osage,0002 ARVONIA,U.S. Senate,,LBT,Robert Garrard,2
-Osage,0003 BARCLAY,U.S. Senate,,LBT,Robert Garrard,4
-Osage,0004 NORTH BURLINGAME,U.S. Senate,,LBT,Robert Garrard,25
-Osage,0005 SOUTH BURLINGAME,U.S. Senate,,LBT,Robert Garrard,35
-Osage,0006 DRAGOON,U.S. Senate,,LBT,Robert Garrard,8
-Osage,0007 ELK,U.S. Senate,,LBT,Robert Garrard,69
-Osage,0008 FAIRFAX,U.S. Senate,,LBT,Robert Garrard,9
-Osage,0009 GRANT,U.S. Senate,,LBT,Robert Garrard,10
-Osage,0010 MICHIGAN VALLEY,U.S. Senate,,LBT,Robert Garrard,22
-Osage,0011 VASSAR,U.S. Senate,,LBT,Robert Garrard,24
-Osage,0012 LINCOLN,U.S. Senate,,LBT,Robert Garrard,4
-Osage,0013 MELVERN,U.S. Senate,,LBT,Robert Garrard,15
-Osage,0014 OLIVET,U.S. Senate,,LBT,Robert Garrard,10
-Osage,0015 NORTH RIDGEWAY,U.S. Senate,,LBT,Robert Garrard,46
-Osage,0016 SOUTH RIDGEWAY,U.S. Senate,,LBT,Robert Garrard,43
-Osage,0017 SCRANTON,U.S. Senate,,LBT,Robert Garrard,32
-Osage,0018 SUPERIOR,U.S. Senate,,LBT,Robert Garrard,6
-Osage,0019 NORTH VALLEY BROOK,U.S. Senate,,LBT,Robert Garrard,39
-Osage,0020 SOUTH VALLEY BROOK,U.S. Senate,,LBT,Robert Garrard,15
-Osage,0021 WARD 1,U.S. Senate,,LBT,Robert Garrard,22
-Osage,0022 WARD 2,U.S. Senate,,LBT,Robert Garrard,9
-Osage,0023 WARD 3,U.S. Senate,,LBT,Robert Garrard,12
-Osage,0024 WARD 4,U.S. Senate,,LBT,Robert Garrard,16
-Osage,0001 AGENCY,U.S. Senate,,,Write-ins,2
-Osage,0002 ARVONIA,U.S. Senate,,,Write-ins,0
-Osage,0003 BARCLAY,U.S. Senate,,,Write-ins,0
-Osage,0004 NORTH BURLINGAME,U.S. Senate,,,Write-ins,1
-Osage,0005 SOUTH BURLINGAME,U.S. Senate,,,Write-ins,2
-Osage,0006 DRAGOON,U.S. Senate,,,Write-ins,0
-Osage,0007 ELK,U.S. Senate,,,Write-ins,2
-Osage,0008 FAIRFAX,U.S. Senate,,,Write-ins,0
-Osage,0009 GRANT,U.S. Senate,,,Write-ins,0
-Osage,0010 MICHIGAN VALLEY,U.S. Senate,,,Write-ins,1
-Osage,0011 VASSAR,U.S. Senate,,,Write-ins,1
-Osage,0012 LINCOLN,U.S. Senate,,,Write-ins,0
-Osage,0013 MELVERN,U.S. Senate,,,Write-ins,0
-Osage,0014 OLIVET,U.S. Senate,,,Write-ins,0
-Osage,0015 NORTH RIDGEWAY,U.S. Senate,,,Write-ins,0
-Osage,0016 SOUTH RIDGEWAY,U.S. Senate,,,Write-ins,2
-Osage,0017 SCRANTON,U.S. Senate,,,Write-ins,1
-Osage,0018 SUPERIOR,U.S. Senate,,,Write-ins,0
-Osage,0019 NORTH VALLEY BROOK,U.S. Senate,,,Write-ins,0
-Osage,0020 SOUTH VALLEY BROOK,U.S. Senate,,,Write-ins,0
-Osage,0021 WARD 1,U.S. Senate,,,Write-ins,0
-Osage,0022 WARD 2,U.S. Senate,,,Write-ins,0
-Osage,0023 WARD 3,U.S. Senate,,,Write-ins,0
-Osage,0024 WARD 4,U.S. Senate,,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+OSAGE,Grant Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",50,000007
+OSAGE,Grant Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",90,000007
+OSAGE,Agency Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",64,000010
+OSAGE,Agency Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",130,000010
+OSAGE,Arvonia Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",31,000020
+OSAGE,Arvonia Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",25,000020
+OSAGE,Barclay Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",39,000030
+OSAGE,Barclay Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",52,000030
+OSAGE,Dragoon Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",37,000040
+OSAGE,Dragoon Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",75,000040
+OSAGE,Elk Township,Kansas House of Representatives,54,Democratic,"Hansen, Renae",398,000050
+OSAGE,Elk Township,Kansas House of Representatives,54,Republican,"Corbet, Ken",497,000050
+OSAGE,Fairfax Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",252,000060
+OSAGE,Lincoln Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",15,000080
+OSAGE,Lincoln Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",39,000080
+OSAGE,Melvern Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",122,000090
+OSAGE,Melvern Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",200,000090
+OSAGE,Michigan Valley Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",215,000100
+OSAGE,North Burlingame,Kansas House of Representatives,54,Democratic,"Hansen, Renae",153,000110
+OSAGE,North Burlingame,Kansas House of Representatives,54,Republican,"Corbet, Ken",258,000110
+OSAGE,North Ridgeway,Kansas House of Representatives,54,Democratic,"Hansen, Renae",238,000120
+OSAGE,North Ridgeway,Kansas House of Representatives,54,Republican,"Corbet, Ken",303,000120
+OSAGE,North Valleybrook,Kansas House of Representatives,59,Republican,"Finch, Blaine",393,000130
+OSAGE,Olivet Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",38,000140
+OSAGE,Olivet Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",83,000140
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",168,000150
+OSAGE,Osage City Ward 1,Kansas House of Representatives,76,Republican,"Smith, Eric L.",161,000150
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",84,000160
+OSAGE,Osage City Ward 2,Kansas House of Representatives,76,Republican,"Smith, Eric L.",106,000160
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",122,000170
+OSAGE,Osage City Ward 3,Kansas House of Representatives,76,Republican,"Smith, Eric L.",122,000170
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",128,000180
+OSAGE,Osage City Ward 4,Kansas House of Representatives,76,Republican,"Smith, Eric L.",181,000180
+OSAGE,Scranton Township,Kansas House of Representatives,54,Democratic,"Hansen, Renae",164,000190
+OSAGE,Scranton Township,Kansas House of Representatives,54,Republican,"Corbet, Ken",279,000190
+OSAGE,South Burlingame,Kansas House of Representatives,54,Democratic,"Hansen, Renae",124,000200
+OSAGE,South Burlingame,Kansas House of Representatives,54,Republican,"Corbet, Ken",221,000200
+OSAGE,South Ridgeway,Kansas House of Representatives,54,Democratic,"Hansen, Renae",230,000210
+OSAGE,South Ridgeway,Kansas House of Representatives,54,Republican,"Corbet, Ken",273,000210
+OSAGE,South Valleybrook,Kansas House of Representatives,59,Republican,"Finch, Blaine",184,000220
+OSAGE,Superior Township,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",66,000230
+OSAGE,Superior Township,Kansas House of Representatives,76,Republican,"Smith, Eric L.",64,000230
+OSAGE,Vassar Township,Kansas House of Representatives,59,Republican,"Finch, Blaine",310,000240
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900010
+OSAGE,Superior Township Enclave 1,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900010
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900020
+OSAGE,Grant Township Enclave 1,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900020
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900030
+OSAGE,Grant Township Enclave 2,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900030
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,Democratic,"Briggs, Teresa",0,900040
+OSAGE,Osage City Ward 2 Exclave,Kansas House of Representatives,76,Republican,"Smith, Eric L.",0,900040
+OSAGE,Grant Township,Kansas Senate,19,Democratic,"Hensley, Anthony",62,000007
+OSAGE,Grant Township,Kansas Senate,19,Republican,"Haney, Zach",80,000007
+OSAGE,Agency Township,Kansas Senate,19,Democratic,"Hensley, Anthony",67,000010
+OSAGE,Agency Township,Kansas Senate,19,Republican,"Haney, Zach",127,000010
+OSAGE,Arvonia Township,Kansas Senate,19,Democratic,"Hensley, Anthony",27,000020
+OSAGE,Arvonia Township,Kansas Senate,19,Republican,"Haney, Zach",29,000020
+OSAGE,Barclay Township,Kansas Senate,19,Democratic,"Hensley, Anthony",40,000030
+OSAGE,Barclay Township,Kansas Senate,19,Republican,"Haney, Zach",52,000030
+OSAGE,Dragoon Township,Kansas Senate,19,Democratic,"Hensley, Anthony",56,000040
+OSAGE,Dragoon Township,Kansas Senate,19,Republican,"Haney, Zach",59,000040
+OSAGE,Elk Township,Kansas Senate,19,Democratic,"Hensley, Anthony",427,000050
+OSAGE,Elk Township,Kansas Senate,19,Republican,"Haney, Zach",475,000050
+OSAGE,Fairfax Township,Kansas Senate,19,Democratic,"Hensley, Anthony",125,000060
+OSAGE,Fairfax Township,Kansas Senate,19,Republican,"Haney, Zach",167,000060
+OSAGE,Lincoln Township,Kansas Senate,19,Democratic,"Hensley, Anthony",15,000080
+OSAGE,Lincoln Township,Kansas Senate,19,Republican,"Haney, Zach",42,000080
+OSAGE,Melvern Township,Kansas Senate,19,Democratic,"Hensley, Anthony",136,000090
+OSAGE,Melvern Township,Kansas Senate,19,Republican,"Haney, Zach",186,000090
+OSAGE,Michigan Valley Township,Kansas Senate,19,Democratic,"Hensley, Anthony",120,000100
+OSAGE,Michigan Valley Township,Kansas Senate,19,Republican,"Haney, Zach",131,000100
+OSAGE,North Burlingame,Kansas Senate,19,Democratic,"Hensley, Anthony",182,000110
+OSAGE,North Burlingame,Kansas Senate,19,Republican,"Haney, Zach",226,000110
+OSAGE,North Ridgeway,Kansas Senate,19,Democratic,"Hensley, Anthony",267,000120
+OSAGE,North Ridgeway,Kansas Senate,19,Republican,"Haney, Zach",275,000120
+OSAGE,North Valleybrook,Kansas Senate,19,Democratic,"Hensley, Anthony",210,000130
+OSAGE,North Valleybrook,Kansas Senate,19,Republican,"Haney, Zach",247,000130
+OSAGE,Olivet Township,Kansas Senate,19,Democratic,"Hensley, Anthony",45,000140
+OSAGE,Olivet Township,Kansas Senate,19,Republican,"Haney, Zach",77,000140
+OSAGE,Osage City Ward 1,Kansas Senate,19,Democratic,"Hensley, Anthony",182,000150
+OSAGE,Osage City Ward 1,Kansas Senate,19,Republican,"Haney, Zach",151,000150
+OSAGE,Osage City Ward 2,Kansas Senate,19,Democratic,"Hensley, Anthony",109,000160
+OSAGE,Osage City Ward 2,Kansas Senate,19,Republican,"Haney, Zach",86,000160
+OSAGE,Osage City Ward 3,Kansas Senate,19,Democratic,"Hensley, Anthony",146,000170
+OSAGE,Osage City Ward 3,Kansas Senate,19,Republican,"Haney, Zach",101,000170
+OSAGE,Osage City Ward 4,Kansas Senate,19,Democratic,"Hensley, Anthony",158,000180
+OSAGE,Osage City Ward 4,Kansas Senate,19,Republican,"Haney, Zach",157,000180
+OSAGE,Scranton Township,Kansas Senate,19,Democratic,"Hensley, Anthony",214,000190
+OSAGE,Scranton Township,Kansas Senate,19,Republican,"Haney, Zach",237,000190
+OSAGE,South Burlingame,Kansas Senate,19,Democratic,"Hensley, Anthony",161,000200
+OSAGE,South Burlingame,Kansas Senate,19,Republican,"Haney, Zach",186,000200
+OSAGE,South Ridgeway,Kansas Senate,19,Democratic,"Hensley, Anthony",259,000210
+OSAGE,South Ridgeway,Kansas Senate,19,Republican,"Haney, Zach",248,000210
+OSAGE,South Valleybrook,Kansas Senate,19,Democratic,"Hensley, Anthony",87,000220
+OSAGE,South Valleybrook,Kansas Senate,19,Republican,"Haney, Zach",126,000220
+OSAGE,Superior Township,Kansas Senate,19,Democratic,"Hensley, Anthony",66,000230
+OSAGE,Superior Township,Kansas Senate,19,Republican,"Haney, Zach",64,000230
+OSAGE,Vassar Township,Kansas Senate,19,Democratic,"Hensley, Anthony",160,000240
+OSAGE,Vassar Township,Kansas Senate,19,Republican,"Haney, Zach",204,000240
+OSAGE,Superior Township Enclave 1,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900010
+OSAGE,Superior Township Enclave 1,Kansas Senate,19,Republican,"Haney, Zach",0,900010
+OSAGE,Grant Township Enclave 1,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900020
+OSAGE,Grant Township Enclave 1,Kansas Senate,19,Republican,"Haney, Zach",0,900020
+OSAGE,Grant Township Enclave 2,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900030
+OSAGE,Grant Township Enclave 2,Kansas Senate,19,Republican,"Haney, Zach",0,900030
+OSAGE,Osage City Ward 2 Exclave,Kansas Senate,19,Democratic,"Hensley, Anthony",0,900040
+OSAGE,Osage City Ward 2 Exclave,Kansas Senate,19,Republican,"Haney, Zach",0,900040
+OSAGE,Grant Township,President / Vice President,,independent,"Stein, Jill",4,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000007
+OSAGE,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000007
+OSAGE,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000007
+OSAGE,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000007
+OSAGE,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",101,000007
+OSAGE,Agency Township,President / Vice President,,independent,"Stein, Jill",6,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+OSAGE,Agency Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+OSAGE,Agency Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000010
+OSAGE,Agency Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+OSAGE,Agency Township,President / Vice President,,Republican,"Trump, Donald J.",153,000010
+OSAGE,Arvonia Township,President / Vice President,,independent,"Stein, Jill",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+OSAGE,Arvonia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+OSAGE,Arvonia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000020
+OSAGE,Arvonia Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000020
+OSAGE,Arvonia Township,President / Vice President,,Republican,"Trump, Donald J.",32,000020
+OSAGE,Barclay Township,President / Vice President,,independent,"Stein, Jill",2,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+OSAGE,Barclay Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+OSAGE,Barclay Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000030
+OSAGE,Barclay Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000030
+OSAGE,Barclay Township,President / Vice President,,Republican,"Trump, Donald J.",68,000030
+OSAGE,Dragoon Township,President / Vice President,,independent,"Stein, Jill",2,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+OSAGE,Dragoon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+OSAGE,Dragoon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000040
+OSAGE,Dragoon Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+OSAGE,Dragoon Township,President / Vice President,,Republican,"Trump, Donald J.",82,000040
+OSAGE,Elk Township,President / Vice President,,independent,"Stein, Jill",21,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+OSAGE,Elk Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+OSAGE,Elk Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",211,000050
+OSAGE,Elk Township,President / Vice President,,Libertarian,"Johnson, Gary",46,000050
+OSAGE,Elk Township,President / Vice President,,Republican,"Trump, Donald J.",611,000050
+OSAGE,Fairfax Township,President / Vice President,,independent,"Stein, Jill",9,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+OSAGE,Fairfax Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+OSAGE,Fairfax Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000060
+OSAGE,Fairfax Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+OSAGE,Fairfax Township,President / Vice President,,Republican,"Trump, Donald J.",192,000060
+OSAGE,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+OSAGE,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+OSAGE,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000080
+OSAGE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+OSAGE,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",44,000080
+OSAGE,Melvern Township,President / Vice President,,independent,"Stein, Jill",9,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+OSAGE,Melvern Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+OSAGE,Melvern Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000090
+OSAGE,Melvern Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000090
+OSAGE,Melvern Township,President / Vice President,,Republican,"Trump, Donald J.",232,000090
+OSAGE,Michigan Valley Township,President / Vice President,,independent,"Stein, Jill",4,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000100
+OSAGE,Michigan Valley Township,President / Vice President,,Republican,"Trump, Donald J.",167,000100
+OSAGE,North Burlingame,President / Vice President,,independent,"Stein, Jill",9,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Hedges, James A",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"McMullin, Evan",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Perry, Darryl",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Smith, Mike",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Sood, Ajay",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+OSAGE,North Burlingame,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+OSAGE,North Burlingame,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000110
+OSAGE,North Burlingame,President / Vice President,,Libertarian,"Johnson, Gary",18,000110
+OSAGE,North Burlingame,President / Vice President,,Republican,"Trump, Donald J.",291,000110
+OSAGE,North Ridgeway,President / Vice President,,independent,"Stein, Jill",10,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Hedges, James A",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"McMullin, Evan",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Perry, Darryl",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Smith, Mike",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Sood, Ajay",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+OSAGE,North Ridgeway,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+OSAGE,North Ridgeway,President / Vice President,,Democratic,"Clinton, Hillary Rodham",142,000120
+OSAGE,North Ridgeway,President / Vice President,,Libertarian,"Johnson, Gary",19,000120
+OSAGE,North Ridgeway,President / Vice President,,Republican,"Trump, Donald J.",366,000120
+OSAGE,North Valleybrook,President / Vice President,,independent,"Stein, Jill",12,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Hedges, James A",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"McMullin, Evan",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Perry, Darryl",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Smith, Mike",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Sood, Ajay",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+OSAGE,North Valleybrook,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+OSAGE,North Valleybrook,President / Vice President,,Democratic,"Clinton, Hillary Rodham",111,000130
+OSAGE,North Valleybrook,President / Vice President,,Libertarian,"Johnson, Gary",26,000130
+OSAGE,North Valleybrook,President / Vice President,,Republican,"Trump, Donald J.",317,000130
+OSAGE,Olivet Township,President / Vice President,,independent,"Stein, Jill",1,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+OSAGE,Olivet Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+OSAGE,Olivet Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000140
+OSAGE,Olivet Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+OSAGE,Olivet Township,President / Vice President,,Republican,"Trump, Donald J.",93,000140
+OSAGE,Osage City Ward 1,President / Vice President,,independent,"Stein, Jill",8,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",108,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000150
+OSAGE,Osage City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",203,000150
+OSAGE,Osage City Ward 2,President / Vice President,,independent,"Stein, Jill",3,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",59,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",6,000160
+OSAGE,Osage City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",122,000160
+OSAGE,Osage City Ward 3,President / Vice President,,independent,"Stein, Jill",4,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",9,000170
+OSAGE,Osage City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",155,000170
+OSAGE,Osage City Ward 4,President / Vice President,,independent,"Stein, Jill",6,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",14,000180
+OSAGE,Osage City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",207,000180
+OSAGE,Scranton Township,President / Vice President,,independent,"Stein, Jill",6,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+OSAGE,Scranton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+OSAGE,Scranton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",117,000190
+OSAGE,Scranton Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000190
+OSAGE,Scranton Township,President / Vice President,,Republican,"Trump, Donald J.",327,000190
+OSAGE,South Burlingame,President / Vice President,,independent,"Stein, Jill",17,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Hedges, James A",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"McMullin, Evan",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Perry, Darryl",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Smith, Mike",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Sood, Ajay",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+OSAGE,South Burlingame,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+OSAGE,South Burlingame,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000200
+OSAGE,South Burlingame,President / Vice President,,Libertarian,"Johnson, Gary",18,000200
+OSAGE,South Burlingame,President / Vice President,,Republican,"Trump, Donald J.",254,000200
+OSAGE,South Ridgeway,President / Vice President,,independent,"Stein, Jill",13,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Hedges, James A",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"McMullin, Evan",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Perry, Darryl",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Smith, Mike",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Sood, Ajay",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+OSAGE,South Ridgeway,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+OSAGE,South Ridgeway,President / Vice President,,Democratic,"Clinton, Hillary Rodham",143,000210
+OSAGE,South Ridgeway,President / Vice President,,Libertarian,"Johnson, Gary",25,000210
+OSAGE,South Ridgeway,President / Vice President,,Republican,"Trump, Donald J.",321,000210
+OSAGE,South Valleybrook,President / Vice President,,independent,"Stein, Jill",5,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Hedges, James A",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"McMullin, Evan",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Perry, Darryl",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Smith, Mike",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Sood, Ajay",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+OSAGE,South Valleybrook,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+OSAGE,South Valleybrook,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000220
+OSAGE,South Valleybrook,President / Vice President,,Libertarian,"Johnson, Gary",6,000220
+OSAGE,South Valleybrook,President / Vice President,,Republican,"Trump, Donald J.",153,000220
+OSAGE,Superior Township,President / Vice President,,independent,"Stein, Jill",3,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+OSAGE,Superior Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+OSAGE,Superior Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000230
+OSAGE,Superior Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000230
+OSAGE,Superior Township,President / Vice President,,Republican,"Trump, Donald J.",88,000230
+OSAGE,Vassar Township,President / Vice President,,independent,"Stein, Jill",11,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+OSAGE,Vassar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+OSAGE,Vassar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000240
+OSAGE,Vassar Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000240
+OSAGE,Vassar Township,President / Vice President,,Republican,"Trump, Donald J.",247,000240
+OSAGE,Superior Township Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+OSAGE,Superior Township Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+OSAGE,Grant Township Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+OSAGE,Grant Township Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+OSAGE,Grant Township Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+OSAGE,Grant Township Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+OSAGE,Osage City Ward 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+OSAGE,Grant Township,United States House of Representatives,2,Democratic,"Potter, Britani",23,000007
+OSAGE,Grant Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000007
+OSAGE,Grant Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",105,000007
+OSAGE,Agency Township,United States House of Representatives,2,Democratic,"Potter, Britani",32,000010
+OSAGE,Agency Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",10,000010
+OSAGE,Agency Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",153,000010
+OSAGE,Arvonia Township,United States House of Representatives,2,Democratic,"Potter, Britani",15,000020
+OSAGE,Arvonia Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000020
+OSAGE,Arvonia Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",41,000020
+OSAGE,Barclay Township,United States House of Representatives,2,Democratic,"Potter, Britani",21,000030
+OSAGE,Barclay Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000030
+OSAGE,Barclay Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000030
+OSAGE,Dragoon Township,United States House of Representatives,2,Democratic,"Potter, Britani",23,000040
+OSAGE,Dragoon Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,000040
+OSAGE,Dragoon Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",81,000040
+OSAGE,Elk Township,United States House of Representatives,2,Democratic,"Potter, Britani",203,000050
+OSAGE,Elk Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",64,000050
+OSAGE,Elk Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",638,000050
+OSAGE,Fairfax Township,United States House of Representatives,2,Democratic,"Potter, Britani",66,000060
+OSAGE,Fairfax Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000060
+OSAGE,Fairfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",214,000060
+OSAGE,Lincoln Township,United States House of Representatives,2,Democratic,"Potter, Britani",11,000080
+OSAGE,Lincoln Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000080
+OSAGE,Lincoln Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",43,000080
+OSAGE,Melvern Township,United States House of Representatives,2,Democratic,"Potter, Britani",65,000090
+OSAGE,Melvern Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",15,000090
+OSAGE,Melvern Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",239,000090
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Democratic,"Potter, Britani",67,000100
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",14,000100
+OSAGE,Michigan Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",171,000100
+OSAGE,North Burlingame,United States House of Representatives,2,Democratic,"Potter, Britani",101,000110
+OSAGE,North Burlingame,United States House of Representatives,2,Libertarian,"Bales, James Houston",25,000110
+OSAGE,North Burlingame,United States House of Representatives,2,Republican,"Jenkins, Lynn",289,000110
+OSAGE,North Ridgeway,United States House of Representatives,2,Democratic,"Potter, Britani",138,000120
+OSAGE,North Ridgeway,United States House of Representatives,2,Libertarian,"Bales, James Houston",47,000120
+OSAGE,North Ridgeway,United States House of Representatives,2,Republican,"Jenkins, Lynn",359,000120
+OSAGE,North Valleybrook,United States House of Representatives,2,Democratic,"Potter, Britani",96,000130
+OSAGE,North Valleybrook,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,000130
+OSAGE,North Valleybrook,United States House of Representatives,2,Republican,"Jenkins, Lynn",339,000130
+OSAGE,Olivet Township,United States House of Representatives,2,Democratic,"Potter, Britani",28,000140
+OSAGE,Olivet Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000140
+OSAGE,Olivet Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",85,000140
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",87,000150
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",18,000150
+OSAGE,Osage City Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",230,000150
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",55,000160
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",9,000160
+OSAGE,Osage City Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",128,000160
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",73,000170
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000170
+OSAGE,Osage City Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",166,000170
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",70,000180
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000180
+OSAGE,Osage City Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",228,000180
+OSAGE,Scranton Township,United States House of Representatives,2,Democratic,"Potter, Britani",104,000190
+OSAGE,Scranton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",36,000190
+OSAGE,Scranton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",321,000190
+OSAGE,South Burlingame,United States House of Representatives,2,Democratic,"Potter, Britani",70,000200
+OSAGE,South Burlingame,United States House of Representatives,2,Libertarian,"Bales, James Houston",40,000200
+OSAGE,South Burlingame,United States House of Representatives,2,Republican,"Jenkins, Lynn",239,000200
+OSAGE,South Ridgeway,United States House of Representatives,2,Democratic,"Potter, Britani",117,000210
+OSAGE,South Ridgeway,United States House of Representatives,2,Libertarian,"Bales, James Houston",28,000210
+OSAGE,South Ridgeway,United States House of Representatives,2,Republican,"Jenkins, Lynn",361,000210
+OSAGE,South Valleybrook,United States House of Representatives,2,Democratic,"Potter, Britani",40,000220
+OSAGE,South Valleybrook,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000220
+OSAGE,South Valleybrook,United States House of Representatives,2,Republican,"Jenkins, Lynn",156,000220
+OSAGE,Superior Township,United States House of Representatives,2,Democratic,"Potter, Britani",25,000230
+OSAGE,Superior Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000230
+OSAGE,Superior Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",102,000230
+OSAGE,Vassar Township,United States House of Representatives,2,Democratic,"Potter, Britani",102,000240
+OSAGE,Vassar Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000240
+OSAGE,Vassar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",247,000240
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+OSAGE,Superior Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+OSAGE,Grant Township Enclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+OSAGE,Grant Township Enclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+OSAGE,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000007
+OSAGE,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000007
+OSAGE,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000007
+OSAGE,Grant Township,United States Senate,,Republican,"Moran, Jerry",110,000007
+OSAGE,Agency Township,United States Senate,,write - in,"Smith, DJ",0,000010
+OSAGE,Agency Township,United States Senate,,Democratic,"Wiesner, Patrick",32,000010
+OSAGE,Agency Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000010
+OSAGE,Agency Township,United States Senate,,Republican,"Moran, Jerry",147,000010
+OSAGE,Arvonia Township,United States Senate,,write - in,"Smith, DJ",0,000020
+OSAGE,Arvonia Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000020
+OSAGE,Arvonia Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+OSAGE,Arvonia Township,United States Senate,,Republican,"Moran, Jerry",39,000020
+OSAGE,Barclay Township,United States Senate,,write - in,"Smith, DJ",0,000030
+OSAGE,Barclay Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000030
+OSAGE,Barclay Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+OSAGE,Barclay Township,United States Senate,,Republican,"Moran, Jerry",77,000030
+OSAGE,Dragoon Township,United States Senate,,write - in,"Smith, DJ",0,000040
+OSAGE,Dragoon Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000040
+OSAGE,Dragoon Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000040
+OSAGE,Dragoon Township,United States Senate,,Republican,"Moran, Jerry",78,000040
+OSAGE,Elk Township,United States Senate,,write - in,"Smith, DJ",0,000050
+OSAGE,Elk Township,United States Senate,,Democratic,"Wiesner, Patrick",190,000050
+OSAGE,Elk Township,United States Senate,,Libertarian,"Garrard, Robert D.",69,000050
+OSAGE,Elk Township,United States Senate,,Republican,"Moran, Jerry",649,000050
+OSAGE,Fairfax Township,United States Senate,,write - in,"Smith, DJ",0,000060
+OSAGE,Fairfax Township,United States Senate,,Democratic,"Wiesner, Patrick",61,000060
+OSAGE,Fairfax Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000060
+OSAGE,Fairfax Township,United States Senate,,Republican,"Moran, Jerry",225,000060
+OSAGE,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000080
+OSAGE,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000080
+OSAGE,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+OSAGE,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",43,000080
+OSAGE,Melvern Township,United States Senate,,write - in,"Smith, DJ",0,000090
+OSAGE,Melvern Township,United States Senate,,Democratic,"Wiesner, Patrick",68,000090
+OSAGE,Melvern Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000090
+OSAGE,Melvern Township,United States Senate,,Republican,"Moran, Jerry",242,000090
+OSAGE,Michigan Valley Township,United States Senate,,write - in,"Smith, DJ",0,000100
+OSAGE,Michigan Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",63,000100
+OSAGE,Michigan Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",22,000100
+OSAGE,Michigan Valley Township,United States Senate,,Republican,"Moran, Jerry",168,000100
+OSAGE,North Burlingame,United States Senate,,write - in,"Smith, DJ",0,000110
+OSAGE,North Burlingame,United States Senate,,Democratic,"Wiesner, Patrick",96,000110
+OSAGE,North Burlingame,United States Senate,,Libertarian,"Garrard, Robert D.",25,000110
+OSAGE,North Burlingame,United States Senate,,Republican,"Moran, Jerry",293,000110
+OSAGE,North Ridgeway,United States Senate,,write - in,"Smith, DJ",0,000120
+OSAGE,North Ridgeway,United States Senate,,Democratic,"Wiesner, Patrick",139,000120
+OSAGE,North Ridgeway,United States Senate,,Libertarian,"Garrard, Robert D.",46,000120
+OSAGE,North Ridgeway,United States Senate,,Republican,"Moran, Jerry",359,000120
+OSAGE,North Valleybrook,United States Senate,,write - in,"Smith, DJ",0,000130
+OSAGE,North Valleybrook,United States Senate,,Democratic,"Wiesner, Patrick",95,000130
+OSAGE,North Valleybrook,United States Senate,,Libertarian,"Garrard, Robert D.",39,000130
+OSAGE,North Valleybrook,United States Senate,,Republican,"Moran, Jerry",331,000130
+OSAGE,Olivet Township,United States Senate,,write - in,"Smith, DJ",0,000140
+OSAGE,Olivet Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000140
+OSAGE,Olivet Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000140
+OSAGE,Olivet Township,United States Senate,,Republican,"Moran, Jerry",87,000140
+OSAGE,Osage City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000150
+OSAGE,Osage City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",91,000150
+OSAGE,Osage City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",22,000150
+OSAGE,Osage City Ward 1,United States Senate,,Republican,"Moran, Jerry",221,000150
+OSAGE,Osage City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000160
+OSAGE,Osage City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",57,000160
+OSAGE,Osage City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",9,000160
+OSAGE,Osage City Ward 2,United States Senate,,Republican,"Moran, Jerry",126,000160
+OSAGE,Osage City Ward 3,United States Senate,,write - in,"Smith, DJ",0,000170
+OSAGE,Osage City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",66,000170
+OSAGE,Osage City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",12,000170
+OSAGE,Osage City Ward 3,United States Senate,,Republican,"Moran, Jerry",170,000170
+OSAGE,Osage City Ward 4,United States Senate,,write - in,"Smith, DJ",0,000180
+OSAGE,Osage City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",77,000180
+OSAGE,Osage City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",16,000180
+OSAGE,Osage City Ward 4,United States Senate,,Republican,"Moran, Jerry",223,000180
+OSAGE,Scranton Township,United States Senate,,write - in,"Smith, DJ",0,000190
+OSAGE,Scranton Township,United States Senate,,Democratic,"Wiesner, Patrick",115,000190
+OSAGE,Scranton Township,United States Senate,,Libertarian,"Garrard, Robert D.",32,000190
+OSAGE,Scranton Township,United States Senate,,Republican,"Moran, Jerry",317,000190
+OSAGE,South Burlingame,United States Senate,,write - in,"Smith, DJ",0,000200
+OSAGE,South Burlingame,United States Senate,,Democratic,"Wiesner, Patrick",70,000200
+OSAGE,South Burlingame,United States Senate,,Libertarian,"Garrard, Robert D.",35,000200
+OSAGE,South Burlingame,United States Senate,,Republican,"Moran, Jerry",245,000200
+OSAGE,South Ridgeway,United States Senate,,write - in,"Smith, DJ",0,000210
+OSAGE,South Ridgeway,United States Senate,,Democratic,"Wiesner, Patrick",129,000210
+OSAGE,South Ridgeway,United States Senate,,Libertarian,"Garrard, Robert D.",43,000210
+OSAGE,South Ridgeway,United States Senate,,Republican,"Moran, Jerry",333,000210
+OSAGE,South Valleybrook,United States Senate,,write - in,"Smith, DJ",0,000220
+OSAGE,South Valleybrook,United States Senate,,Democratic,"Wiesner, Patrick",52,000220
+OSAGE,South Valleybrook,United States Senate,,Libertarian,"Garrard, Robert D.",15,000220
+OSAGE,South Valleybrook,United States Senate,,Republican,"Moran, Jerry",149,000220
+OSAGE,Superior Township,United States Senate,,write - in,"Smith, DJ",0,000230
+OSAGE,Superior Township,United States Senate,,Democratic,"Wiesner, Patrick",31,000230
+OSAGE,Superior Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000230
+OSAGE,Superior Township,United States Senate,,Republican,"Moran, Jerry",95,000230
+OSAGE,Vassar Township,United States Senate,,write - in,"Smith, DJ",0,000240
+OSAGE,Vassar Township,United States Senate,,Democratic,"Wiesner, Patrick",93,000240
+OSAGE,Vassar Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000240
+OSAGE,Vassar Township,United States Senate,,Republican,"Moran, Jerry",250,000240
+OSAGE,Superior Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+OSAGE,Superior Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+OSAGE,Superior Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+OSAGE,Superior Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010
+OSAGE,Grant Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900020
+OSAGE,Grant Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+OSAGE,Grant Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+OSAGE,Grant Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900020
+OSAGE,Grant Township Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900030
+OSAGE,Grant Township Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+OSAGE,Grant Township Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+OSAGE,Grant Township Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900030
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+OSAGE,Osage City Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900040

--- a/2016/20161108__ks__general__osborne__precinct.csv
+++ b/2016/20161108__ks__general__osborne__precinct.csv
@@ -1,973 +1,973 @@
-county,precinct,office,district,candidate,party,votes
-Osborne,Bethany Township,President,,"Stein, Jill  ",independent,3
-Osborne,Bethany Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Bethany Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Bethany Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Bethany Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Bethany Township,President,,"Hedges, James A ",write - in,0
-Osborne,Bethany Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Bethany Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Bethany Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Bethany Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Bethany Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Bethany Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Bethany Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Bethany Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Bethany Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Bethany Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Bethany Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Bethany Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Bethany Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Bethany Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Bethany Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Bethany Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Bethany Township,President,,"Clinton, Hillary Rodham ",Democratic,11
-Osborne,Bethany Township,President,,"Johnson, Gary  ",Libertarian,2
-Osborne,Bethany Township,President,,"Trump, Donald J. ",Republican,73
-Osborne,Bloom Township,President,,"Stein, Jill  ",independent,0
-Osborne,Bloom Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Bloom Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Bloom Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Bloom Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Bloom Township,President,,"Hedges, James A ",write - in,0
-Osborne,Bloom Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Bloom Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Bloom Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Bloom Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Bloom Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Bloom Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Bloom Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Bloom Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Bloom Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Bloom Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Bloom Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Bloom Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Bloom Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Bloom Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Bloom Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Bloom Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Bloom Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Osborne,Bloom Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Bloom Township,President,,"Trump, Donald J. ",Republican,32
-Osborne,Corinth Township,President,,"Stein, Jill  ",independent,1
-Osborne,Corinth Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Corinth Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Corinth Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Corinth Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Corinth Township,President,,"Hedges, James A ",write - in,0
-Osborne,Corinth Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Corinth Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Corinth Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Corinth Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Corinth Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Corinth Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Corinth Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Corinth Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Corinth Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Corinth Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Corinth Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Corinth Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Corinth Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Corinth Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Corinth Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Corinth Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Corinth Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-Osborne,Corinth Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Corinth Township,President,,"Trump, Donald J. ",Republican,26
-Osborne,Covert Township,President,,"Stein, Jill  ",independent,0
-Osborne,Covert Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Covert Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Covert Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Covert Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Covert Township,President,,"Hedges, James A ",write - in,0
-Osborne,Covert Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Covert Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Covert Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Covert Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Covert Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Covert Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Covert Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Covert Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Covert Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Covert Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Covert Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Covert Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Covert Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Covert Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Covert Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Covert Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Covert Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Covert Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Covert Township,President,,"Trump, Donald J. ",Republican,4
-Osborne,Delhi Township,President,,"Stein, Jill  ",independent,0
-Osborne,Delhi Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Delhi Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Delhi Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Delhi Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Delhi Township,President,,"Hedges, James A ",write - in,0
-Osborne,Delhi Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Delhi Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Delhi Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Delhi Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Delhi Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Delhi Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Delhi Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Delhi Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Delhi Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Delhi Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Delhi Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Delhi Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Delhi Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Delhi Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Delhi Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Delhi Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Delhi Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Osborne,Delhi Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Delhi Township,President,,"Trump, Donald J. ",Republican,13
-Osborne,Grant Township,President,,"Stein, Jill  ",independent,0
-Osborne,Grant Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Grant Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Grant Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Grant Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Grant Township,President,,"Hedges, James A ",write - in,0
-Osborne,Grant Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Grant Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Grant Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Grant Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Grant Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Grant Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Grant Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Grant Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Grant Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Grant Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Grant Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Grant Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Grant Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Grant Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Grant Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Grant Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Grant Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Grant Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Grant Township,President,,"Trump, Donald J. ",Republican,14
-Osborne,Hancock Township,President,,"Stein, Jill  ",independent,0
-Osborne,Hancock Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Hancock Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Hancock Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Hancock Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Hancock Township,President,,"Hedges, James A ",write - in,0
-Osborne,Hancock Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Hancock Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Hancock Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Hancock Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Hancock Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Hancock Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Hancock Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Hancock Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Hancock Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Hancock Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Hancock Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Hancock Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Hancock Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Hancock Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Hancock Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Hancock Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Hancock Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Hancock Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Hancock Township,President,,"Trump, Donald J. ",Republican,12
-Osborne,Hawkeye Township,President,,"Stein, Jill  ",independent,0
-Osborne,Hawkeye Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Hawkeye Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Hawkeye Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Hawkeye Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Hawkeye Township,President,,"Hedges, James A ",write - in,0
-Osborne,Hawkeye Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Hawkeye Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Hawkeye Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Hawkeye Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Hawkeye Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Hawkeye Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Hawkeye Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Hawkeye Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Hawkeye Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Hawkeye Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Hawkeye Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Hawkeye Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Hawkeye Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Hawkeye Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Hawkeye Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Hawkeye Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Hawkeye Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Hawkeye Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Hawkeye Township,President,,"Trump, Donald J. ",Republican,12
-Osborne,Independence Township,President,,"Stein, Jill  ",independent,0
-Osborne,Independence Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Independence Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Independence Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Independence Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Independence Township,President,,"Hedges, James A ",write - in,0
-Osborne,Independence Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Independence Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Independence Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Independence Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Independence Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Independence Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Independence Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Independence Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Independence Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Independence Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Independence Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Independence Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Independence Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Independence Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Independence Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Independence Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Independence Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Osborne,Independence Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Independence Township,President,,"Trump, Donald J. ",Republican,15
-Osborne,Jackson Township,President,,"Stein, Jill  ",independent,0
-Osborne,Jackson Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Jackson Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Jackson Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Jackson Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Jackson Township,President,,"Hedges, James A ",write - in,0
-Osborne,Jackson Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Jackson Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Jackson Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Jackson Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Jackson Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Jackson Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Jackson Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Jackson Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Jackson Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Jackson Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Jackson Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Jackson Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Jackson Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Jackson Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Jackson Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Jackson Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Jackson Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Osborne,Jackson Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Jackson Township,President,,"Trump, Donald J. ",Republican,19
-Osborne,Kill Creek Township,President,,"Stein, Jill  ",independent,0
-Osborne,Kill Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Kill Creek Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Kill Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Kill Creek Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Kill Creek Township,President,,"Hedges, James A ",write - in,0
-Osborne,Kill Creek Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Kill Creek Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Kill Creek Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Kill Creek Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Kill Creek Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Kill Creek Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Kill Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Kill Creek Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Kill Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Kill Creek Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Kill Creek Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Kill Creek Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Kill Creek Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Kill Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Kill Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Kill Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Kill Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Kill Creek Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Kill Creek Township,President,,"Trump, Donald J. ",Republican,4
-Osborne,Lawrence Township,President,,"Stein, Jill  ",independent,0
-Osborne,Lawrence Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Lawrence Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Lawrence Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Lawrence Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Lawrence Township,President,,"Hedges, James A ",write - in,0
-Osborne,Lawrence Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Lawrence Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Lawrence Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Lawrence Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Lawrence Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Lawrence Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Lawrence Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Lawrence Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Lawrence Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Lawrence Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Lawrence Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Lawrence Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Lawrence Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Lawrence Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Lawrence Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Lawrence Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Lawrence Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-Osborne,Lawrence Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Lawrence Township,President,,"Trump, Donald J. ",Republican,14
-Osborne,Liberty Township,President,,"Stein, Jill  ",independent,0
-Osborne,Liberty Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Liberty Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Liberty Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Liberty Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Liberty Township,President,,"Hedges, James A ",write - in,0
-Osborne,Liberty Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Liberty Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Liberty Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Liberty Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Liberty Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Liberty Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Liberty Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Liberty Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Liberty Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Liberty Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Liberty Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Liberty Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Liberty Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Liberty Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Liberty Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Liberty Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Liberty Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Osborne,Liberty Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Liberty Township,President,,"Trump, Donald J. ",Republican,10
-Osborne,Mount Ayr Township,President,,"Stein, Jill  ",independent,0
-Osborne,Mount Ayr Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Mount Ayr Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Mount Ayr Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Hedges, James A ",write - in,0
-Osborne,Mount Ayr Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Mount Ayr Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Mount Ayr Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Mount Ayr Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Mount Ayr Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Mount Ayr Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Mount Ayr Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Mount Ayr Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Mount Ayr Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Mount Ayr Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Mount Ayr Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Mount Ayr Township,President,,"Trump, Donald J. ",Republican,24
-Osborne,Natoma Township,President,,"Stein, Jill  ",independent,3
-Osborne,Natoma Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Natoma Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Natoma Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Natoma Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Natoma Township,President,,"Hedges, James A ",write - in,0
-Osborne,Natoma Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Natoma Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Natoma Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Natoma Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Natoma Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Natoma Township,President,,"McMullin, Evan  ",write - in,4
-Osborne,Natoma Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Natoma Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Natoma Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Natoma Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Natoma Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Natoma Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Natoma Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Natoma Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Natoma Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Natoma Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Natoma Township,President,,"Clinton, Hillary Rodham ",Democratic,17
-Osborne,Natoma Township,President,,"Johnson, Gary  ",Libertarian,2
-Osborne,Natoma Township,President,,"Trump, Donald J. ",Republican,134
-Osborne,Osborne Ward 1,President,,"Stein, Jill  ",independent,7
-Osborne,Osborne Ward 1,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Osborne Ward 1,President,,"Castle, Darrell L ",write - in,1
-Osborne,Osborne Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Hedges, James A ",write - in,0
-Osborne,Osborne Ward 1,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Osborne Ward 1,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Osborne Ward 1,President,,"Maturen, Michael A ",write - in,0
-Osborne,Osborne Ward 1,President,,"McMullin, Evan  ",write - in,2
-Osborne,Osborne Ward 1,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Osborne Ward 1,President,,"Perry, Darryl  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Osborne Ward 1,President,,"Schriner, Joe C ",write - in,0
-Osborne,Osborne Ward 1,President,,"Smith, Mike  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Sood, Ajay  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Osborne Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Osborne Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Osborne Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,36
-Osborne,Osborne Ward 1,President,,"Johnson, Gary  ",Libertarian,10
-Osborne,Osborne Ward 1,President,,"Trump, Donald J. ",Republican,175
-Osborne,Osborne Ward 2,President,,"Stein, Jill  ",independent,6
-Osborne,Osborne Ward 2,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Osborne Ward 2,President,,"Castle, Darrell L ",write - in,1
-Osborne,Osborne Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Hedges, James A ",write - in,0
-Osborne,Osborne Ward 2,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Osborne Ward 2,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Osborne Ward 2,President,,"Maturen, Michael A ",write - in,0
-Osborne,Osborne Ward 2,President,,"McMullin, Evan  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Osborne Ward 2,President,,"Perry, Darryl  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Osborne Ward 2,President,,"Schriner, Joe C ",write - in,0
-Osborne,Osborne Ward 2,President,,"Smith, Mike  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Sood, Ajay  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Osborne Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Osborne Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Osborne Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,54
-Osborne,Osborne Ward 2,President,,"Johnson, Gary  ",Libertarian,5
-Osborne,Osborne Ward 2,President,,"Trump, Donald J. ",Republican,228
-Osborne,Osborne Ward 3,President,,"Stein, Jill  ",independent,6
-Osborne,Osborne Ward 3,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Osborne Ward 3,President,,"Castle, Darrell L ",write - in,0
-Osborne,Osborne Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Hedges, James A ",write - in,0
-Osborne,Osborne Ward 3,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Osborne Ward 3,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Osborne Ward 3,President,,"Maturen, Michael A ",write - in,0
-Osborne,Osborne Ward 3,President,,"McMullin, Evan  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Osborne Ward 3,President,,"Perry, Darryl  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Osborne Ward 3,President,,"Schriner, Joe C ",write - in,0
-Osborne,Osborne Ward 3,President,,"Smith, Mike  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Sood, Ajay  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Osborne Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Osborne Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Osborne Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,18
-Osborne,Osborne Ward 3,President,,"Johnson, Gary  ",Libertarian,4
-Osborne,Osborne Ward 3,President,,"Trump, Donald J. ",Republican,104
-Osborne,Penn Township,President,,"Stein, Jill  ",independent,0
-Osborne,Penn Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Penn Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Penn Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Penn Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Penn Township,President,,"Hedges, James A ",write - in,0
-Osborne,Penn Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Penn Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Penn Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Penn Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Penn Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Penn Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Penn Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Penn Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Penn Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Penn Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Penn Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Penn Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Penn Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Penn Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Penn Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Penn Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Penn Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-Osborne,Penn Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Penn Township,President,,"Trump, Donald J. ",Republican,48
-Osborne,Ross 1,President,,"Stein, Jill  ",independent,9
-Osborne,Ross 1,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Ross 1,President,,"Castle, Darrell L ",write - in,0
-Osborne,Ross 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Ross 1,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Ross 1,President,,"Hedges, James A ",write - in,0
-Osborne,Ross 1,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Ross 1,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Ross 1,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Ross 1,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Ross 1,President,,"Maturen, Michael A ",write - in,0
-Osborne,Ross 1,President,,"McMullin, Evan  ",write - in,0
-Osborne,Ross 1,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Ross 1,President,,"Perry, Darryl  ",write - in,0
-Osborne,Ross 1,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Ross 1,President,,"Schriner, Joe C ",write - in,0
-Osborne,Ross 1,President,,"Smith, Mike  ",write - in,0
-Osborne,Ross 1,President,,"Sood, Ajay  ",write - in,0
-Osborne,Ross 1,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Ross 1,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Ross 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Ross 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Ross 1,President,,"Clinton, Hillary Rodham ",Democratic,62
-Osborne,Ross 1,President,,"Johnson, Gary  ",Libertarian,10
-Osborne,Ross 1,President,,"Trump, Donald J. ",Republican,302
-Osborne,Ross 2,President,,"Stein, Jill  ",independent,1
-Osborne,Ross 2,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Ross 2,President,,"Castle, Darrell L ",write - in,0
-Osborne,Ross 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Ross 2,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Ross 2,President,,"Hedges, James A ",write - in,0
-Osborne,Ross 2,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Ross 2,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Ross 2,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Ross 2,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Ross 2,President,,"Maturen, Michael A ",write - in,0
-Osborne,Ross 2,President,,"McMullin, Evan  ",write - in,0
-Osborne,Ross 2,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Ross 2,President,,"Perry, Darryl  ",write - in,0
-Osborne,Ross 2,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Ross 2,President,,"Schriner, Joe C ",write - in,0
-Osborne,Ross 2,President,,"Smith, Mike  ",write - in,0
-Osborne,Ross 2,President,,"Sood, Ajay  ",write - in,0
-Osborne,Ross 2,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Ross 2,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Ross 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Ross 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Ross 2,President,,"Clinton, Hillary Rodham ",Democratic,4
-Osborne,Ross 2,President,,"Johnson, Gary  ",Libertarian,3
-Osborne,Ross 2,President,,"Trump, Donald J. ",Republican,45
-Osborne,Round Mound Township,President,,"Stein, Jill  ",independent,0
-Osborne,Round Mound Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Round Mound Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Round Mound Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Round Mound Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Round Mound Township,President,,"Hedges, James A ",write - in,0
-Osborne,Round Mound Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Round Mound Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Round Mound Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Round Mound Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Round Mound Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Round Mound Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Round Mound Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Round Mound Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Round Mound Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Round Mound Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Round Mound Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Round Mound Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Round Mound Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Round Mound Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Round Mound Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Round Mound Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Round Mound Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Round Mound Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Round Mound Township,President,,"Trump, Donald J. ",Republican,23
-Osborne,Sumner Township,President,,"Stein, Jill  ",independent,3
-Osborne,Sumner Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Sumner Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Sumner Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Sumner Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Sumner Township,President,,"Hedges, James A ",write - in,0
-Osborne,Sumner Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Sumner Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Sumner Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Sumner Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Sumner Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Sumner Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Sumner Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Sumner Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Sumner Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Sumner Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Sumner Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Sumner Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Sumner Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Sumner Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Sumner Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Sumner Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Sumner Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Osborne,Sumner Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Sumner Township,President,,"Trump, Donald J. ",Republican,71
-Osborne,Tilden Township,President,,"Stein, Jill  ",independent,1
-Osborne,Tilden Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Tilden Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Tilden Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Tilden Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Tilden Township,President,,"Hedges, James A ",write - in,0
-Osborne,Tilden Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Tilden Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Tilden Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Tilden Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Tilden Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Tilden Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Tilden Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Tilden Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Tilden Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Tilden Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Tilden Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Tilden Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Tilden Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Tilden Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Tilden Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Tilden Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Tilden Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Tilden Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Tilden Township,President,,"Trump, Donald J. ",Republican,36
-Osborne,Valley Township,President,,"Stein, Jill  ",independent,1
-Osborne,Valley Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Valley Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Valley Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Valley Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Valley Township,President,,"Hedges, James A ",write - in,0
-Osborne,Valley Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Valley Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Valley Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Valley Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Valley Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Valley Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Valley Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Valley Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Valley Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Valley Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Valley Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Valley Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Valley Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Valley Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Valley Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Valley Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Valley Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-Osborne,Valley Township,President,,"Johnson, Gary  ",Libertarian,1
-Osborne,Valley Township,President,,"Trump, Donald J. ",Republican,6
-Osborne,Victor Township,President,,"Stein, Jill  ",independent,0
-Osborne,Victor Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Victor Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Victor Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Victor Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Victor Township,President,,"Hedges, James A ",write - in,0
-Osborne,Victor Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Victor Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Victor Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Victor Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Victor Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Victor Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Victor Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Victor Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Victor Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Victor Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Victor Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Victor Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Victor Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Victor Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Victor Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Victor Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Victor Township,President,,"Clinton, Hillary Rodham ",Democratic,3
-Osborne,Victor Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Victor Township,President,,"Trump, Donald J. ",Republican,8
-Osborne,Winfield Township,President,,"Stein, Jill  ",independent,0
-Osborne,Winfield Township,President,,"Basiago, Andrew D. ",write - in,0
-Osborne,Winfield Township,President,,"Castle, Darrell L ",write - in,0
-Osborne,Winfield Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Osborne,Winfield Township,President,,"Giordani, Rocky  ",write - in,0
-Osborne,Winfield Township,President,,"Hedges, James A ",write - in,0
-Osborne,Winfield Township,President,,"Hoefling, Tom  ",write - in,0
-Osborne,Winfield Township,President,,"Kahn, Lynn  ",write - in,0
-Osborne,Winfield Township,President,,"La Riva, Gloria  ",write - in,0
-Osborne,Winfield Township,President,,"Levinson, Michael S. ",write - in,0
-Osborne,Winfield Township,President,,"Maturen, Michael A ",write - in,0
-Osborne,Winfield Township,President,,"McMullin, Evan  ",write - in,0
-Osborne,Winfield Township,President,,"Moorehead, Monica G. ",write - in,0
-Osborne,Winfield Township,President,,"Perry, Darryl  ",write - in,0
-Osborne,Winfield Township,President,,"Schoenke, Marshall R. ",write - in,0
-Osborne,Winfield Township,President,,"Schriner, Joe C ",write - in,0
-Osborne,Winfield Township,President,,"Smith, Mike  ",write - in,0
-Osborne,Winfield Township,President,,"Sood, Ajay  ",write - in,0
-Osborne,Winfield Township,President,,"Sterling, Shawna  ",write - in,0
-Osborne,Winfield Township,President,,"Valdivia, Anthony J ",write - in,0
-Osborne,Winfield Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Osborne,Winfield Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Osborne,Winfield Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Osborne,Winfield Township,President,,"Johnson, Gary  ",Libertarian,0
-Osborne,Winfield Township,President,,"Trump, Donald J. ",Republican,8
-Osborne,Bethany Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Bethany Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,11
-Osborne,Bethany Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Osborne,Bethany Township,U.S. Senate,,"Moran, Jerry  ",Republican,80
-Osborne,Bloom Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Bloom Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Osborne,Bloom Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Osborne,Bloom Township,U.S. Senate,,"Moran, Jerry  ",Republican,38
-Osborne,Corinth Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Corinth Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Corinth Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Osborne,Corinth Township,U.S. Senate,,"Moran, Jerry  ",Republican,28
-Osborne,Covert Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Covert Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Covert Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Covert Township,U.S. Senate,,"Moran, Jerry  ",Republican,4
-Osborne,Delhi Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Delhi Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Osborne,Delhi Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Delhi Township,U.S. Senate,,"Moran, Jerry  ",Republican,14
-Osborne,Grant Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Grant Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Grant Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Osborne,Grant Township,U.S. Senate,,"Moran, Jerry  ",Republican,14
-Osborne,Hancock Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Hancock Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Hancock Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Hancock Township,U.S. Senate,,"Moran, Jerry  ",Republican,12
-Osborne,Hawkeye Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Hawkeye Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Osborne,Hawkeye Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Hawkeye Township,U.S. Senate,,"Moran, Jerry  ",Republican,12
-Osborne,Independence Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Independence Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Independence Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Osborne,Independence Township,U.S. Senate,,"Moran, Jerry  ",Republican,16
-Osborne,Jackson Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Jackson Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Osborne,Jackson Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Jackson Township,U.S. Senate,,"Moran, Jerry  ",Republican,20
-Osborne,Kill Creek Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Kill Creek Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Kill Creek Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Kill Creek Township,U.S. Senate,,"Moran, Jerry  ",Republican,4
-Osborne,Lawrence Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Lawrence Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Osborne,Lawrence Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Lawrence Township,U.S. Senate,,"Moran, Jerry  ",Republican,15
-Osborne,Liberty Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Liberty Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Liberty Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Liberty Township,U.S. Senate,,"Moran, Jerry  ",Republican,12
-Osborne,Mount Ayr Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Mount Ayr Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Mount Ayr Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Osborne,Mount Ayr Township,U.S. Senate,,"Moran, Jerry  ",Republican,22
-Osborne,Natoma Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Natoma Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,12
-Osborne,Natoma Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-Osborne,Natoma Township,U.S. Senate,,"Moran, Jerry  ",Republican,140
-Osborne,Osborne Ward 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Osborne Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,33
-Osborne,Osborne Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Osborne,Osborne Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,183
-Osborne,Osborne Ward 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Osborne Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,51
-Osborne,Osborne Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Osborne,Osborne Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,232
-Osborne,Osborne Ward 3,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Osborne Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,21
-Osborne,Osborne Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,9
-Osborne,Osborne Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,101
-Osborne,Penn Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Penn Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2
-Osborne,Penn Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4
-Osborne,Penn Township,U.S. Senate,,"Moran, Jerry  ",Republican,50
-Osborne,Ross 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Ross 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,40
-Osborne,Ross 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,15
-Osborne,Ross 1,U.S. Senate,,"Moran, Jerry  ",Republican,323
-Osborne,Ross 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Ross 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Osborne,Ross 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Osborne,Ross 2,U.S. Senate,,"Moran, Jerry  ",Republican,48
-Osborne,Round Mound Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Round Mound Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Osborne,Round Mound Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Osborne,Round Mound Township,U.S. Senate,,"Moran, Jerry  ",Republican,21
-Osborne,Sumner Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Sumner Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Osborne,Sumner Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,7
-Osborne,Sumner Township,U.S. Senate,,"Moran, Jerry  ",Republican,66
-Osborne,Tilden Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Tilden Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Osborne,Tilden Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Tilden Township,U.S. Senate,,"Moran, Jerry  ",Republican,37
-Osborne,Valley Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Valley Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Valley Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Osborne,Valley Township,U.S. Senate,,"Moran, Jerry  ",Republican,9
-Osborne,Victor Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Victor Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Victor Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Victor Township,U.S. Senate,,"Moran, Jerry  ",Republican,11
-Osborne,Winfield Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Osborne,Winfield Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Osborne,Winfield Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Osborne,Winfield Township,U.S. Senate,,"Moran, Jerry  ",Republican,9
-Osborne,Bethany Township,U.S. House,1,"LaPolice, Alan  ",independent,16
-Osborne,Bethany Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Bethany Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Osborne,Bethany Township,U.S. House,1,"Marshall, Roger  ",Republican,76
-Osborne,Bloom Township,U.S. House,1,"LaPolice, Alan  ",independent,8
-Osborne,Bloom Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Bloom Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Osborne,Bloom Township,U.S. House,1,"Marshall, Roger  ",Republican,32
-Osborne,Corinth Township,U.S. House,1,"LaPolice, Alan  ",independent,12
-Osborne,Corinth Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Corinth Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Osborne,Corinth Township,U.S. House,1,"Marshall, Roger  ",Republican,17
-Osborne,Covert Township,U.S. House,1,"LaPolice, Alan  ",independent,3
-Osborne,Covert Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Covert Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Covert Township,U.S. House,1,"Marshall, Roger  ",Republican,1
-Osborne,Delhi Township,U.S. House,1,"LaPolice, Alan  ",independent,7
-Osborne,Delhi Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Delhi Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Delhi Township,U.S. House,1,"Marshall, Roger  ",Republican,8
-Osborne,Grant Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Osborne,Grant Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Grant Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Osborne,Grant Township,U.S. House,1,"Marshall, Roger  ",Republican,12
-Osborne,Hancock Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Osborne,Hancock Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Hancock Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Hancock Township,U.S. House,1,"Marshall, Roger  ",Republican,11
-Osborne,Hawkeye Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Osborne,Hawkeye Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Hawkeye Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Hawkeye Township,U.S. House,1,"Marshall, Roger  ",Republican,12
-Osborne,Independence Township,U.S. House,1,"LaPolice, Alan  ",independent,4
-Osborne,Independence Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Independence Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Independence Township,U.S. House,1,"Marshall, Roger  ",Republican,12
-Osborne,Jackson Township,U.S. House,1,"LaPolice, Alan  ",independent,7
-Osborne,Jackson Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Jackson Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Jackson Township,U.S. House,1,"Marshall, Roger  ",Republican,14
-Osborne,Kill Creek Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Osborne,Kill Creek Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Kill Creek Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Kill Creek Township,U.S. House,1,"Marshall, Roger  ",Republican,3
-Osborne,Lawrence Township,U.S. House,1,"LaPolice, Alan  ",independent,3
-Osborne,Lawrence Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Lawrence Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Lawrence Township,U.S. House,1,"Marshall, Roger  ",Republican,11
-Osborne,Liberty Township,U.S. House,1,"LaPolice, Alan  ",independent,5
-Osborne,Liberty Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Liberty Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Osborne,Liberty Township,U.S. House,1,"Marshall, Roger  ",Republican,6
-Osborne,Mount Ayr Township,U.S. House,1,"LaPolice, Alan  ",independent,5
-Osborne,Mount Ayr Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Mount Ayr Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Osborne,Mount Ayr Township,U.S. House,1,"Marshall, Roger  ",Republican,17
-Osborne,Natoma Township,U.S. House,1,"LaPolice, Alan  ",independent,33
-Osborne,Natoma Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Natoma Township,U.S. House,1,"Burt, Kerry  ",Libertarian,5
-Osborne,Natoma Township,U.S. House,1,"Marshall, Roger  ",Republican,114
-Osborne,Osborne Ward 1,U.S. House,1,"LaPolice, Alan  ",independent,68
-Osborne,Osborne Ward 1,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Osborne,Osborne Ward 1,U.S. House,1,"Burt, Kerry  ",Libertarian,5
-Osborne,Osborne Ward 1,U.S. House,1,"Marshall, Roger  ",Republican,142
-Osborne,Osborne Ward 2,U.S. House,1,"LaPolice, Alan  ",independent,95
-Osborne,Osborne Ward 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Osborne Ward 2,U.S. House,1,"Burt, Kerry  ",Libertarian,18
-Osborne,Osborne Ward 2,U.S. House,1,"Marshall, Roger  ",Republican,177
-Osborne,Osborne Ward 3,U.S. House,1,"LaPolice, Alan  ",independent,31
-Osborne,Osborne Ward 3,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Osborne Ward 3,U.S. House,1,"Burt, Kerry  ",Libertarian,10
-Osborne,Osborne Ward 3,U.S. House,1,"Marshall, Roger  ",Republican,84
-Osborne,Penn Township,U.S. House,1,"LaPolice, Alan  ",independent,22
-Osborne,Penn Township,U.S. House,1,"Huelskamp, Tim  ",write - in,1
-Osborne,Penn Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Osborne,Penn Township,U.S. House,1,"Marshall, Roger  ",Republican,31
-Osborne,Ross 1,U.S. House,1,"LaPolice, Alan  ",independent,113
-Osborne,Ross 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Ross 1,U.S. House,1,"Burt, Kerry  ",Libertarian,13
-Osborne,Ross 1,U.S. House,1,"Marshall, Roger  ",Republican,247
-Osborne,Ross 2,U.S. House,1,"LaPolice, Alan  ",independent,13
-Osborne,Ross 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Ross 2,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Ross 2,U.S. House,1,"Marshall, Roger  ",Republican,41
-Osborne,Round Mound Township,U.S. House,1,"LaPolice, Alan  ",independent,6
-Osborne,Round Mound Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Round Mound Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Osborne,Round Mound Township,U.S. House,1,"Marshall, Roger  ",Republican,14
-Osborne,Sumner Township,U.S. House,1,"LaPolice, Alan  ",independent,15
-Osborne,Sumner Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Sumner Township,U.S. House,1,"Burt, Kerry  ",Libertarian,5
-Osborne,Sumner Township,U.S. House,1,"Marshall, Roger  ",Republican,55
-Osborne,Tilden Township,U.S. House,1,"LaPolice, Alan  ",independent,10
-Osborne,Tilden Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Tilden Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2
-Osborne,Tilden Township,U.S. House,1,"Marshall, Roger  ",Republican,26
-Osborne,Valley Township,U.S. House,1,"LaPolice, Alan  ",independent,2
-Osborne,Valley Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Valley Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Valley Township,U.S. House,1,"Marshall, Roger  ",Republican,8
-Osborne,Victor Township,U.S. House,1,"LaPolice, Alan  ",independent,3
-Osborne,Victor Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Victor Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Victor Township,U.S. House,1,"Marshall, Roger  ",Republican,8
-Osborne,Winfield Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Osborne,Winfield Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Osborne,Winfield Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Osborne,Winfield Township,U.S. House,1,"Marshall, Roger  ",Republican,8
-Osborne,Bethany Township,State Senate,36,"Angevine, Brian G. ",Democratic,19
-Osborne,Bethany Township,State Senate,36,"Bowers, Elaine S. ",Republican,72
-Osborne,Bloom Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Osborne,Bloom Township,State Senate,36,"Bowers, Elaine S. ",Republican,39
-Osborne,Corinth Township,State Senate,36,"Angevine, Brian G. ",Democratic,4
-Osborne,Corinth Township,State Senate,36,"Bowers, Elaine S. ",Republican,27
-Osborne,Covert Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Covert Township,State Senate,36,"Bowers, Elaine S. ",Republican,4
-Osborne,Delhi Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Delhi Township,State Senate,36,"Bowers, Elaine S. ",Republican,13
-Osborne,Grant Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Osborne,Grant Township,State Senate,36,"Bowers, Elaine S. ",Republican,12
-Osborne,Hancock Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Hancock Township,State Senate,36,"Bowers, Elaine S. ",Republican,11
-Osborne,Hawkeye Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Hawkeye Township,State Senate,36,"Bowers, Elaine S. ",Republican,13
-Osborne,Independence Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Osborne,Independence Township,State Senate,36,"Bowers, Elaine S. ",Republican,13
-Osborne,Jackson Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Osborne,Jackson Township,State Senate,36,"Bowers, Elaine S. ",Republican,18
-Osborne,Kill Creek Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Kill Creek Township,State Senate,36,"Bowers, Elaine S. ",Republican,4
-Osborne,Lawrence Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-Osborne,Lawrence Township,State Senate,36,"Bowers, Elaine S. ",Republican,15
-Osborne,Liberty Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-Osborne,Liberty Township,State Senate,36,"Bowers, Elaine S. ",Republican,11
-Osborne,Mount Ayr Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Osborne,Mount Ayr Township,State Senate,36,"Bowers, Elaine S. ",Republican,22
-Osborne,Natoma Township,State Senate,36,"Angevine, Brian G. ",Democratic,20
-Osborne,Natoma Township,State Senate,36,"Bowers, Elaine S. ",Republican,130
-Osborne,Osborne Ward 1,State Senate,36,"Angevine, Brian G. ",Democratic,31
-Osborne,Osborne Ward 1,State Senate,36,"Bowers, Elaine S. ",Republican,189
-Osborne,Osborne Ward 2,State Senate,36,"Angevine, Brian G. ",Democratic,59
-Osborne,Osborne Ward 2,State Senate,36,"Bowers, Elaine S. ",Republican,227
-Osborne,Osborne Ward 3,State Senate,36,"Angevine, Brian G. ",Democratic,29
-Osborne,Osborne Ward 3,State Senate,36,"Bowers, Elaine S. ",Republican,97
-Osborne,Penn Township,State Senate,36,"Angevine, Brian G. ",Democratic,7
-Osborne,Penn Township,State Senate,36,"Bowers, Elaine S. ",Republican,46
-Osborne,Ross 1,State Senate,36,"Angevine, Brian G. ",Democratic,53
-Osborne,Ross 1,State Senate,36,"Bowers, Elaine S. ",Republican,320
-Osborne,Ross 2,State Senate,36,"Angevine, Brian G. ",Democratic,6
-Osborne,Ross 2,State Senate,36,"Bowers, Elaine S. ",Republican,47
-Osborne,Round Mound Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Round Mound Township,State Senate,36,"Bowers, Elaine S. ",Republican,21
-Osborne,Sumner Township,State Senate,36,"Angevine, Brian G. ",Democratic,4
-Osborne,Sumner Township,State Senate,36,"Bowers, Elaine S. ",Republican,69
-Osborne,Tilden Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Tilden Township,State Senate,36,"Bowers, Elaine S. ",Republican,38
-Osborne,Valley Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Valley Township,State Senate,36,"Bowers, Elaine S. ",Republican,10
-Osborne,Victor Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Osborne,Victor Township,State Senate,36,"Bowers, Elaine S. ",Republican,8
-Osborne,Winfield Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Osborne,Winfield Township,State Senate,36,"Bowers, Elaine S. ",Republican,9
-Osborne,Bethany Township,State House,109,"Waymaster, Troy L. ",Republican,80
-Osborne,Bloom Township,State House,109,"Waymaster, Troy L. ",Republican,37
-Osborne,Corinth Township,State House,109,"Waymaster, Troy L. ",Republican,25
-Osborne,Covert Township,State House,109,"Waymaster, Troy L. ",Republican,4
-Osborne,Delhi Township,State House,109,"Waymaster, Troy L. ",Republican,13
-Osborne,Grant Township,State House,109,"Waymaster, Troy L. ",Republican,14
-Osborne,Hancock Township,State House,109,"Waymaster, Troy L. ",Republican,12
-Osborne,Hawkeye Township,State House,109,"Waymaster, Troy L. ",Republican,12
-Osborne,Independence Township,State House,109,"Waymaster, Troy L. ",Republican,13
-Osborne,Jackson Township,State House,109,"Waymaster, Troy L. ",Republican,21
-Osborne,Kill Creek Township,State House,109,"Waymaster, Troy L. ",Republican,4
-Osborne,Lawrence Township,State House,109,"Waymaster, Troy L. ",Republican,14
-Osborne,Liberty Township,State House,109,"Waymaster, Troy L. ",Republican,10
-Osborne,Mount Ayr Township,State House,109,"Waymaster, Troy L. ",Republican,23
-Osborne,Natoma Township,State House,109,"Waymaster, Troy L. ",Republican,147
-Osborne,Osborne Ward 1,State House,109,"Waymaster, Troy L. ",Republican,196
-Osborne,Osborne Ward 2,State House,109,"Waymaster, Troy L. ",Republican,244
-Osborne,Osborne Ward 3,State House,109,"Waymaster, Troy L. ",Republican,115
-Osborne,Penn Township,State House,109,"Waymaster, Troy L. ",Republican,52
-Osborne,Ross 1,State House,109,"Waymaster, Troy L. ",Republican,335
-Osborne,Ross 2,State House,109,"Waymaster, Troy L. ",Republican,47
-Osborne,Round Mound Township,State House,109,"Waymaster, Troy L. ",Republican,22
-Osborne,Sumner Township,State House,109,"Waymaster, Troy L. ",Republican,72
-Osborne,Tilden Township,State House,109,"Waymaster, Troy L. ",Republican,34
-Osborne,Valley Township,State House,109,"Waymaster, Troy L. ",Republican,10
-Osborne,Victor Township,State House,109,"Waymaster, Troy L. ",Republican,9
-Osborne,Winfield Township,State House,109,"Waymaster, Troy L. ",Republican,9
+county,precinct,office,district,party,candidate,votes,vtd
+OSBORNE,Bethany Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",80,000010
+OSBORNE,Bloom Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",37,000020
+OSBORNE,Corinth Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000030
+OSBORNE,Covert Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",4,000040
+OSBORNE,Delhi Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000050
+OSBORNE,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000060
+OSBORNE,Hancock Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000070
+OSBORNE,Hawkeye Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000080
+OSBORNE,Independence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000090
+OSBORNE,Jackson Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000100
+OSBORNE,Kill Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",4,000110
+OSBORNE,Lawrence Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",14,000120
+OSBORNE,Liberty Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000130
+OSBORNE,Mount Ayr Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000140
+OSBORNE,Natoma Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",147,000150
+OSBORNE,Osborne Ward 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",196,000160
+OSBORNE,Osborne Ward 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",244,000170
+OSBORNE,Osborne Ward 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",115,000180
+OSBORNE,Penn Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000190
+OSBORNE,Ross 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",335,000200
+OSBORNE,Ross 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",47,000210
+OSBORNE,Round Mound Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",22,000220
+OSBORNE,Sumner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",72,000230
+OSBORNE,Tilden Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",34,000240
+OSBORNE,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000250
+OSBORNE,Victor Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000260
+OSBORNE,Winfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000270
+OSBORNE,Bethany Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",19,000010
+OSBORNE,Bethany Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",72,000010
+OSBORNE,Bloom Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000020
+OSBORNE,Bloom Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000020
+OSBORNE,Corinth Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000030
+OSBORNE,Corinth Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000030
+OSBORNE,Covert Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000040
+OSBORNE,Covert Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",4,000040
+OSBORNE,Delhi Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000050
+OSBORNE,Delhi Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000050
+OSBORNE,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000060
+OSBORNE,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",12,000060
+OSBORNE,Hancock Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000070
+OSBORNE,Hancock Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000070
+OSBORNE,Hawkeye Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000080
+OSBORNE,Hawkeye Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000080
+OSBORNE,Independence Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000090
+OSBORNE,Independence Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000090
+OSBORNE,Jackson Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000100
+OSBORNE,Jackson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000100
+OSBORNE,Kill Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000110
+OSBORNE,Kill Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",4,000110
+OSBORNE,Lawrence Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000120
+OSBORNE,Lawrence Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000120
+OSBORNE,Liberty Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000130
+OSBORNE,Liberty Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000130
+OSBORNE,Mount Ayr Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000140
+OSBORNE,Mount Ayr Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",22,000140
+OSBORNE,Natoma Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000150
+OSBORNE,Natoma Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",130,000150
+OSBORNE,Osborne Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",31,000160
+OSBORNE,Osborne Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",189,000160
+OSBORNE,Osborne Ward 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",59,000170
+OSBORNE,Osborne Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",227,000170
+OSBORNE,Osborne Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",29,000180
+OSBORNE,Osborne Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",97,000180
+OSBORNE,Penn Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000190
+OSBORNE,Penn Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",46,000190
+OSBORNE,Ross 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",53,000200
+OSBORNE,Ross 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",320,000200
+OSBORNE,Ross 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000210
+OSBORNE,Ross 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",47,000210
+OSBORNE,Round Mound Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000220
+OSBORNE,Round Mound Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",21,000220
+OSBORNE,Sumner Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000230
+OSBORNE,Sumner Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",69,000230
+OSBORNE,Tilden Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000240
+OSBORNE,Tilden Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",38,000240
+OSBORNE,Valley Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000250
+OSBORNE,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000250
+OSBORNE,Victor Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000260
+OSBORNE,Victor Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",8,000260
+OSBORNE,Winfield Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000270
+OSBORNE,Winfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",9,000270
+OSBORNE,Bethany Township,President / Vice President,,independent,"Stein, Jill",3,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+OSBORNE,Bethany Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+OSBORNE,Bethany Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000010
+OSBORNE,Bethany Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+OSBORNE,Bethany Township,President / Vice President,,Republican,"Trump, Donald J.",73,000010
+OSBORNE,Bloom Township,President / Vice President,,independent,"Stein, Jill",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+OSBORNE,Bloom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+OSBORNE,Bloom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000020
+OSBORNE,Bloom Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+OSBORNE,Bloom Township,President / Vice President,,Republican,"Trump, Donald J.",32,000020
+OSBORNE,Corinth Township,President / Vice President,,independent,"Stein, Jill",1,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+OSBORNE,Corinth Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+OSBORNE,Corinth Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+OSBORNE,Corinth Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+OSBORNE,Corinth Township,President / Vice President,,Republican,"Trump, Donald J.",26,000030
+OSBORNE,Covert Township,President / Vice President,,independent,"Stein, Jill",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+OSBORNE,Covert Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+OSBORNE,Covert Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+OSBORNE,Covert Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+OSBORNE,Covert Township,President / Vice President,,Republican,"Trump, Donald J.",4,000040
+OSBORNE,Delhi Township,President / Vice President,,independent,"Stein, Jill",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+OSBORNE,Delhi Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+OSBORNE,Delhi Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000050
+OSBORNE,Delhi Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+OSBORNE,Delhi Township,President / Vice President,,Republican,"Trump, Donald J.",13,000050
+OSBORNE,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+OSBORNE,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+OSBORNE,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000060
+OSBORNE,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+OSBORNE,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",14,000060
+OSBORNE,Hancock Township,President / Vice President,,independent,"Stein, Jill",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+OSBORNE,Hancock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+OSBORNE,Hancock Township,President / Vice President,,Republican,"Trump, Donald J.",12,000070
+OSBORNE,Hawkeye Township,President / Vice President,,independent,"Stein, Jill",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+OSBORNE,Hawkeye Township,President / Vice President,,Republican,"Trump, Donald J.",12,000080
+OSBORNE,Independence Township,President / Vice President,,independent,"Stein, Jill",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+OSBORNE,Independence Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+OSBORNE,Independence Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000090
+OSBORNE,Independence Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+OSBORNE,Independence Township,President / Vice President,,Republican,"Trump, Donald J.",15,000090
+OSBORNE,Jackson Township,President / Vice President,,independent,"Stein, Jill",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+OSBORNE,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+OSBORNE,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000100
+OSBORNE,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+OSBORNE,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",19,000100
+OSBORNE,Kill Creek Township,President / Vice President,,independent,"Stein, Jill",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+OSBORNE,Kill Creek Township,President / Vice President,,Republican,"Trump, Donald J.",4,000110
+OSBORNE,Lawrence Township,President / Vice President,,independent,"Stein, Jill",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000120
+OSBORNE,Lawrence Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+OSBORNE,Lawrence Township,President / Vice President,,Republican,"Trump, Donald J.",14,000120
+OSBORNE,Liberty Township,President / Vice President,,independent,"Stein, Jill",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+OSBORNE,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+OSBORNE,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000130
+OSBORNE,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+OSBORNE,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",10,000130
+OSBORNE,Mount Ayr Township,President / Vice President,,independent,"Stein, Jill",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+OSBORNE,Mount Ayr Township,President / Vice President,,Republican,"Trump, Donald J.",24,000140
+OSBORNE,Natoma Township,President / Vice President,,independent,"Stein, Jill",3,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"McMullin, Evan",4,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+OSBORNE,Natoma Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+OSBORNE,Natoma Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000150
+OSBORNE,Natoma Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+OSBORNE,Natoma Township,President / Vice President,,Republican,"Trump, Donald J.",134,000150
+OSBORNE,Osborne Ward 1,President / Vice President,,independent,"Stein, Jill",7,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Castle, Darrell L",1,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000160
+OSBORNE,Osborne Ward 1,President / Vice President,,Republican,"Trump, Donald J.",175,000160
+OSBORNE,Osborne Ward 2,President / Vice President,,independent,"Stein, Jill",6,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+OSBORNE,Osborne Ward 2,President / Vice President,,Republican,"Trump, Donald J.",228,000170
+OSBORNE,Osborne Ward 3,President / Vice President,,independent,"Stein, Jill",6,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000180
+OSBORNE,Osborne Ward 3,President / Vice President,,Republican,"Trump, Donald J.",104,000180
+OSBORNE,Penn Township,President / Vice President,,independent,"Stein, Jill",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+OSBORNE,Penn Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+OSBORNE,Penn Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000190
+OSBORNE,Penn Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+OSBORNE,Penn Township,President / Vice President,,Republican,"Trump, Donald J.",48,000190
+OSBORNE,Ross 1,President / Vice President,,independent,"Stein, Jill",9,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Hedges, James A",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"McMullin, Evan",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Perry, Darryl",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Smith, Mike",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Sood, Ajay",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+OSBORNE,Ross 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+OSBORNE,Ross 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000200
+OSBORNE,Ross 1,President / Vice President,,Libertarian,"Johnson, Gary",10,000200
+OSBORNE,Ross 1,President / Vice President,,Republican,"Trump, Donald J.",302,000200
+OSBORNE,Ross 2,President / Vice President,,independent,"Stein, Jill",1,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Hedges, James A",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"McMullin, Evan",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Perry, Darryl",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Smith, Mike",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Sood, Ajay",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+OSBORNE,Ross 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+OSBORNE,Ross 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000210
+OSBORNE,Ross 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000210
+OSBORNE,Ross 2,President / Vice President,,Republican,"Trump, Donald J.",45,000210
+OSBORNE,Round Mound Township,President / Vice President,,independent,"Stein, Jill",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+OSBORNE,Round Mound Township,President / Vice President,,Republican,"Trump, Donald J.",23,000220
+OSBORNE,Sumner Township,President / Vice President,,independent,"Stein, Jill",3,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+OSBORNE,Sumner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+OSBORNE,Sumner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000230
+OSBORNE,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+OSBORNE,Sumner Township,President / Vice President,,Republican,"Trump, Donald J.",71,000230
+OSBORNE,Tilden Township,President / Vice President,,independent,"Stein, Jill",1,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+OSBORNE,Tilden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+OSBORNE,Tilden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000240
+OSBORNE,Tilden Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000240
+OSBORNE,Tilden Township,President / Vice President,,Republican,"Trump, Donald J.",36,000240
+OSBORNE,Valley Township,President / Vice President,,independent,"Stein, Jill",1,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+OSBORNE,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+OSBORNE,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000250
+OSBORNE,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000250
+OSBORNE,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",6,000250
+OSBORNE,Victor Township,President / Vice President,,independent,"Stein, Jill",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+OSBORNE,Victor Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+OSBORNE,Victor Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000260
+OSBORNE,Victor Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+OSBORNE,Victor Township,President / Vice President,,Republican,"Trump, Donald J.",8,000260
+OSBORNE,Winfield Township,President / Vice President,,independent,"Stein, Jill",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+OSBORNE,Winfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+OSBORNE,Winfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000270
+OSBORNE,Winfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+OSBORNE,Winfield Township,President / Vice President,,Republican,"Trump, Donald J.",8,000270
+OSBORNE,Bethany Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000010
+OSBORNE,Bethany Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+OSBORNE,Bethany Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+OSBORNE,Bethany Township,United States House of Representatives,1,Republican,"Marshall, Roger",76,000010
+OSBORNE,Bloom Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000020
+OSBORNE,Bloom Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+OSBORNE,Bloom Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000020
+OSBORNE,Bloom Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000020
+OSBORNE,Corinth Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000030
+OSBORNE,Corinth Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+OSBORNE,Corinth Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+OSBORNE,Corinth Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000030
+OSBORNE,Covert Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000040
+OSBORNE,Covert Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+OSBORNE,Covert Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+OSBORNE,Covert Township,United States House of Representatives,1,Republican,"Marshall, Roger",1,000040
+OSBORNE,Delhi Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000050
+OSBORNE,Delhi Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+OSBORNE,Delhi Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+OSBORNE,Delhi Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000050
+OSBORNE,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000060
+OSBORNE,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+OSBORNE,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+OSBORNE,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000060
+OSBORNE,Hancock Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000070
+OSBORNE,Hancock Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+OSBORNE,Hancock Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000070
+OSBORNE,Hancock Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000070
+OSBORNE,Hawkeye Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000080
+OSBORNE,Hawkeye Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+OSBORNE,Hawkeye Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+OSBORNE,Hawkeye Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000080
+OSBORNE,Independence Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000090
+OSBORNE,Independence Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+OSBORNE,Independence Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+OSBORNE,Independence Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000090
+OSBORNE,Jackson Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000100
+OSBORNE,Jackson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+OSBORNE,Jackson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+OSBORNE,Jackson Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000100
+OSBORNE,Kill Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000110
+OSBORNE,Kill Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+OSBORNE,Kill Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+OSBORNE,Kill Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",3,000110
+OSBORNE,Lawrence Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000120
+OSBORNE,Lawrence Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+OSBORNE,Lawrence Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+OSBORNE,Lawrence Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000120
+OSBORNE,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000130
+OSBORNE,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+OSBORNE,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000130
+OSBORNE,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",6,000130
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000140
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000140
+OSBORNE,Mount Ayr Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000140
+OSBORNE,Natoma Township,United States House of Representatives,1,independent,"LaPolice, Alan",33,000150
+OSBORNE,Natoma Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+OSBORNE,Natoma Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000150
+OSBORNE,Natoma Township,United States House of Representatives,1,Republican,"Marshall, Roger",114,000150
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",68,000160
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000160
+OSBORNE,Osborne Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",142,000160
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",95,000170
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000170
+OSBORNE,Osborne Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",177,000170
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",31,000180
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000180
+OSBORNE,Osborne Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",84,000180
+OSBORNE,Penn Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000190
+OSBORNE,Penn Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000190
+OSBORNE,Penn Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000190
+OSBORNE,Penn Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000190
+OSBORNE,Ross 1,United States House of Representatives,1,independent,"LaPolice, Alan",113,000200
+OSBORNE,Ross 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+OSBORNE,Ross 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000200
+OSBORNE,Ross 1,United States House of Representatives,1,Republican,"Marshall, Roger",247,000200
+OSBORNE,Ross 2,United States House of Representatives,1,independent,"LaPolice, Alan",13,000210
+OSBORNE,Ross 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+OSBORNE,Ross 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000210
+OSBORNE,Ross 2,United States House of Representatives,1,Republican,"Marshall, Roger",41,000210
+OSBORNE,Round Mound Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000220
+OSBORNE,Round Mound Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+OSBORNE,Round Mound Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000220
+OSBORNE,Round Mound Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000220
+OSBORNE,Sumner Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000230
+OSBORNE,Sumner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+OSBORNE,Sumner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000230
+OSBORNE,Sumner Township,United States House of Representatives,1,Republican,"Marshall, Roger",55,000230
+OSBORNE,Tilden Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000240
+OSBORNE,Tilden Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+OSBORNE,Tilden Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000240
+OSBORNE,Tilden Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000240
+OSBORNE,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000250
+OSBORNE,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+OSBORNE,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000250
+OSBORNE,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000250
+OSBORNE,Victor Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000260
+OSBORNE,Victor Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+OSBORNE,Victor Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000260
+OSBORNE,Victor Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000260
+OSBORNE,Winfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000270
+OSBORNE,Winfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+OSBORNE,Winfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000270
+OSBORNE,Winfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000270
+OSBORNE,Bethany Township,United States Senate,,write - in,"Smith, DJ",0,000010
+OSBORNE,Bethany Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000010
+OSBORNE,Bethany Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000010
+OSBORNE,Bethany Township,United States Senate,,Republican,"Moran, Jerry",80,000010
+OSBORNE,Bloom Township,United States Senate,,write - in,"Smith, DJ",0,000020
+OSBORNE,Bloom Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+OSBORNE,Bloom Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+OSBORNE,Bloom Township,United States Senate,,Republican,"Moran, Jerry",38,000020
+OSBORNE,Corinth Township,United States Senate,,write - in,"Smith, DJ",0,000030
+OSBORNE,Corinth Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000030
+OSBORNE,Corinth Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000030
+OSBORNE,Corinth Township,United States Senate,,Republican,"Moran, Jerry",28,000030
+OSBORNE,Covert Township,United States Senate,,write - in,"Smith, DJ",0,000040
+OSBORNE,Covert Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000040
+OSBORNE,Covert Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+OSBORNE,Covert Township,United States Senate,,Republican,"Moran, Jerry",4,000040
+OSBORNE,Delhi Township,United States Senate,,write - in,"Smith, DJ",0,000050
+OSBORNE,Delhi Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000050
+OSBORNE,Delhi Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+OSBORNE,Delhi Township,United States Senate,,Republican,"Moran, Jerry",14,000050
+OSBORNE,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000060
+OSBORNE,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+OSBORNE,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+OSBORNE,Grant Township,United States Senate,,Republican,"Moran, Jerry",14,000060
+OSBORNE,Hancock Township,United States Senate,,write - in,"Smith, DJ",0,000070
+OSBORNE,Hancock Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000070
+OSBORNE,Hancock Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+OSBORNE,Hancock Township,United States Senate,,Republican,"Moran, Jerry",12,000070
+OSBORNE,Hawkeye Township,United States Senate,,write - in,"Smith, DJ",0,000080
+OSBORNE,Hawkeye Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000080
+OSBORNE,Hawkeye Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+OSBORNE,Hawkeye Township,United States Senate,,Republican,"Moran, Jerry",12,000080
+OSBORNE,Independence Township,United States Senate,,write - in,"Smith, DJ",0,000090
+OSBORNE,Independence Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000090
+OSBORNE,Independence Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000090
+OSBORNE,Independence Township,United States Senate,,Republican,"Moran, Jerry",16,000090
+OSBORNE,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000100
+OSBORNE,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000100
+OSBORNE,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+OSBORNE,Jackson Township,United States Senate,,Republican,"Moran, Jerry",20,000100
+OSBORNE,Kill Creek Township,United States Senate,,write - in,"Smith, DJ",0,000110
+OSBORNE,Kill Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000110
+OSBORNE,Kill Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+OSBORNE,Kill Creek Township,United States Senate,,Republican,"Moran, Jerry",4,000110
+OSBORNE,Lawrence Township,United States Senate,,write - in,"Smith, DJ",0,000120
+OSBORNE,Lawrence Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000120
+OSBORNE,Lawrence Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+OSBORNE,Lawrence Township,United States Senate,,Republican,"Moran, Jerry",15,000120
+OSBORNE,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000130
+OSBORNE,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000130
+OSBORNE,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000130
+OSBORNE,Liberty Township,United States Senate,,Republican,"Moran, Jerry",12,000130
+OSBORNE,Mount Ayr Township,United States Senate,,write - in,"Smith, DJ",0,000140
+OSBORNE,Mount Ayr Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000140
+OSBORNE,Mount Ayr Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000140
+OSBORNE,Mount Ayr Township,United States Senate,,Republican,"Moran, Jerry",22,000140
+OSBORNE,Natoma Township,United States Senate,,write - in,"Smith, DJ",0,000150
+OSBORNE,Natoma Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000150
+OSBORNE,Natoma Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000150
+OSBORNE,Natoma Township,United States Senate,,Republican,"Moran, Jerry",140,000150
+OSBORNE,Osborne Ward 1,United States Senate,,write - in,"Smith, DJ",0,000160
+OSBORNE,Osborne Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",33,000160
+OSBORNE,Osborne Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",12,000160
+OSBORNE,Osborne Ward 1,United States Senate,,Republican,"Moran, Jerry",183,000160
+OSBORNE,Osborne Ward 2,United States Senate,,write - in,"Smith, DJ",0,000170
+OSBORNE,Osborne Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",51,000170
+OSBORNE,Osborne Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",12,000170
+OSBORNE,Osborne Ward 2,United States Senate,,Republican,"Moran, Jerry",232,000170
+OSBORNE,Osborne Ward 3,United States Senate,,write - in,"Smith, DJ",0,000180
+OSBORNE,Osborne Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",21,000180
+OSBORNE,Osborne Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",9,000180
+OSBORNE,Osborne Ward 3,United States Senate,,Republican,"Moran, Jerry",101,000180
+OSBORNE,Penn Township,United States Senate,,write - in,"Smith, DJ",0,000190
+OSBORNE,Penn Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000190
+OSBORNE,Penn Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000190
+OSBORNE,Penn Township,United States Senate,,Republican,"Moran, Jerry",50,000190
+OSBORNE,Ross 1,United States Senate,,write - in,"Smith, DJ",0,000200
+OSBORNE,Ross 1,United States Senate,,Democratic,"Wiesner, Patrick",40,000200
+OSBORNE,Ross 1,United States Senate,,Libertarian,"Garrard, Robert D.",15,000200
+OSBORNE,Ross 1,United States Senate,,Republican,"Moran, Jerry",323,000200
+OSBORNE,Ross 2,United States Senate,,write - in,"Smith, DJ",0,000210
+OSBORNE,Ross 2,United States Senate,,Democratic,"Wiesner, Patrick",3,000210
+OSBORNE,Ross 2,United States Senate,,Libertarian,"Garrard, Robert D.",3,000210
+OSBORNE,Ross 2,United States Senate,,Republican,"Moran, Jerry",48,000210
+OSBORNE,Round Mound Township,United States Senate,,write - in,"Smith, DJ",0,000220
+OSBORNE,Round Mound Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000220
+OSBORNE,Round Mound Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000220
+OSBORNE,Round Mound Township,United States Senate,,Republican,"Moran, Jerry",21,000220
+OSBORNE,Sumner Township,United States Senate,,write - in,"Smith, DJ",0,000230
+OSBORNE,Sumner Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000230
+OSBORNE,Sumner Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000230
+OSBORNE,Sumner Township,United States Senate,,Republican,"Moran, Jerry",66,000230
+OSBORNE,Tilden Township,United States Senate,,write - in,"Smith, DJ",0,000240
+OSBORNE,Tilden Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000240
+OSBORNE,Tilden Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000240
+OSBORNE,Tilden Township,United States Senate,,Republican,"Moran, Jerry",37,000240
+OSBORNE,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000250
+OSBORNE,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000250
+OSBORNE,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000250
+OSBORNE,Valley Township,United States Senate,,Republican,"Moran, Jerry",9,000250
+OSBORNE,Victor Township,United States Senate,,write - in,"Smith, DJ",0,000260
+OSBORNE,Victor Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000260
+OSBORNE,Victor Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000260
+OSBORNE,Victor Township,United States Senate,,Republican,"Moran, Jerry",11,000260
+OSBORNE,Winfield Township,United States Senate,,write - in,"Smith, DJ",0,000270
+OSBORNE,Winfield Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000270
+OSBORNE,Winfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000270
+OSBORNE,Winfield Township,United States Senate,,Republican,"Moran, Jerry",9,000270

--- a/2016/20161108__ks__general__ottawa__precinct.csv
+++ b/2016/20161108__ks__general__ottawa__precinct.csv
@@ -1,415 +1,865 @@
-county,precinct,office,district,party,candidate,votes
-Ottawa,Bennington,President,,REP,Trump/Pence,458
-Ottawa,Bennington,President,,DEM,Clinton/Kaine,104
-Ottawa,Bennington,President,,LIB,Johnson/Weld,43
-Ottawa,Bennington,President,,IND,Stein/Baraka,4
-Ottawa,Bennington,President,,,Write-ins,10
-Ottawa,Bennington,U.S. Senate,,DEM,Patrick Wiesner,94
-Ottawa,Bennington,U.S. Senate,,LIB,Robert D. Garrard,45
-Ottawa,Bennington,U.S. Senate,,REP,Jerry Moran,473
-Ottawa,Bennington,U.S. Senate,,,Write-ins,0
-Ottawa,Bennington,U.S. House,1,IND,Alan LaPolice,206
-Ottawa,Bennington,U.S. House,1,REP,Roger Marshall,357
-Ottawa,Bennington,U.S. House,1,LIB,Kerry Burt,41
-Ottawa,Bennington,U.S. House,1,,Write-ins,2
-Ottawa,Bennington,State Senate,36,REP,Elaine S. Bowers,490
-Ottawa,Bennington,State Senate,36,DEM,Brian G. Angevine,108
-Ottawa,Bennington,State Senate,36,,Write-ins,2
-Ottawa,Bennington,State House,107,REP,Susan L. Concannon,525
-Ottawa,Bennington,State House,107,,Write-ins,5
-Ottawa,Blaine,President,,REP,Trump/Pence,53
-Ottawa,Blaine,President,,DEM,Clinton/Kaine,11
-Ottawa,Blaine,President,,LIB,Johnson/Weld,8
-Ottawa,Blaine,President,,IND,Stein/Baraka,2
-Ottawa,Blaine,President,,,Write-ins,1
-Ottawa,Blaine,U.S. Senate,,DEM,Patrick Wiesner,11
-Ottawa,Blaine,U.S. Senate,,LIB,Robert D Garrard,3
-Ottawa,Blaine,U.S. Senate,,REP,Jerry Moran,60
-Ottawa,Blaine,U.S. Senate,,,Write-ins,1
-Ottawa,Blaine,U.S. House,1,IND,Alan LaPolice,40
-Ottawa,Blaine,U.S. House,1,REP,Roger Marshall,34
-Ottawa,Blaine,U.S. House,1,LIB,Kerry Burt,0
-Ottawa,Blaine,U.S. House,1,,Write-ins,0
-Ottawa,Blaine,State Senate,36,REP,Elaine S. Bowers,63
-Ottawa,Blaine,State Senate,36,DEM,Brian G. Angevine,11
-Ottawa,Blaine,State Senate,36,,Write-ins,0
-Ottawa,Blaine,State House,107,REP,Susan L. Concannon,60
-Ottawa,Blaine,State House,107,,Write-ins,0
-Ottawa,Buckeye,President,,REP,Trump/Pence,43
-Ottawa,Buckeye,President,,DEM,Clinton/Kaine,9
-Ottawa,Buckeye,President,,LIB,Johnson/Weld,1
-Ottawa,Buckeye,President,,IND,Stein/Baraka,0
-Ottawa,Buckeye,President,,,Write-ins,0
-Ottawa,Buckeye,U.S. Senate,,DEM,Patrick Wiesner,9
-Ottawa,Buckeye,U.S. Senate,,LIB,Robert D Garrard,3
-Ottawa,Buckeye,U.S. Senate,,REP,Jerry Moran,40
-Ottawa,Buckeye,U.S. Senate,,,Write-ins,0
-Ottawa,Buckeye,U.S. House,1,IND,Alan LaPolice,18
-Ottawa,Buckeye,U.S. House,1,REP,Roger Marshall,31
-Ottawa,Buckeye,U.S. House,1,LIB,Kerry Burt,3
-Ottawa,Buckeye,U.S. House,1,,Write-ins,0
-Ottawa,Buckeye,State Senate,36,REP,Elaine S. Bowers,45
-Ottawa,Buckeye,State Senate,36,DEM,Brian G. Angevine,8
-Ottawa,Buckeye,State Senate,36,,Write-ins,0
-Ottawa,Buckeye,State House,107,REP,Susan L. Concannon,49
-Ottawa,Buckeye,State House,107,,Write-ins,0
-Ottawa,Center,President,,REP,Trump/Pence,41
-Ottawa,Center,President,,DEM,Clinton/Kaine,3
-Ottawa,Center,President,,LIB,Johnson/Weld,1
-Ottawa,Center,President,,IND,Stein/Baraka,2
-Ottawa,Center,President,,,Write-ins,0
-Ottawa,Center,U.S. Senate,,DEM,Patrick Wiesner,1
-Ottawa,Center,U.S. Senate,,LIB,Robert D. Garrard,3
-Ottawa,Center,U.S. Senate,,REP,Jerry Moran,42
-Ottawa,Center,U.S. Senate,,,Write-ins,0
-Ottawa,Center,U.S. House,1,IND,Alan LaPolice,15
-Ottawa,Center,U.S. House,1,REP,Roger Marshall,25
-Ottawa,Center,U.S. House,1,LIB,Kerry Burt,1
-Ottawa,Center,U.S. House,1,,Write-ins,1
-Ottawa,Center,State Senate,36,REP,Elaine S. Bowers,45
-Ottawa,Center,State Senate,36,DEM,Brian G. Angevine,2
-Ottawa,Center,State Senate,36,,Write-ins,0
-Ottawa,Center,State House,107,REP,Susan L. Concannon,36
-Ottawa,Center,State House,107,,Write-ins,1
-Ottawa,Chapman,President,,REP,Trump/Pence,36
-Ottawa,Chapman,President,,DEM,Clinton/Kaine,3
-Ottawa,Chapman,President,,LIB,Johnson/Weld,0
-Ottawa,Chapman,President,,IND,Stein/Baraka,0
-Ottawa,Chapman,President,,,Write-ins,0
-Ottawa,Chapman,U.S. Senate,,DEM,Patrick Wiesner,2
-Ottawa,Chapman,U.S. Senate,,LIB,Robert D. Garrard,0
-Ottawa,Chapman,U.S. Senate,,REP,Jerry Moran,37
-Ottawa,Chapman,U.S. Senate,,,Write-ins,0
-Ottawa,Chapman,U.S. House,1,IND,Alan LaPolice,18
-Ottawa,Chapman,U.S. House,1,REP,Roger Marshall,19
-Ottawa,Chapman,U.S. House,1,LIB,Kerry Burt,2
-Ottawa,Chapman,U.S. House,1,,Write-ins,0
-Ottawa,Chapman,State Senate,36,REP,Elaine S. Bowers,38
-Ottawa,Chapman,State Senate,36,DEM,Brian G. Angevine,0
-Ottawa,Chapman,State Senate,36,,Write-ins,0
-Ottawa,Chapman,State House,107,REP,Susan L. Concannon,35
-Ottawa,Chapman,State House,107,,Write-ins,0
-Ottawa,Concod,President,,IND,Stein/Baraka,0
-Ottawa,Concord,President,,REP,Trump/Pence,105
-Ottawa,Concord,President,,DEM,Clinton/Kaine,23
-Ottawa,Concord,President,,LIB,Johnson/Weld,0
-Ottawa,Concord,President,,,Write-ins,0
-Ottawa,Concord,U.S. Senate,,DEM,Patrick Wiesner,18
-Ottawa,Concord,U.S. Senate,,LIB,Robert D. Garrard,11
-Ottawa,Concord,U.S. Senate,,REP,Jerry Moran,99
-Ottawa,Concord,U.S. Senate,,,Write-ins,0
-Ottawa,Concord,U.S. House,1,IND,Alan LaPolice,54
-Ottawa,Concord,U.S. House,1,REP,Roger Marshall,68
-Ottawa,Concord,U.S. House,1,LIB,Kerry Burt,2
-Ottawa,Concord,U.S. House,1,,Write-ins,2
-Ottawa,Concord,State Senate,36,REP,Elaine S. Bowers,107
-Ottawa,Concord,State Senate,36,DEM,Brian G. Angevine,16
-Ottawa,Concord,State Senate,36,,Write-ins,0
-Ottawa,Concord,State House,107,REP,Susan L. Concannon,106
-Ottawa,Concord,State House,107,,Write-ins,0
-Ottawa,Culver,President,,REP,Trump/Pence,103
-Ottawa,Culver,President,,DEM,Clinton/Kaine,18
-Ottawa,Culver,President,,LIB,Johnson/Weld,7
-Ottawa,Culver,President,,IND,Stein/Baraka,0
-Ottawa,Culver,President,,,Write-ins,0
-Ottawa,Culver,U.S. Senate,,DEM,Patrick Wiesner,15
-Ottawa,Culver,U.S. Senate,,LIB,Robert D. Garrard,16
-Ottawa,Culver,U.S. Senate,,REP,Jerry Moran,99
-Ottawa,Culver,U.S. Senate,,,Write-ins,0
-Ottawa,Culver,U.S. House,1,IND,Alan LaPolice,50
-Ottawa,Culver,U.S. House,1,REP,Roger Marshall,67
-Ottawa,Culver,U.S. House,1,LIB,Kerry Burt,11
-Ottawa,Culver,U.S. House,1,,Write-ins,0
-Ottawa,Culver,State Senate,36,REP,Elaine S. Bowers,103
-Ottawa,Culver,State Senate,36,DEM,Brian G. Angevine,20
-Ottawa,Culver,State Senate,36,,Write-ins,0
-Ottawa,Culver,State House,107,REP,Susan L. Concannon,110
-Ottawa,Culver,State House,107,,Write-ins,1
-Ottawa,Durham,President,,REP,Trump/Pence,6
-Ottawa,Durham,President,,DEM,Clinton/Kaine,0
-Ottawa,Durham,President,,LIB,Johnson/Weld,0
-Ottawa,Durham,President,,IND,Stein/Baraka,1
-Ottawa,Durham,President,,,Write-ins,0
-Ottawa,Durham,U.S. Senate,,DEM,Patrick Wiesner,1
-Ottawa,Durham,U.S. Senate,,LIB,Robert D. Garrard,1
-Ottawa,Durham,U.S. Senate,,REP,Jerry Moran,6
-Ottawa,Durham,U.S. Senate,,,Write-ins,0
-Ottawa,Durham,U.S. House,1,IND,Alan LaPolice,4
-Ottawa,Durham,U.S. House,1,REP,Roger Marshall,4
-Ottawa,Durham,U.S. House,1,LIB,Kerry Burt,1
-Ottawa,Durham,U.S. House,1,,Write-ins,0
-Ottawa,Durham,State Senate,36,REP,Elaine S. Bowers,9
-Ottawa,Durham,State Senate,36,DEM,Brian G. Angevine,0
-Ottawa,Durham,State Senate,36,,Write-ins,0
-Ottawa,Durham,State House,107,REP,Susan L. Concannon,8
-Ottawa,Durham,State House,107,,Write-ins,0
-Ottawa,Fountain,President,,REP,Trump/Pence,42
-Ottawa,Fountain,President,,DEM,Clinton/Kaine,7
-Ottawa,Fountain,President,,LIB,Johnson/Weld,1
-Ottawa,Fountain,President,,IND,Stein/Baraka,4
-Ottawa,Fountain,President,,,Write-ins,1
-Ottawa,Fountain,U.S. Senate,,DEM,Patrick Wiesner,5
-Ottawa,Fountain,U.S. Senate,,LIB,Robert D. Garrard,7
-Ottawa,Fountain,U.S. Senate,,REP,Jerry Moran,42
-Ottawa,Fountain,U.S. Senate,,,Write-ins,0
-Ottawa,Fountain,U.S. House,1,IND,Alan LaPolice,23
-Ottawa,Fountain,U.S. House,1,REP,Roger Marshall,26
-Ottawa,Fountain,U.S. House,1,LIB,Kerry Burt,2
-Ottawa,Fountain,U.S. House,1,,Write-ins,3
-Ottawa,Fountain,State Senate,36,REP,Elaine S. Bowers,47
-Ottawa,Fountain,State Senate,36,DEM,Brian G. Angevine,6
-Ottawa,Fountain,State Senate,36,,Write-ins,0
-Ottawa,Fountain,State House,107,REP,Susan L. Concannon,43
-Ottawa,Fountain,State House,107,,Write-ins,0
-Ottawa,Garfield,President,,REP,Trump/Pence,40
-Ottawa,Garfield,President,,DEM,Clinton/Kaine,7
-Ottawa,Garfield,President,,LIB,Johnson/Weld,0
-Ottawa,Garfield,President,,IND,Stein/Baraka,1
-Ottawa,Garfield,President,,,Write-ins,1
-Ottawa,Garfield,U.S. Senate,,DEM,Patrick Wiesner,3
-Ottawa,Garfield,U.S. Senate,,LIB,Robert D. Garrard,1
-Ottawa,Garfield,U.S. Senate,,REP,Jerry Moran,45
-Ottawa,Garfield,U.S. Senate,,,Write-ins,0
-Ottawa,Garfield,U.S. House,1,IND,Alan LaPolice,21
-Ottawa,Garfield,U.S. House,1,REP,Roger Marshall,27
-Ottawa,Garfield,U.S. House,1,LIB,Kerry Burt,1
-Ottawa,Garfield,U.S. House,1,,Write-ins,0
-Ottawa,Garfield,State Senate,36,REP,Elaine S. Bowers,44
-Ottawa,Garfield,State Senate,36,DEM,Brian G. Angevine,4
-Ottawa,Garfield,State Senate,36,,Write-ins,0
-Ottawa,Garfield,State House,107,REP,Susan L. Concannon,40
-Ottawa,Garfield,State House,107,,Write-ins,0
-Ottawa,Grant,President,,REP,Trump/Pence,46
-Ottawa,Grant,President,,DEM,Clinton/Kaine,6
-Ottawa,Grant,President,,LIB,Johnson/Weld,4
-Ottawa,Grant,President,,IND,Stein/Baraka,0
-Ottawa,Grant,President,,,Write-ins,0
-Ottawa,Grant,U.S. Senate,,DEM,Patrick Wiesner,5
-Ottawa,Grant,U.S. Senate,,REP,Jerry Moran,49
-Ottawa,Grant,U.S. Senate,,,Write-ins,0
-Ottawa,Grant,U.S. House,1,IND,Alan LaPolice,23
-Ottawa,Grant,U.S. House,1,LIB,Kerry Burt,3
-Ottawa,Grant,U.S. House,1,,Write-ins,3
-Ottawa,Grant,State Senate,36,REP,Elaine S. Bowers,52
-Ottawa,Grant,State Senate,36,DEM,Brian G. Angevine,6
-Ottawa,Grant,State Senate,36,,Write-ins,0
-Ottawa,Grant,State House,107,REP,Susan L. Concannon,45
-Ottawa,Grant,State House,107,,Write-ins,3
-Ottawa,Grant ,U.S. Senate,,LIB,Robert D. Garrard,2
-Ottawa,Grant ,U.S. House,1,REP,Roger Marshall,31
-Ottawa,Henry,President,,REP,Trump/Pence,9
-Ottawa,Henry,President,,DEM,Clinton/Kaine,2
-Ottawa,Henry,President,,LIB,Johnson/Weld,0
-Ottawa,Henry,President,,IND,Stein/Baraka,0
-Ottawa,Henry,President,,,Write-ins,0
-Ottawa,Henry,U.S. Senate,,DEM,Patrick Wiesner,1
-Ottawa,Henry,U.S. Senate,,LIB,Robert D. Garrard,1
-Ottawa,Henry,U.S. Senate,,REP,Jerry Moran,9
-Ottawa,Henry,U.S. Senate,,,Write-ins,0
-Ottawa,Henry,U.S. House,1,IND,Alan LaPolice,3
-Ottawa,Henry,U.S. House,1,REP,Roger Marshall,8
-Ottawa,Henry,U.S. House,1,LIB,Kerry Burt,0
-Ottawa,Henry,U.S. House,1,,Write-ins,0
-Ottawa,Henry,State Senate,36,REP,Elaine S. Bowers,10
-Ottawa,Henry,State Senate,36,DEM,Brian G. Angevine,1
-Ottawa,Henry,State Senate,36,,Write-ins,0
-Ottawa,Henry,State House,107,REP,Susan L. Concannon,11
-Ottawa,Henry,State House,107,,Write-ins,0
-Ottawa,Lincoln,President,,REP,Trump/Pence,54
-Ottawa,Lincoln,President,,DEM,Clinton/Kaine,22
-Ottawa,Lincoln,President,,LIB,Johnson/Weld,1
-Ottawa,Lincoln,President,,IND,Stein/Baraka,0
-Ottawa,Lincoln,President,,,Write-ins,0
-Ottawa,Lincoln,U.S. Senate,,DEM,Patrick Wiesner,20
-Ottawa,Lincoln,U.S. Senate,,LIB,Robert D. Garrard,4
-Ottawa,Lincoln,U.S. Senate,,REP,Jerry Moran,53
-Ottawa,Lincoln,U.S. Senate,,,Write-ins,0
-Ottawa,Lincoln,U.S. House,1,IND,Alan LaPolice,29
-Ottawa,Lincoln,U.S. House,1,REP,Roger Marshall,44
-Ottawa,Lincoln,U.S. House,1,LIB,Kerry Burt,2
-Ottawa,Lincoln,U.S. House,1,,Write-ins,2
-Ottawa,Lincoln,State Senate,36,REP,Elaine S. Bowers,54
-Ottawa,Lincoln,State Senate,36,DEM,Brian G. Angevine,23
-Ottawa,Lincoln,State Senate,36,,Write-ins,0
-Ottawa,Lincoln,State House,107,REP,Susan L. Concannon,62
-Ottawa,Lincoln,State House,107,,Write-ins,3
-Ottawa,Logan,President,,REP,Trump/Pence,34
-Ottawa,Logan,President,,DEM,Clinton/Kaine,8
-Ottawa,Logan,President,,LIB,Johnson/Weld,2
-Ottawa,Logan,President,,IND,Stein/Baraka,0
-Ottawa,Logan,President,,,Write-ins,0
-Ottawa,Logan,U.S. Senate,,DEM,Patrick Wiesner,5
-Ottawa,Logan,U.S. Senate,,LIB,Robert D. Garrard,3
-Ottawa,Logan,U.S. Senate,,REP,Jerry Moran,35
-Ottawa,Logan,U.S. Senate,,,Write-ins,0
-Ottawa,Logan,U.S. House,1,IND,Alan LaPolice,21
-Ottawa,Logan,U.S. House,1,REP,Roger Marshall,23
-Ottawa,Logan,U.S. House,1,LIB,Kerry Burt,0
-Ottawa,Logan,U.S. House,1,,Write-ins,0
-Ottawa,Logan,State Senate,36,REP,Elaine S. Bowers,38
-Ottawa,Logan,State Senate,36,DEM,Brian G. Angevine,4
-Ottawa,Logan,State Senate,36,,Write-ins,0
-Ottawa,Logan,State House,107,REP,Susan L. Concannon,34
-Ottawa,Logan,State House,107,,Write-ins,1
-Ottawa,Minneapolis I,President,,REP,Trump/Pence,231
-Ottawa,Minneapolis I,President,,DEM,Clinton/Kaine,53
-Ottawa,Minneapolis I,President,,LIB,Johnson/Weld,11
-Ottawa,Minneapolis I,President,,IND,Stein/Baraka,5
-Ottawa,Minneapolis I,President,,,Write-ins,5
-Ottawa,Minneapolis I,U.S. Senate,,DEM,Patrick Wiesner,45
-Ottawa,Minneapolis I,U.S. Senate,,LIB,Robert D. Garrard,17
-Ottawa,Minneapolis I,U.S. Senate,,REP,Jerry Moran,240
-Ottawa,Minneapolis I,U.S. Senate,,,Write-ins,0
-Ottawa,Minneapolis I,U.S. House,1,IND,Alan LaPolice,132
-Ottawa,Minneapolis I,U.S. House,1,REP,Roger Marshall,158
-Ottawa,Minneapolis I,U.S. House,1,LIB,Kerry Burt,6
-Ottawa,Minneapolis I,U.S. House,1,,Write-ins,3
-Ottawa,Minneapolis I,State Senate,36,REP,Elaine S. Bowers,272
-Ottawa,Minneapolis I,State Senate,36,DEM,Brian G. Angevine,25
-Ottawa,Minneapolis I,State Senate,36,,Write-ins,1
-Ottawa,Minneapolis I,State House,107,REP,Susan L. Concannon,254
-Ottawa,Minneapolis I,State House,107,,Write-ins,0
-Ottawa,Minneapolis II,President,,REP,Trump/Pence,187
-Ottawa,Minneapolis II,President,,DEM,Clinton/Kaine,32
-Ottawa,Minneapolis II,President,,LIB,Johnson/Weld,14
-Ottawa,Minneapolis II,President,,IND,Stein/Baraka,2
-Ottawa,Minneapolis II,President,,,Write-ins,0
-Ottawa,Minneapolis II,U.S. Senate,,DEM,Patrick Wiesner,24
-Ottawa,Minneapolis II,U.S. Senate,,LIB,Robert D. Garrard,23
-Ottawa,Minneapolis II,U.S. Senate,,REP,Jerry Moran,179
-Ottawa,Minneapolis II,U.S. Senate,,,Write-ins,2
-Ottawa,Minneapolis II,U.S. House,1,IND,Alan LaPolice,101
-Ottawa,Minneapolis II,U.S. House,1,REP,Roger Marshall,117
-Ottawa,Minneapolis II,U.S. House,1,LIB,Kerry Burt,6
-Ottawa,Minneapolis II,U.S. House,1,,Write-ins,2
-Ottawa,Minneapolis II,State Senate,36,REP,Elaine S. Bowers,196
-Ottawa,Minneapolis II,State Senate,36,DEM,Brian G. Angevine,25
-Ottawa,Minneapolis II,State Senate,36,,Write-ins,1
-Ottawa,Minneapolis II,State House,107,REP,Susan L. Concannon,194
-Ottawa,Minneapolis II,State House,107,,Write-ins,1
-Ottawa,Minneapolis III,President,,REP,Trump/Pence,279
-Ottawa,Minneapolis III,President,,DEM,Clinton/Kaine,49
-Ottawa,Minneapolis III,President,,LIB,Johnson/Weld,22
-Ottawa,Minneapolis III,President,,IND,Stein/Baraka,5
-Ottawa,Minneapolis III,President,,,Write-ins,9
-Ottawa,Minneapolis III,U.S. Senate,,DEM,Patrick Wiesner,33
-Ottawa,Minneapolis III,U.S. Senate,,LIB,Robert D. Garrard,28
-Ottawa,Minneapolis III,U.S. Senate,,REP,Jerry Moran,289
-Ottawa,Minneapolis III,U.S. Senate,,,Write-ins,0
-Ottawa,Minneapolis III,U.S. House,1,IND,Alan LaPolice,139
-Ottawa,Minneapolis III,U.S. House,1,REP,Roger Marshall,195
-Ottawa,Minneapolis III,U.S. House,1,LIB,Kerry Burt,18
-Ottawa,Minneapolis III,U.S. House,1,,Write-ins,2
-Ottawa,Minneapolis III,State Senate,36,REP,Elaine S. Bowers,314
-Ottawa,Minneapolis III,State Senate,36,DEM,Brian G. Angevine,35
-Ottawa,Minneapolis III,State Senate,36,,Write-ins,0
-Ottawa,Minneapolis III,State House,107,REP,Susan L. Concannon,297
-Ottawa,Minneapolis III,State House,107,,Write-ins,0
-Ottawa,Morton,President,,REP,Trump/Pence,176
-Ottawa,Morton,President,,DEM,Clinton/Kaine,19
-Ottawa,Morton,President,,LIB,Johnson/Weld,14
-Ottawa,Morton,President,,IND,Stein/Baraka,5
-Ottawa,Morton,President,,,Write-ins,1
-Ottawa,Morton,U.S. Senate,,DEM,Patrick Wiesner,16
-Ottawa,Morton,U.S. Senate,,LIB,Robert D. Garrard,20
-Ottawa,Morton,U.S. Senate,,REP,Jerry Moran,176
-Ottawa,Morton,U.S. Senate,,,Write-ins,0
-Ottawa,Morton,U.S. House,1,IND,Alan LaPolice,109
-Ottawa,Morton,U.S. House,1,REP,Roger Marshall,88
-Ottawa,Morton,U.S. House,1,LIB,Kerry Burt,15
-Ottawa,Morton,U.S. House,1,,Write-ins,0
-Ottawa,Morton,State Senate,36,REP,Elaine S. Bowers,177
-Ottawa,Morton,State Senate,36,DEM,Brian G. Angevine,31
-Ottawa,Morton,State Senate,36,,Write-ins,0
-Ottawa,Morton,State House,107,REP,Susan L. Concannon,187
-Ottawa,Morton,State House,107,,Write-ins,0
-Ottawa,Ottawa,President,,REP,Trump/Pence,17
-Ottawa,Ottawa,President,,DEM,Clinton/Kaine,5
-Ottawa,Ottawa,President,,LIB,Johnson/Weld,0
-Ottawa,Ottawa,President,,IND,Stein/Baraka,0
-Ottawa,Ottawa,President,,,Write-ins,0
-Ottawa,Ottawa,U.S. Senate,,DEM,Patrick Wiesner,3
-Ottawa,Ottawa,U.S. Senate,,LIB,Robert D. Garrard,1
-Ottawa,Ottawa,U.S. Senate,,REP,Jerry Moran,18
-Ottawa,Ottawa,U.S. Senate,,,Write-ins,0
-Ottawa,Ottawa,U.S. House,1,IND,Alan LaPolice,5
-Ottawa,Ottawa,U.S. House,1,REP,Roger Marshall,16
-Ottawa,Ottawa,U.S. House,1,LIB,Kerry Burt,1
-Ottawa,Ottawa,U.S. House,1,,Write-ins,0
-Ottawa,Ottawa,State Senate,36,REP,Elaine S. Bowers,20
-Ottawa,Ottawa,State Senate,36,DEM,Brian G. Angevine,2
-Ottawa,Ottawa,State Senate,36,,Write-ins,0
-Ottawa,Ottawa,State House,107,REP,Susan L. Concannon,18
-Ottawa,Ottawa,State House,107,,Write-ins,0
-Ottawa,Richland,President,,REP,Trump/Pence,111
-Ottawa,Richland,President,,DEM,Clinton/Kaine,9
-Ottawa,Richland,President,,LIB,Johnson/Weld,4
-Ottawa,Richland,President,,IND,Stein/Baraka,3
-Ottawa,Richland,President,,,Write-ins,2
-Ottawa,Richland,U.S. Senate,,DEM,Patrick Wiesner,6
-Ottawa,Richland,U.S. Senate,,LIB,Robert D. Garrard,6
-Ottawa,Richland,U.S. Senate,,REP,Jerry Moran,116
-Ottawa,Richland,U.S. Senate,,,Write-ins,0
-Ottawa,Richland,U.S. House,1,IND,Alan LaPolice,42
-Ottawa,Richland,U.S. House,1,REP,Roger Marshall,88
-Ottawa,Richland,U.S. House,1,LIB,Kerry Burt,0
-Ottawa,Richland,U.S. House,1,,Write-ins,0
-Ottawa,Richland,State Senate,36,REP,Elaine S. Bowers,120
-Ottawa,Richland,State Senate,36,DEM,Brian G. Angevine,9
-Ottawa,Richland,State Senate,36,,Write-ins,0
-Ottawa,Richland,State House,107,REP,Susan L. Concannon,114
-Ottawa,Richland,State House,107,,Write-ins,0
-Ottawa,Sheridan,President,,REP,Trump/Pence,164
-Ottawa,Sheridan,President,,DEM,Clinton/Kaine,29
-Ottawa,Sheridan,President,,LIB,Johnson/Weld,10
-Ottawa,Sheridan,President,,IND,Stein/Baraka,8
-Ottawa,Sheridan,President,,,Write-ins,0
-Ottawa,Sheridan,U.S. Senate,,DEM,Patrick Wiesner,32
-Ottawa,Sheridan,U.S. Senate,,LIB,Robert D. Garrard,20
-Ottawa,Sheridan,U.S. Senate,,REP,Jerry Moran,159
-Ottawa,Sheridan,U.S. Senate,,,Write-ins,0
-Ottawa,Sheridan,U.S. House,1,IND,Alan LaPolice,109
-Ottawa,Sheridan,U.S. House,1,REP,Roger Marshall,103
-Ottawa,Sheridan,U.S. House,1,LIB,Kerry Burt,104
-Ottawa,Sheridan,U.S. House,1,,Write-ins,0
-Ottawa,Sheridan,State Senate,36,REP,Elaine S. Bowers,193
-Ottawa,Sheridan,State Senate,36,DEM,Brian G. Angevine,24
-Ottawa,Sheridan,State Senate,36,,Write-ins,0
-Ottawa,Sheridan,State House,107,REP,Susan L. Concannon,182
-Ottawa,Sheridan,State House,107,,Write-ins,1
-Ottawa,Sherman,President,,REP,Trump/Pence,27
-Ottawa,Sherman,President,,DEM,Clinton/Kaine,1
-Ottawa,Sherman,President,,LIB,Johnson/Weld,1
-Ottawa,Sherman,President,,IND,Stein/Baraka,0
-Ottawa,Sherman,President,,,Write-ins,1
-Ottawa,Sherman,U.S. Senate,,DEM,Patrick Wiesner,0
-Ottawa,Sherman,U.S. Senate,,LIB,Robert D. Garrard,0
-Ottawa,Sherman,U.S. Senate,,REP,Jerry Moran,31
-Ottawa,Sherman,U.S. Senate,,,Write-ins,0
-Ottawa,Sherman,U.S. House,1,IND,Alan LaPolice,13
-Ottawa,Sherman,U.S. House,1,REP,Roger Marshall,16
-Ottawa,Sherman,U.S. House,1,LIB,Kerry Burt,0
-Ottawa,Sherman,U.S. House,1,,Write-ins,0
-Ottawa,Sherman,State Senate,36,REP,Elaine S. Bowers,29
-Ottawa,Sherman,State Senate,36,DEM,Brian G. Angevine,0
-Ottawa,Sherman,State Senate,36,,Write-ins,0
-Ottawa,Sherman,State House,107,REP,Susan L. Concannon,25
-Ottawa,Sherman,State House,107,,Write-ins,0
-Ottawa,Stanton,President,,REP,Trump/Pence,21
-Ottawa,Stanton,President,,DEM,Clinton/Kaine,4
-Ottawa,Stanton,President,,LIB,Johnson/Weld,0
-Ottawa,Stanton,President,,IND,Stein/Baraka,0
-Ottawa,Stanton,President,,,Write-ins,0
-Ottawa,Stanton,U.S. Senate,,DEM,Patrick Wiesner,5
-Ottawa,Stanton,U.S. Senate,,LIB,Robert D. Garrard,2
-Ottawa,Stanton,U.S. Senate,,REP,Jerry Moran,19
-Ottawa,Stanton,U.S. Senate,,,Write-ins,0
-Ottawa,Stanton,U.S. House,1,IND,Alan LaPolice,15
-Ottawa,Stanton,U.S. House,1,REP,Roger Marshall,10
-Ottawa,Stanton,U.S. House,1,LIB,Kerry Burt,0
-Ottawa,Stanton,U.S. House,1,,Write-ins,0
-Ottawa,Stanton,State Senate,36,REP,Elaine S. Bowers,19
-Ottawa,Stanton,State Senate,36,DEM,Brian G. Angevine,7
-Ottawa,Stanton,State Senate,36,,Write-ins,0
-Ottawa,Stanton,State House,107,REP,Susan L. Concannon,21
-Ottawa,Stanton,State House,107,,Write-ins,7
+county,precinct,office,district,party,candidate,votes,vtd
+OTTAWA,Bennington Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",525,000010
+OTTAWA,Blaine Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",60,000020
+OTTAWA,Buckeye Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",49,000030
+OTTAWA,Center Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",36,000040
+OTTAWA,Chapman Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",35,000050
+OTTAWA,Concord Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",106,000060
+OTTAWA,Culver Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",110,000070
+OTTAWA,Durham Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",8,000080
+OTTAWA,Fountain Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",43,000090
+OTTAWA,Garfield Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",40,000100
+OTTAWA,Grant Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",45,000110
+OTTAWA,Henry Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",11,000120
+OTTAWA,Lincoln Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",62,000130
+OTTAWA,Logan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",34,000140
+OTTAWA,Minneapolis Precinct 1,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",254,000150
+OTTAWA,Minneapolis Precinct 2,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",194,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",0,00016B
+OTTAWA,Minneapolis Precinct 3,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",297,000170
+OTTAWA,Morton Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",187,000180
+OTTAWA,Ottawa Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",18,000190
+OTTAWA,Richland Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",114,000200
+OTTAWA,Sheridan Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",182,000210
+OTTAWA,Sherman Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",25,000220
+OTTAWA,Stanton Township,Kansas House of Representatives,107,Republican,"Concannon, Susan L.",21,000230
+OTTAWA,Bennington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",108,000010
+OTTAWA,Bennington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",490,000010
+OTTAWA,Blaine Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",11,000020
+OTTAWA,Blaine Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",63,000020
+OTTAWA,Buckeye Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000030
+OTTAWA,Buckeye Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",45,000030
+OTTAWA,Center Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000040
+OTTAWA,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",45,000040
+OTTAWA,Chapman Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000050
+OTTAWA,Chapman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",38,000050
+OTTAWA,Concord Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",16,000060
+OTTAWA,Concord Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",107,000060
+OTTAWA,Culver Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000070
+OTTAWA,Culver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",103,000070
+OTTAWA,Durham Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000080
+OTTAWA,Durham Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",9,000080
+OTTAWA,Fountain Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000090
+OTTAWA,Fountain Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",47,000090
+OTTAWA,Garfield Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000100
+OTTAWA,Garfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",44,000100
+OTTAWA,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000110
+OTTAWA,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000110
+OTTAWA,Henry Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000120
+OTTAWA,Henry Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000120
+OTTAWA,Lincoln Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",23,000130
+OTTAWA,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000130
+OTTAWA,Logan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000140
+OTTAWA,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",38,000140
+OTTAWA,Minneapolis Precinct 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,000150
+OTTAWA,Minneapolis Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",272,000150
+OTTAWA,Minneapolis Precinct 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,00016A
+OTTAWA,Minneapolis Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",196,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00016B
+OTTAWA,Minneapolis Precinct 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",35,000170
+OTTAWA,Minneapolis Precinct 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",314,000170
+OTTAWA,Morton Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",31,000180
+OTTAWA,Morton Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",177,000180
+OTTAWA,Ottawa Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000190
+OTTAWA,Ottawa Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000190
+OTTAWA,Richland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000200
+OTTAWA,Richland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",120,000200
+OTTAWA,Sheridan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",24,000210
+OTTAWA,Sheridan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",193,000210
+OTTAWA,Sherman Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000220
+OTTAWA,Sherman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000220
+OTTAWA,Stanton Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000230
+OTTAWA,Stanton Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000230
+OTTAWA,Bennington Township,President / Vice President,,independent,"Stein, Jill",4,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"McMullin, Evan",3,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+OTTAWA,Bennington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+OTTAWA,Bennington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",104,000010
+OTTAWA,Bennington Township,President / Vice President,,Libertarian,"Johnson, Gary",43,000010
+OTTAWA,Bennington Township,President / Vice President,,Republican,"Trump, Donald J.",458,000010
+OTTAWA,Blaine Township,President / Vice President,,independent,"Stein, Jill",2,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+OTTAWA,Blaine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+OTTAWA,Blaine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000020
+OTTAWA,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000020
+OTTAWA,Blaine Township,President / Vice President,,Republican,"Trump, Donald J.",53,000020
+OTTAWA,Buckeye Township,President / Vice President,,independent,"Stein, Jill",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+OTTAWA,Buckeye Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000030
+OTTAWA,Buckeye Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+OTTAWA,Buckeye Township,President / Vice President,,Republican,"Trump, Donald J.",43,000030
+OTTAWA,Center Township,President / Vice President,,independent,"Stein, Jill",2,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+OTTAWA,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+OTTAWA,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000040
+OTTAWA,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+OTTAWA,Center Township,President / Vice President,,Republican,"Trump, Donald J.",41,000040
+OTTAWA,Chapman Township,President / Vice President,,independent,"Stein, Jill",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+OTTAWA,Chapman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+OTTAWA,Chapman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000050
+OTTAWA,Chapman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+OTTAWA,Chapman Township,President / Vice President,,Republican,"Trump, Donald J.",36,000050
+OTTAWA,Concord Township,President / Vice President,,independent,"Stein, Jill",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+OTTAWA,Concord Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+OTTAWA,Concord Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000060
+OTTAWA,Concord Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+OTTAWA,Concord Township,President / Vice President,,Republican,"Trump, Donald J.",105,000060
+OTTAWA,Culver Township,President / Vice President,,independent,"Stein, Jill",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+OTTAWA,Culver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+OTTAWA,Culver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000070
+OTTAWA,Culver Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000070
+OTTAWA,Culver Township,President / Vice President,,Republican,"Trump, Donald J.",103,000070
+OTTAWA,Durham Township,President / Vice President,,independent,"Stein, Jill",1,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+OTTAWA,Durham Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+OTTAWA,Durham Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000080
+OTTAWA,Durham Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+OTTAWA,Durham Township,President / Vice President,,Republican,"Trump, Donald J.",6,000080
+OTTAWA,Fountain Township,President / Vice President,,independent,"Stein, Jill",4,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+OTTAWA,Fountain Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+OTTAWA,Fountain Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000090
+OTTAWA,Fountain Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+OTTAWA,Fountain Township,President / Vice President,,Republican,"Trump, Donald J.",42,000090
+OTTAWA,Garfield Township,President / Vice President,,independent,"Stein, Jill",1,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",1,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+OTTAWA,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+OTTAWA,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000100
+OTTAWA,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+OTTAWA,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",40,000100
+OTTAWA,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+OTTAWA,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+OTTAWA,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000110
+OTTAWA,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000110
+OTTAWA,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",46,000110
+OTTAWA,Henry Township,President / Vice President,,independent,"Stein, Jill",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+OTTAWA,Henry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+OTTAWA,Henry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000120
+OTTAWA,Henry Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+OTTAWA,Henry Township,President / Vice President,,Republican,"Trump, Donald J.",9,000120
+OTTAWA,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+OTTAWA,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000130
+OTTAWA,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+OTTAWA,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",54,000130
+OTTAWA,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+OTTAWA,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+OTTAWA,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000140
+OTTAWA,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+OTTAWA,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",34,000140
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",2,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",1,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",11,000150
+OTTAWA,Minneapolis Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",231,000150
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,independent,"Stein, Jill",2,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,00016A
+OTTAWA,Minneapolis Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",187,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00016B
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,independent,"Stein, Jill",5,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"McMullin, Evan",2,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",22,000170
+OTTAWA,Minneapolis Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",279,000170
+OTTAWA,Morton Township,President / Vice President,,independent,"Stein, Jill",5,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+OTTAWA,Morton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+OTTAWA,Morton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000180
+OTTAWA,Morton Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000180
+OTTAWA,Morton Township,President / Vice President,,Republican,"Trump, Donald J.",176,000180
+OTTAWA,Ottawa Township,President / Vice President,,independent,"Stein, Jill",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000190
+OTTAWA,Ottawa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+OTTAWA,Ottawa Township,President / Vice President,,Republican,"Trump, Donald J.",17,000190
+OTTAWA,Richland Township,President / Vice President,,independent,"Stein, Jill",3,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+OTTAWA,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+OTTAWA,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000200
+OTTAWA,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000200
+OTTAWA,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",111,000200
+OTTAWA,Sheridan Township,President / Vice President,,independent,"Stein, Jill",8,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+OTTAWA,Sheridan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000210
+OTTAWA,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000210
+OTTAWA,Sheridan Township,President / Vice President,,Republican,"Trump, Donald J.",164,000210
+OTTAWA,Sherman Township,President / Vice President,,independent,"Stein, Jill",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",1,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+OTTAWA,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+OTTAWA,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000220
+OTTAWA,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+OTTAWA,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",27,000220
+OTTAWA,Stanton Township,President / Vice President,,independent,"Stein, Jill",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+OTTAWA,Stanton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+OTTAWA,Stanton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000230
+OTTAWA,Stanton Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+OTTAWA,Stanton Township,President / Vice President,,Republican,"Trump, Donald J.",21,000230
+OTTAWA,Bennington Township,United States House of Representatives,1,independent,"LaPolice, Alan",206,000010
+OTTAWA,Bennington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+OTTAWA,Bennington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",41,000010
+OTTAWA,Bennington Township,United States House of Representatives,1,Republican,"Marshall, Roger",357,000010
+OTTAWA,Blaine Township,United States House of Representatives,1,independent,"LaPolice, Alan",40,000020
+OTTAWA,Blaine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+OTTAWA,Blaine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+OTTAWA,Blaine Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000020
+OTTAWA,Buckeye Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000030
+OTTAWA,Buckeye Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+OTTAWA,Buckeye Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000030
+OTTAWA,Buckeye Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000030
+OTTAWA,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000040
+OTTAWA,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+OTTAWA,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+OTTAWA,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000040
+OTTAWA,Chapman Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000050
+OTTAWA,Chapman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+OTTAWA,Chapman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000050
+OTTAWA,Chapman Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000050
+OTTAWA,Concord Township,United States House of Representatives,1,independent,"LaPolice, Alan",54,000060
+OTTAWA,Concord Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000060
+OTTAWA,Concord Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000060
+OTTAWA,Concord Township,United States House of Representatives,1,Republican,"Marshall, Roger",68,000060
+OTTAWA,Culver Township,United States House of Representatives,1,independent,"LaPolice, Alan",50,000070
+OTTAWA,Culver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+OTTAWA,Culver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000070
+OTTAWA,Culver Township,United States House of Representatives,1,Republican,"Marshall, Roger",67,000070
+OTTAWA,Durham Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000080
+OTTAWA,Durham Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+OTTAWA,Durham Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+OTTAWA,Durham Township,United States House of Representatives,1,Republican,"Marshall, Roger",4,000080
+OTTAWA,Fountain Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000090
+OTTAWA,Fountain Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000090
+OTTAWA,Fountain Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+OTTAWA,Fountain Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000090
+OTTAWA,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000100
+OTTAWA,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+OTTAWA,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+OTTAWA,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000100
+OTTAWA,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000110
+OTTAWA,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000110
+OTTAWA,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000110
+OTTAWA,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000110
+OTTAWA,Henry Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000120
+OTTAWA,Henry Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+OTTAWA,Henry Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+OTTAWA,Henry Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000120
+OTTAWA,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000130
+OTTAWA,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000130
+OTTAWA,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000130
+OTTAWA,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",44,000130
+OTTAWA,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000140
+OTTAWA,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+OTTAWA,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+OTTAWA,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000140
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",132,000150
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000150
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000150
+OTTAWA,Minneapolis Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",158,000150
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",101,00016A
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00016A
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,00016A
+OTTAWA,Minneapolis Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",117,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00016B
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",139,000170
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000170
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000170
+OTTAWA,Minneapolis Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",195,000170
+OTTAWA,Morton Township,United States House of Representatives,1,independent,"LaPolice, Alan",109,000180
+OTTAWA,Morton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+OTTAWA,Morton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000180
+OTTAWA,Morton Township,United States House of Representatives,1,Republican,"Marshall, Roger",88,000180
+OTTAWA,Ottawa Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000190
+OTTAWA,Ottawa Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+OTTAWA,Ottawa Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000190
+OTTAWA,Ottawa Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000190
+OTTAWA,Richland Township,United States House of Representatives,1,independent,"LaPolice, Alan",42,000200
+OTTAWA,Richland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+OTTAWA,Richland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000200
+OTTAWA,Richland Township,United States House of Representatives,1,Republican,"Marshall, Roger",88,000200
+OTTAWA,Sheridan Township,United States House of Representatives,1,independent,"LaPolice, Alan",109,000210
+OTTAWA,Sheridan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+OTTAWA,Sheridan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000210
+OTTAWA,Sheridan Township,United States House of Representatives,1,Republican,"Marshall, Roger",103,000210
+OTTAWA,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000220
+OTTAWA,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+OTTAWA,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+OTTAWA,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000220
+OTTAWA,Stanton Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000230
+OTTAWA,Stanton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+OTTAWA,Stanton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000230
+OTTAWA,Stanton Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000230
+OTTAWA,Bennington Township,United States Senate,,write - in,"Smith, DJ",0,000010
+OTTAWA,Bennington Township,United States Senate,,Democratic,"Wiesner, Patrick",94,000010
+OTTAWA,Bennington Township,United States Senate,,Libertarian,"Garrard, Robert D.",45,000010
+OTTAWA,Bennington Township,United States Senate,,Republican,"Moran, Jerry",473,000010
+OTTAWA,Blaine Township,United States Senate,,write - in,"Smith, DJ",0,000020
+OTTAWA,Blaine Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000020
+OTTAWA,Blaine Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000020
+OTTAWA,Blaine Township,United States Senate,,Republican,"Moran, Jerry",60,000020
+OTTAWA,Buckeye Township,United States Senate,,write - in,"Smith, DJ",0,000030
+OTTAWA,Buckeye Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000030
+OTTAWA,Buckeye Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000030
+OTTAWA,Buckeye Township,United States Senate,,Republican,"Moran, Jerry",40,000030
+OTTAWA,Center Township,United States Senate,,write - in,"Smith, DJ",0,000040
+OTTAWA,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+OTTAWA,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000040
+OTTAWA,Center Township,United States Senate,,Republican,"Moran, Jerry",42,000040
+OTTAWA,Chapman Township,United States Senate,,write - in,"Smith, DJ",0,000050
+OTTAWA,Chapman Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000050
+OTTAWA,Chapman Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000050
+OTTAWA,Chapman Township,United States Senate,,Republican,"Moran, Jerry",37,000050
+OTTAWA,Concord Township,United States Senate,,write - in,"Smith, DJ",0,000060
+OTTAWA,Concord Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000060
+OTTAWA,Concord Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000060
+OTTAWA,Concord Township,United States Senate,,Republican,"Moran, Jerry",99,000060
+OTTAWA,Culver Township,United States Senate,,write - in,"Smith, DJ",0,000070
+OTTAWA,Culver Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000070
+OTTAWA,Culver Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000070
+OTTAWA,Culver Township,United States Senate,,Republican,"Moran, Jerry",99,000070
+OTTAWA,Durham Township,United States Senate,,write - in,"Smith, DJ",0,000080
+OTTAWA,Durham Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000080
+OTTAWA,Durham Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+OTTAWA,Durham Township,United States Senate,,Republican,"Moran, Jerry",6,000080
+OTTAWA,Fountain Township,United States Senate,,write - in,"Smith, DJ",0,000090
+OTTAWA,Fountain Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000090
+OTTAWA,Fountain Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000090
+OTTAWA,Fountain Township,United States Senate,,Republican,"Moran, Jerry",42,000090
+OTTAWA,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000100
+OTTAWA,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000100
+OTTAWA,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+OTTAWA,Garfield Township,United States Senate,,Republican,"Moran, Jerry",45,000100
+OTTAWA,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000110
+OTTAWA,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000110
+OTTAWA,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+OTTAWA,Grant Township,United States Senate,,Republican,"Moran, Jerry",49,000110
+OTTAWA,Henry Township,United States Senate,,write - in,"Smith, DJ",0,000120
+OTTAWA,Henry Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000120
+OTTAWA,Henry Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000120
+OTTAWA,Henry Township,United States Senate,,Republican,"Moran, Jerry",9,000120
+OTTAWA,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000130
+OTTAWA,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000130
+OTTAWA,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+OTTAWA,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",53,000130
+OTTAWA,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000140
+OTTAWA,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000140
+OTTAWA,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000140
+OTTAWA,Logan Township,United States Senate,,Republican,"Moran, Jerry",35,000140
+OTTAWA,Minneapolis Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000150
+OTTAWA,Minneapolis Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",45,000150
+OTTAWA,Minneapolis Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000150
+OTTAWA,Minneapolis Precinct 1,United States Senate,,Republican,"Moran, Jerry",240,000150
+OTTAWA,Minneapolis Precinct 2,United States Senate,,write - in,"Smith, DJ",0,00016A
+OTTAWA,Minneapolis Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",24,00016A
+OTTAWA,Minneapolis Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",23,00016A
+OTTAWA,Minneapolis Precinct 2,United States Senate,,Republican,"Moran, Jerry",179,00016A
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00016B
+OTTAWA,Minneapolis Precinct 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00016B
+OTTAWA,Minneapolis Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000170
+OTTAWA,Minneapolis Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",33,000170
+OTTAWA,Minneapolis Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",28,000170
+OTTAWA,Minneapolis Precinct 3,United States Senate,,Republican,"Moran, Jerry",289,000170
+OTTAWA,Morton Township,United States Senate,,write - in,"Smith, DJ",0,000180
+OTTAWA,Morton Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000180
+OTTAWA,Morton Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000180
+OTTAWA,Morton Township,United States Senate,,Republican,"Moran, Jerry",176,000180
+OTTAWA,Ottawa Township,United States Senate,,write - in,"Smith, DJ",0,000190
+OTTAWA,Ottawa Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000190
+OTTAWA,Ottawa Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+OTTAWA,Ottawa Township,United States Senate,,Republican,"Moran, Jerry",18,000190
+OTTAWA,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000200
+OTTAWA,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000200
+OTTAWA,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000200
+OTTAWA,Richland Township,United States Senate,,Republican,"Moran, Jerry",116,000200
+OTTAWA,Sheridan Township,United States Senate,,write - in,"Smith, DJ",0,000210
+OTTAWA,Sheridan Township,United States Senate,,Democratic,"Wiesner, Patrick",32,000210
+OTTAWA,Sheridan Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000210
+OTTAWA,Sheridan Township,United States Senate,,Republican,"Moran, Jerry",159,000210
+OTTAWA,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000220
+OTTAWA,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000220
+OTTAWA,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000220
+OTTAWA,Sherman Township,United States Senate,,Republican,"Moran, Jerry",31,000220
+OTTAWA,Stanton Township,United States Senate,,write - in,"Smith, DJ",0,000230
+OTTAWA,Stanton Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000230
+OTTAWA,Stanton Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000230
+OTTAWA,Stanton Township,United States Senate,,Republican,"Moran, Jerry",19,000230

--- a/2016/20161108__ks__general__pawnee__precinct.csv
+++ b/2016/20161108__ks__general__pawnee__precinct.csv
@@ -1,495 +1,1009 @@
-county,precinct,office,district,party,candidate,votes
-Pawnee,Ash Valley Township,President,,Democratic,Clinton/Kaine,13
-Pawnee,Browns Grove Township C1,President,,Democratic,Clinton/Kaine,20
-Pawnee,Browns Grove Township C4,President,,Democratic,Clinton/Kaine,0
-Pawnee,Conkling Township,President,,Democratic,Clinton/Kaine,2
-Pawnee,Garfield Township,President,,Democratic,Clinton/Kaine,15
-Pawnee,Grant Township C1,President,,Democratic,Clinton/Kaine,10
-Pawnee,Grant Township C4,President,,Democratic,Clinton/Kaine,1
-Pawnee,Keysville Township,President,,Democratic,Clinton/Kaine,4
-Pawnee,Larned Township,President,,Democratic,Clinton/Kaine,22
-Pawnee,Larned Ward 1,President,,Democratic,Clinton/Kaine,83
-Pawnee,Larned Ward 2,President,,Democratic,Clinton/Kaine,139
-Pawnee,Larned Ward 3,President,,Democratic,Clinton/Kaine,124
-Pawnee,Larned Ward 4,President,,Democratic,Clinton/Kaine,75
-Pawnee,Lincoln Township,President,,Democratic,Clinton/Kaine,0
-Pawnee,Logan Township,President,,Democratic,Clinton/Kaine,0
-Pawnee,Morton Township,President,,Democratic,Clinton/Kaine,7
-Pawnee,Orange Township,President,,Democratic,Clinton/Kaine,6
-Pawnee,Pawnee Township,President,,Democratic,Clinton/Kaine,6
-Pawnee,Pleasant Grove Township,President,,Democratic,Clinton/Kaine,12
-Pawnee,Pleasant Grove Township Rural Enclave,President,,Democratic,Clinton/Kaine,0
-Pawnee,Pleasant Ridge Township,President,,Democratic,Clinton/Kaine,3
-Pawnee,Pleasant Valley Township,President,,Democratic,Clinton/Kaine,4
-Pawnee,River Township,President,,Democratic,Clinton/Kaine,1
-Pawnee,Santa Fe Township,President,,Democratic,Clinton/Kaine,25
-Pawnee,Sawmill Township,President,,Democratic,Clinton/Kaine,0
-Pawnee,Shiley Township,President,,Democratic,Clinton/Kaine,1
-Pawnee,Valley Center Township,President,,Democratic,Clinton/Kaine,0
-Pawnee,Walnut Township,President,,Democratic,Clinton/Kaine,6
-Pawnee,Total,President,,Democratic,Clinton/Kaine,579
-Pawnee,Ash Valley Township,President,,Republican,Trump/Pence,17
-Pawnee,Browns Grove Township C1,President,,Republican,Trump/Pence,125
-Pawnee,Browns Grove Township C4,President,,Republican,Trump/Pence,2
-Pawnee,Conkling Township,President,,Republican,Trump/Pence,13
-Pawnee,Garfield Township,President,,Republican,Trump/Pence,65
-Pawnee,Grant Township C1,President,,Republican,Trump/Pence,84
-Pawnee,Grant Township C4,President,,Republican,Trump/Pence,9
-Pawnee,Keysville Township,President,,Republican,Trump/Pence,13
-Pawnee,Larned Township,President,,Republican,Trump/Pence,107
-Pawnee,Larned Ward 1,President,,Republican,Trump/Pence,256
-Pawnee,Larned Ward 2,President,,Republican,Trump/Pence,345
-Pawnee,Larned Ward 3,President,,Republican,Trump/Pence,331
-Pawnee,Larned Ward 4,President,,Republican,Trump/Pence,157
-Pawnee,Lincoln Township,President,,Republican,Trump/Pence,11
-Pawnee,Logan Township,President,,Republican,Trump/Pence,30
-Pawnee,Morton Township,President,,Republican,Trump/Pence,18
-Pawnee,Orange Township,President,,Republican,Trump/Pence,18
-Pawnee,Pawnee Township,President,,Republican,Trump/Pence,37
-Pawnee,Pleasant Grove Township,President,,Republican,Trump/Pence,73
-Pawnee,Pleasant Grove Township Rural Enclave,President,,Republican,Trump/Pence,0
-Pawnee,Pleasant Ridge Township,President,,Republican,Trump/Pence,17
-Pawnee,Pleasant Valley Township,President,,Republican,Trump/Pence,37
-Pawnee,River Township,President,,Republican,Trump/Pence,30
-Pawnee,Santa Fe Township,President,,Republican,Trump/Pence,35
-Pawnee,Sawmill Township,President,,Republican,Trump/Pence,12
-Pawnee,Shiley Township,President,,Republican,Trump/Pence,13
-Pawnee,Valley Center Township,President,,Republican,Trump/Pence,18
-Pawnee,Walnut Township,President,,Republican,Trump/Pence,31
-Pawnee,Total,President,,Republican,Trump/Pence,1904
-Pawnee,Ash Valley Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Browns Grove Township C1,President,,Libertarian,Johnson/Weld,1
-Pawnee,Browns Grove Township C4,President,,Libertarian,Johnson/Weld,0
-Pawnee,Conkling Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Garfield Township,President,,Libertarian,Johnson/Weld,6
-Pawnee,Grant Township C1,President,,Libertarian,Johnson/Weld,3
-Pawnee,Grant Township C4,President,,Libertarian,Johnson/Weld,1
-Pawnee,Keysville Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Larned Township,President,,Libertarian,Johnson/Weld,6
-Pawnee,Larned Ward 1,President,,Libertarian,Johnson/Weld,25
-Pawnee,Larned Ward 2,President,,Libertarian,Johnson/Weld,25
-Pawnee,Larned Ward 3,President,,Libertarian,Johnson/Weld,30
-Pawnee,Larned Ward 4,President,,Libertarian,Johnson/Weld,18
-Pawnee,Lincoln Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Logan Township,President,,Libertarian,Johnson/Weld,2
-Pawnee,Morton Township,President,,Libertarian,Johnson/Weld,1
-Pawnee,Orange Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Pawnee Township,President,,Libertarian,Johnson/Weld,3
-Pawnee,Pleasant Grove Township,President,,Libertarian,Johnson/Weld,3
-Pawnee,Pleasant Grove Township Rural Enclave,President,,Libertarian,Johnson/Weld,0
-Pawnee,Pleasant Ridge Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Pleasant Valley Township,President,,Libertarian,Johnson/Weld,2
-Pawnee,River Township,President,,Libertarian,Johnson/Weld,1
-Pawnee,Santa Fe Township,President,,Libertarian,Johnson/Weld,1
-Pawnee,Sawmill Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Shiley Township,President,,Libertarian,Johnson/Weld,1
-Pawnee,Valley Center Township,President,,Libertarian,Johnson/Weld,0
-Pawnee,Walnut Township,President,,Libertarian,Johnson/Weld,2
-Pawnee,Total,President,,Libertarian,Johnson/Weld,131
-Pawnee,Ash Valley Township,President,,Independent,Stein/Baraka,0
-Pawnee,Browns Grove Township C1,President,,Independent,Stein/Baraka,0
-Pawnee,Browns Grove Township C4,President,,Independent,Stein/Baraka,0
-Pawnee,Conkling Township,President,,Independent,Stein/Baraka,0
-Pawnee,Garfield Township,President,,Independent,Stein/Baraka,1
-Pawnee,Grant Township C1,President,,Independent,Stein/Baraka,0
-Pawnee,Grant Township C4,President,,Independent,Stein/Baraka,0
-Pawnee,Keysville Township,President,,Independent,Stein/Baraka,0
-Pawnee,Larned Township,President,,Independent,Stein/Baraka,3
-Pawnee,Larned Ward 1,President,,Independent,Stein/Baraka,8
-Pawnee,Larned Ward 2,President,,Independent,Stein/Baraka,6
-Pawnee,Larned Ward 3,President,,Independent,Stein/Baraka,7
-Pawnee,Larned Ward 4,President,,Independent,Stein/Baraka,4
-Pawnee,Lincoln Township,President,,Independent,Stein/Baraka,1
-Pawnee,Logan Township,President,,Independent,Stein/Baraka,0
-Pawnee,Morton Township,President,,Independent,Stein/Baraka,0
-Pawnee,Orange Township,President,,Independent,Stein/Baraka,1
-Pawnee,Pawnee Township,President,,Independent,Stein/Baraka,0
-Pawnee,Pleasant Grove Township,President,,Independent,Stein/Baraka,0
-Pawnee,Pleasant Grove Township Rural Enclave,President,,Independent,Stein/Baraka,0
-Pawnee,Pleasant Ridge Township,President,,Independent,Stein/Baraka,0
-Pawnee,Pleasant Valley Township,President,,Independent,Stein/Baraka,1
-Pawnee,River Township,President,,Independent,Stein/Baraka,1
-Pawnee,Santa Fe Township,President,,Independent,Stein/Baraka,0
-Pawnee,Sawmill Township,President,,Independent,Stein/Baraka,0
-Pawnee,Shiley Township,President,,Independent,Stein/Baraka,0
-Pawnee,Valley Center Township,President,,Independent,Stein/Baraka,0
-Pawnee,Walnut Township,President,,Independent,Stein/Baraka,1
-Pawnee,Total,President,,Independent,Stein/Baraka,34
-Pawnee,Ash Valley Township,President,,,Castle/Bradley,0
-Pawnee,Browns Grove Township C1,President,,,Castle/Bradley,0
-Pawnee,Browns Grove Township C4,President,,,Castle/Bradley,0
-Pawnee,Conkling Township,President,,,Castle/Bradley,0
-Pawnee,Garfield Township,President,,,Castle/Bradley,0
-Pawnee,Grant Township C1,President,,,Castle/Bradley,0
-Pawnee,Grant Township C4,President,,,Castle/Bradley,0
-Pawnee,Keysville Township,President,,,Castle/Bradley,0
-Pawnee,Larned Township,President,,,Castle/Bradley,0
-Pawnee,Larned Ward 1,President,,,Castle/Bradley,0
-Pawnee,Larned Ward 2,President,,,Castle/Bradley,0
-Pawnee,Larned Ward 3,President,,,Castle/Bradley,0
-Pawnee,Larned Ward 4,President,,,Castle/Bradley,0
-Pawnee,Lincoln Township,President,,,Castle/Bradley,0
-Pawnee,Logan Township,President,,,Castle/Bradley,2
-Pawnee,Morton Township,President,,,Castle/Bradley,0
-Pawnee,Orange Township,President,,,Castle/Bradley,0
-Pawnee,Pawnee Township,President,,,Castle/Bradley,0
-Pawnee,Pleasant Grove Township,President,,,Castle/Bradley,0
-Pawnee,Pleasant Grove Township Rural Enclave,President,,,Castle/Bradley,0
-Pawnee,Pleasant Ridge Township,President,,,Castle/Bradley,0
-Pawnee,Pleasant Valley Township,President,,,Castle/Bradley,0
-Pawnee,River Township,President,,,Castle/Bradley,0
-Pawnee,Santa Fe Township,President,,,Castle/Bradley,0
-Pawnee,Sawmill Township,President,,,Castle/Bradley,0
-Pawnee,Shiley Township,President,,,Castle/Bradley,0
-Pawnee,Valley Center Township,President,,,Castle/Bradley,0
-Pawnee,Walnut Township,President,,,Castle/Bradley,0
-Pawnee,Total,President,,,Castle/Bradley,2
-Pawnee,Ash Valley Township,President,,,Hedges/Bayes,0
-Pawnee,Browns Grove Township C1,President,,,Hedges/Bayes,0
-Pawnee,Browns Grove Township C4,President,,,Hedges/Bayes,0
-Pawnee,Conkling Township,President,,,Hedges/Bayes,0
-Pawnee,Garfield Township,President,,,Hedges/Bayes,0
-Pawnee,Grant Township C1,President,,,Hedges/Bayes,0
-Pawnee,Grant Township C4,President,,,Hedges/Bayes,0
-Pawnee,Keysville Township,President,,,Hedges/Bayes,0
-Pawnee,Larned Township,President,,,Hedges/Bayes,0
-Pawnee,Larned Ward 1,President,,,Hedges/Bayes,0
-Pawnee,Larned Ward 2,President,,,Hedges/Bayes,1
-Pawnee,Larned Ward 3,President,,,Hedges/Bayes,0
-Pawnee,Larned Ward 4,President,,,Hedges/Bayes,0
-Pawnee,Lincoln Township,President,,,Hedges/Bayes,0
-Pawnee,Logan Township,President,,,Hedges/Bayes,0
-Pawnee,Morton Township,President,,,Hedges/Bayes,0
-Pawnee,Orange Township,President,,,Hedges/Bayes,0
-Pawnee,Pawnee Township,President,,,Hedges/Bayes,0
-Pawnee,Pleasant Grove Township,President,,,Hedges/Bayes,0
-Pawnee,Pleasant Grove Township Rural Enclave,President,,,Hedges/Bayes,0
-Pawnee,Pleasant Ridge Township,President,,,Hedges/Bayes,0
-Pawnee,Pleasant Valley Township,President,,,Hedges/Bayes,0
-Pawnee,River Township,President,,,Hedges/Bayes,0
-Pawnee,Santa Fe Township,President,,,Hedges/Bayes,0
-Pawnee,Sawmill Township,President,,,Hedges/Bayes,0
-Pawnee,Shiley Township,President,,,Hedges/Bayes,0
-Pawnee,Valley Center Township,President,,,Hedges/Bayes,0
-Pawnee,Walnut Township,President,,,Hedges/Bayes,0
-Pawnee,Total,President,,,Hedges/Bayes,1
-Pawnee,Ash Valley Township,President,,,McMullin/Johnson,0
-Pawnee,Browns Grove Township C1,President,,,McMullin/Johnson,0
-Pawnee,Browns Grove Township C4,President,,,McMullin/Johnson,0
-Pawnee,Conkling Township,President,,,McMullin/Johnson,0
-Pawnee,Garfield Township,President,,,McMullin/Johnson,0
-Pawnee,Grant Township C1,President,,,McMullin/Johnson,0
-Pawnee,Grant Township C4,President,,,McMullin/Johnson,0
-Pawnee,Keysville Township,President,,,McMullin/Johnson,0
-Pawnee,Larned Township,President,,,McMullin/Johnson,0
-Pawnee,Larned Ward 1,President,,,McMullin/Johnson,7
-Pawnee,Larned Ward 2,President,,,McMullin/Johnson,1
-Pawnee,Larned Ward 3,President,,,McMullin/Johnson,0
-Pawnee,Larned Ward 4,President,,,McMullin/Johnson,2
-Pawnee,Lincoln Township,President,,,McMullin/Johnson,0
-Pawnee,Logan Township,President,,,McMullin/Johnson,0
-Pawnee,Morton Township,President,,,McMullin/Johnson,0
-Pawnee,Orange Township,President,,,McMullin/Johnson,0
-Pawnee,Pawnee Township,President,,,McMullin/Johnson,0
-Pawnee,Pleasant Grove Township,President,,,McMullin/Johnson,0
-Pawnee,Pleasant Grove Township Rural Enclave,President,,,McMullin/Johnson,0
-Pawnee,Pleasant Ridge Township,President,,,McMullin/Johnson,0
-Pawnee,Pleasant Valley Township,President,,,McMullin/Johnson,0
-Pawnee,River Township,President,,,McMullin/Johnson,0
-Pawnee,Santa Fe Township,President,,,McMullin/Johnson,0
-Pawnee,Sawmill Township,President,,,McMullin/Johnson,0
-Pawnee,Shiley Township,President,,,McMullin/Johnson,0
-Pawnee,Valley Center Township,President,,,McMullin/Johnson,0
-Pawnee,Walnut Township,President,,,McMullin/Johnson,0
-Pawnee,Total,President,,,McMullin/Johnson,10
-Pawnee,Ash Valley Township,U.S. Senate,,Democratic,Patrick Wiesner,12
-Pawnee,Browns Grove Township C1,U.S. Senate,,Democratic,Patrick Wiesner,12
-Pawnee,Browns Grove Township C4,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Conkling Township,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Garfield Township,U.S. Senate,,Democratic,Patrick Wiesner,17
-Pawnee,Grant Township C1,U.S. Senate,,Democratic,Patrick Wiesner,9
-Pawnee,Grant Township C4,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Keysville Township,U.S. Senate,,Democratic,Patrick Wiesner,1
-Pawnee,Larned Township,U.S. Senate,,Democratic,Patrick Wiesner,16
-Pawnee,Larned Ward 1,U.S. Senate,,Democratic,Patrick Wiesner,68
-Pawnee,Larned Ward 2,U.S. Senate,,Democratic,Patrick Wiesner,89
-Pawnee,Larned Ward 3,U.S. Senate,,Democratic,Patrick Wiesner,99
-Pawnee,Larned Ward 4,U.S. Senate,,Democratic,Patrick Wiesner,56
-Pawnee,Lincoln Township,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Logan Township,U.S. Senate,,Democratic,Patrick Wiesner,1
-Pawnee,Morton Township,U.S. Senate,,Democratic,Patrick Wiesner,2
-Pawnee,Orange Township,U.S. Senate,,Democratic,Patrick Wiesner,3
-Pawnee,Pawnee Township,U.S. Senate,,Democratic,Patrick Wiesner,7
-Pawnee,Pleasant Grove Township,U.S. Senate,,Democratic,Patrick Wiesner,8
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Pleasant Ridge Township,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Pleasant Valley Township,U.S. Senate,,Democratic,Patrick Wiesner,4
-Pawnee,River Township,U.S. Senate,,Democratic,Patrick Wiesner,2
-Pawnee,Santa Fe Township,U.S. Senate,,Democratic,Patrick Wiesner,21
-Pawnee,Sawmill Township,U.S. Senate,,Democratic,Patrick Wiesner,1
-Pawnee,Shiley Township,U.S. Senate,,Democratic,Patrick Wiesner,1
-Pawnee,Valley Center Township,U.S. Senate,,Democratic,Patrick Wiesner,0
-Pawnee,Walnut Township,U.S. Senate,,Democratic,Patrick Wiesner,3
-Pawnee,Total,U.S. Senate,,Democratic,Patrick Wiesner,432
-Pawnee,Ash Valley Township,U.S. Senate,,Republican,Jerry Moran,20
-Pawnee,Browns Grove Township C1,U.S. Senate,,Republican,Jerry Moran,134
-Pawnee,Browns Grove Township C4,U.S. Senate,,Republican,Jerry Moran,2
-Pawnee,Conkling Township,U.S. Senate,,Republican,Jerry Moran,14
-Pawnee,Garfield Township,U.S. Senate,,Republican,Jerry Moran,70
-Pawnee,Grant Township C1,U.S. Senate,,Republican,Jerry Moran,82
-Pawnee,Grant Township C4,U.S. Senate,,Republican,Jerry Moran,10
-Pawnee,Keysville Township,U.S. Senate,,Republican,Jerry Moran,16
-Pawnee,Larned Township,U.S. Senate,,Republican,Jerry Moran,114
-Pawnee,Larned Ward 1,U.S. Senate,,Republican,Jerry Moran,279
-Pawnee,Larned Ward 2,U.S. Senate,,Republican,Jerry Moran,413
-Pawnee,Larned Ward 3,U.S. Senate,,Republican,Jerry Moran,381
-Pawnee,Larned Ward 4,U.S. Senate,,Republican,Jerry Moran,175
-Pawnee,Lincoln Township,U.S. Senate,,Republican,Jerry Moran,12
-Pawnee,Logan Township,U.S. Senate,,Republican,Jerry Moran,29
-Pawnee,Morton Township,U.S. Senate,,Republican,Jerry Moran,24
-Pawnee,Orange Township,U.S. Senate,,Republican,Jerry Moran,22
-Pawnee,Pawnee Township,U.S. Senate,,Republican,Jerry Moran,39
-Pawnee,Pleasant Grove Township,U.S. Senate,,Republican,Jerry Moran,73
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. Senate,,Republican,Jerry Moran,0
-Pawnee,Pleasant Ridge Township,U.S. Senate,,Republican,Jerry Moran,20
-Pawnee,Pleasant Valley Township,U.S. Senate,,Republican,Jerry Moran,36
-Pawnee,River Township,U.S. Senate,,Republican,Jerry Moran,29
-Pawnee,Santa Fe Township,U.S. Senate,,Republican,Jerry Moran,40
-Pawnee,Sawmill Township,U.S. Senate,,Republican,Jerry Moran,10
-Pawnee,Shiley Township,U.S. Senate,,Republican,Jerry Moran,13
-Pawnee,Valley Center Township,U.S. Senate,,Republican,Jerry Moran,16
-Pawnee,Walnut Township,U.S. Senate,,Republican,Jerry Moran,35
-Pawnee,Total,U.S. Senate,,Republican,Jerry Moran,2108
-Pawnee,Ash Valley Township,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Browns Grove Township C1,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Browns Grove Township C4,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Conkling Township,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Garfield Township,U.S. Senate,,Libertarian,Robert D. Garrard,1
-Pawnee,Grant Township C1,U.S. Senate,,Libertarian,Robert D. Garrard,3
-Pawnee,Grant Township C4,U.S. Senate,,Libertarian,Robert D. Garrard,1
-Pawnee,Keysville Township,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Larned Township,U.S. Senate,,Libertarian,Robert D. Garrard,10
-Pawnee,Larned Ward 1,U.S. Senate,,Libertarian,Robert D. Garrard,30
-Pawnee,Larned Ward 2,U.S. Senate,,Libertarian,Robert D. Garrard,23
-Pawnee,Larned Ward 3,U.S. Senate,,Libertarian,Robert D. Garrard,21
-Pawnee,Larned Ward 4,U.S. Senate,,Libertarian,Robert D. Garrard,24
-Pawnee,Lincoln Township,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Logan Township,U.S. Senate,,Libertarian,Robert D. Garrard,2
-Pawnee,Morton Township,U.S. Senate,,Libertarian,Robert D. Garrard,1
-Pawnee,Orange Township,U.S. Senate,,Libertarian,Robert D. Garrard,1
-Pawnee,Pawnee Township,U.S. Senate,,Libertarian,Robert D. Garrard,2
-Pawnee,Pleasant Grove Township,U.S. Senate,,Libertarian,Robert D. Garrard,6
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Pleasant Ridge Township,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Pleasant Valley Township,U.S. Senate,,Libertarian,Robert D. Garrard,4
-Pawnee,River Township,U.S. Senate,,Libertarian,Robert D. Garrard,2
-Pawnee,Santa Fe Township,U.S. Senate,,Libertarian,Robert D. Garrard,1
-Pawnee,Sawmill Township,U.S. Senate,,Libertarian,Robert D. Garrard,1
-Pawnee,Shiley Township,U.S. Senate,,Libertarian,Robert D. Garrard,0
-Pawnee,Valley Center Township,U.S. Senate,,Libertarian,Robert D. Garrard,2
-Pawnee,Walnut Township,U.S. Senate,,Libertarian,Robert D. Garrard,2
-Pawnee,Total,U.S. Senate,,Libertarian,Robert D. Garrard,137
-Pawnee,Ash Valley Township,U.S. House,1,Republican,Roger Marshall,14
-Pawnee,Browns Grove Township C1,U.S. House,1,Republican,Roger Marshall,101
-Pawnee,Conkling Township,U.S. House,1,Republican,Roger Marshall,9
-Pawnee,Grant Township C1,U.S. House,1,Republican,Roger Marshall,51
-Pawnee,Larned Township,U.S. House,1,Republican,Roger Marshall,87
-Pawnee,Larned Ward 1,U.S. House,1,Republican,Roger Marshall,237
-Pawnee,Larned Ward 2,U.S. House,1,Republican,Roger Marshall,366
-Pawnee,Larned Ward 3,U.S. House,1,Republican,Roger Marshall,337
-Pawnee,Larned Ward 4,U.S. House,1,Republican,Roger Marshall,144
-Pawnee,Lincoln Township,U.S. House,1,Republican,Roger Marshall,7
-Pawnee,Logan Township,U.S. House,1,Republican,Roger Marshall,20
-Pawnee,Morton Township,U.S. House,1,Republican,Roger Marshall,22
-Pawnee,Orange Township,U.S. House,1,Republican,Roger Marshall,15
-Pawnee,Pawnee Township,U.S. House,1,Republican,Roger Marshall,35
-Pawnee,Pleasant Grove Township,U.S. House,1,Republican,Roger Marshall,62
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. House,1,Republican,Roger Marshall,0
-Pawnee,Pleasant Valley Township,U.S. House,1,Republican,Roger Marshall,25
-Pawnee,River Township,U.S. House,1,Republican,Roger Marshall,19
-Pawnee,Santa Fe Township,U.S. House,1,Republican,Roger Marshall,44
-Pawnee,Shiley Township,U.S. House,1,Republican,Roger Marshall,12
-Pawnee,Valley Center Township,U.S. House,1,Republican,Roger Marshall,12
-Pawnee,Walnut Township,U.S. House,1,Republican,Roger Marshall,33
-Pawnee,Total,U.S. House,1,Republican,Roger Marshall,1652
-Pawnee,Ash Valley Township,U.S. House,1,Libertarian,Kerry Burt,1
-Pawnee,Browns Grove Township C1,U.S. House,1,Libertarian,Kerry Burt,2
-Pawnee,Conkling Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Grant Township C1,U.S. House,1,Libertarian,Kerry Burt,6
-Pawnee,Larned Township,U.S. House,1,Libertarian,Kerry Burt,11
-Pawnee,Larned Ward 1,U.S. House,1,Libertarian,Kerry Burt,25
-Pawnee,Larned Ward 2,U.S. House,1,Libertarian,Kerry Burt,28
-Pawnee,Larned Ward 3,U.S. House,1,Libertarian,Kerry Burt,27
-Pawnee,Larned Ward 4,U.S. House,1,Libertarian,Kerry Burt,30
-Pawnee,Lincoln Township,U.S. House,1,Libertarian,Kerry Burt,1
-Pawnee,Logan Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Morton Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Orange Township,U.S. House,1,Libertarian,Kerry Burt,2
-Pawnee,Pawnee Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Pleasant Grove Township,U.S. House,1,Libertarian,Kerry Burt,4
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Pleasant Valley Township,U.S. House,1,Libertarian,Kerry Burt,3
-Pawnee,River Township,U.S. House,1,Libertarian,Kerry Burt,2
-Pawnee,Santa Fe Township,U.S. House,1,Libertarian,Kerry Burt,1
-Pawnee,Shiley Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Valley Center Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Walnut Township,U.S. House,1,Libertarian,Kerry Burt,0
-Pawnee,Total,U.S. House,1,Libertarian,Kerry Burt,143
-Pawnee,Ash Valley Township,U.S. House,1,Independent,Alan LaPolice,16
-Pawnee,Browns Grove Township C1,U.S. House,1,Independent,Alan LaPolice,36
-Pawnee,Conkling Township,U.S. House,1,Independent,Alan LaPolice,3
-Pawnee,Grant Township C1,U.S. House,1,Independent,Alan LaPolice,33
-Pawnee,Larned Township,U.S. House,1,Independent,Alan LaPolice,39
-Pawnee,Larned Ward 1,U.S. House,1,Independent,Alan LaPolice,104
-Pawnee,Larned Ward 2,U.S. House,1,Independent,Alan LaPolice,123
-Pawnee,Larned Ward 3,U.S. House,1,Independent,Alan LaPolice,130
-Pawnee,Larned Ward 4,U.S. House,1,Independent,Alan LaPolice,79
-Pawnee,Lincoln Township,U.S. House,1,Independent,Alan LaPolice,4
-Pawnee,Logan Township,U.S. House,1,Independent,Alan LaPolice,11
-Pawnee,Morton Township,U.S. House,1,Independent,Alan LaPolice,4
-Pawnee,Orange Township,U.S. House,1,Independent,Alan LaPolice,7
-Pawnee,Pawnee Township,U.S. House,1,Independent,Alan LaPolice,10
-Pawnee,Pleasant Grove Township,U.S. House,1,Independent,Alan LaPolice,16
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. House,1,Independent,Alan LaPolice,0
-Pawnee,Pleasant Valley Township,U.S. House,1,Independent,Alan LaPolice,15
-Pawnee,River Township,U.S. House,1,Independent,Alan LaPolice,12
-Pawnee,Santa Fe Township,U.S. House,1,Independent,Alan LaPolice,16
-Pawnee,Shiley Township,U.S. House,1,Independent,Alan LaPolice,1
-Pawnee,Valley Center Township,U.S. House,1,Independent,Alan LaPolice,3
-Pawnee,Walnut Township,U.S. House,1,Independent,Alan LaPolice,7
-Pawnee,Total,U.S. House,1,Independent,Alan LaPolice,669
-Pawnee,Ash Valley Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Browns Grove Township C1,U.S. House,1,,Tim Huelskamp,2
-Pawnee,Conkling Township,U.S. House,1,,Tim Huelskamp,2
-Pawnee,Grant Township C1,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Larned Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Larned Ward 1,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Larned Ward 2,U.S. House,1,,Tim Huelskamp,4
-Pawnee,Larned Ward 3,U.S. House,1,,Tim Huelskamp,1
-Pawnee,Larned Ward 4,U.S. House,1,,Tim Huelskamp,2
-Pawnee,Lincoln Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Logan Township,U.S. House,1,,Tim Huelskamp,2
-Pawnee,Morton Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Orange Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Pawnee Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Pleasant Grove Township,U.S. House,1,,Tim Huelskamp,3
-Pawnee,Pleasant Grove Township Rural Enclave,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Pleasant Valley Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,River Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Santa Fe Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Shiley Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Valley Center Township,U.S. House,1,,Tim Huelskamp,1
-Pawnee,Walnut Township,U.S. House,1,,Tim Huelskamp,0
-Pawnee,Total,U.S. House,1,,Tim Huelskamp,17
-Pawnee,Browns Grove Township C4,U.S. House,4,Democratic,Daniel B. Giroux,0
-Pawnee,Garfield Township,U.S. House,4,Democratic,Daniel B. Giroux,13
-Pawnee,Grant Township C4,U.S. House,4,Democratic,Daniel B. Giroux,0
-Pawnee,Keysville Township,U.S. House,4,Democratic,Daniel B. Giroux,1
-Pawnee,Pleasant Ridge Township,U.S. House,4,Democratic,Daniel B. Giroux,3
-Pawnee,Sawmill Township,U.S. House,4,Democratic,Daniel B. Giroux,1
-Pawnee,Total,U.S. House,4,Democratic,Daniel B. Giroux,18
-Pawnee,Browns Grove Township C4,U.S. House,4,Republican,Michael Pompeo,2
-Pawnee,Garfield Township,U.S. House,4,Republican,Michael Pompeo,65
-Pawnee,Grant Township C4,U.S. House,4,Republican,Michael Pompeo,9
-Pawnee,Keysville Township,U.S. House,4,Republican,Michael Pompeo,15
-Pawnee,Pleasant Ridge Township,U.S. House,4,Republican,Michael Pompeo,17
-Pawnee,Sawmill Township,U.S. House,4,Republican,Michael Pompeo,9
-Pawnee,Total,U.S. House,4,Republican,Michael Pompeo,117
-Pawnee,Browns Grove Township C4,U.S. House,4,Libertarian,Gorden J. Bakken,0
-Pawnee,Garfield Township,U.S. House,4,Libertarian,Gorden J. Bakken,2
-Pawnee,Grant Township C4,U.S. House,4,Libertarian,Gorden J. Bakken,1
-Pawnee,Keysville Township,U.S. House,4,Libertarian,Gorden J. Bakken,0
-Pawnee,Pleasant Ridge Township,U.S. House,4,Libertarian,Gorden J. Bakken,0
-Pawnee,Sawmill Township,U.S. House,4,Libertarian,Gorden J. Bakken,0
-Pawnee,Total,U.S. House,4,Libertarian,Gorden J. Bakken,3
-Pawnee,Browns Grove Township C4,U.S. House,4,Independent,Miranda Allen,0
-Pawnee,Garfield Township,U.S. House,4,Independent,Miranda Allen,7
-Pawnee,Grant Township C4,U.S. House,4,Independent,Miranda Allen,1
-Pawnee,Keysville Township,U.S. House,4,Independent,Miranda Allen,0
-Pawnee,Pleasant Ridge Township,U.S. House,4,Independent,Miranda Allen,0
-Pawnee,Sawmill Township,U.S. House,4,Independent,Miranda Allen,2
-Pawnee,Total,U.S. House,4,Independent,Miranda Allen,10
-Pawnee,Ash Valley Township,State Senate,33,Democratic,"Bristow, Matt  ",11
-Pawnee,Ash Valley Township,State Senate,33,Republican,"Taylor, Mary Jo ",20
-Pawnee,Conkling Township,State Senate,33,Democratic,"Bristow, Matt  ",3
-Pawnee,Conkling Township,State Senate,33,Republican,"Taylor, Mary Jo ",12
-Pawnee,Garfield Township,State Senate,33,Democratic,"Bristow, Matt  ",24
-Pawnee,Garfield Township,State Senate,33,Republican,"Taylor, Mary Jo ",57
-Pawnee,Keysville Township,State Senate,33,Democratic,"Bristow, Matt  ",2
-Pawnee,Keysville Township,State Senate,33,Republican,"Taylor, Mary Jo ",13
-Pawnee,Larned Township,State Senate,33,Democratic,"Bristow, Matt  ",24
-Pawnee,Larned Township,State Senate,33,Republican,"Taylor, Mary Jo ",110
-Pawnee,Larned Ward 1,State Senate,33,Democratic,"Bristow, Matt  ",126
-Pawnee,Larned Ward 1,State Senate,33,Republican,"Taylor, Mary Jo ",243
-Pawnee,Larned Ward 2,State Senate,33,Democratic,"Bristow, Matt  ",147
-Pawnee,Larned Ward 2,State Senate,33,Republican,"Taylor, Mary Jo ",372
-Pawnee,Larned Ward 3,State Senate,33,Democratic,"Bristow, Matt  ",145
-Pawnee,Larned Ward 3,State Senate,33,Republican,"Taylor, Mary Jo ",333
-Pawnee,Larned Ward 4,State Senate,33,Democratic,"Bristow, Matt  ",96
-Pawnee,Larned Ward 4,State Senate,33,Republican,"Taylor, Mary Jo ",160
-Pawnee,Lincoln Township,State Senate,33,Democratic,"Bristow, Matt  ",1
-Pawnee,Lincoln Township,State Senate,33,Republican,"Taylor, Mary Jo ",10
-Pawnee,Logan Township,State Senate,33,Democratic,"Bristow, Matt  ",6
-Pawnee,Logan Township,State Senate,33,Republican,"Taylor, Mary Jo ",25
-Pawnee,Morton Township,State Senate,33,Democratic,"Bristow, Matt  ",6
-Pawnee,Morton Township,State Senate,33,Republican,"Taylor, Mary Jo ",20
-Pawnee,Orange Township,State Senate,33,Democratic,"Bristow, Matt  ",7
-Pawnee,Orange Township,State Senate,33,Republican,"Taylor, Mary Jo ",17
-Pawnee,Pawnee Township,State Senate,33,Democratic,"Bristow, Matt  ",12
-Pawnee,Pawnee Township,State Senate,33,Republican,"Taylor, Mary Jo ",35
-Pawnee,Pleasant Grove Township,State Senate,33,Democratic,"Bristow, Matt  ",20
-Pawnee,Pleasant Grove Township,State Senate,33,Republican,"Taylor, Mary Jo ",63
-Pawnee,Pleasant Grove Township Rural Enclave,State Senate,33,Democratic,"Bristow, Matt  ",0
-Pawnee,Pleasant Grove Township Rural Enclave,State Senate,33,Republican,"Taylor, Mary Jo ",0
-Pawnee,Pleasant Ridge Township,State Senate,33,Democratic,"Bristow, Matt  ",4
-Pawnee,Pleasant Ridge Township,State Senate,33,Republican,"Taylor, Mary Jo ",14
-Pawnee,Pleasant Valley Township,State Senate,33,Democratic,"Bristow, Matt  ",10
-Pawnee,Pleasant Valley Township,State Senate,33,Republican,"Taylor, Mary Jo ",32
-Pawnee,River Township,State Senate,33,Democratic,"Bristow, Matt  ",6
-Pawnee,River Township,State Senate,33,Republican,"Taylor, Mary Jo ",26
-Pawnee,Santa Fe Township,State Senate,33,Democratic,"Bristow, Matt  ",23
-Pawnee,Santa Fe Township,State Senate,33,Republican,"Taylor, Mary Jo ",38
-Pawnee,Sawmill Township,State Senate,33,Democratic,"Bristow, Matt  ",3
-Pawnee,Sawmill Township,State Senate,33,Republican,"Taylor, Mary Jo ",9
-Pawnee,Shiley Township,State Senate,33,Democratic,"Bristow, Matt  ",1
-Pawnee,Shiley Township,State Senate,33,Republican,"Taylor, Mary Jo ",13
-Pawnee,Valley Center Township,State Senate,33,Democratic,"Bristow, Matt  ",2
-Pawnee,Valley Center Township,State Senate,33,Republican,"Taylor, Mary Jo ",16
-Pawnee,Walnut Township,State Senate,33,Democratic,"Bristow, Matt  ",9
-Pawnee,Walnut Township,State Senate,33,Republican,"Taylor, Mary Jo ",31
-Pawnee,Browns Grove Township C1,State Senate,33,Democratic,"Bristow, Matt  ",23
-Pawnee,Browns Grove Township C1,State Senate,33,Republican,"Taylor, Mary Jo ",113
-Pawnee,Browns Grove Township C4,State Senate,33,Democratic,"Bristow, Matt  ",0
-Pawnee,Browns Grove Township C4,State Senate,33,Republican,"Taylor, Mary Jo ",2
-Pawnee,Grant Township C1,State Senate,33,Democratic,"Bristow, Matt  ",23
-Pawnee,Grant Township C1,State Senate,33,Republican,"Taylor, Mary Jo ",68
-Pawnee,Grant Township C4,State Senate,33,Democratic,"Bristow, Matt  ",0
-Pawnee,Grant Township C4,State Senate,33,Republican,"Taylor, Mary Jo ",11
-Pawnee,Ash Valley Township,State House,117,Republican,"Mastroni, Leonard A. ",24
-Pawnee,Conkling Township,State House,117,Republican,"Mastroni, Leonard A. ",15
-Pawnee,Garfield Township,State House,117,Republican,"Mastroni, Leonard A. ",80
-Pawnee,Keysville Township,State House,117,Republican,"Mastroni, Leonard A. ",15
-Pawnee,Larned Township,State House,117,Republican,"Mastroni, Leonard A. ",122
-Pawnee,Larned Ward 1,State House,117,Republican,"Mastroni, Leonard A. ",327
-Pawnee,Larned Ward 2,State House,117,Republican,"Mastroni, Leonard A. ",482
-Pawnee,Larned Ward 3,State House,117,Republican,"Mastroni, Leonard A. ",428
-Pawnee,Larned Ward 4,State House,117,Republican,"Mastroni, Leonard A. ",216
-Pawnee,Lincoln Township,State House,117,Republican,"Mastroni, Leonard A. ",10
-Pawnee,Logan Township,State House,113,Republican,"Lewis, Greg  ",30
-Pawnee,Morton Township,State House,117,Republican,"Mastroni, Leonard A. ",20
-Pawnee,Orange Township,State House,117,Republican,"Mastroni, Leonard A. ",22
-Pawnee,Pawnee Township,State House,117,Republican,"Mastroni, Leonard A. ",41
-Pawnee,Pleasant Grove Township,State House,117,Republican,"Mastroni, Leonard A. ",77
-Pawnee,Pleasant Grove Township Rural Enclave,State House,117,Republican,"Mastroni, Leonard A. ",0
-Pawnee,Pleasant Ridge Township,State House,117,Republican,"Mastroni, Leonard A. ",17
-Pawnee,Pleasant Valley Township,State House,117,Republican,"Mastroni, Leonard A. ",37
-Pawnee,River Township,State House,113,Republican,"Lewis, Greg  ",32
-Pawnee,Santa Fe Township,State House,117,Republican,"Mastroni, Leonard A. ",50
-Pawnee,Sawmill Township,State House,117,Republican,"Mastroni, Leonard A. ",12
-Pawnee,Shiley Township,State House,117,Republican,"Mastroni, Leonard A. ",13
-Pawnee,Valley Center Township,State House,113,Republican,"Lewis, Greg  ",18
-Pawnee,Walnut Township,State House,117,Republican,"Mastroni, Leonard A. ",37
-Pawnee,Browns Grove Township C1,State House,117,Republican,"Mastroni, Leonard A. ",131
-Pawnee,Browns Grove Township C4,State House,117,Republican,"Mastroni, Leonard A. ",2
-Pawnee,Grant Township C1,State House,117,Republican,"Mastroni, Leonard A. ",85
-Pawnee,Grant Township C4,State House,117,Republican,"Mastroni, Leonard A. ",11
+county,precinct,office,district,party,candidate,votes,vtd
+PAWNEE,Ash Valley Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",24,000010
+PAWNEE,Conkling Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",15,000030
+PAWNEE,Garfield Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",80,000040
+PAWNEE,Keysville Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",15,000060
+PAWNEE,Larned Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",122,000070
+PAWNEE,Larned Ward 1,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",327,000080
+PAWNEE,Larned Ward 2,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",482,000090
+PAWNEE,Larned Ward 3,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",428,000100
+PAWNEE,Larned Ward 4,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",216,000110
+PAWNEE,Lincoln Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",10,000120
+PAWNEE,Logan Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",30,000130
+PAWNEE,Morton Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",20,000140
+PAWNEE,Orange Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",22,000150
+PAWNEE,Pawnee Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",41,000160
+PAWNEE,Pleasant Grove Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",77,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",0,00017B
+PAWNEE,Pleasant Ridge Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",17,000180
+PAWNEE,Pleasant Valley Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",37,000190
+PAWNEE,River Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",32,000200
+PAWNEE,Santa Fe Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",50,000210
+PAWNEE,Sawmill Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",12,000220
+PAWNEE,Shiley Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",13,000230
+PAWNEE,Valley Center Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",18,000240
+PAWNEE,Walnut Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",37,000250
+PAWNEE,Browns Grove Township C1,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",131,120020
+PAWNEE,Browns Grove Township C4,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",2,120030
+PAWNEE,Grant Township C1,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",85,120040
+PAWNEE,Grant Township C4,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",11,120050
+PAWNEE,Ash Valley Township,Kansas Senate,33,Democratic,"Bristow, Matt",11,000010
+PAWNEE,Ash Valley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",20,000010
+PAWNEE,Conkling Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000030
+PAWNEE,Conkling Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",12,000030
+PAWNEE,Garfield Township,Kansas Senate,33,Democratic,"Bristow, Matt",24,000040
+PAWNEE,Garfield Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",57,000040
+PAWNEE,Keysville Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000060
+PAWNEE,Keysville Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",13,000060
+PAWNEE,Larned Township,Kansas Senate,33,Democratic,"Bristow, Matt",24,000070
+PAWNEE,Larned Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",110,000070
+PAWNEE,Larned Ward 1,Kansas Senate,33,Democratic,"Bristow, Matt",126,000080
+PAWNEE,Larned Ward 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",243,000080
+PAWNEE,Larned Ward 2,Kansas Senate,33,Democratic,"Bristow, Matt",147,000090
+PAWNEE,Larned Ward 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",372,000090
+PAWNEE,Larned Ward 3,Kansas Senate,33,Democratic,"Bristow, Matt",145,000100
+PAWNEE,Larned Ward 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",333,000100
+PAWNEE,Larned Ward 4,Kansas Senate,33,Democratic,"Bristow, Matt",96,000110
+PAWNEE,Larned Ward 4,Kansas Senate,33,Republican,"Taylor, Mary Jo",160,000110
+PAWNEE,Lincoln Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000120
+PAWNEE,Lincoln Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",10,000120
+PAWNEE,Logan Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000130
+PAWNEE,Logan Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",25,000130
+PAWNEE,Morton Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000140
+PAWNEE,Morton Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",20,000140
+PAWNEE,Orange Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000150
+PAWNEE,Orange Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",17,000150
+PAWNEE,Pawnee Township,Kansas Senate,33,Democratic,"Bristow, Matt",12,000160
+PAWNEE,Pawnee Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",35,000160
+PAWNEE,Pleasant Grove Township,Kansas Senate,33,Democratic,"Bristow, Matt",20,00017A
+PAWNEE,Pleasant Grove Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",63,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas Senate,33,Democratic,"Bristow, Matt",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00017B
+PAWNEE,Pleasant Ridge Township,Kansas Senate,33,Democratic,"Bristow, Matt",4,000180
+PAWNEE,Pleasant Ridge Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",14,000180
+PAWNEE,Pleasant Valley Township,Kansas Senate,33,Democratic,"Bristow, Matt",10,000190
+PAWNEE,Pleasant Valley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",32,000190
+PAWNEE,River Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000200
+PAWNEE,River Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",26,000200
+PAWNEE,Santa Fe Township,Kansas Senate,33,Democratic,"Bristow, Matt",23,000210
+PAWNEE,Santa Fe Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",38,000210
+PAWNEE,Sawmill Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000220
+PAWNEE,Sawmill Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",9,000220
+PAWNEE,Shiley Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000230
+PAWNEE,Shiley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",13,000230
+PAWNEE,Valley Center Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000240
+PAWNEE,Valley Center Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",16,000240
+PAWNEE,Walnut Township,Kansas Senate,33,Democratic,"Bristow, Matt",9,000250
+PAWNEE,Walnut Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",31,000250
+PAWNEE,Browns Grove Township C1,Kansas Senate,33,Democratic,"Bristow, Matt",23,120020
+PAWNEE,Browns Grove Township C1,Kansas Senate,33,Republican,"Taylor, Mary Jo",113,120020
+PAWNEE,Browns Grove Township C4,Kansas Senate,33,Democratic,"Bristow, Matt",0,120030
+PAWNEE,Browns Grove Township C4,Kansas Senate,33,Republican,"Taylor, Mary Jo",2,120030
+PAWNEE,Grant Township C1,Kansas Senate,33,Democratic,"Bristow, Matt",23,120040
+PAWNEE,Grant Township C1,Kansas Senate,33,Republican,"Taylor, Mary Jo",68,120040
+PAWNEE,Grant Township C4,Kansas Senate,33,Democratic,"Bristow, Matt",0,120050
+PAWNEE,Grant Township C4,Kansas Senate,33,Republican,"Taylor, Mary Jo",11,120050
+PAWNEE,Ash Valley Township,President / Vice President,,independent,"Stein, Jill",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+PAWNEE,Ash Valley Township,President / Vice President,,Republican,"Trump, Donald J.",17,000010
+PAWNEE,Conkling Township,President / Vice President,,independent,"Stein, Jill",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+PAWNEE,Conkling Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+PAWNEE,Conkling Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+PAWNEE,Conkling Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+PAWNEE,Conkling Township,President / Vice President,,Republican,"Trump, Donald J.",13,000030
+PAWNEE,Garfield Township,President / Vice President,,independent,"Stein, Jill",1,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+PAWNEE,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+PAWNEE,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000040
+PAWNEE,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+PAWNEE,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",65,000040
+PAWNEE,Keysville Township,President / Vice President,,independent,"Stein, Jill",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+PAWNEE,Keysville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+PAWNEE,Keysville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000060
+PAWNEE,Keysville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+PAWNEE,Keysville Township,President / Vice President,,Republican,"Trump, Donald J.",13,000060
+PAWNEE,Larned Township,President / Vice President,,independent,"Stein, Jill",3,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+PAWNEE,Larned Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+PAWNEE,Larned Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000070
+PAWNEE,Larned Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+PAWNEE,Larned Township,President / Vice President,,Republican,"Trump, Donald J.",107,000070
+PAWNEE,Larned Ward 1,President / Vice President,,independent,"Stein, Jill",8,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"McMullin, Evan",7,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",25,000080
+PAWNEE,Larned Ward 1,President / Vice President,,Republican,"Trump, Donald J.",256,000080
+PAWNEE,Larned Ward 2,President / Vice President,,independent,"Stein, Jill",6,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Hedges, James A",1,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",139,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",25,000090
+PAWNEE,Larned Ward 2,President / Vice President,,Republican,"Trump, Donald J.",345,000090
+PAWNEE,Larned Ward 3,President / Vice President,,independent,"Stein, Jill",7,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",124,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",30,000100
+PAWNEE,Larned Ward 3,President / Vice President,,Republican,"Trump, Donald J.",331,000100
+PAWNEE,Larned Ward 4,President / Vice President,,independent,"Stein, Jill",4,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",18,000110
+PAWNEE,Larned Ward 4,President / Vice President,,Republican,"Trump, Donald J.",157,000110
+PAWNEE,Lincoln Township,President / Vice President,,independent,"Stein, Jill",1,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+PAWNEE,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",11,000120
+PAWNEE,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",2,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+PAWNEE,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+PAWNEE,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000130
+PAWNEE,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+PAWNEE,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",30,000130
+PAWNEE,Morton Township,President / Vice President,,independent,"Stein, Jill",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+PAWNEE,Morton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+PAWNEE,Morton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000140
+PAWNEE,Morton Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+PAWNEE,Morton Township,President / Vice President,,Republican,"Trump, Donald J.",18,000140
+PAWNEE,Orange Township,President / Vice President,,independent,"Stein, Jill",1,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+PAWNEE,Orange Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+PAWNEE,Orange Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000150
+PAWNEE,Orange Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+PAWNEE,Orange Township,President / Vice President,,Republican,"Trump, Donald J.",18,000150
+PAWNEE,Pawnee Township,President / Vice President,,independent,"Stein, Jill",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+PAWNEE,Pawnee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000160
+PAWNEE,Pawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+PAWNEE,Pawnee Township,President / Vice President,,Republican,"Trump, Donald J.",37,000160
+PAWNEE,Pleasant Grove Township,President / Vice President,,independent,"Stein, Jill",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Hedges, James A",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"McMullin, Evan",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Smith, Mike",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00017A
+PAWNEE,Pleasant Grove Township,President / Vice President,,Republican,"Trump, Donald J.",73,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,independent,"Stein, Jill",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Hedges, James A",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Smith, Mike",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00017B
+PAWNEE,Pleasant Ridge Township,President / Vice President,,independent,"Stein, Jill",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+PAWNEE,Pleasant Ridge Township,President / Vice President,,Republican,"Trump, Donald J.",17,000180
+PAWNEE,Pleasant Valley Township,President / Vice President,,independent,"Stein, Jill",1,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+PAWNEE,Pleasant Valley Township,President / Vice President,,Republican,"Trump, Donald J.",37,000190
+PAWNEE,River Township,President / Vice President,,independent,"Stein, Jill",1,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+PAWNEE,River Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+PAWNEE,River Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000200
+PAWNEE,River Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+PAWNEE,River Township,President / Vice President,,Republican,"Trump, Donald J.",30,000200
+PAWNEE,Santa Fe Township,President / Vice President,,independent,"Stein, Jill",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+PAWNEE,Santa Fe Township,President / Vice President,,Republican,"Trump, Donald J.",35,000210
+PAWNEE,Sawmill Township,President / Vice President,,independent,"Stein, Jill",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+PAWNEE,Sawmill Township,President / Vice President,,Republican,"Trump, Donald J.",12,000220
+PAWNEE,Shiley Township,President / Vice President,,independent,"Stein, Jill",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+PAWNEE,Shiley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+PAWNEE,Shiley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000230
+PAWNEE,Shiley Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+PAWNEE,Shiley Township,President / Vice President,,Republican,"Trump, Donald J.",13,000230
+PAWNEE,Valley Center Township,President / Vice President,,independent,"Stein, Jill",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+PAWNEE,Valley Center Township,President / Vice President,,Republican,"Trump, Donald J.",18,000240
+PAWNEE,Walnut Township,President / Vice President,,independent,"Stein, Jill",1,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+PAWNEE,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+PAWNEE,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000250
+PAWNEE,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+PAWNEE,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",31,000250
+PAWNEE,Browns Grove Township C1,President / Vice President,,independent,"Stein, Jill",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Hedges, James A",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"McMullin, Evan",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Perry, Darryl",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Smith, Mike",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Sood, Ajay",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Libertarian,"Johnson, Gary",1,120020
+PAWNEE,Browns Grove Township C1,President / Vice President,,Republican,"Trump, Donald J.",125,120020
+PAWNEE,Browns Grove Township C4,President / Vice President,,independent,"Stein, Jill",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Hedges, James A",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"McMullin, Evan",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Perry, Darryl",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Smith, Mike",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Sood, Ajay",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+PAWNEE,Browns Grove Township C4,President / Vice President,,Republican,"Trump, Donald J.",2,120030
+PAWNEE,Grant Township C1,President / Vice President,,independent,"Stein, Jill",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Hedges, James A",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"McMullin, Evan",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Perry, Darryl",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Smith, Mike",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Sood, Ajay",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+PAWNEE,Grant Township C1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,120040
+PAWNEE,Grant Township C1,President / Vice President,,Libertarian,"Johnson, Gary",3,120040
+PAWNEE,Grant Township C1,President / Vice President,,Republican,"Trump, Donald J.",84,120040
+PAWNEE,Grant Township C4,President / Vice President,,independent,"Stein, Jill",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Hedges, James A",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"McMullin, Evan",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Perry, Darryl",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Smith, Mike",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Sood, Ajay",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+PAWNEE,Grant Township C4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,120050
+PAWNEE,Grant Township C4,President / Vice President,,Libertarian,"Johnson, Gary",1,120050
+PAWNEE,Grant Township C4,President / Vice President,,Republican,"Trump, Donald J.",9,120050
+PAWNEE,Ash Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000010
+PAWNEE,Ash Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+PAWNEE,Ash Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+PAWNEE,Ash Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",14,000010
+PAWNEE,Conkling Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000030
+PAWNEE,Conkling Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000030
+PAWNEE,Conkling Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+PAWNEE,Conkling Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000030
+PAWNEE,Garfield Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000040
+PAWNEE,Garfield Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000040
+PAWNEE,Garfield Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000040
+PAWNEE,Garfield Township,United States House of Representatives,4,Republican,"Pompeo, Michael",65,000040
+PAWNEE,Keysville Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000060
+PAWNEE,Keysville Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000060
+PAWNEE,Keysville Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000060
+PAWNEE,Keysville Township,United States House of Representatives,4,Republican,"Pompeo, Michael",15,000060
+PAWNEE,Larned Township,United States House of Representatives,1,independent,"LaPolice, Alan",39,000070
+PAWNEE,Larned Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+PAWNEE,Larned Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000070
+PAWNEE,Larned Township,United States House of Representatives,1,Republican,"Marshall, Roger",87,000070
+PAWNEE,Larned Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",104,000080
+PAWNEE,Larned Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+PAWNEE,Larned Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000080
+PAWNEE,Larned Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",237,000080
+PAWNEE,Larned Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",123,000090
+PAWNEE,Larned Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000090
+PAWNEE,Larned Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000090
+PAWNEE,Larned Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",366,000090
+PAWNEE,Larned Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",130,000100
+PAWNEE,Larned Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+PAWNEE,Larned Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000100
+PAWNEE,Larned Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",337,000100
+PAWNEE,Larned Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",79,000110
+PAWNEE,Larned Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000110
+PAWNEE,Larned Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,000110
+PAWNEE,Larned Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",144,000110
+PAWNEE,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000120
+PAWNEE,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+PAWNEE,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000120
+PAWNEE,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",7,000120
+PAWNEE,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000130
+PAWNEE,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000130
+PAWNEE,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+PAWNEE,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000130
+PAWNEE,Morton Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000140
+PAWNEE,Morton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+PAWNEE,Morton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+PAWNEE,Morton Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000140
+PAWNEE,Orange Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000150
+PAWNEE,Orange Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+PAWNEE,Orange Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000150
+PAWNEE,Orange Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000150
+PAWNEE,Pawnee Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000160
+PAWNEE,Pawnee Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+PAWNEE,Pawnee Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000160
+PAWNEE,Pawnee Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000160
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,00017A
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,00017A
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,00017A
+PAWNEE,Pleasant Grove Township,United States House of Representatives,1,Republican,"Marshall, Roger",62,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00017B
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000180
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000180
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000180
+PAWNEE,Pleasant Ridge Township,United States House of Representatives,4,Republican,"Pompeo, Michael",17,000180
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000190
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000190
+PAWNEE,Pleasant Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000190
+PAWNEE,River Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000200
+PAWNEE,River Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+PAWNEE,River Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000200
+PAWNEE,River Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000200
+PAWNEE,Santa Fe Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000210
+PAWNEE,Santa Fe Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+PAWNEE,Santa Fe Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000210
+PAWNEE,Santa Fe Township,United States House of Representatives,1,Republican,"Marshall, Roger",44,000210
+PAWNEE,Sawmill Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000220
+PAWNEE,Sawmill Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000220
+PAWNEE,Sawmill Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000220
+PAWNEE,Sawmill Township,United States House of Representatives,4,Republican,"Pompeo, Michael",9,000220
+PAWNEE,Shiley Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000230
+PAWNEE,Shiley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+PAWNEE,Shiley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000230
+PAWNEE,Shiley Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000230
+PAWNEE,Valley Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000240
+PAWNEE,Valley Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000240
+PAWNEE,Valley Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000240
+PAWNEE,Valley Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000240
+PAWNEE,Walnut Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000250
+PAWNEE,Walnut Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+PAWNEE,Walnut Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000250
+PAWNEE,Walnut Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000250
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,independent,"LaPolice, Alan",36,120020
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,120020
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,120020
+PAWNEE,Browns Grove Township C1,United States House of Representatives,1,Republican,"Marshall, Roger",101,120020
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,independent,"Allen, Miranda",0,120030
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,120030
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,120030
+PAWNEE,Browns Grove Township C4,United States House of Representatives,4,Republican,"Pompeo, Michael",2,120030
+PAWNEE,Grant Township C1,United States House of Representatives,1,independent,"LaPolice, Alan",33,120040
+PAWNEE,Grant Township C1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+PAWNEE,Grant Township C1,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,120040
+PAWNEE,Grant Township C1,United States House of Representatives,1,Republican,"Marshall, Roger",51,120040
+PAWNEE,Grant Township C4,United States House of Representatives,4,independent,"Allen, Miranda",1,120050
+PAWNEE,Grant Township C4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,120050
+PAWNEE,Grant Township C4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,120050
+PAWNEE,Grant Township C4,United States House of Representatives,4,Republican,"Pompeo, Michael",9,120050
+PAWNEE,Ash Valley Township,United States Senate,,write - in,"Smith, DJ",0,000010
+PAWNEE,Ash Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000010
+PAWNEE,Ash Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+PAWNEE,Ash Valley Township,United States Senate,,Republican,"Moran, Jerry",20,000010
+PAWNEE,Conkling Township,United States Senate,,write - in,"Smith, DJ",0,000030
+PAWNEE,Conkling Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000030
+PAWNEE,Conkling Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+PAWNEE,Conkling Township,United States Senate,,Republican,"Moran, Jerry",14,000030
+PAWNEE,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000040
+PAWNEE,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000040
+PAWNEE,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+PAWNEE,Garfield Township,United States Senate,,Republican,"Moran, Jerry",70,000040
+PAWNEE,Keysville Township,United States Senate,,write - in,"Smith, DJ",0,000060
+PAWNEE,Keysville Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000060
+PAWNEE,Keysville Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+PAWNEE,Keysville Township,United States Senate,,Republican,"Moran, Jerry",16,000060
+PAWNEE,Larned Township,United States Senate,,write - in,"Smith, DJ",0,000070
+PAWNEE,Larned Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000070
+PAWNEE,Larned Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000070
+PAWNEE,Larned Township,United States Senate,,Republican,"Moran, Jerry",114,000070
+PAWNEE,Larned Ward 1,United States Senate,,write - in,"Smith, DJ",0,000080
+PAWNEE,Larned Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",68,000080
+PAWNEE,Larned Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",30,000080
+PAWNEE,Larned Ward 1,United States Senate,,Republican,"Moran, Jerry",279,000080
+PAWNEE,Larned Ward 2,United States Senate,,write - in,"Smith, DJ",0,000090
+PAWNEE,Larned Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",89,000090
+PAWNEE,Larned Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",23,000090
+PAWNEE,Larned Ward 2,United States Senate,,Republican,"Moran, Jerry",413,000090
+PAWNEE,Larned Ward 3,United States Senate,,write - in,"Smith, DJ",0,000100
+PAWNEE,Larned Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",99,000100
+PAWNEE,Larned Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",21,000100
+PAWNEE,Larned Ward 3,United States Senate,,Republican,"Moran, Jerry",381,000100
+PAWNEE,Larned Ward 4,United States Senate,,write - in,"Smith, DJ",0,000110
+PAWNEE,Larned Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",56,000110
+PAWNEE,Larned Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",24,000110
+PAWNEE,Larned Ward 4,United States Senate,,Republican,"Moran, Jerry",175,000110
+PAWNEE,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000120
+PAWNEE,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000120
+PAWNEE,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+PAWNEE,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",12,000120
+PAWNEE,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000130
+PAWNEE,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000130
+PAWNEE,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000130
+PAWNEE,Logan Township,United States Senate,,Republican,"Moran, Jerry",29,000130
+PAWNEE,Morton Township,United States Senate,,write - in,"Smith, DJ",0,000140
+PAWNEE,Morton Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000140
+PAWNEE,Morton Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+PAWNEE,Morton Township,United States Senate,,Republican,"Moran, Jerry",24,000140
+PAWNEE,Orange Township,United States Senate,,write - in,"Smith, DJ",0,000150
+PAWNEE,Orange Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000150
+PAWNEE,Orange Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000150
+PAWNEE,Orange Township,United States Senate,,Republican,"Moran, Jerry",22,000150
+PAWNEE,Pawnee Township,United States Senate,,write - in,"Smith, DJ",0,000160
+PAWNEE,Pawnee Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000160
+PAWNEE,Pawnee Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000160
+PAWNEE,Pawnee Township,United States Senate,,Republican,"Moran, Jerry",39,000160
+PAWNEE,Pleasant Grove Township,United States Senate,,write - in,"Smith, DJ",0,00017A
+PAWNEE,Pleasant Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",8,00017A
+PAWNEE,Pleasant Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,00017A
+PAWNEE,Pleasant Grove Township,United States Senate,,Republican,"Moran, Jerry",73,00017A
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,write - in,"Smith, DJ",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00017B
+PAWNEE,Pleasant Grove Township Rural Enclave,United States Senate,,Republican,"Moran, Jerry",0,00017B
+PAWNEE,Pleasant Ridge Township,United States Senate,,write - in,"Smith, DJ",0,000180
+PAWNEE,Pleasant Ridge Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+PAWNEE,Pleasant Ridge Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+PAWNEE,Pleasant Ridge Township,United States Senate,,Republican,"Moran, Jerry",20,000180
+PAWNEE,Pleasant Valley Township,United States Senate,,write - in,"Smith, DJ",0,000190
+PAWNEE,Pleasant Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000190
+PAWNEE,Pleasant Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000190
+PAWNEE,Pleasant Valley Township,United States Senate,,Republican,"Moran, Jerry",36,000190
+PAWNEE,River Township,United States Senate,,write - in,"Smith, DJ",0,000200
+PAWNEE,River Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000200
+PAWNEE,River Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000200
+PAWNEE,River Township,United States Senate,,Republican,"Moran, Jerry",29,000200
+PAWNEE,Santa Fe Township,United States Senate,,write - in,"Smith, DJ",0,000210
+PAWNEE,Santa Fe Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000210
+PAWNEE,Santa Fe Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000210
+PAWNEE,Santa Fe Township,United States Senate,,Republican,"Moran, Jerry",40,000210
+PAWNEE,Sawmill Township,United States Senate,,write - in,"Smith, DJ",0,000220
+PAWNEE,Sawmill Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000220
+PAWNEE,Sawmill Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000220
+PAWNEE,Sawmill Township,United States Senate,,Republican,"Moran, Jerry",10,000220
+PAWNEE,Shiley Township,United States Senate,,write - in,"Smith, DJ",0,000230
+PAWNEE,Shiley Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000230
+PAWNEE,Shiley Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000230
+PAWNEE,Shiley Township,United States Senate,,Republican,"Moran, Jerry",13,000230
+PAWNEE,Valley Center Township,United States Senate,,write - in,"Smith, DJ",0,000240
+PAWNEE,Valley Center Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000240
+PAWNEE,Valley Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000240
+PAWNEE,Valley Center Township,United States Senate,,Republican,"Moran, Jerry",16,000240
+PAWNEE,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000250
+PAWNEE,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000250
+PAWNEE,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000250
+PAWNEE,Walnut Township,United States Senate,,Republican,"Moran, Jerry",35,000250
+PAWNEE,Browns Grove Township C1,United States Senate,,write - in,"Smith, DJ",0,120020
+PAWNEE,Browns Grove Township C1,United States Senate,,Democratic,"Wiesner, Patrick",12,120020
+PAWNEE,Browns Grove Township C1,United States Senate,,Libertarian,"Garrard, Robert D.",0,120020
+PAWNEE,Browns Grove Township C1,United States Senate,,Republican,"Moran, Jerry",134,120020
+PAWNEE,Browns Grove Township C4,United States Senate,,write - in,"Smith, DJ",0,120030
+PAWNEE,Browns Grove Township C4,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+PAWNEE,Browns Grove Township C4,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+PAWNEE,Browns Grove Township C4,United States Senate,,Republican,"Moran, Jerry",2,120030
+PAWNEE,Grant Township C1,United States Senate,,write - in,"Smith, DJ",0,120040
+PAWNEE,Grant Township C1,United States Senate,,Democratic,"Wiesner, Patrick",9,120040
+PAWNEE,Grant Township C1,United States Senate,,Libertarian,"Garrard, Robert D.",3,120040
+PAWNEE,Grant Township C1,United States Senate,,Republican,"Moran, Jerry",82,120040
+PAWNEE,Grant Township C4,United States Senate,,write - in,"Smith, DJ",0,120050
+PAWNEE,Grant Township C4,United States Senate,,Democratic,"Wiesner, Patrick",0,120050
+PAWNEE,Grant Township C4,United States Senate,,Libertarian,"Garrard, Robert D.",1,120050
+PAWNEE,Grant Township C4,United States Senate,,Republican,"Moran, Jerry",10,120050

--- a/2016/20161108__ks__general__phillips__precinct.csv
+++ b/2016/20161108__ks__general__phillips__precinct.csv
@@ -1,843 +1,1045 @@
-county,precinct,office,district,candidate,party,votes
-Phillips,Arcade Township,President,,"Stein, Jill  ",independent,0
-Phillips,Arcade Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Arcade Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Arcade Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Arcade Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Arcade Township,President,,"Hedges, James A ",write - in,0
-Phillips,Arcade Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Arcade Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Arcade Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Arcade Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Arcade Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Arcade Township,President,,"McMullin, Evan  ",write - in,2
-Phillips,Arcade Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Arcade Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Arcade Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Arcade Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Arcade Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Arcade Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Arcade Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Arcade Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Arcade Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Arcade Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Arcade Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-Phillips,Arcade Township,President,,"Johnson, Gary  ",Libertarian,3
-Phillips,Arcade Township,President,,"Trump, Donald J. ",Republican,42
-Phillips,Beaver Township,President,,"Stein, Jill  ",independent,0
-Phillips,Beaver Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Beaver Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Beaver Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Beaver Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Beaver Township,President,,"Hedges, James A ",write - in,0
-Phillips,Beaver Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Beaver Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Beaver Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Beaver Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Beaver Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Beaver Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Beaver Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Beaver Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Beaver Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Beaver Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Beaver Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Beaver Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Beaver Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Beaver Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Beaver Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Beaver Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Beaver Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Phillips,Beaver Township,President,,"Johnson, Gary  ",Libertarian,1
-Phillips,Beaver Township,President,,"Trump, Donald J. ",Republican,24
-Phillips,Belmont Township,President,,"Stein, Jill  ",independent,0
-Phillips,Belmont Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Belmont Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Belmont Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Belmont Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Belmont Township,President,,"Hedges, James A ",write - in,0
-Phillips,Belmont Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Belmont Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Belmont Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Belmont Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Belmont Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Belmont Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Belmont Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Belmont Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Belmont Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Belmont Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Belmont Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Belmont Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Belmont Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Belmont Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Belmont Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Belmont Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Belmont Township,President,,"Clinton, Hillary Rodham ",Democratic,7
-Phillips,Belmont Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Belmont Township,President,,"Trump, Donald J. ",Republican,44
-Phillips,Bow Creek Township,President,,"Stein, Jill  ",independent,0
-Phillips,Bow Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Bow Creek Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Bow Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Bow Creek Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Bow Creek Township,President,,"Hedges, James A ",write - in,0
-Phillips,Bow Creek Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Bow Creek Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Bow Creek Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Bow Creek Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Bow Creek Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Bow Creek Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Bow Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Bow Creek Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Bow Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Bow Creek Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Bow Creek Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Bow Creek Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Bow Creek Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Bow Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Bow Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Bow Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Bow Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Phillips,Bow Creek Township,President,,"Johnson, Gary  ",Libertarian,1
-Phillips,Bow Creek Township,President,,"Trump, Donald J. ",Republican,18
-Phillips,Crystal Township,President,,"Stein, Jill  ",independent,0
-Phillips,Crystal Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Crystal Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Crystal Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Crystal Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Crystal Township,President,,"Hedges, James A ",write - in,0
-Phillips,Crystal Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Crystal Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Crystal Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Crystal Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Crystal Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Crystal Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Crystal Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Crystal Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Crystal Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Crystal Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Crystal Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Crystal Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Crystal Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Crystal Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Crystal Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Crystal Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Crystal Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Phillips,Crystal Township,President,,"Johnson, Gary  ",Libertarian,2
-Phillips,Crystal Township,President,,"Trump, Donald J. ",Republican,27
-Phillips,Dayton Township,President,,"Stein, Jill  ",independent,0
-Phillips,Dayton Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Dayton Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Dayton Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Dayton Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Dayton Township,President,,"Hedges, James A ",write - in,0
-Phillips,Dayton Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Dayton Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Dayton Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Dayton Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Dayton Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Dayton Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Dayton Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Dayton Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Dayton Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Dayton Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Dayton Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Dayton Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Dayton Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Dayton Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Dayton Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Dayton Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Dayton Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-Phillips,Dayton Township,President,,"Johnson, Gary  ",Libertarian,1
-Phillips,Dayton Township,President,,"Trump, Donald J. ",Republican,19
-Phillips,Deer Creek Township,President,,"Stein, Jill  ",independent,1
-Phillips,Deer Creek Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Deer Creek Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Deer Creek Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Deer Creek Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Deer Creek Township,President,,"Hedges, James A ",write - in,0
-Phillips,Deer Creek Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Deer Creek Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Deer Creek Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Deer Creek Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Deer Creek Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Deer Creek Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Deer Creek Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Deer Creek Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Deer Creek Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Deer Creek Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Deer Creek Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Deer Creek Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Deer Creek Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Deer Creek Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Deer Creek Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Deer Creek Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Deer Creek Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-Phillips,Deer Creek Township,President,,"Johnson, Gary  ",Libertarian,1
-Phillips,Deer Creek Township,President,,"Trump, Donald J. ",Republican,42
-Phillips,Freedom Township,President,,"Stein, Jill  ",independent,0
-Phillips,Freedom Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Freedom Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Freedom Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Freedom Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Freedom Township,President,,"Hedges, James A ",write - in,0
-Phillips,Freedom Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Freedom Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Freedom Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Freedom Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Freedom Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Freedom Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Freedom Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Freedom Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Freedom Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Freedom Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Freedom Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Freedom Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Freedom Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Freedom Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Freedom Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Freedom Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Freedom Township,President,,"Clinton, Hillary Rodham ",Democratic,2
-Phillips,Freedom Township,President,,"Johnson, Gary  ",Libertarian,1
-Phillips,Freedom Township,President,,"Trump, Donald J. ",Republican,52
-Phillips,Glenwood Township,President,,"Stein, Jill  ",independent,0
-Phillips,Glenwood Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Glenwood Township,President,,"Castle, Darrell L ",write - in,2
-Phillips,Glenwood Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Glenwood Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Glenwood Township,President,,"Hedges, James A ",write - in,0
-Phillips,Glenwood Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Glenwood Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Glenwood Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Glenwood Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Glenwood Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Glenwood Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Glenwood Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Glenwood Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Glenwood Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Glenwood Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Glenwood Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Glenwood Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Glenwood Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Glenwood Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Glenwood Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Glenwood Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Glenwood Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Phillips,Glenwood Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Glenwood Township,President,,"Trump, Donald J. ",Republican,15
-Phillips,Granite Township,President,,"Stein, Jill  ",independent,1
-Phillips,Granite Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Granite Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Granite Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Granite Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Granite Township,President,,"Hedges, James A ",write - in,0
-Phillips,Granite Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Granite Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Granite Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Granite Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Granite Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Granite Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Granite Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Granite Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Granite Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Granite Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Granite Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Granite Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Granite Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Granite Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Granite Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Granite Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Granite Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Phillips,Granite Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Granite Township,President,,"Trump, Donald J. ",Republican,16
-Phillips,Greenwood Township,President,,"Stein, Jill  ",independent,0
-Phillips,Greenwood Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Greenwood Township,President,,"Castle, Darrell L ",write - in,1
-Phillips,Greenwood Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Greenwood Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Greenwood Township,President,,"Hedges, James A ",write - in,0
-Phillips,Greenwood Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Greenwood Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Greenwood Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Greenwood Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Greenwood Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Greenwood Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Greenwood Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Greenwood Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Greenwood Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Greenwood Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Greenwood Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Greenwood Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Greenwood Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Greenwood Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Greenwood Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Greenwood Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Greenwood Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Phillips,Greenwood Township,President,,"Johnson, Gary  ",Libertarian,1
-Phillips,Greenwood Township,President,,"Trump, Donald J. ",Republican,22
-Phillips,Kirwin Township,President,,"Stein, Jill  ",independent,1
-Phillips,Kirwin Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Kirwin Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Kirwin Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Kirwin Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Kirwin Township,President,,"Hedges, James A ",write - in,0
-Phillips,Kirwin Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Kirwin Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Kirwin Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Kirwin Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Kirwin Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Kirwin Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Kirwin Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Kirwin Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Kirwin Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Kirwin Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Kirwin Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Kirwin Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Kirwin Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Kirwin Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Kirwin Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Kirwin Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Kirwin Township,President,,"Clinton, Hillary Rodham ",Democratic,9
-Phillips,Kirwin Township,President,,"Johnson, Gary  ",Libertarian,5
-Phillips,Kirwin Township,President,,"Trump, Donald J. ",Republican,91
-Phillips,Logan Township,President,,"Stein, Jill  ",independent,2
-Phillips,Logan Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Logan Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Logan Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Logan Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Logan Township,President,,"Hedges, James A ",write - in,0
-Phillips,Logan Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Logan Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Logan Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Logan Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Logan Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Logan Township,President,,"McMullin, Evan  ",write - in,2
-Phillips,Logan Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Logan Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Logan Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Logan Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Logan Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Logan Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Logan Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Logan Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Logan Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Logan Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Logan Township,President,,"Clinton, Hillary Rodham ",Democratic,38
-Phillips,Logan Township,President,,"Johnson, Gary  ",Libertarian,10
-Phillips,Logan Township,President,,"Trump, Donald J. ",Republican,227
-Phillips,Long Island Township,President,,"Stein, Jill  ",independent,1
-Phillips,Long Island Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Long Island Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Long Island Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Long Island Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Long Island Township,President,,"Hedges, James A ",write - in,0
-Phillips,Long Island Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Long Island Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Long Island Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Long Island Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Long Island Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Long Island Township,President,,"McMullin, Evan  ",write - in,2
-Phillips,Long Island Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Long Island Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Long Island Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Long Island Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Long Island Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Long Island Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Long Island Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Long Island Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Long Island Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Long Island Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Long Island Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Phillips,Long Island Township,President,,"Johnson, Gary  ",Libertarian,4
-Phillips,Long Island Township,President,,"Trump, Donald J. ",Republican,96
-Phillips,Mound Township,President,,"Stein, Jill  ",independent,0
-Phillips,Mound Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Mound Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Mound Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Mound Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Mound Township,President,,"Hedges, James A ",write - in,0
-Phillips,Mound Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Mound Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Mound Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Mound Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Mound Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Mound Township,President,,"McMullin, Evan  ",write - in,1
-Phillips,Mound Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Mound Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Mound Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Mound Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Mound Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Mound Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Mound Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Mound Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Mound Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Mound Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Mound Township,President,,"Clinton, Hillary Rodham ",Democratic,11
-Phillips,Mound Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Mound Township,President,,"Trump, Donald J. ",Republican,52
-Phillips,Phillipsburg City Ward 1,President,,"Stein, Jill  ",independent,12
-Phillips,Phillipsburg City Ward 1,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Castle, Darrell L ",write - in,1
-Phillips,Phillipsburg City Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Hedges, James A ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Maturen, Michael A ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"McMullin, Evan  ",write - in,1
-Phillips,Phillipsburg City Ward 1,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Perry, Darryl  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Schriner, Joe C ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Smith, Mike  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Sood, Ajay  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Phillipsburg City Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,63
-Phillips,Phillipsburg City Ward 1,President,,"Johnson, Gary  ",Libertarian,8
-Phillips,Phillipsburg City Ward 1,President,,"Trump, Donald J. ",Republican,375
-Phillips,Phillipsburg City Ward 2,President,,"Stein, Jill  ",independent,3
-Phillips,Phillipsburg City Ward 2,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Castle, Darrell L ",write - in,1
-Phillips,Phillipsburg City Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Hedges, James A ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Maturen, Michael A ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"McMullin, Evan  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Perry, Darryl  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Schriner, Joe C ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Smith, Mike  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Sood, Ajay  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Phillipsburg City Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,43
-Phillips,Phillipsburg City Ward 2,President,,"Johnson, Gary  ",Libertarian,15
-Phillips,Phillipsburg City Ward 2,President,,"Trump, Donald J. ",Republican,263
-Phillips,Phillipsburg City Ward 3,President,,"Stein, Jill  ",independent,5
-Phillips,Phillipsburg City Ward 3,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Castle, Darrell L ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Hedges, James A ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Maturen, Michael A ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"McMullin, Evan  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Perry, Darryl  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Schriner, Joe C ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Smith, Mike  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Sood, Ajay  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Phillipsburg City Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,45
-Phillips,Phillipsburg City Ward 3,President,,"Johnson, Gary  ",Libertarian,12
-Phillips,Phillipsburg City Ward 3,President,,"Trump, Donald J. ",Republican,291
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Stein, Jill  ",independent,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Castle, Darrell L ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Hedges, James A ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Maturen, Michael A ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"McMullin, Evan  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Perry, Darryl  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Schriner, Joe C ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Smith, Mike  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Sood, Ajay  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Phillipsburg City Ward 3 Exclave,President,,"Trump, Donald J. ",Republican,0
-Phillips,Phillipsburg Township,President,,"Stein, Jill  ",independent,1
-Phillips,Phillipsburg Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Phillipsburg Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Phillipsburg Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Hedges, James A ",write - in,0
-Phillips,Phillipsburg Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Phillipsburg Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Phillipsburg Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Phillipsburg Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Phillipsburg Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Phillipsburg Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Phillipsburg Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Phillipsburg Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Phillipsburg Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Phillipsburg Township,President,,"Clinton, Hillary Rodham ",Democratic,14
-Phillips,Phillipsburg Township,President,,"Johnson, Gary  ",Libertarian,6
-Phillips,Phillipsburg Township,President,,"Trump, Donald J. ",Republican,125
-Phillips,Plainview Township,President,,"Stein, Jill  ",independent,0
-Phillips,Plainview Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Plainview Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Plainview Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Plainview Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Plainview Township,President,,"Hedges, James A ",write - in,0
-Phillips,Plainview Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Plainview Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Plainview Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Plainview Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Plainview Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Plainview Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Plainview Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Plainview Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Plainview Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Plainview Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Plainview Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Plainview Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Plainview Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Plainview Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Plainview Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Plainview Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Plainview Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Phillips,Plainview Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Plainview Township,President,,"Trump, Donald J. ",Republican,11
-Phillips,Plum Township,President,,"Stein, Jill  ",independent,2
-Phillips,Plum Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Plum Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Plum Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Plum Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Plum Township,President,,"Hedges, James A ",write - in,0
-Phillips,Plum Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Plum Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Plum Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Plum Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Plum Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Plum Township,President,,"McMullin, Evan  ",write - in,1
-Phillips,Plum Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Plum Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Plum Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Plum Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Plum Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Plum Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Plum Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Plum Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Plum Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Plum Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Plum Township,President,,"Clinton, Hillary Rodham ",Democratic,22
-Phillips,Plum Township,President,,"Johnson, Gary  ",Libertarian,7
-Phillips,Plum Township,President,,"Trump, Donald J. ",Republican,155
-Phillips,Prairie View Township,President,,"Stein, Jill  ",independent,0
-Phillips,Prairie View Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Prairie View Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Prairie View Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Prairie View Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Prairie View Township,President,,"Hedges, James A ",write - in,0
-Phillips,Prairie View Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Prairie View Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Prairie View Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Prairie View Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Prairie View Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Prairie View Township,President,,"McMullin, Evan  ",write - in,1
-Phillips,Prairie View Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Prairie View Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Prairie View Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Prairie View Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Prairie View Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Prairie View Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Prairie View Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Prairie View Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Prairie View Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Prairie View Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Prairie View Township,President,,"Clinton, Hillary Rodham ",Democratic,8
-Phillips,Prairie View Township,President,,"Johnson, Gary  ",Libertarian,2
-Phillips,Prairie View Township,President,,"Trump, Donald J. ",Republican,93
-Phillips,Rushville Township,President,,"Stein, Jill  ",independent,0
-Phillips,Rushville Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Rushville Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Rushville Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Rushville Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Rushville Township,President,,"Hedges, James A ",write - in,0
-Phillips,Rushville Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Rushville Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Rushville Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Rushville Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Rushville Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Rushville Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Rushville Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Rushville Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Rushville Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Rushville Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Rushville Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Rushville Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Rushville Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Rushville Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Rushville Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Rushville Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Rushville Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Phillips,Rushville Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Rushville Township,President,,"Trump, Donald J. ",Republican,10
-Phillips,Solomon Township,President,,"Stein, Jill  ",independent,0
-Phillips,Solomon Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Solomon Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Solomon Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Solomon Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Solomon Township,President,,"Hedges, James A ",write - in,0
-Phillips,Solomon Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Solomon Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Solomon Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Solomon Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Solomon Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Solomon Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Solomon Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Solomon Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Solomon Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Solomon Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Solomon Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Solomon Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Solomon Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Solomon Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Solomon Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Solomon Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Solomon Township,President,,"Clinton, Hillary Rodham ",Democratic,10
-Phillips,Solomon Township,President,,"Johnson, Gary  ",Libertarian,4
-Phillips,Solomon Township,President,,"Trump, Donald J. ",Republican,74
-Phillips,Sumner Township,President,,"Stein, Jill  ",independent,0
-Phillips,Sumner Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Sumner Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Sumner Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Sumner Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Sumner Township,President,,"Hedges, James A ",write - in,0
-Phillips,Sumner Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Sumner Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Sumner Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Sumner Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Sumner Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Sumner Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Sumner Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Sumner Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Sumner Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Sumner Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Sumner Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Sumner Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Sumner Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Sumner Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Sumner Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Sumner Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Sumner Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Phillips,Sumner Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Sumner Township,President,,"Trump, Donald J. ",Republican,18
-Phillips,Towanda Township,President,,"Stein, Jill  ",independent,0
-Phillips,Towanda Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Towanda Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Towanda Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Towanda Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Towanda Township,President,,"Hedges, James A ",write - in,0
-Phillips,Towanda Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Towanda Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Towanda Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Towanda Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Towanda Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Towanda Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Towanda Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Towanda Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Towanda Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Towanda Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Towanda Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Towanda Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Towanda Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Towanda Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Towanda Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Towanda Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Towanda Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Phillips,Towanda Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Towanda Township,President,,"Trump, Donald J. ",Republican,15
-Phillips,Valley Township,President,,"Stein, Jill  ",independent,0
-Phillips,Valley Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Valley Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Valley Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Valley Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Valley Township,President,,"Hedges, James A ",write - in,0
-Phillips,Valley Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Valley Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Valley Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Valley Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Valley Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Valley Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Valley Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Valley Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Valley Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Valley Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Valley Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Valley Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Valley Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Valley Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Valley Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Valley Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Valley Township,President,,"Clinton, Hillary Rodham ",Democratic,1
-Phillips,Valley Township,President,,"Johnson, Gary  ",Libertarian,3
-Phillips,Valley Township,President,,"Trump, Donald J. ",Republican,10
-Phillips,Walnut Township,President,,"Stein, Jill  ",independent,0
-Phillips,Walnut Township,President,,"Basiago, Andrew D. ",write - in,0
-Phillips,Walnut Township,President,,"Castle, Darrell L ",write - in,0
-Phillips,Walnut Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Phillips,Walnut Township,President,,"Giordani, Rocky  ",write - in,0
-Phillips,Walnut Township,President,,"Hedges, James A ",write - in,0
-Phillips,Walnut Township,President,,"Hoefling, Tom  ",write - in,0
-Phillips,Walnut Township,President,,"Kahn, Lynn  ",write - in,0
-Phillips,Walnut Township,President,,"La Riva, Gloria  ",write - in,0
-Phillips,Walnut Township,President,,"Levinson, Michael S. ",write - in,0
-Phillips,Walnut Township,President,,"Maturen, Michael A ",write - in,0
-Phillips,Walnut Township,President,,"McMullin, Evan  ",write - in,0
-Phillips,Walnut Township,President,,"Moorehead, Monica G. ",write - in,0
-Phillips,Walnut Township,President,,"Perry, Darryl  ",write - in,0
-Phillips,Walnut Township,President,,"Schoenke, Marshall R. ",write - in,0
-Phillips,Walnut Township,President,,"Schriner, Joe C ",write - in,0
-Phillips,Walnut Township,President,,"Smith, Mike  ",write - in,0
-Phillips,Walnut Township,President,,"Sood, Ajay  ",write - in,0
-Phillips,Walnut Township,President,,"Sterling, Shawna  ",write - in,0
-Phillips,Walnut Township,President,,"Valdivia, Anthony J ",write - in,0
-Phillips,Walnut Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Phillips,Walnut Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Phillips,Walnut Township,President,,"Clinton, Hillary Rodham ",Democratic,0
-Phillips,Walnut Township,President,,"Johnson, Gary  ",Libertarian,0
-Phillips,Walnut Township,President,,"Trump, Donald J. ",Republican,6
-Phillips,Plainview Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Phillips,Plainview Township,U.S. Senate,,"Moran, Jerry  ",Republican,9
-Phillips,Plum Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Plum Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,14
-Phillips,Plum Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,10
-Phillips,Plum Township,U.S. Senate,,"Moran, Jerry  ",Republican,160
-Phillips,Prairie View Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Prairie View Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Phillips,Prairie View Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Phillips,Prairie View Township,U.S. Senate,,"Moran, Jerry  ",Republican,101
-Phillips,Rushville Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Rushville Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Phillips,Rushville Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Phillips,Rushville Township,U.S. Senate,,"Moran, Jerry  ",Republican,8
-Phillips,Solomon Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Solomon Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,10
-Phillips,Solomon Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Phillips,Solomon Township,U.S. Senate,,"Moran, Jerry  ",Republican,71
-Phillips,Sumner Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Sumner Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Phillips,Sumner Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Phillips,Sumner Township,U.S. Senate,,"Moran, Jerry  ",Republican,18
-Phillips,Towanda Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Towanda Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Phillips,Towanda Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Phillips,Towanda Township,U.S. Senate,,"Moran, Jerry  ",Republican,15
-Phillips,Valley Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Valley Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Phillips,Valley Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Phillips,Valley Township,U.S. Senate,,"Moran, Jerry  ",Republican,11
-Phillips,Walnut Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Phillips,Walnut Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Phillips,Walnut Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Phillips,Walnut Township,U.S. Senate,,"Moran, Jerry  ",Republican,6
-Phillips,Plainview Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Phillips,Plainview Township,U.S. House,1,"Marshall, Roger  ",Republican,9
-Phillips,Plum Township,U.S. House,1,"LaPolice, Alan  ",independent,45
-Phillips,Plum Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Plum Township,U.S. House,1,"Burt, Kerry  ",Libertarian,6
-Phillips,Plum Township,U.S. House,1,"Marshall, Roger  ",Republican,128
-Phillips,Prairie View Township,U.S. House,1,"LaPolice, Alan  ",independent,11
-Phillips,Prairie View Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Prairie View Township,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Phillips,Prairie View Township,U.S. House,1,"Marshall, Roger  ",Republican,90
-Phillips,Rushville Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Phillips,Rushville Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Rushville Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Phillips,Rushville Township,U.S. House,1,"Marshall, Roger  ",Republican,8
-Phillips,Solomon Township,U.S. House,1,"LaPolice, Alan  ",independent,16
-Phillips,Solomon Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Solomon Township,U.S. House,1,"Burt, Kerry  ",Libertarian,13
-Phillips,Solomon Township,U.S. House,1,"Marshall, Roger  ",Republican,58
-Phillips,Sumner Township,U.S. House,1,"LaPolice, Alan  ",independent,2
-Phillips,Sumner Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Sumner Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Phillips,Sumner Township,U.S. House,1,"Marshall, Roger  ",Republican,16
-Phillips,Towanda Township,U.S. House,1,"LaPolice, Alan  ",independent,1
-Phillips,Towanda Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Towanda Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Phillips,Towanda Township,U.S. House,1,"Marshall, Roger  ",Republican,13
-Phillips,Valley Township,U.S. House,1,"LaPolice, Alan  ",independent,2
-Phillips,Valley Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Valley Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Phillips,Valley Township,U.S. House,1,"Marshall, Roger  ",Republican,10
-Phillips,Walnut Township,U.S. House,1,"LaPolice, Alan  ",independent,0
-Phillips,Walnut Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Phillips,Walnut Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Phillips,Walnut Township,U.S. House,1,"Marshall, Roger  ",Republican,7
-Phillips,Phillipsburg City Ward 1,State Senate,36,"Bowers, Elaine S. ",Republican,391
-Phillips,Phillipsburg City Ward 2,State Senate,36,"Angevine, Brian G. ",Democratic,39
-Phillips,Phillipsburg City Ward 2,State Senate,36,"Bowers, Elaine S. ",Republican,283
-Phillips,Phillipsburg City Ward 3,State Senate,36,"Angevine, Brian G. ",Democratic,37
-Phillips,Phillipsburg City Ward 3,State Senate,36,"Bowers, Elaine S. ",Republican,307
-Phillips,Phillipsburg City Ward 3 Exclave,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Phillips,Phillipsburg City Ward 3 Exclave,State Senate,36,"Bowers, Elaine S. ",Republican,0
-Phillips,Phillipsburg Township,State Senate,36,"Angevine, Brian G. ",Democratic,15
-Phillips,Phillipsburg Township,State Senate,36,"Bowers, Elaine S. ",Republican,127
-Phillips,Plainview Township,State Senate,40,"Herman, Alex  ",Democratic,3
-Phillips,Plainview Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,8
-Phillips,Plum Township,State Senate,36,"Angevine, Brian G. ",Democratic,20
-Phillips,Plum Township,State Senate,36,"Bowers, Elaine S. ",Republican,160
-Phillips,Prairie View Township,State Senate,40,"Herman, Alex  ",Democratic,11
-Phillips,Prairie View Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,90
-Phillips,Rushville Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Phillips,Rushville Township,State Senate,36,"Bowers, Elaine S. ",Republican,10
-Phillips,Solomon Township,State Senate,36,"Angevine, Brian G. ",Democratic,11
-Phillips,Solomon Township,State Senate,36,"Bowers, Elaine S. ",Republican,74
-Phillips,Sumner Township,State Senate,36,"Angevine, Brian G. ",Democratic,1
-Phillips,Sumner Township,State Senate,36,"Bowers, Elaine S. ",Republican,17
-Phillips,Towanda Township,State Senate,40,"Herman, Alex  ",Democratic,1
-Phillips,Towanda Township,State Senate,40,"Billinger, Richard (Rick)  ",Republican,13
-Phillips,Valley Township,State Senate,36,"Angevine, Brian G. ",Democratic,2
-Phillips,Valley Township,State Senate,36,"Bowers, Elaine S. ",Republican,10
-Phillips,Walnut Township,State Senate,36,"Angevine, Brian G. ",Democratic,0
-Phillips,Walnut Township,State Senate,36,"Bowers, Elaine S. ",Republican,6
-Phillips,Freedom Township,State House,110,"Rahjes, Ken  ",Republican,45
-Phillips,Glenwood Township,State House,110,"Rahjes, Ken  ",Republican,20
-Phillips,Granite Township,State House,110,"Rahjes, Ken  ",Republican,16
-Phillips,Greenwood Township,State House,110,"Rahjes, Ken  ",Republican,24
-Phillips,Kirwin Township,State House,110,"Rahjes, Ken  ",Republican,86
-Phillips,Logan Township,State House,110,"Rahjes, Ken  ",Republican,251
-Phillips,Long Island Township,State House,110,"Rahjes, Ken  ",Republican,107
-Phillips,Mound Township,State House,110,"Rahjes, Ken  ",Republican,57
-Phillips,Phillipsburg City Ward 1,State House,110,"Rahjes, Ken  ",Republican,421
-Phillips,Phillipsburg City Ward 2,State House,110,"Rahjes, Ken  ",Republican,306
-Phillips,Phillipsburg City Ward 3,State House,110,"Rahjes, Ken  ",Republican,329
-Phillips,Phillipsburg City Ward 3 Exclave,State House,110,"Rahjes, Ken  ",Republican,0
-Phillips,Phillipsburg Township,State House,110,"Rahjes, Ken  ",Republican,134
-Phillips,Plainview Township,State House,110,"Rahjes, Ken  ",Republican,12
-Phillips,Plum Township,State House,110,"Rahjes, Ken  ",Republican,178
-Phillips,Prairie View Township,State House,110,"Rahjes, Ken  ",Republican,103
-Phillips,Rushville Township,State House,110,"Rahjes, Ken  ",Republican,9
-Phillips,Solomon Township,State House,110,"Rahjes, Ken  ",Republican,81
-Phillips,Sumner Township,State House,110,"Rahjes, Ken  ",Republican,19
-Phillips,Towanda Township,State House,110,"Rahjes, Ken  ",Republican,15
-Phillips,Valley Township,State House,110,"Rahjes, Ken  ",Republican,12
-Phillips,Walnut Township,State House,110,"Rahjes, Ken  ",Republican,5
+county,precinct,office,district,party,candidate,votes,vtd
+PHILLIPS,Arcade Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",46,000010
+PHILLIPS,Beaver Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",25,000020
+PHILLIPS,Belmont Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",45,000030
+PHILLIPS,Bow Creek Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",19,000040
+PHILLIPS,Crystal Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",30,000050
+PHILLIPS,Dayton Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",22,000060
+PHILLIPS,Deer Creek Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",40,000070
+PHILLIPS,Freedom Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",45,000080
+PHILLIPS,Glenwood Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",20,000090
+PHILLIPS,Granite Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",16,000100
+PHILLIPS,Greenwood Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",24,000110
+PHILLIPS,Kirwin Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",86,000120
+PHILLIPS,Logan Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",251,000130
+PHILLIPS,Long Island Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",107,000140
+PHILLIPS,Mound Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",57,000150
+PHILLIPS,Phillipsburg City Ward 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",421,000160
+PHILLIPS,Phillipsburg City Ward 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",306,000170
+PHILLIPS,Phillipsburg City Ward 3,Kansas House of Representatives,110,Republican,"Rahjes, Ken",329,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas House of Representatives,110,Republican,"Rahjes, Ken",0,00018B
+PHILLIPS,Phillipsburg Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",134,000190
+PHILLIPS,Plainview Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",12,000200
+PHILLIPS,Plum Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",178,000210
+PHILLIPS,Prairie View Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",103,000220
+PHILLIPS,Rushville Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",9,000230
+PHILLIPS,Solomon Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",81,000240
+PHILLIPS,Sumner Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",19,000250
+PHILLIPS,Towanda Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",15,000260
+PHILLIPS,Valley Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",12,000270
+PHILLIPS,Walnut Township,Kansas House of Representatives,110,Republican,"Rahjes, Ken",5,000280
+PHILLIPS,Arcade Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000010
+PHILLIPS,Arcade Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000010
+PHILLIPS,Beaver Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000020
+PHILLIPS,Beaver Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",22,000020
+PHILLIPS,Belmont Township,Kansas Senate,40,Democratic,"Herman, Alex",12,000030
+PHILLIPS,Belmont Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",34,000030
+PHILLIPS,Bow Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000040
+PHILLIPS,Bow Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",18,000040
+PHILLIPS,Crystal Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000050
+PHILLIPS,Crystal Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000050
+PHILLIPS,Dayton Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000060
+PHILLIPS,Dayton Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",21,000060
+PHILLIPS,Deer Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000070
+PHILLIPS,Deer Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000070
+PHILLIPS,Freedom Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000080
+PHILLIPS,Freedom Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",51,000080
+PHILLIPS,Glenwood Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000090
+PHILLIPS,Glenwood Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000090
+PHILLIPS,Granite Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000100
+PHILLIPS,Granite Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",17,000100
+PHILLIPS,Greenwood Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000110
+PHILLIPS,Greenwood Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000110
+PHILLIPS,Kirwin Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",13,000120
+PHILLIPS,Kirwin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",82,000120
+PHILLIPS,Logan Township,Kansas Senate,40,Democratic,"Herman, Alex",53,000130
+PHILLIPS,Logan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",209,000130
+PHILLIPS,Long Island Township,Kansas Senate,40,Democratic,"Herman, Alex",16,000140
+PHILLIPS,Long Island Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",92,000140
+PHILLIPS,Mound Township,Kansas Senate,40,Democratic,"Herman, Alex",13,000150
+PHILLIPS,Mound Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",51,000150
+PHILLIPS,Phillipsburg City Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",50,000160
+PHILLIPS,Phillipsburg City Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",391,000160
+PHILLIPS,Phillipsburg City Ward 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",39,000170
+PHILLIPS,Phillipsburg City Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",283,000170
+PHILLIPS,Phillipsburg City Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",37,00018A
+PHILLIPS,Phillipsburg City Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",307,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00018B
+PHILLIPS,Phillipsburg Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,000190
+PHILLIPS,Phillipsburg Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",127,000190
+PHILLIPS,Plainview Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000200
+PHILLIPS,Plainview Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",8,000200
+PHILLIPS,Plum Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000210
+PHILLIPS,Plum Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",160,000210
+PHILLIPS,Prairie View Township,Kansas Senate,40,Democratic,"Herman, Alex",11,000220
+PHILLIPS,Prairie View Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",90,000220
+PHILLIPS,Rushville Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000230
+PHILLIPS,Rushville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000230
+PHILLIPS,Solomon Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",11,000240
+PHILLIPS,Solomon Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",74,000240
+PHILLIPS,Sumner Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000250
+PHILLIPS,Sumner Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",17,000250
+PHILLIPS,Towanda Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000260
+PHILLIPS,Towanda Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",13,000260
+PHILLIPS,Valley Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000270
+PHILLIPS,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000270
+PHILLIPS,Walnut Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000280
+PHILLIPS,Walnut Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",6,000280
+PHILLIPS,Arcade Township,President / Vice President,,independent,"Stein, Jill",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"McMullin, Evan",2,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+PHILLIPS,Arcade Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000010
+PHILLIPS,Arcade Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+PHILLIPS,Arcade Township,President / Vice President,,Republican,"Trump, Donald J.",42,000010
+PHILLIPS,Beaver Township,President / Vice President,,independent,"Stein, Jill",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000020
+PHILLIPS,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+PHILLIPS,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",24,000020
+PHILLIPS,Belmont Township,President / Vice President,,independent,"Stein, Jill",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000030
+PHILLIPS,Belmont Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+PHILLIPS,Belmont Township,President / Vice President,,Republican,"Trump, Donald J.",44,000030
+PHILLIPS,Bow Creek Township,President / Vice President,,independent,"Stein, Jill",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+PHILLIPS,Bow Creek Township,President / Vice President,,Republican,"Trump, Donald J.",18,000040
+PHILLIPS,Crystal Township,President / Vice President,,independent,"Stein, Jill",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+PHILLIPS,Crystal Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000050
+PHILLIPS,Crystal Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000050
+PHILLIPS,Crystal Township,President / Vice President,,Republican,"Trump, Donald J.",27,000050
+PHILLIPS,Dayton Township,President / Vice President,,independent,"Stein, Jill",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+PHILLIPS,Dayton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000060
+PHILLIPS,Dayton Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+PHILLIPS,Dayton Township,President / Vice President,,Republican,"Trump, Donald J.",19,000060
+PHILLIPS,Deer Creek Township,President / Vice President,,independent,"Stein, Jill",1,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+PHILLIPS,Deer Creek Township,President / Vice President,,Republican,"Trump, Donald J.",42,000070
+PHILLIPS,Freedom Township,President / Vice President,,independent,"Stein, Jill",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+PHILLIPS,Freedom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000080
+PHILLIPS,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+PHILLIPS,Freedom Township,President / Vice President,,Republican,"Trump, Donald J.",52,000080
+PHILLIPS,Glenwood Township,President / Vice President,,independent,"Stein, Jill",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Castle, Darrell L",2,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+PHILLIPS,Glenwood Township,President / Vice President,,Republican,"Trump, Donald J.",15,000090
+PHILLIPS,Granite Township,President / Vice President,,independent,"Stein, Jill",1,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+PHILLIPS,Granite Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+PHILLIPS,Granite Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000100
+PHILLIPS,Granite Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+PHILLIPS,Granite Township,President / Vice President,,Republican,"Trump, Donald J.",16,000100
+PHILLIPS,Greenwood Township,President / Vice President,,independent,"Stein, Jill",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Castle, Darrell L",1,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+PHILLIPS,Greenwood Township,President / Vice President,,Republican,"Trump, Donald J.",22,000110
+PHILLIPS,Kirwin Township,President / Vice President,,independent,"Stein, Jill",1,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+PHILLIPS,Kirwin Township,President / Vice President,,Republican,"Trump, Donald J.",91,000120
+PHILLIPS,Logan Township,President / Vice President,,independent,"Stein, Jill",2,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"McMullin, Evan",2,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+PHILLIPS,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+PHILLIPS,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000130
+PHILLIPS,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000130
+PHILLIPS,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",227,000130
+PHILLIPS,Long Island Township,President / Vice President,,independent,"Stein, Jill",1,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"McMullin, Evan",2,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+PHILLIPS,Long Island Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000140
+PHILLIPS,Long Island Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+PHILLIPS,Long Island Township,President / Vice President,,Republican,"Trump, Donald J.",96,000140
+PHILLIPS,Mound Township,President / Vice President,,independent,"Stein, Jill",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"McMullin, Evan",1,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+PHILLIPS,Mound Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+PHILLIPS,Mound Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000150
+PHILLIPS,Mound Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+PHILLIPS,Mound Township,President / Vice President,,Republican,"Trump, Donald J.",52,000150
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,independent,"Stein, Jill",12,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",1,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+PHILLIPS,Phillipsburg City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",375,000160
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,independent,"Stein, Jill",3,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000170
+PHILLIPS,Phillipsburg City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",263,000170
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,independent,"Stein, Jill",5,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",12,00018A
+PHILLIPS,Phillipsburg City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",291,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00018B
+PHILLIPS,Phillipsburg Township,President / Vice President,,independent,"Stein, Jill",1,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000190
+PHILLIPS,Phillipsburg Township,President / Vice President,,Republican,"Trump, Donald J.",125,000190
+PHILLIPS,Plainview Township,President / Vice President,,independent,"Stein, Jill",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000200
+PHILLIPS,Plainview Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+PHILLIPS,Plainview Township,President / Vice President,,Republican,"Trump, Donald J.",11,000200
+PHILLIPS,Plum Township,President / Vice President,,independent,"Stein, Jill",2,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"McMullin, Evan",1,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+PHILLIPS,Plum Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+PHILLIPS,Plum Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000210
+PHILLIPS,Plum Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000210
+PHILLIPS,Plum Township,President / Vice President,,Republican,"Trump, Donald J.",155,000210
+PHILLIPS,Prairie View Township,President / Vice President,,independent,"Stein, Jill",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"McMullin, Evan",1,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000220
+PHILLIPS,Prairie View Township,President / Vice President,,Republican,"Trump, Donald J.",93,000220
+PHILLIPS,Rushville Township,President / Vice President,,independent,"Stein, Jill",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+PHILLIPS,Rushville Township,President / Vice President,,Republican,"Trump, Donald J.",10,000230
+PHILLIPS,Solomon Township,President / Vice President,,independent,"Stein, Jill",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+PHILLIPS,Solomon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000240
+PHILLIPS,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000240
+PHILLIPS,Solomon Township,President / Vice President,,Republican,"Trump, Donald J.",74,000240
+PHILLIPS,Sumner Township,President / Vice President,,independent,"Stein, Jill",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000250
+PHILLIPS,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000250
+PHILLIPS,Sumner Township,President / Vice President,,Republican,"Trump, Donald J.",18,000250
+PHILLIPS,Towanda Township,President / Vice President,,independent,"Stein, Jill",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000260
+PHILLIPS,Towanda Township,President / Vice President,,Republican,"Trump, Donald J.",15,000260
+PHILLIPS,Valley Township,President / Vice President,,independent,"Stein, Jill",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+PHILLIPS,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+PHILLIPS,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000270
+PHILLIPS,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000270
+PHILLIPS,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",10,000270
+PHILLIPS,Walnut Township,President / Vice President,,independent,"Stein, Jill",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000280
+PHILLIPS,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",6,000280
+PHILLIPS,Arcade Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000010
+PHILLIPS,Arcade Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+PHILLIPS,Arcade Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+PHILLIPS,Arcade Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000010
+PHILLIPS,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000020
+PHILLIPS,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+PHILLIPS,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+PHILLIPS,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000020
+PHILLIPS,Belmont Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000030
+PHILLIPS,Belmont Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+PHILLIPS,Belmont Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000030
+PHILLIPS,Belmont Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000030
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000040
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+PHILLIPS,Bow Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000040
+PHILLIPS,Crystal Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000050
+PHILLIPS,Crystal Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+PHILLIPS,Crystal Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+PHILLIPS,Crystal Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000050
+PHILLIPS,Dayton Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000060
+PHILLIPS,Dayton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+PHILLIPS,Dayton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+PHILLIPS,Dayton Township,United States House of Representatives,1,Republican,"Marshall, Roger",17,000060
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000070
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000070
+PHILLIPS,Deer Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000070
+PHILLIPS,Freedom Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000080
+PHILLIPS,Freedom Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+PHILLIPS,Freedom Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+PHILLIPS,Freedom Township,United States House of Representatives,1,Republican,"Marshall, Roger",45,000080
+PHILLIPS,Glenwood Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000090
+PHILLIPS,Glenwood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000090
+PHILLIPS,Glenwood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000090
+PHILLIPS,Glenwood Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000090
+PHILLIPS,Granite Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000100
+PHILLIPS,Granite Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+PHILLIPS,Granite Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+PHILLIPS,Granite Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000100
+PHILLIPS,Greenwood Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000110
+PHILLIPS,Greenwood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+PHILLIPS,Greenwood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+PHILLIPS,Greenwood Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000110
+PHILLIPS,Kirwin Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000120
+PHILLIPS,Kirwin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+PHILLIPS,Kirwin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000120
+PHILLIPS,Kirwin Township,United States House of Representatives,1,Republican,"Marshall, Roger",64,000120
+PHILLIPS,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",57,000130
+PHILLIPS,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000130
+PHILLIPS,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000130
+PHILLIPS,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",203,000130
+PHILLIPS,Long Island Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000140
+PHILLIPS,Long Island Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+PHILLIPS,Long Island Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000140
+PHILLIPS,Long Island Township,United States House of Representatives,1,Republican,"Marshall, Roger",87,000140
+PHILLIPS,Mound Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000150
+PHILLIPS,Mound Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+PHILLIPS,Mound Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000150
+PHILLIPS,Mound Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000150
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",80,000160
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000160
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000160
+PHILLIPS,Phillipsburg City Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",342,000160
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",66,000170
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000170
+PHILLIPS,Phillipsburg City Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",230,000170
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",88,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",255,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00018B
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000190
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000190
+PHILLIPS,Phillipsburg Township,United States House of Representatives,1,Republican,"Marshall, Roger",112,000190
+PHILLIPS,Plainview Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000200
+PHILLIPS,Plainview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+PHILLIPS,Plainview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000200
+PHILLIPS,Plainview Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000200
+PHILLIPS,Plum Township,United States House of Representatives,1,independent,"LaPolice, Alan",45,000210
+PHILLIPS,Plum Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+PHILLIPS,Plum Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000210
+PHILLIPS,Plum Township,United States House of Representatives,1,Republican,"Marshall, Roger",128,000210
+PHILLIPS,Prairie View Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000220
+PHILLIPS,Prairie View Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+PHILLIPS,Prairie View Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000220
+PHILLIPS,Prairie View Township,United States House of Representatives,1,Republican,"Marshall, Roger",90,000220
+PHILLIPS,Rushville Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000230
+PHILLIPS,Rushville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+PHILLIPS,Rushville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000230
+PHILLIPS,Rushville Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000230
+PHILLIPS,Solomon Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000240
+PHILLIPS,Solomon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+PHILLIPS,Solomon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000240
+PHILLIPS,Solomon Township,United States House of Representatives,1,Republican,"Marshall, Roger",58,000240
+PHILLIPS,Sumner Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000250
+PHILLIPS,Sumner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+PHILLIPS,Sumner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000250
+PHILLIPS,Sumner Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000250
+PHILLIPS,Towanda Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000260
+PHILLIPS,Towanda Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+PHILLIPS,Towanda Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000260
+PHILLIPS,Towanda Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000260
+PHILLIPS,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000270
+PHILLIPS,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+PHILLIPS,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000270
+PHILLIPS,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000270
+PHILLIPS,Walnut Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000280
+PHILLIPS,Walnut Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+PHILLIPS,Walnut Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000280
+PHILLIPS,Walnut Township,United States House of Representatives,1,Republican,"Marshall, Roger",7,000280
+PHILLIPS,Arcade Township,United States Senate,,write - in,"Smith, DJ",0,000010
+PHILLIPS,Arcade Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000010
+PHILLIPS,Arcade Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000010
+PHILLIPS,Arcade Township,United States Senate,,Republican,"Moran, Jerry",41,000010
+PHILLIPS,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000020
+PHILLIPS,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+PHILLIPS,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+PHILLIPS,Beaver Township,United States Senate,,Republican,"Moran, Jerry",24,000020
+PHILLIPS,Belmont Township,United States Senate,,write - in,"Smith, DJ",0,000030
+PHILLIPS,Belmont Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+PHILLIPS,Belmont Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+PHILLIPS,Belmont Township,United States Senate,,Republican,"Moran, Jerry",45,000030
+PHILLIPS,Bow Creek Township,United States Senate,,write - in,"Smith, DJ",0,000040
+PHILLIPS,Bow Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000040
+PHILLIPS,Bow Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000040
+PHILLIPS,Bow Creek Township,United States Senate,,Republican,"Moran, Jerry",18,000040
+PHILLIPS,Crystal Township,United States Senate,,write - in,"Smith, DJ",0,000050
+PHILLIPS,Crystal Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000050
+PHILLIPS,Crystal Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+PHILLIPS,Crystal Township,United States Senate,,Republican,"Moran, Jerry",30,000050
+PHILLIPS,Dayton Township,United States Senate,,write - in,"Smith, DJ",0,000060
+PHILLIPS,Dayton Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000060
+PHILLIPS,Dayton Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+PHILLIPS,Dayton Township,United States Senate,,Republican,"Moran, Jerry",21,000060
+PHILLIPS,Deer Creek Township,United States Senate,,write - in,"Smith, DJ",0,000070
+PHILLIPS,Deer Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000070
+PHILLIPS,Deer Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000070
+PHILLIPS,Deer Creek Township,United States Senate,,Republican,"Moran, Jerry",37,000070
+PHILLIPS,Freedom Township,United States Senate,,write - in,"Smith, DJ",0,000080
+PHILLIPS,Freedom Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000080
+PHILLIPS,Freedom Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+PHILLIPS,Freedom Township,United States Senate,,Republican,"Moran, Jerry",45,000080
+PHILLIPS,Glenwood Township,United States Senate,,write - in,"Smith, DJ",0,000090
+PHILLIPS,Glenwood Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000090
+PHILLIPS,Glenwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+PHILLIPS,Glenwood Township,United States Senate,,Republican,"Moran, Jerry",19,000090
+PHILLIPS,Granite Township,United States Senate,,write - in,"Smith, DJ",0,000100
+PHILLIPS,Granite Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000100
+PHILLIPS,Granite Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+PHILLIPS,Granite Township,United States Senate,,Republican,"Moran, Jerry",16,000100
+PHILLIPS,Greenwood Township,United States Senate,,write - in,"Smith, DJ",0,000110
+PHILLIPS,Greenwood Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+PHILLIPS,Greenwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+PHILLIPS,Greenwood Township,United States Senate,,Republican,"Moran, Jerry",25,000110
+PHILLIPS,Kirwin Township,United States Senate,,write - in,"Smith, DJ",0,000120
+PHILLIPS,Kirwin Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000120
+PHILLIPS,Kirwin Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000120
+PHILLIPS,Kirwin Township,United States Senate,,Republican,"Moran, Jerry",82,000120
+PHILLIPS,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000130
+PHILLIPS,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000130
+PHILLIPS,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000130
+PHILLIPS,Logan Township,United States Senate,,Republican,"Moran, Jerry",240,000130
+PHILLIPS,Long Island Township,United States Senate,,write - in,"Smith, DJ",0,000140
+PHILLIPS,Long Island Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000140
+PHILLIPS,Long Island Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000140
+PHILLIPS,Long Island Township,United States Senate,,Republican,"Moran, Jerry",99,000140
+PHILLIPS,Mound Township,United States Senate,,write - in,"Smith, DJ",0,000150
+PHILLIPS,Mound Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000150
+PHILLIPS,Mound Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000150
+PHILLIPS,Mound Township,United States Senate,,Republican,"Moran, Jerry",56,000150
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000160
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",35,000160
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",18,000160
+PHILLIPS,Phillipsburg City Ward 1,United States Senate,,Republican,"Moran, Jerry",404,000160
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000170
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",37,000170
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",15,000170
+PHILLIPS,Phillipsburg City Ward 2,United States Senate,,Republican,"Moran, Jerry",274,000170
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,write - in,"Smith, DJ",0,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",34,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",12,00018A
+PHILLIPS,Phillipsburg City Ward 3,United States Senate,,Republican,"Moran, Jerry",308,00018A
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00018B
+PHILLIPS,Phillipsburg City Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00018B
+PHILLIPS,Phillipsburg Township,United States Senate,,write - in,"Smith, DJ",0,000190
+PHILLIPS,Phillipsburg Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000190
+PHILLIPS,Phillipsburg Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000190
+PHILLIPS,Phillipsburg Township,United States Senate,,Republican,"Moran, Jerry",133,000190
+PHILLIPS,Plainview Township,United States Senate,,write - in,"Smith, DJ",0,000200
+PHILLIPS,Plainview Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000200
+PHILLIPS,Plainview Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000200
+PHILLIPS,Plainview Township,United States Senate,,Republican,"Moran, Jerry",9,000200
+PHILLIPS,Plum Township,United States Senate,,write - in,"Smith, DJ",0,000210
+PHILLIPS,Plum Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000210
+PHILLIPS,Plum Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000210
+PHILLIPS,Plum Township,United States Senate,,Republican,"Moran, Jerry",160,000210
+PHILLIPS,Prairie View Township,United States Senate,,write - in,"Smith, DJ",0,000220
+PHILLIPS,Prairie View Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000220
+PHILLIPS,Prairie View Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000220
+PHILLIPS,Prairie View Township,United States Senate,,Republican,"Moran, Jerry",101,000220
+PHILLIPS,Rushville Township,United States Senate,,write - in,"Smith, DJ",0,000230
+PHILLIPS,Rushville Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000230
+PHILLIPS,Rushville Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000230
+PHILLIPS,Rushville Township,United States Senate,,Republican,"Moran, Jerry",8,000230
+PHILLIPS,Solomon Township,United States Senate,,write - in,"Smith, DJ",0,000240
+PHILLIPS,Solomon Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000240
+PHILLIPS,Solomon Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000240
+PHILLIPS,Solomon Township,United States Senate,,Republican,"Moran, Jerry",71,000240
+PHILLIPS,Sumner Township,United States Senate,,write - in,"Smith, DJ",0,000250
+PHILLIPS,Sumner Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000250
+PHILLIPS,Sumner Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000250
+PHILLIPS,Sumner Township,United States Senate,,Republican,"Moran, Jerry",18,000250
+PHILLIPS,Towanda Township,United States Senate,,write - in,"Smith, DJ",0,000260
+PHILLIPS,Towanda Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000260
+PHILLIPS,Towanda Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000260
+PHILLIPS,Towanda Township,United States Senate,,Republican,"Moran, Jerry",15,000260
+PHILLIPS,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000270
+PHILLIPS,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000270
+PHILLIPS,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000270
+PHILLIPS,Valley Township,United States Senate,,Republican,"Moran, Jerry",11,000270
+PHILLIPS,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000280
+PHILLIPS,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000280
+PHILLIPS,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000280
+PHILLIPS,Walnut Township,United States Senate,,Republican,"Moran, Jerry",6,000280

--- a/2016/20161108__ks__general__pottawatomie__precinct.csv
+++ b/2016/20161108__ks__general__pottawatomie__precinct.csv
@@ -1,474 +1,1111 @@
-county,precinct,office,district,party,candidate,votes
-Pottawatomie,Belvue,President,,Rep,Trump/Pence,123
-Pottawatomie,Blue,President,,Rep,Trump/Pence,1073
-Pottawatomie,Blue Valley,President,,Rep,Trump/Pence,122
-Pottawatomie,Center,President,,Rep,Trump/Pence,57
-Pottawatomie,Clear Creek,President,,Rep,Trump/Pence,52
-Pottawatomie,Emmett,President,,Rep,Trump/Pence,133
-Pottawatomie,Grant,President,,Rep,Trump/Pence,99
-Pottawatomie,Green,President,,Rep,Trump/Pence,79
-Pottawatomie,Lincoln,President,,Rep,Trump/Pence,47
-Pottawatomie,Lone Tree,President,,Rep,Trump/Pence,86
-Pottawatomie,Louisville,President,,Rep,Trump/Pence,329
-Pottawatomie,Mill Creek,President,,Rep,Trump/Pence,293
-Pottawatomie,Pottawatomie,President,,Rep,Trump/Pence,248
-Pottawatomie,Rock Creek,President,,Rep,Trump/Pence,227
-Pottawatomie,Shannon,President,,Rep,Trump/Pence,103
-Pottawatomie,Sherman,President,,Rep,Trump/Pence,35
-Pottawatomie,Spring Creek,President,,Rep,Trump/Pence,17
-Pottawatomie,St. Clere,President,,Rep,Trump/Pence,18
-Pottawatomie,St. George 1,President,,Rep,Trump/Pence,15
-Pottawatomie,St. George 17,President,,Rep,Trump/Pence,1168
-Pottawatomie,St. Mary's City,President,,Rep,Trump/Pence,1020
-Pottawatomie,St. Mary's Township,President,,Rep,Trump/Pence,405
-Pottawatomie,Union,President,,Rep,Trump/Pence,88
-Pottawatomie,Vienna,President,,Rep,Trump/Pence,44
-Pottawatomie,Wamego City 18,President,,Rep,Trump/Pence,788
-Pottawatomie,Wamego City 17,President,,Rep,Trump/Pence,442
-Pottawatomie,Wamego Twp 1,President,,Rep,Trump/Pence,10
-Pottawatomie,Wamego Twp 17,President,,Rep,Trump/Pence,203
-Pottawatomie,Wamego Twp 18,President,,Rep,Trump/Pence,127
-Pottawatomie,Provisionals,President,,Rep,Trump/Pence,137
-Pottawatomie,Federal,President,,Rep,Trump/Pence,24
-Pottawatomie,Total,President,,Rep,Trump/Pence,7612
-Pottawatomie,Belvue,President,,Dem,Clinton/Kaine,25
-Pottawatomie,Blue,President,,Dem,Clinton/Kaine,511
-Pottawatomie,Blue Valley,President,,Dem,Clinton/Kaine,37
-Pottawatomie,Center,President,,Dem,Clinton/Kaine,4
-Pottawatomie,Clear Creek,President,,Dem,Clinton/Kaine,15
-Pottawatomie,Emmett,President,,Dem,Clinton/Kaine,22
-Pottawatomie,Grant,President,,Dem,Clinton/Kaine,21
-Pottawatomie,Green,President,,Dem,Clinton/Kaine,21
-Pottawatomie,Lincoln,President,,Dem,Clinton/Kaine,9
-Pottawatomie,Lone Tree,President,,Dem,Clinton/Kaine,15
-Pottawatomie,Louisville,President,,Dem,Clinton/Kaine,55
-Pottawatomie,Mill Creek,President,,Dem,Clinton/Kaine,101
-Pottawatomie,Pottawatomie,President,,Dem,Clinton/Kaine,54
-Pottawatomie,Rock Creek,President,,Dem,Clinton/Kaine,64
-Pottawatomie,Shannon,President,,Dem,Clinton/Kaine,24
-Pottawatomie,Sherman,President,,Dem,Clinton/Kaine,9
-Pottawatomie,Spring Creek,President,,Dem,Clinton/Kaine,9
-Pottawatomie,St. Clere,President,,Dem,Clinton/Kaine,7
-Pottawatomie,St. George 1,President,,Dem,Clinton/Kaine,9
-Pottawatomie,St. George 17,President,,Dem,Clinton/Kaine,398
-Pottawatomie,St. Mary's City,President,,Dem,Clinton/Kaine,115
-Pottawatomie,St. Mary's Township,President,,Dem,Clinton/Kaine,37
-Pottawatomie,Union,President,,Dem,Clinton/Kaine,26
-Pottawatomie,Vienna,President,,Dem,Clinton/Kaine,6
-Pottawatomie,Wamego City 18,President,,Dem,Clinton/Kaine,336
-Pottawatomie,Wamego City 17,President,,Dem,Clinton/Kaine,153
-Pottawatomie,Wamego Twp 1,President,,Dem,Clinton/Kaine,1
-Pottawatomie,Wamego Twp 17,President,,Dem,Clinton/Kaine,81
-Pottawatomie,Wamego Twp 18,President,,Dem,Clinton/Kaine,26
-Pottawatomie,Provisionals,President,,Dem,Clinton/Kaine,22
-Pottawatomie,Federal,President,,Dem,Clinton/Kaine,12
-Pottawatomie,Total,President,,Dem,Clinton/Kaine,2225
-Pottawatomie,Belvue,President,,Lib,Johnson/Weld,5
-Pottawatomie,Blue,President,,Lib,Johnson/Weld,117
-Pottawatomie,Manhattan W2P5,President,,Lib,Johnson/Weld,1
-Pottawatomie,Blue Valley,President,,Lib,Johnson/Weld,9
-Pottawatomie,Center,President,,Lib,Johnson/Weld,2
-Pottawatomie,Clear Creek,President,,Lib,Johnson/Weld,3
-Pottawatomie,Emmett,President,,Lib,Johnson/Weld,6
-Pottawatomie,Grant,President,,Lib,Johnson/Weld,4
-Pottawatomie,Green,President,,Lib,Johnson/Weld,6
-Pottawatomie,Lincoln,President,,Lib,Johnson/Weld,5
-Pottawatomie,Lone Tree,President,,Lib,Johnson/Weld,5
-Pottawatomie,Louisville,President,,Lib,Johnson/Weld,27
-Pottawatomie,Mill Creek,President,,Lib,Johnson/Weld,19
-Pottawatomie,Pottawatomie,President,,Lib,Johnson/Weld,7
-Pottawatomie,Rock Creek,President,,Lib,Johnson/Weld,23
-Pottawatomie,Shannon,President,,Lib,Johnson/Weld,8
-Pottawatomie,Sherman,President,,Lib,Johnson/Weld,3
-Pottawatomie,Spring Creek,President,,Lib,Johnson/Weld,1
-Pottawatomie,St. Clere,President,,Lib,Johnson/Weld,3
-Pottawatomie,St. George 1,President,,Lib,Johnson/Weld,0
-Pottawatomie,St. George 17,President,,Lib,Johnson/Weld,91
-Pottawatomie,St. Mary's City,President,,Lib,Johnson/Weld,19
-Pottawatomie,St. Mary's Township,President,,Lib,Johnson/Weld,8
-Pottawatomie,Union,President,,Lib,Johnson/Weld,10
-Pottawatomie,Vienna,President,,Lib,Johnson/Weld,3
-Pottawatomie,Wamego City 18,President,,Lib,Johnson/Weld,91
-Pottawatomie,Wamego City 17,President,,Lib,Johnson/Weld,34
-Pottawatomie,Wamego Twp 1,President,,Lib,Johnson/Weld,1
-Pottawatomie,Wamego Twp 17,President,,Lib,Johnson/Weld,13
-Pottawatomie,Wamego Twp 18,President,,Lib,Johnson/Weld,8
-Pottawatomie,Provisionals,President,,Lib,Johnson/Weld,9
-Pottawatomie,Federal,President,,Lib,Johnson/Weld,2
-Pottawatomie,Total,President,,Lib,Johnson/Weld,543
-Pottawatomie,Belvue,President,,Ind,Stein/Baraka,3
-Pottawatomie,Blue,President,,Ind,Stein/Baraka,19
-Pottawatomie,Blue Valley,President,,Ind,Stein/Baraka,5
-Pottawatomie,Center,President,,Ind,Stein/Baraka,0
-Pottawatomie,Clear Creek,President,,Ind,Stein/Baraka,1
-Pottawatomie,Emmett,President,,Ind,Stein/Baraka,5
-Pottawatomie,Grant,President,,Ind,Stein/Baraka,0
-Pottawatomie,Green,President,,Ind,Stein/Baraka,1
-Pottawatomie,Lincoln,President,,Ind,Stein/Baraka,0
-Pottawatomie,Lone Tree,President,,Ind,Stein/Baraka,3
-Pottawatomie,Louisville,President,,Ind,Stein/Baraka,7
-Pottawatomie,Mill Creek,President,,Ind,Stein/Baraka,4
-Pottawatomie,Pottawatomie,President,,Ind,Stein/Baraka,0
-Pottawatomie,Rock Creek,President,,Ind,Stein/Baraka,10
-Pottawatomie,Shannon,President,,Ind,Stein/Baraka,3
-Pottawatomie,Sherman,President,,Ind,Stein/Baraka,1
-Pottawatomie,Spring Creek,President,,Ind,Stein/Baraka,2
-Pottawatomie,St. Clere,President,,Ind,Stein/Baraka,1
-Pottawatomie,St. George 1,President,,Ind,Stein/Baraka,0
-Pottawatomie,St. George 17,President,,Ind,Stein/Baraka,40
-Pottawatomie,St. Mary's City,President,,Ind,Stein/Baraka,11
-Pottawatomie,St. Mary's Township,President,,Ind,Stein/Baraka,3
-Pottawatomie,Union,President,,Ind,Stein/Baraka,1
-Pottawatomie,Vienna,President,,Ind,Stein/Baraka,1
-Pottawatomie,Wamego City 18,President,,Ind,Stein/Baraka,42
-Pottawatomie,Wamego City 17,President,,Ind,Stein/Baraka,11
-Pottawatomie,Wamego Twp 1,President,,Ind,Stein/Baraka,0
-Pottawatomie,Wamego Twp 17,President,,Ind,Stein/Baraka,7
-Pottawatomie,Wamego Twp 18,President,,Ind,Stein/Baraka,4
-Pottawatomie,Provisionals,President,,Ind,Stein/Baraka,8
-Pottawatomie,Federal,President,,Ind,Stein/Baraka,0
-Pottawatomie,Total,President,,Ind,Stein/Baraka,193
-Pottawatomie,Belvue,U.S. Senate,,Dem,Patrick Wiesner,20
-Pottawatomie,Blue,U.S. Senate,,Dem,Patrick Wiesner,401
-Pottawatomie,Blue Valley,U.S. Senate,,Dem,Patrick Wiesner,30
-Pottawatomie,Center,U.S. Senate,,Dem,Patrick Wiesner,0
-Pottawatomie,Clear Creek,U.S. Senate,,Dem,Patrick Wiesner,7
-Pottawatomie,Emmett,U.S. Senate,,Dem,Patrick Wiesner,23
-Pottawatomie,Grant,U.S. Senate,,Dem,Patrick Wiesner,21
-Pottawatomie,Green,U.S. Senate,,Dem,Patrick Wiesner,20
-Pottawatomie,Lincoln,U.S. Senate,,Dem,Patrick Wiesner,9
-Pottawatomie,Lone Tree,U.S. Senate,,Dem,Patrick Wiesner,10
-Pottawatomie,Louisville,U.S. Senate,,Dem,Patrick Wiesner,53
-Pottawatomie,Mill Creek,U.S. Senate,,Dem,Patrick Wiesner,90
-Pottawatomie,Pottawatomie,U.S. Senate,,Dem,Patrick Wiesner,39
-Pottawatomie,Rock Creek,U.S. Senate,,Dem,Patrick Wiesner,42
-Pottawatomie,Shannon,U.S. Senate,,Dem,Patrick Wiesner,21
-Pottawatomie,Sherman,U.S. Senate,,Dem,Patrick Wiesner,4
-Pottawatomie,Spring Creek,U.S. Senate,,Dem,Patrick Wiesner,8
-Pottawatomie,St. Clere,U.S. Senate,,Dem,Patrick Wiesner,4
-Pottawatomie,St. George 1,U.S. Senate,,Dem,Patrick Wiesner,5
-Pottawatomie,St. George 17,U.S. Senate,,Dem,Patrick Wiesner,313
-Pottawatomie,St. Mary's City,U.S. Senate,,Dem,Patrick Wiesner,103
-Pottawatomie,St. Mary's Township,U.S. Senate,,Dem,Patrick Wiesner,37
-Pottawatomie,Union,U.S. Senate,,Dem,Patrick Wiesner,27
-Pottawatomie,Vienna,U.S. Senate,,Dem,Patrick Wiesner,7
-Pottawatomie,Wamego City 18,U.S. Senate,,Dem,Patrick Wiesner,295
-Pottawatomie,Wamego City 17,U.S. Senate,,Dem,Patrick Wiesner,133
-Pottawatomie,Wamego Twp 1,U.S. Senate,,Dem,Patrick Wiesner,0
-Pottawatomie,Wamego Twp 17,U.S. Senate,,Dem,Patrick Wiesner,59
-Pottawatomie,Wamego Twp 18,U.S. Senate,,Dem,Patrick Wiesner,22
-Pottawatomie,Provisionals,U.S. Senate,,Dem,Patrick Wiesner,17
-Pottawatomie,Federal,U.S. Senate,,Dem,Patrick Wiesner,9
-Pottawatomie,Total,U.S. Senate,,Dem,Patrick Wiesner,1829
-Pottawatomie,Belvue,U.S. Senate,,Rep,Jerry Moran,121
-Pottawatomie,Blue,U.S. Senate,,Rep,Jerry Moran,1281
-Pottawatomie,Manhattan W2P5,U.S. Senate,,Rep,Jerry Moran,1
-Pottawatomie,Blue Valley,U.S. Senate,,Rep,Jerry Moran,141
-Pottawatomie,Center,U.S. Senate,,Rep,Jerry Moran,63
-Pottawatomie,Clear Creek,U.S. Senate,,Rep,Jerry Moran,61
-Pottawatomie,Emmett,U.S. Senate,,Rep,Jerry Moran,131
-Pottawatomie,Grant,U.S. Senate,,Rep,Jerry Moran,94
-Pottawatomie,Green,U.S. Senate,,Rep,Jerry Moran,87
-Pottawatomie,Lincoln,U.S. Senate,,Rep,Jerry Moran,49
-Pottawatomie,Lone Tree,U.S. Senate,,Rep,Jerry Moran,92
-Pottawatomie,Louisville,U.S. Senate,,Rep,Jerry Moran,347
-Pottawatomie,Mill Creek,U.S. Senate,,Rep,Jerry Moran,318
-Pottawatomie,Pottawatomie,U.S. Senate,,Rep,Jerry Moran,267
-Pottawatomie,Rock Creek,U.S. Senate,,Rep,Jerry Moran,251
-Pottawatomie,Shannon,U.S. Senate,,Rep,Jerry Moran,119
-Pottawatomie,Sherman,U.S. Senate,,Rep,Jerry Moran,44
-Pottawatomie,Spring Creek,U.S. Senate,,Rep,Jerry Moran,21
-Pottawatomie,St. Clere,U.S. Senate,,Rep,Jerry Moran,24
-Pottawatomie,St. George 1,U.S. Senate,,Rep,Jerry Moran,18
-Pottawatomie,St. George 17,U.S. Senate,,Rep,Jerry Moran,1311
-Pottawatomie,St. Mary's City,U.S. Senate,,Rep,Jerry Moran,1038
-Pottawatomie,St. Mary's Township,U.S. Senate,,Rep,Jerry Moran,403
-Pottawatomie,Union,U.S. Senate,,Rep,Jerry Moran,100
-Pottawatomie,Vienna,U.S. Senate,,Rep,Jerry Moran,47
-Pottawatomie,Wamego City 18,U.S. Senate,,Rep,Jerry Moran,912
-Pottawatomie,Wamego City 17,U.S. Senate,,Rep,Jerry Moran,498
-Pottawatomie,Wamego Twp 1,U.S. Senate,,Rep,Jerry Moran,12
-Pottawatomie,Wamego Twp 17,U.S. Senate,,Rep,Jerry Moran,244
-Pottawatomie,Wamego Twp 18,U.S. Senate,,Rep,Jerry Moran,133
-Pottawatomie,Provisionals,U.S. Senate,,Rep,Jerry Moran,147
-Pottawatomie,Federal,U.S. Senate,,Rep,Jerry Moran,32
-Pottawatomie,Total,U.S. Senate,,Rep,Jerry Moran,8407
-Pottawatomie,Belvue,U.S. Senate,,Lib,Robert D. Garrard,9
-Pottawatomie,Blue,U.S. Senate,,Lib,Robert D. Garrard,75
-Pottawatomie,Blue Valley,U.S. Senate,,Lib,Robert D. Garrard,4
-Pottawatomie,Center,U.S. Senate,,Lib,Robert D. Garrard,1
-Pottawatomie,Clear Creek,U.S. Senate,,Lib,Robert D. Garrard,5
-Pottawatomie,Emmett,U.S. Senate,,Lib,Robert D. Garrard,9
-Pottawatomie,Grant,U.S. Senate,,Lib,Robert D. Garrard,7
-Pottawatomie,Green,U.S. Senate,,Lib,Robert D. Garrard,2
-Pottawatomie,Lincoln,U.S. Senate,,Lib,Robert D. Garrard,5
-Pottawatomie,Lone Tree,U.S. Senate,,Lib,Robert D. Garrard,7
-Pottawatomie,Louisville,U.S. Senate,,Lib,Robert D. Garrard,20
-Pottawatomie,Mill Creek,U.S. Senate,,Lib,Robert D. Garrard,12
-Pottawatomie,Pottawatomie,U.S. Senate,,Lib,Robert D. Garrard,11
-Pottawatomie,Rock Creek,U.S. Senate,,Lib,Robert D. Garrard,31
-Pottawatomie,Shannon,U.S. Senate,,Lib,Robert D. Garrard,2
-Pottawatomie,Sherman,U.S. Senate,,Lib,Robert D. Garrard,1
-Pottawatomie,Spring Creek,U.S. Senate,,Lib,Robert D. Garrard,0
-Pottawatomie,St. Clere,U.S. Senate,,Lib,Robert D. Garrard,2
-Pottawatomie,St. George 1,U.S. Senate,,Lib,Robert D. Garrard,1
-Pottawatomie,St. George 17,U.S. Senate,,Lib,Robert D. Garrard,96
-Pottawatomie,St. Mary's City,U.S. Senate,,Lib,Robert D. Garrard,42
-Pottawatomie,St. Mary's Township,U.S. Senate,,Lib,Robert D. Garrard,4
-Pottawatomie,Union,U.S. Senate,,Lib,Robert D. Garrard,3
-Pottawatomie,Vienna,U.S. Senate,,Lib,Robert D. Garrard,1
-Pottawatomie,Wamego City 18,U.S. Senate,,Lib,Robert D. Garrard,81
-Pottawatomie,Wamego City 17,U.S. Senate,,Lib,Robert D. Garrard,22
-Pottawatomie,Wamego Twp 1,U.S. Senate,,Lib,Robert D. Garrard,1
-Pottawatomie,Wamego Twp 17,U.S. Senate,,Lib,Robert D. Garrard,12
-Pottawatomie,Wamego Twp 18,U.S. Senate,,Lib,Robert D. Garrard,11
-Pottawatomie,Provisionals,U.S. Senate,,Lib,Robert D. Garrard,9
-Pottawatomie,Federal,U.S. Senate,,Lib,Robert D. Garrard,4
-Pottawatomie,Total,U.S. Senate,,Lib,Robert D. Garrard,490
-Pottawatomie,Belvue,U.S House,1,Rep,Roger Marshall,103
-Pottawatomie,Blue,U.S House,1,Rep,Roger Marshall,1084
-Pottawatomie,Manhattan W2P5,U.S House,1,Rep,Roger Marshall,1
-Pottawatomie,Blue Valley,U.S House,1,Rep,Roger Marshall,113
-Pottawatomie,Center,U.S House,1,Rep,Roger Marshall,44
-Pottawatomie,Clear Creek,U.S House,1,Rep,Roger Marshall,56
-Pottawatomie,Emmett,U.S House,1,Rep,Roger Marshall,103
-Pottawatomie,Grant,U.S House,1,Rep,Roger Marshall,79
-Pottawatomie,Green,U.S House,1,Rep,Roger Marshall,78
-Pottawatomie,Lincoln,U.S House,1,Rep,Roger Marshall,42
-Pottawatomie,Lone Tree,U.S House,1,Rep,Roger Marshall,80
-Pottawatomie,Louisville,U.S House,1,Rep,Roger Marshall,318
-Pottawatomie,Mill Creek,U.S House,1,Rep,Roger Marshall,284
-Pottawatomie,Pottawatomie,U.S House,1,Rep,Roger Marshall,244
-Pottawatomie,Rock Creek,U.S House,1,Rep,Roger Marshall,223
-Pottawatomie,Shannon,U.S House,1,Rep,Roger Marshall,100
-Pottawatomie,Sherman,U.S House,1,Rep,Roger Marshall,31
-Pottawatomie,Spring Creek,U.S House,1,Rep,Roger Marshall,18
-Pottawatomie,St. Clere,U.S House,1,Rep,Roger Marshall,19
-Pottawatomie,St. George 1,U.S House,1,Rep,Roger Marshall,14
-Pottawatomie,St. George 17,U.S House,1,Rep,Roger Marshall,1159
-Pottawatomie,St. Mary's City,U.S House,1,Rep,Roger Marshall,695
-Pottawatomie,St. Mary's Township,U.S House,1,Rep,Roger Marshall,289
-Pottawatomie,Union,U.S House,1,Rep,Roger Marshall,94
-Pottawatomie,Vienna,U.S House,1,Rep,Roger Marshall,44
-Pottawatomie,Wamego City 18,U.S House,1,Rep,Roger Marshall,831
-Pottawatomie,Wamego City 17,U.S House,1,Rep,Roger Marshall,476
-Pottawatomie,Wamego Twp 1,U.S House,1,Rep,Roger Marshall,11
-Pottawatomie,Wamego Twp 17,U.S House,1,Rep,Roger Marshall,221
-Pottawatomie,Wamego Twp 18,U.S House,1,Rep,Roger Marshall,110
-Pottawatomie,Provisionals,U.S House,1,Rep,Roger Marshall,125
-Pottawatomie,Federal,U.S House,1,Rep,Roger Marshall,23
-Pottawatomie,Total,U.S House,1,Rep,Roger Marshall,7112
-Pottawatomie,Belvue,U.S House,1,Lib,Kerry Burt,12
-Pottawatomie,Blue,U.S House,1,Lib,Kerry Burt,131
-Pottawatomie,Blue Valley,U.S House,1,Lib,Kerry Burt,3
-Pottawatomie,Center,U.S House,1,Lib,Kerry Burt,3
-Pottawatomie,Clear Creek,U.S House,1,Lib,Kerry Burt,3
-Pottawatomie,Emmett,U.S House,1,Lib,Kerry Burt,9
-Pottawatomie,Grant,U.S House,1,Lib,Kerry Burt,8
-Pottawatomie,Green,U.S House,1,Lib,Kerry Burt,7
-Pottawatomie,Lincoln,U.S House,1,Lib,Kerry Burt,5
-Pottawatomie,Lone Tree,U.S House,1,Lib,Kerry Burt,6
-Pottawatomie,Louisville,U.S House,1,Lib,Kerry Burt,25
-Pottawatomie,Mill Creek,U.S House,1,Lib,Kerry Burt,28
-Pottawatomie,Pottawatomie,U.S House,1,Lib,Kerry Burt,14
-Pottawatomie,Rock Creek,U.S House,1,Lib,Kerry Burt,28
-Pottawatomie,Shannon,U.S House,1,Lib,Kerry Burt,6
-Pottawatomie,Sherman,U.S House,1,Lib,Kerry Burt,2
-Pottawatomie,Spring Creek,U.S House,1,Lib,Kerry Burt,0
-Pottawatomie,St. Clere,U.S House,1,Lib,Kerry Burt,1
-Pottawatomie,St. George 1,U.S House,1,Lib,Kerry Burt,1
-Pottawatomie,St. George 17,U.S House,1,Lib,Kerry Burt,121
-Pottawatomie,St. Mary's City,U.S House,1,Lib,Kerry Burt,42
-Pottawatomie,St. Mary's Township,U.S House,1,Lib,Kerry Burt,15
-Pottawatomie,Union,U.S House,1,Lib,Kerry Burt,8
-Pottawatomie,Vienna,U.S House,1,Lib,Kerry Burt,0
-Pottawatomie,Wamego City 18,U.S House,1,Lib,Kerry Burt,118
-Pottawatomie,Wamego City 17,U.S House,1,Lib,Kerry Burt,38
-Pottawatomie,Wamego Twp 1,U.S House,1,Lib,Kerry Burt,1
-Pottawatomie,Wamego Twp 17,U.S House,1,Lib,Kerry Burt,21
-Pottawatomie,Wamego Twp 18,U.S House,1,Lib,Kerry Burt,14
-Pottawatomie,Provisionals,U.S House,1,Lib,Kerry Burt,10
-Pottawatomie,Federal,U.S House,1,Lib,Kerry Burt,7
-Pottawatomie,Total,U.S House,1,Lib,Kerry Burt,687
-Pottawatomie,Belvue,U.S House,1,Ind,Alan LaPolice,29
-Pottawatomie,Blue,U.S House,1,Ind,Alan LaPolice,486
-Pottawatomie,Blue Valley,U.S House,1,Ind,Alan LaPolice,54
-Pottawatomie,Center,U.S House,1,Ind,Alan LaPolice,10
-Pottawatomie,Clear Creek,U.S House,1,Ind,Alan LaPolice,12
-Pottawatomie,Emmett,U.S House,1,Ind,Alan LaPolice,35
-Pottawatomie,Grant,U.S House,1,Ind,Alan LaPolice,30
-Pottawatomie,Green,U.S House,1,Ind,Alan LaPolice,20
-Pottawatomie,Lincoln,U.S House,1,Ind,Alan LaPolice,14
-Pottawatomie,Lone Tree,U.S House,1,Ind,Alan LaPolice,18
-Pottawatomie,Louisville,U.S House,1,Ind,Alan LaPolice,70
-Pottawatomie,Mill Creek,U.S House,1,Ind,Alan LaPolice,87
-Pottawatomie,Pottawatomie,U.S House,1,Ind,Alan LaPolice,54
-Pottawatomie,Rock Creek,U.S House,1,Ind,Alan LaPolice,69
-Pottawatomie,Shannon,U.S House,1,Ind,Alan LaPolice,31
-Pottawatomie,Sherman,U.S House,1,Ind,Alan LaPolice,13
-Pottawatomie,Spring Creek,U.S House,1,Ind,Alan LaPolice,10
-Pottawatomie,St. Clere,U.S House,1,Ind,Alan LaPolice,8
-Pottawatomie,St. George 1,U.S House,1,Ind,Alan LaPolice,8
-Pottawatomie,St. George 17,U.S House,1,Ind,Alan LaPolice,396
-Pottawatomie,St. Mary's City,U.S House,1,Ind,Alan LaPolice,183
-Pottawatomie,St. Mary's Township,U.S House,1,Ind,Alan LaPolice,44
-Pottawatomie,Union,U.S House,1,Ind,Alan LaPolice,23
-Pottawatomie,Vienna,U.S House,1,Ind,Alan LaPolice,10
-Pottawatomie,Wamego City 18,U.S House,1,Ind,Alan LaPolice,293
-Pottawatomie,Wamego City 17,U.S House,1,Ind,Alan LaPolice,119
-Pottawatomie,Wamego Twp 1,U.S House,1,Ind,Alan LaPolice,1
-Pottawatomie,Wamego Twp 17,U.S House,1,Ind,Alan LaPolice,66
-Pottawatomie,Wamego Twp 18,U.S House,1,Ind,Alan LaPolice,36
-Pottawatomie,Provisionals,U.S House,1,Ind,Alan LaPolice,29
-Pottawatomie,Federal,U.S House,1,Ind,Alan LaPolice,10
-Pottawatomie,Total,U.S House,1,Ind,Alan LaPolice,2268
-Pottawatomie,Belvue,State Senate,1,Dem,Jerry Henry,32
-Pottawatomie,Blue,State Senate,1,Dem,Jerry Henry,581
-Pottawatomie,Blue Valley,State Senate,1,Dem,Jerry Henry,41
-Pottawatomie,Center,State Senate,1,Dem,Jerry Henry,5
-Pottawatomie,Clear Creek,State Senate,1,Dem,Jerry Henry,21
-Pottawatomie,Emmett,State Senate,1,Dem,Jerry Henry,37
-Pottawatomie,Grant,State Senate,1,Dem,Jerry Henry,29
-Pottawatomie,Green,State Senate,1,Dem,Jerry Henry,28
-Pottawatomie,Lincoln,State Senate,1,Dem,Jerry Henry,12
-Pottawatomie,Lone Tree,State Senate,1,Dem,Jerry Henry,26
-Pottawatomie,Louisville,State Senate,1,Dem,Jerry Henry,86
-Pottawatomie,Mill Creek,State Senate,1,Dem,Jerry Henry,145
-Pottawatomie,Pottawatomie,State Senate,1,Dem,Jerry Henry,79
-Pottawatomie,Rock Creek,State Senate,1,Dem,Jerry Henry,91
-Pottawatomie,Shannon,State Senate,1,Dem,Jerry Henry,37
-Pottawatomie,Sherman,State Senate,1,Dem,Jerry Henry,10
-Pottawatomie,Spring Creek,State Senate,1,Dem,Jerry Henry,11
-Pottawatomie,St. Clere,State Senate,1,Dem,Jerry Henry,10
-Pottawatomie,St. George 1,State Senate,1,Dem,Jerry Henry,9
-Pottawatomie,Union,State Senate,1,Dem,Jerry Henry,44
-Pottawatomie,Vienna,State Senate,1,Dem,Jerry Henry,12
-Pottawatomie,Wamego Twp 1,State Senate,1,Dem,Jerry Henry,1
-Pottawatomie,Provisionals,State Senate,1,Dem,Jerry Henry,13
-Pottawatomie,Federal,State Senate,1,Dem,Jerry Henry,7
-Pottawatomie,Total,State Senate,1,Dem,Jerry Henry,1367
-Pottawatomie,Belvue,State Senate,1,Rep,Dennis D. Pyle,125
-Pottawatomie,Blue,State Senate,1,Rep,Dennis D. Pyle,1133
-Pottawatomie,Manhattan W2P5,State Senate,1,Rep,Dennis D. Pyle,1
-Pottawatomie,Blue Valley,State Senate,1,Rep,Dennis D. Pyle,130
-Pottawatomie,Center,State Senate,1,Rep,Dennis D. Pyle,61
-Pottawatomie,Clear Creek,State Senate,1,Rep,Dennis D. Pyle,53
-Pottawatomie,Emmett,State Senate,1,Rep,Dennis D. Pyle,126
-Pottawatomie,Grant,State Senate,1,Rep,Dennis D. Pyle,95
-Pottawatomie,Green,State Senate,1,Rep,Dennis D. Pyle,77
-Pottawatomie,Lincoln,State Senate,1,Rep,Dennis D. Pyle,49
-Pottawatomie,Lone Tree,State Senate,1,Rep,Dennis D. Pyle,82
-Pottawatomie,Louisville,State Senate,1,Rep,Dennis D. Pyle,332
-Pottawatomie,Mill Creek,State Senate,1,Rep,Dennis D. Pyle,272
-Pottawatomie,Pottawatomie,State Senate,1,Rep,Dennis D. Pyle,233
-Pottawatomie,Rock Creek,State Senate,1,Rep,Dennis D. Pyle,226
-Pottawatomie,Shannon,State Senate,1,Rep,Dennis D. Pyle,102
-Pottawatomie,Sherman,State Senate,1,Rep,Dennis D. Pyle,41
-Pottawatomie,Spring Creek,State Senate,1,Rep,Dennis D. Pyle,18
-Pottawatomie,St. Clere,State Senate,1,Rep,Dennis D. Pyle,19
-Pottawatomie,St. George 1,State Senate,1,Rep,Dennis D. Pyle,14
-Pottawatomie,Union,State Senate,1,Rep,Dennis D. Pyle,85
-Pottawatomie,Vienna,State Senate,1,Rep,Dennis D. Pyle,43
-Pottawatomie,Wamego Twp 1,State Senate,1,Rep,Dennis D. Pyle,12
-Pottawatomie,Provisionals,State Senate,1,Rep,Dennis D. Pyle,27
-Pottawatomie,Federal,State Senate,1,Rep,Dennis D. Pyle,18
-Pottawatomie,Total,State Senate,1,Rep,Dennis D. Pyle,3374
-Pottawatomie,St. George 17,State Senate,17,Dem,Susan G. Fowler,530
-Pottawatomie,Wamego City 17,State Senate,17,Dem,Susan G. Fowler,182
-Pottawatomie,Wamego Twp 17,State Senate,17,Dem,Susan G. Fowler,95
-Pottawatomie,Provisionals,State Senate,17,Dem,Susan G. Fowler,6
-Pottawatomie,Federal,State Senate,17,Dem,Susan G. Fowler,2
-Pottawatomie,Total,State Senate,17,Dem,Susan G. Fowler,815
-Pottawatomie,St. George 17,State Senate,17,Rep,Jeff Longbine,1130
-Pottawatomie,Wamego City 17,State Senate,17,Rep,Jeff Longbine,451
-Pottawatomie,Wamego Twp 17,State Senate,17,Rep,Jeff Longbine,212
-Pottawatomie,Provisionals,State Senate,17,Rep,Jeff Longbine,25
-Pottawatomie,Federal,State Senate,17,Rep,Jeff Longbine,6
-Pottawatomie,Total,State Senate,17,Rep,Jeff Longbine,1824
-Pottawatomie,St. Mary's City,State Senate,18,Dem,Laura Kelly,192
-Pottawatomie,St. Mary's Township,State Senate,18,Dem,Laura Kelly,61
-Pottawatomie,Wamego City 18,State Senate,18,Dem,Laura Kelly,541
-Pottawatomie,Wamego Twp 18,State Senate,18,Dem,Laura Kelly,63
-Pottawatomie,Provisionals,State Senate,18,Dem,Laura Kelly,18
-Pottawatomie,Federal,State Senate,18,Dem,Laura Kelly,4
-Pottawatomie,Total,State Senate,18,Dem,Laura Kelly,879
-Pottawatomie,St. Mary's City,State Senate,18,Rep,Dave Jackson,1008
-Pottawatomie,St. Mary's Township,State Senate,18,Rep,Dave Jackson,393
-Pottawatomie,Wamego City 18,State Senate,18,Rep,Dave Jackson,737
-Pottawatomie,Wamego Twp 18,State Senate,18,Rep,Dave Jackson,100
-Pottawatomie,Provisionals,State Senate,18,Rep,Dave Jackson,65
-Pottawatomie,Federal,State Senate,18,Rep,Dave Jackson,17
-Pottawatomie,Total,State Senate,18,Rep,Dave Jackson,2320
-Pottawatomie,Blue,State House,51,Dem,Adrienne Olejnik,803
-Pottawatomie,St. George 1,State House,51,Dem,Adrienne Olejnik,15
-Pottawatomie,St. George 17,State House,51,Dem,Adrienne Olejnik,777
-Pottawatomie,Wamego City 18,State House,51,Dem,Adrienne Olejnik,638
-Pottawatomie,Wamego City 17,State House,51,Dem,Adrienne Olejnik,299
-Pottawatomie,Wamego Twp 1,State House,51,Dem,Adrienne Olejnik,1
-Pottawatomie,Wamego Twp 17,State House,51,Dem,Adrienne Olejnik,127
-Pottawatomie,Wamego Twp 18,State House,51,Dem,Adrienne Olejnik,55
-Pottawatomie,Provisionals,State House,51,Dem,Adrienne Olejnik,24
-Pottawatomie,Federal,State House,51,Dem,Adrienne Olejnik,5
-Pottawatomie,Total,State House,51,Dem,Adrienne Olejnik,2744
-Pottawatomie,Blue,State House,51,Rep,Ron Highland,936
-Pottawatomie,St. George 1,State House,51,Rep,Ron Highland,8
-Pottawatomie,St. George 17,State House,51,Rep,Ron Highland,933
-Pottawatomie,Wamego City 18,State House,51,Rep,Ron Highland,658
-Pottawatomie,Wamego City 17,State House,51,Rep,Ron Highland,351
-Pottawatomie,Wamego Twp 1,State House,51,Rep,Ron Highland,12
-Pottawatomie,Wamego Twp 17,State House,51,Rep,Ron Highland,188
-Pottawatomie,Wamego Twp 18,State House,51,Rep,Ron Highland,111
-Pottawatomie,Provisionals,State House,51,Rep,Ron Highland,61
-Pottawatomie,Federal,State House,51,Rep,Ron Highland,22
-Pottawatomie,Total,State House,51,Rep,Ron Highland,3280
-Pottawatomie,Belvue,State House,61,Dem,Lauren Van Wagoner,34
-Pottawatomie,Blue Valley,State House,61,Dem,Lauren Van Wagoner,46
-Pottawatomie,Center,State House,61,Dem,Lauren Van Wagoner,15
-Pottawatomie,Clear Creek,State House,61,Dem,Lauren Van Wagoner,22
-Pottawatomie,Emmett,State House,61,Dem,Lauren Van Wagoner,53
-Pottawatomie,Grant,State House,61,Dem,Lauren Van Wagoner,35
-Pottawatomie,Green,State House,61,Dem,Lauren Van Wagoner,28
-Pottawatomie,Lincoln,State House,61,Dem,Lauren Van Wagoner,14
-Pottawatomie,Lone Tree,State House,61,Dem,Lauren Van Wagoner,23
-Pottawatomie,Louisville,State House,61,Dem,Lauren Van Wagoner,71
-Pottawatomie,Mill Creek,State House,61,Dem,Lauren Van Wagoner,170
-Pottawatomie,Pottawatomie,State House,61,Dem,Lauren Van Wagoner,73
-Pottawatomie,Rock Creek,State House,61,Dem,Lauren Van Wagoner,103
-Pottawatomie,Shannon,State House,61,Dem,Lauren Van Wagoner,35
-Pottawatomie,Sherman,State House,61,Dem,Lauren Van Wagoner,8
-Pottawatomie,Spring Creek,State House,61,Dem,Lauren Van Wagoner,9
-Pottawatomie,St. Clere,State House,61,Dem,Lauren Van Wagoner,15
-Pottawatomie,St. Mary's City,State House,61,Dem,Lauren Van Wagoner,254
-Pottawatomie,St. Mary's Township,State House,61,Dem,Lauren Van Wagoner,89
-Pottawatomie,Union,State House,61,Dem,Lauren Van Wagoner,43
-Pottawatomie,Vienna,State House,61,Dem,Lauren Van Wagoner,18
-Pottawatomie,Provisionals,State House,61,Dem,Lauren Van Wagoner,16
-Pottawatomie,Federal,State House,61,Dem,Lauren Van Wagoner,2
-Pottawatomie,Total,State House,61,Dem,Lauren Van Wagoner,1176
-Pottawatomie,Belvue,State House,61,Rep,Francis Awerkamp,123
-Pottawatomie,Blue Valley,State House,61,Rep,Francis Awerkamp,124
-Pottawatomie,Center,State House,61,Rep,Francis Awerkamp,51
-Pottawatomie,Clear Creek,State House,61,Rep,Francis Awerkamp,48
-Pottawatomie,Emmett,State House,61,Rep,Francis Awerkamp,112
-Pottawatomie,Grant,State House,61,Rep,Francis Awerkamp,85
-Pottawatomie,Green,State House,61,Rep,Francis Awerkamp,78
-Pottawatomie,Lincoln,State House,61,Rep,Francis Awerkamp,48
-Pottawatomie,Lone Tree,State House,61,Rep,Francis Awerkamp,84
-Pottawatomie,Louisville,State House,61,Rep,Francis Awerkamp,344
-Pottawatomie,Mill Creek,State House,61,Rep,Francis Awerkamp,239
-Pottawatomie,Pottawatomie,State House,61,Rep,Francis Awerkamp,237
-Pottawatomie,Rock Creek,State House,61,Rep,Francis Awerkamp,210
-Pottawatomie,Shannon,State House,61,Rep,Francis Awerkamp,104
-Pottawatomie,Sherman,State House,61,Rep,Francis Awerkamp,40
-Pottawatomie,Spring Creek,State House,61,Rep,Francis Awerkamp,19
-Pottawatomie,St. Clere,State House,61,Rep,Francis Awerkamp,14
-Pottawatomie,St. Mary's City,State House,61,Rep,Francis Awerkamp,971
-Pottawatomie,St. Mary's Township,State House,61,Rep,Francis Awerkamp,374
-Pottawatomie,Union,State House,61,Rep,Francis Awerkamp,83
-Pottawatomie,Vienna,State House,61,Rep,Francis Awerkamp,37
-Pottawatomie,Provisionals,State House,61,Rep,Francis Awerkamp,58
-Pottawatomie,Federal,State House,61,Rep,Francis Awerkamp,16
-Pottawatomie,Total,State House,61,Rep,Francis Awerkamp,3499
-Pottawatomie,Manhattan W2P5,State House,66,Dem,Sydney Carlin,1
-Pottawatomie,Total,State House,66,Dem,Sydney Carlin,1
-Pottawatomie,Total,State House,66,Rep,Stanley Hoerman,0
+county,precinct,office,district,party,candidate,votes,vtd
+POTTAWATOMIE,Belvue Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",34,000010
+POTTAWATOMIE,Belvue Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",129,000010
+POTTAWATOMIE,Blue Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",807,000020
+POTTAWATOMIE,Blue Township,Kansas House of Representatives,51,Republican,"Highland, Ron",953,000020
+POTTAWATOMIE,Blue Valley Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",46,000030
+POTTAWATOMIE,Blue Valley Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",125,000030
+POTTAWATOMIE,Center Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",15,000040
+POTTAWATOMIE,Center Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",51,000040
+POTTAWATOMIE,Clear Creek Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",23,000050
+POTTAWATOMIE,Clear Creek Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",49,000050
+POTTAWATOMIE,Emmett Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",53,000060
+POTTAWATOMIE,Emmett Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",114,000060
+POTTAWATOMIE,Grant Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",38,000070
+POTTAWATOMIE,Grant Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",87,000070
+POTTAWATOMIE,Green Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",28,000080
+POTTAWATOMIE,Green Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",79,000080
+POTTAWATOMIE,Lincoln Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",15,000090
+POTTAWATOMIE,Lincoln Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",50,000090
+POTTAWATOMIE,Lone Tree Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",23,000100
+POTTAWATOMIE,Lone Tree Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",85,000100
+POTTAWATOMIE,Louisville Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",71,000110
+POTTAWATOMIE,Louisville Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",345,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",1,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",0,000120
+POTTAWATOMIE,Mill Creek Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",175,000130
+POTTAWATOMIE,Mill Creek Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",242,000130
+POTTAWATOMIE,Pottawatomie County,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",74,000140
+POTTAWATOMIE,Pottawatomie County,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",239,000140
+POTTAWATOMIE,Rock Creek Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",104,000150
+POTTAWATOMIE,Rock Creek Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",213,000150
+POTTAWATOMIE,Shannon Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",35,000160
+POTTAWATOMIE,Shannon Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",104,000160
+POTTAWATOMIE,Sherman Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",8,000170
+POTTAWATOMIE,Sherman Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",40,000170
+POTTAWATOMIE,Spring Creek Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",10,000180
+POTTAWATOMIE,Spring Creek Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",19,000180
+POTTAWATOMIE,St. Clere Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",15,000190
+POTTAWATOMIE,St. Clere Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",15,000190
+POTTAWATOMIE,Union Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",43,000230
+POTTAWATOMIE,Union Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",84,000230
+POTTAWATOMIE,Vienna Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",19,000240
+POTTAWATOMIE,Vienna Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",39,000240
+POTTAWATOMIE,St. George Township S1,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",15,120020
+POTTAWATOMIE,St. George Township S1,Kansas House of Representatives,51,Republican,"Highland, Ron",8,120020
+POTTAWATOMIE,St. George Township S17,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",785,120030
+POTTAWATOMIE,St. George Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",951,120030
+POTTAWATOMIE,Wamego Township S1,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",1,120060
+POTTAWATOMIE,Wamego Township S1,Kansas House of Representatives,51,Republican,"Highland, Ron",12,120060
+POTTAWATOMIE,Wamego Township S17,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",127,120070
+POTTAWATOMIE,Wamego Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",192,120070
+POTTAWATOMIE,Wamego Township S18,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",56,120080
+POTTAWATOMIE,Wamego Township S18,Kansas House of Representatives,51,Republican,"Highland, Ron",116,120080
+POTTAWATOMIE,St. Marys City,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",256,130010
+POTTAWATOMIE,St. Marys City,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",1003,130010
+POTTAWATOMIE,St. Marys Township,Kansas House of Representatives,61,Democratic,"Van Wagoner, Lauren",91,130020
+POTTAWATOMIE,St. Marys Township,Kansas House of Representatives,61,Republican,"Awerkamp, Francis",387,130020
+POTTAWATOMIE,Wamego City S18,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",651,130030
+POTTAWATOMIE,Wamego City S18,Kansas House of Representatives,51,Republican,"Highland, Ron",690,130030
+POTTAWATOMIE,Wamego City S17,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",302,130040
+POTTAWATOMIE,Wamego City S17,Kansas House of Representatives,51,Republican,"Highland, Ron",358,130040
+POTTAWATOMIE,Belvue Township,Kansas Senate,1,Democratic,"Henry, Jerry",34,000010
+POTTAWATOMIE,Belvue Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",128,000010
+POTTAWATOMIE,Blue Township,Kansas Senate,1,Democratic,"Henry, Jerry",585,000020
+POTTAWATOMIE,Blue Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",1150,000020
+POTTAWATOMIE,Blue Valley Township,Kansas Senate,1,Democratic,"Henry, Jerry",41,000030
+POTTAWATOMIE,Blue Valley Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",131,000030
+POTTAWATOMIE,Center Township,Kansas Senate,1,Democratic,"Henry, Jerry",5,000040
+POTTAWATOMIE,Center Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",62,000040
+POTTAWATOMIE,Clear Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",22,000050
+POTTAWATOMIE,Clear Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",54,000050
+POTTAWATOMIE,Emmett Township,Kansas Senate,1,Democratic,"Henry, Jerry",38,000060
+POTTAWATOMIE,Emmett Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",127,000060
+POTTAWATOMIE,Grant Township,Kansas Senate,1,Democratic,"Henry, Jerry",32,000070
+POTTAWATOMIE,Grant Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",97,000070
+POTTAWATOMIE,Green Township,Kansas Senate,1,Democratic,"Henry, Jerry",28,000080
+POTTAWATOMIE,Green Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",78,000080
+POTTAWATOMIE,Lincoln Township,Kansas Senate,1,Democratic,"Henry, Jerry",13,000090
+POTTAWATOMIE,Lincoln Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",51,000090
+POTTAWATOMIE,Lone Tree Township,Kansas Senate,1,Democratic,"Henry, Jerry",27,000100
+POTTAWATOMIE,Lone Tree Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",82,000100
+POTTAWATOMIE,Louisville Township,Kansas Senate,1,Democratic,"Henry, Jerry",86,000110
+POTTAWATOMIE,Louisville Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",333,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas Senate,1,Democratic,"Henry, Jerry",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,Kansas Senate,1,Republican,"Pyle, Dennis D.",1,000120
+POTTAWATOMIE,Mill Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",148,000130
+POTTAWATOMIE,Mill Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",277,000130
+POTTAWATOMIE,Pottawatomie County,Kansas Senate,1,Democratic,"Henry, Jerry",79,000140
+POTTAWATOMIE,Pottawatomie County,Kansas Senate,1,Republican,"Pyle, Dennis D.",236,000140
+POTTAWATOMIE,Rock Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",93,000150
+POTTAWATOMIE,Rock Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",229,000150
+POTTAWATOMIE,Shannon Township,Kansas Senate,1,Democratic,"Henry, Jerry",37,000160
+POTTAWATOMIE,Shannon Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",102,000160
+POTTAWATOMIE,Sherman Township,Kansas Senate,1,Democratic,"Henry, Jerry",10,000170
+POTTAWATOMIE,Sherman Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",41,000170
+POTTAWATOMIE,Spring Creek Township,Kansas Senate,1,Democratic,"Henry, Jerry",12,000180
+POTTAWATOMIE,Spring Creek Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",18,000180
+POTTAWATOMIE,St. Clere Township,Kansas Senate,1,Democratic,"Henry, Jerry",10,000190
+POTTAWATOMIE,St. Clere Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",20,000190
+POTTAWATOMIE,Union Township,Kansas Senate,1,Democratic,"Henry, Jerry",44,000230
+POTTAWATOMIE,Union Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",86,000230
+POTTAWATOMIE,Vienna Township,Kansas Senate,1,Democratic,"Henry, Jerry",13,000240
+POTTAWATOMIE,Vienna Township,Kansas Senate,1,Republican,"Pyle, Dennis D.",45,000240
+POTTAWATOMIE,St. George Township S1,Kansas Senate,1,Democratic,"Henry, Jerry",9,120020
+POTTAWATOMIE,St. George Township S1,Kansas Senate,1,Republican,"Pyle, Dennis D.",14,120020
+POTTAWATOMIE,St. George Township S17,Kansas Senate,17,Democratic,"Fowler, Susan G",535,120030
+POTTAWATOMIE,St. George Township S17,Kansas Senate,17,Republican,"Longbine, Jeff",1151,120030
+POTTAWATOMIE,Wamego Township S1,Kansas Senate,1,Democratic,"Henry, Jerry",1,120060
+POTTAWATOMIE,Wamego Township S1,Kansas Senate,1,Republican,"Pyle, Dennis D.",12,120060
+POTTAWATOMIE,Wamego Township S17,Kansas Senate,17,Democratic,"Fowler, Susan G",96,120070
+POTTAWATOMIE,Wamego Township S17,Kansas Senate,17,Republican,"Longbine, Jeff",215,120070
+POTTAWATOMIE,Wamego Township S18,Kansas Senate,18,Democratic,"Kelly, Laura",65,120080
+POTTAWATOMIE,Wamego Township S18,Kansas Senate,18,Republican,"Jackson, Dave",104,120080
+POTTAWATOMIE,St. Marys City,Kansas Senate,18,Democratic,"Kelly, Laura",195,130010
+POTTAWATOMIE,St. Marys City,Kansas Senate,18,Republican,"Jackson, Dave",1036,130010
+POTTAWATOMIE,St. Marys Township,Kansas Senate,18,Democratic,"Kelly, Laura",62,130020
+POTTAWATOMIE,St. Marys Township,Kansas Senate,18,Republican,"Jackson, Dave",407,130020
+POTTAWATOMIE,Wamego City S18,Kansas Senate,18,Democratic,"Kelly, Laura",557,130030
+POTTAWATOMIE,Wamego City S18,Kansas Senate,18,Republican,"Jackson, Dave",763,130030
+POTTAWATOMIE,Wamego City S17,Kansas Senate,17,Democratic,"Fowler, Susan G",184,130040
+POTTAWATOMIE,Wamego City S17,Kansas Senate,17,Republican,"Longbine, Jeff",458,130040
+POTTAWATOMIE,Belvue Township,President / Vice President,,independent,"Stein, Jill",3,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+POTTAWATOMIE,Belvue Township,President / Vice President,,Republican,"Trump, Donald J.",129,000010
+POTTAWATOMIE,Blue Township,President / Vice President,,independent,"Stein, Jill",20,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Castle, Darrell L",1,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"McMullin, Evan",32,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",514,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Libertarian,"Johnson, Gary",118,000020
+POTTAWATOMIE,Blue Township,President / Vice President,,Republican,"Trump, Donald J.",1089,000020
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,independent,"Stein, Jill",5,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"McMullin, Evan",3,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000030
+POTTAWATOMIE,Blue Valley Township,President / Vice President,,Republican,"Trump, Donald J.",124,000030
+POTTAWATOMIE,Center Township,President / Vice President,,independent,"Stein, Jill",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+POTTAWATOMIE,Center Township,President / Vice President,,Republican,"Trump, Donald J.",58,000040
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,independent,"Stein, Jill",1,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+POTTAWATOMIE,Clear Creek Township,President / Vice President,,Republican,"Trump, Donald J.",52,000050
+POTTAWATOMIE,Emmett Township,President / Vice President,,independent,"Stein, Jill",5,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000060
+POTTAWATOMIE,Emmett Township,President / Vice President,,Republican,"Trump, Donald J.",135,000060
+POTTAWATOMIE,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+POTTAWATOMIE,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",101,000070
+POTTAWATOMIE,Green Township,President / Vice President,,independent,"Stein, Jill",1,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"McMullin, Evan",2,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000080
+POTTAWATOMIE,Green Township,President / Vice President,,Republican,"Trump, Donald J.",80,000080
+POTTAWATOMIE,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",2,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+POTTAWATOMIE,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",49,000090
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,independent,"Stein, Jill",3,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+POTTAWATOMIE,Lone Tree Township,President / Vice President,,Republican,"Trump, Donald J.",87,000100
+POTTAWATOMIE,Louisville Township,President / Vice President,,independent,"Stein, Jill",7,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"McMullin, Evan",3,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Libertarian,"Johnson, Gary",27,000110
+POTTAWATOMIE,Louisville Township,President / Vice President,,Republican,"Trump, Donald J.",330,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,independent,"Stein, Jill",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Hedges, James A",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"McMullin, Evan",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Perry, Darryl",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Smith, Mike",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Sood, Ajay",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,President / Vice President,,Republican,"Trump, Donald J.",0,000120
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,independent,"Stein, Jill",4,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000130
+POTTAWATOMIE,Mill Creek Township,President / Vice President,,Republican,"Trump, Donald J.",298,000130
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,independent,"Stein, Jill",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Hedges, James A",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"McMullin, Evan",5,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Perry, Darryl",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Smith, Mike",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Sood, Ajay",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Libertarian,"Johnson, Gary",7,000140
+POTTAWATOMIE,Pottawatomie County,President / Vice President,,Republican,"Trump, Donald J.",249,000140
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,independent,"Stein, Jill",11,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000150
+POTTAWATOMIE,Rock Creek Township,President / Vice President,,Republican,"Trump, Donald J.",230,000150
+POTTAWATOMIE,Shannon Township,President / Vice President,,independent,"Stein, Jill",3,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Castle, Darrell L",2,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000160
+POTTAWATOMIE,Shannon Township,President / Vice President,,Republican,"Trump, Donald J.",103,000160
+POTTAWATOMIE,Sherman Township,President / Vice President,,independent,"Stein, Jill",1,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",5,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+POTTAWATOMIE,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",35,000170
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,independent,"Stein, Jill",3,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+POTTAWATOMIE,Spring Creek Township,President / Vice President,,Republican,"Trump, Donald J.",17,000180
+POTTAWATOMIE,St. Clere Township,President / Vice President,,independent,"Stein, Jill",1,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000190
+POTTAWATOMIE,St. Clere Township,President / Vice President,,Republican,"Trump, Donald J.",19,000190
+POTTAWATOMIE,Union Township,President / Vice President,,independent,"Stein, Jill",1,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"McMullin, Evan",2,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000230
+POTTAWATOMIE,Union Township,President / Vice President,,Republican,"Trump, Donald J.",89,000230
+POTTAWATOMIE,Vienna Township,President / Vice President,,independent,"Stein, Jill",1,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"McMullin, Evan",2,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000240
+POTTAWATOMIE,Vienna Township,President / Vice President,,Republican,"Trump, Donald J.",44,000240
+POTTAWATOMIE,St. George Township S1,President / Vice President,,independent,"Stein, Jill",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Hedges, James A",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"McMullin, Evan",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Perry, Darryl",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Smith, Mike",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Sood, Ajay",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+POTTAWATOMIE,St. George Township S1,President / Vice President,,Republican,"Trump, Donald J.",15,120020
+POTTAWATOMIE,St. George Township S17,President / Vice President,,independent,"Stein, Jill",40,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Castle, Darrell L",1,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Hedges, James A",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"McMullin, Evan",4,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Perry, Darryl",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Smith, Mike",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Sood, Ajay",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",400,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Libertarian,"Johnson, Gary",93,120030
+POTTAWATOMIE,St. George Township S17,President / Vice President,,Republican,"Trump, Donald J.",1192,120030
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,independent,"Stein, Jill",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Hedges, James A",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"McMullin, Evan",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Perry, Darryl",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Smith, Mike",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Sood, Ajay",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Libertarian,"Johnson, Gary",1,120060
+POTTAWATOMIE,Wamego Township S1,President / Vice President,,Republican,"Trump, Donald J.",10,120060
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,independent,"Stein, Jill",7,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Hedges, James A",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"McMullin, Evan",4,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Perry, Darryl",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Smith, Mike",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Sood, Ajay",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Libertarian,"Johnson, Gary",13,120070
+POTTAWATOMIE,Wamego Township S17,President / Vice President,,Republican,"Trump, Donald J.",206,120070
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,independent,"Stein, Jill",4,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Basiago, Andrew D.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Castle, Darrell L",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Giordani, Rocky",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Hedges, James A",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Hoefling, Tom",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Kahn, Lynn",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"La Riva, Gloria",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Levinson, Michael S.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Maturen, Michael A",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"McMullin, Evan",2,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Moorehead, Monica G.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Perry, Darryl",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Schriner, Joe C",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Smith, Mike",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Sood, Ajay",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Sterling, Shawna",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Valdivia, Anthony J",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Libertarian,"Johnson, Gary",9,120080
+POTTAWATOMIE,Wamego Township S18,President / Vice President,,Republican,"Trump, Donald J.",135,120080
+POTTAWATOMIE,St. Marys City,President / Vice President,,independent,"Stein, Jill",11,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Castle, Darrell L",14,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Hedges, James A",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Maturen, Michael A",3,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"McMullin, Evan",4,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Perry, Darryl",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Smith, Mike",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Sood, Ajay",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",116,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,Libertarian,"Johnson, Gary",20,130010
+POTTAWATOMIE,St. Marys City,President / Vice President,,Republican,"Trump, Donald J.",1049,130010
+POTTAWATOMIE,St. Marys Township,President / Vice President,,independent,"Stein, Jill",3,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Castle, Darrell L",6,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Giordani, Rocky",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Hedges, James A",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Hoefling, Tom",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Kahn, Lynn",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"La Riva, Gloria",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Maturen, Michael A",1,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"McMullin, Evan",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Perry, Darryl",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Schriner, Joe C",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Smith, Mike",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Sood, Ajay",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Sterling, Shawna",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,Libertarian,"Johnson, Gary",8,130020
+POTTAWATOMIE,St. Marys Township,President / Vice President,,Republican,"Trump, Donald J.",418,130020
+POTTAWATOMIE,Wamego City S18,President / Vice President,,independent,"Stein, Jill",47,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Basiago, Andrew D.",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Castle, Darrell L",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Giordani, Rocky",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Hedges, James A",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Hoefling, Tom",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Kahn, Lynn",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"La Riva, Gloria",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Levinson, Michael S.",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Maturen, Michael A",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"McMullin, Evan",11,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Moorehead, Monica G.",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Perry, Darryl",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Schriner, Joe C",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Smith, Mike",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Sood, Ajay",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Sterling, Shawna",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Valdivia, Anthony J",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",346,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,Libertarian,"Johnson, Gary",94,130030
+POTTAWATOMIE,Wamego City S18,President / Vice President,,Republican,"Trump, Donald J.",818,130030
+POTTAWATOMIE,Wamego City S17,President / Vice President,,independent,"Stein, Jill",11,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Basiago, Andrew D.",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Castle, Darrell L",2,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Giordani, Rocky",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Hedges, James A",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Hoefling, Tom",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Kahn, Lynn",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"La Riva, Gloria",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Levinson, Michael S.",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Maturen, Michael A",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"McMullin, Evan",7,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Moorehead, Monica G.",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Perry, Darryl",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Schriner, Joe C",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Smith, Mike",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Sood, Ajay",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Sterling, Shawna",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Valdivia, Anthony J",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",155,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,Libertarian,"Johnson, Gary",34,130040
+POTTAWATOMIE,Wamego City S17,President / Vice President,,Republican,"Trump, Donald J.",451,130040
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000010
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000010
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000010
+POTTAWATOMIE,Belvue Township,United States House of Representatives,1,Republican,"Marshall, Roger",109,000010
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,independent,"LaPolice, Alan",496,000020
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000020
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",133,000020
+POTTAWATOMIE,Blue Township,United States House of Representatives,1,Republican,"Marshall, Roger",1098,000020
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",54,000030
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000030
+POTTAWATOMIE,Blue Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",114,000030
+POTTAWATOMIE,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000040
+POTTAWATOMIE,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+POTTAWATOMIE,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000040
+POTTAWATOMIE,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",44,000040
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000050
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000050
+POTTAWATOMIE,Clear Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",56,000050
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000060
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",9,000060
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000060
+POTTAWATOMIE,Emmett Township,United States House of Representatives,1,Republican,"Marshall, Roger",104,000060
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000070
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000070
+POTTAWATOMIE,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",82,000070
+POTTAWATOMIE,Green Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000080
+POTTAWATOMIE,Green Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+POTTAWATOMIE,Green Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000080
+POTTAWATOMIE,Green Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000080
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000090
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000090
+POTTAWATOMIE,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",45,000090
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000100
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000100
+POTTAWATOMIE,Lone Tree Township,United States House of Representatives,1,Republican,"Marshall, Roger",81,000100
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,independent,"LaPolice, Alan",70,000110
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000110
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000110
+POTTAWATOMIE,Louisville Township,United States House of Representatives,1,Republican,"Marshall, Roger",319,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,independent,"LaPolice, Alan",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States House of Representatives,1,Republican,"Marshall, Roger",1,000120
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",91,000130
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000130
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000130
+POTTAWATOMIE,Mill Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",287,000130
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,independent,"LaPolice, Alan",54,000140
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000140
+POTTAWATOMIE,Pottawatomie County,United States House of Representatives,1,Republican,"Marshall, Roger",247,000140
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",71,000150
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000150
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000150
+POTTAWATOMIE,Rock Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",225,000150
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000160
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000160
+POTTAWATOMIE,Shannon Township,United States House of Representatives,1,Republican,"Marshall, Roger",100,000160
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000170
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000170
+POTTAWATOMIE,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000170
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000180
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000180
+POTTAWATOMIE,Spring Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000180
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000190
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000190
+POTTAWATOMIE,St. Clere Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000190
+POTTAWATOMIE,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000230
+POTTAWATOMIE,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+POTTAWATOMIE,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000230
+POTTAWATOMIE,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",95,000230
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000240
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000240
+POTTAWATOMIE,Vienna Township,United States House of Representatives,1,Republican,"Marshall, Roger",46,000240
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,independent,"LaPolice, Alan",8,120020
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120020
+POTTAWATOMIE,St. George Township S1,United States House of Representatives,1,Republican,"Marshall, Roger",14,120020
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,independent,"LaPolice, Alan",400,120030
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,Libertarian,"Burt, Kerry",122,120030
+POTTAWATOMIE,St. George Township S17,United States House of Representatives,1,Republican,"Marshall, Roger",1180,120030
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,independent,"LaPolice, Alan",1,120060
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120060
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120060
+POTTAWATOMIE,Wamego Township S1,United States House of Representatives,1,Republican,"Marshall, Roger",11,120060
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,independent,"LaPolice, Alan",67,120070
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,120070
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,Libertarian,"Burt, Kerry",21,120070
+POTTAWATOMIE,Wamego Township S17,United States House of Representatives,1,Republican,"Marshall, Roger",225,120070
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,independent,"LaPolice, Alan",37,120080
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120080
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,120080
+POTTAWATOMIE,Wamego Township S18,United States House of Representatives,1,Republican,"Marshall, Roger",120,120080
+POTTAWATOMIE,St. Marys City,United States House of Representatives,1,independent,"LaPolice, Alan",186,130010
+POTTAWATOMIE,St. Marys City,United States House of Representatives,1,write - in,"Huelskamp, Tim",130,130010
+POTTAWATOMIE,St. Marys City,United States House of Representatives,1,Libertarian,"Burt, Kerry",44,130010
+POTTAWATOMIE,St. Marys City,United States House of Representatives,1,Republican,"Marshall, Roger",715,130010
+POTTAWATOMIE,St. Marys Township,United States House of Representatives,1,independent,"LaPolice, Alan",45,130020
+POTTAWATOMIE,St. Marys Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",54,130020
+POTTAWATOMIE,St. Marys Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,130020
+POTTAWATOMIE,St. Marys Township,United States House of Representatives,1,Republican,"Marshall, Roger",300,130020
+POTTAWATOMIE,Wamego City S18,United States House of Representatives,1,independent,"LaPolice, Alan",302,130030
+POTTAWATOMIE,Wamego City S18,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,130030
+POTTAWATOMIE,Wamego City S18,United States House of Representatives,1,Libertarian,"Burt, Kerry",125,130030
+POTTAWATOMIE,Wamego City S18,United States House of Representatives,1,Republican,"Marshall, Roger",859,130030
+POTTAWATOMIE,Wamego City S17,United States House of Representatives,1,independent,"LaPolice, Alan",119,130040
+POTTAWATOMIE,Wamego City S17,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,130040
+POTTAWATOMIE,Wamego City S17,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,130040
+POTTAWATOMIE,Wamego City S17,United States House of Representatives,1,Republican,"Marshall, Roger",487,130040
+POTTAWATOMIE,Belvue Township,United States Senate,,write - in,"Smith, DJ",0,000010
+POTTAWATOMIE,Belvue Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000010
+POTTAWATOMIE,Belvue Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000010
+POTTAWATOMIE,Belvue Township,United States Senate,,Republican,"Moran, Jerry",125,000010
+POTTAWATOMIE,Blue Township,United States Senate,,write - in,"Smith, DJ",0,000020
+POTTAWATOMIE,Blue Township,United States Senate,,Democratic,"Wiesner, Patrick",405,000020
+POTTAWATOMIE,Blue Township,United States Senate,,Libertarian,"Garrard, Robert D.",76,000020
+POTTAWATOMIE,Blue Township,United States Senate,,Republican,"Moran, Jerry",1302,000020
+POTTAWATOMIE,Blue Valley Township,United States Senate,,write - in,"Smith, DJ",0,000030
+POTTAWATOMIE,Blue Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",30,000030
+POTTAWATOMIE,Blue Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+POTTAWATOMIE,Blue Valley Township,United States Senate,,Republican,"Moran, Jerry",142,000030
+POTTAWATOMIE,Center Township,United States Senate,,write - in,"Smith, DJ",0,000040
+POTTAWATOMIE,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000040
+POTTAWATOMIE,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+POTTAWATOMIE,Center Township,United States Senate,,Republican,"Moran, Jerry",64,000040
+POTTAWATOMIE,Clear Creek Township,United States Senate,,write - in,"Smith, DJ",0,000050
+POTTAWATOMIE,Clear Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000050
+POTTAWATOMIE,Clear Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000050
+POTTAWATOMIE,Clear Creek Township,United States Senate,,Republican,"Moran, Jerry",61,000050
+POTTAWATOMIE,Emmett Township,United States Senate,,write - in,"Smith, DJ",0,000060
+POTTAWATOMIE,Emmett Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000060
+POTTAWATOMIE,Emmett Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000060
+POTTAWATOMIE,Emmett Township,United States Senate,,Republican,"Moran, Jerry",132,000060
+POTTAWATOMIE,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000070
+POTTAWATOMIE,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000070
+POTTAWATOMIE,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000070
+POTTAWATOMIE,Grant Township,United States Senate,,Republican,"Moran, Jerry",97,000070
+POTTAWATOMIE,Green Township,United States Senate,,write - in,"Smith, DJ",0,000080
+POTTAWATOMIE,Green Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000080
+POTTAWATOMIE,Green Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+POTTAWATOMIE,Green Township,United States Senate,,Republican,"Moran, Jerry",88,000080
+POTTAWATOMIE,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000090
+POTTAWATOMIE,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000090
+POTTAWATOMIE,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000090
+POTTAWATOMIE,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",52,000090
+POTTAWATOMIE,Lone Tree Township,United States Senate,,write - in,"Smith, DJ",0,000100
+POTTAWATOMIE,Lone Tree Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000100
+POTTAWATOMIE,Lone Tree Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000100
+POTTAWATOMIE,Lone Tree Township,United States Senate,,Republican,"Moran, Jerry",92,000100
+POTTAWATOMIE,Louisville Township,United States Senate,,write - in,"Smith, DJ",0,000110
+POTTAWATOMIE,Louisville Township,United States Senate,,Democratic,"Wiesner, Patrick",53,000110
+POTTAWATOMIE,Louisville Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000110
+POTTAWATOMIE,Louisville Township,United States Senate,,Republican,"Moran, Jerry",348,000110
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,write - in,"Smith, DJ",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,Democratic,"Wiesner, Patrick",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+POTTAWATOMIE,Manhattan Ward 2 Precinct 5,United States Senate,,Republican,"Moran, Jerry",1,000120
+POTTAWATOMIE,Mill Creek Township,United States Senate,,write - in,"Smith, DJ",0,000130
+POTTAWATOMIE,Mill Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",93,000130
+POTTAWATOMIE,Mill Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000130
+POTTAWATOMIE,Mill Creek Township,United States Senate,,Republican,"Moran, Jerry",323,000130
+POTTAWATOMIE,Pottawatomie County,United States Senate,,write - in,"Smith, DJ",0,000140
+POTTAWATOMIE,Pottawatomie County,United States Senate,,Democratic,"Wiesner, Patrick",39,000140
+POTTAWATOMIE,Pottawatomie County,United States Senate,,Libertarian,"Garrard, Robert D.",11,000140
+POTTAWATOMIE,Pottawatomie County,United States Senate,,Republican,"Moran, Jerry",270,000140
+POTTAWATOMIE,Rock Creek Township,United States Senate,,write - in,"Smith, DJ",0,000150
+POTTAWATOMIE,Rock Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",43,000150
+POTTAWATOMIE,Rock Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",31,000150
+POTTAWATOMIE,Rock Creek Township,United States Senate,,Republican,"Moran, Jerry",255,000150
+POTTAWATOMIE,Shannon Township,United States Senate,,write - in,"Smith, DJ",0,000160
+POTTAWATOMIE,Shannon Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000160
+POTTAWATOMIE,Shannon Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000160
+POTTAWATOMIE,Shannon Township,United States Senate,,Republican,"Moran, Jerry",119,000160
+POTTAWATOMIE,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000170
+POTTAWATOMIE,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000170
+POTTAWATOMIE,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000170
+POTTAWATOMIE,Sherman Township,United States Senate,,Republican,"Moran, Jerry",44,000170
+POTTAWATOMIE,Spring Creek Township,United States Senate,,write - in,"Smith, DJ",0,000180
+POTTAWATOMIE,Spring Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000180
+POTTAWATOMIE,Spring Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000180
+POTTAWATOMIE,Spring Creek Township,United States Senate,,Republican,"Moran, Jerry",22,000180
+POTTAWATOMIE,St. Clere Township,United States Senate,,write - in,"Smith, DJ",0,000190
+POTTAWATOMIE,St. Clere Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000190
+POTTAWATOMIE,St. Clere Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000190
+POTTAWATOMIE,St. Clere Township,United States Senate,,Republican,"Moran, Jerry",25,000190
+POTTAWATOMIE,Union Township,United States Senate,,write - in,"Smith, DJ",0,000230
+POTTAWATOMIE,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",27,000230
+POTTAWATOMIE,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000230
+POTTAWATOMIE,Union Township,United States Senate,,Republican,"Moran, Jerry",101,000230
+POTTAWATOMIE,Vienna Township,United States Senate,,write - in,"Smith, DJ",0,000240
+POTTAWATOMIE,Vienna Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000240
+POTTAWATOMIE,Vienna Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+POTTAWATOMIE,Vienna Township,United States Senate,,Republican,"Moran, Jerry",49,000240
+POTTAWATOMIE,St. George Township S1,United States Senate,,write - in,"Smith, DJ",0,120020
+POTTAWATOMIE,St. George Township S1,United States Senate,,Democratic,"Wiesner, Patrick",5,120020
+POTTAWATOMIE,St. George Township S1,United States Senate,,Libertarian,"Garrard, Robert D.",1,120020
+POTTAWATOMIE,St. George Township S1,United States Senate,,Republican,"Moran, Jerry",18,120020
+POTTAWATOMIE,St. George Township S17,United States Senate,,write - in,"Smith, DJ",0,120030
+POTTAWATOMIE,St. George Township S17,United States Senate,,Democratic,"Wiesner, Patrick",314,120030
+POTTAWATOMIE,St. George Township S17,United States Senate,,Libertarian,"Garrard, Robert D.",98,120030
+POTTAWATOMIE,St. George Township S17,United States Senate,,Republican,"Moran, Jerry",1336,120030
+POTTAWATOMIE,Wamego Township S1,United States Senate,,write - in,"Smith, DJ",0,120060
+POTTAWATOMIE,Wamego Township S1,United States Senate,,Democratic,"Wiesner, Patrick",0,120060
+POTTAWATOMIE,Wamego Township S1,United States Senate,,Libertarian,"Garrard, Robert D.",1,120060
+POTTAWATOMIE,Wamego Township S1,United States Senate,,Republican,"Moran, Jerry",12,120060
+POTTAWATOMIE,Wamego Township S17,United States Senate,,write - in,"Smith, DJ",0,120070
+POTTAWATOMIE,Wamego Township S17,United States Senate,,Democratic,"Wiesner, Patrick",60,120070
+POTTAWATOMIE,Wamego Township S17,United States Senate,,Libertarian,"Garrard, Robert D.",12,120070
+POTTAWATOMIE,Wamego Township S17,United States Senate,,Republican,"Moran, Jerry",248,120070
+POTTAWATOMIE,Wamego Township S18,United States Senate,,write - in,"Smith, DJ",0,120080
+POTTAWATOMIE,Wamego Township S18,United States Senate,,Democratic,"Wiesner, Patrick",24,120080
+POTTAWATOMIE,Wamego Township S18,United States Senate,,Libertarian,"Garrard, Robert D.",11,120080
+POTTAWATOMIE,Wamego Township S18,United States Senate,,Republican,"Moran, Jerry",142,120080
+POTTAWATOMIE,St. Marys City,United States Senate,,write - in,"Smith, DJ",0,130010
+POTTAWATOMIE,St. Marys City,United States Senate,,Democratic,"Wiesner, Patrick",103,130010
+POTTAWATOMIE,St. Marys City,United States Senate,,Libertarian,"Garrard, Robert D.",44,130010
+POTTAWATOMIE,St. Marys City,United States Senate,,Republican,"Moran, Jerry",1067,130010
+POTTAWATOMIE,St. Marys Township,United States Senate,,write - in,"Smith, DJ",0,130020
+POTTAWATOMIE,St. Marys Township,United States Senate,,Democratic,"Wiesner, Patrick",38,130020
+POTTAWATOMIE,St. Marys Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,130020
+POTTAWATOMIE,St. Marys Township,United States Senate,,Republican,"Moran, Jerry",417,130020
+POTTAWATOMIE,Wamego City S18,United States Senate,,write - in,"Smith, DJ",0,130030
+POTTAWATOMIE,Wamego City S18,United States Senate,,Democratic,"Wiesner, Patrick",303,130030
+POTTAWATOMIE,Wamego City S18,United States Senate,,Libertarian,"Garrard, Robert D.",84,130030
+POTTAWATOMIE,Wamego City S18,United States Senate,,Republican,"Moran, Jerry",947,130030
+POTTAWATOMIE,Wamego City S17,United States Senate,,write - in,"Smith, DJ",0,130040
+POTTAWATOMIE,Wamego City S17,United States Senate,,Democratic,"Wiesner, Patrick",134,130040
+POTTAWATOMIE,Wamego City S17,United States Senate,,Libertarian,"Garrard, Robert D.",22,130040
+POTTAWATOMIE,Wamego City S17,United States Senate,,Republican,"Moran, Jerry",508,130040

--- a/2016/20161108__ks__general__pratt__precinct.csv
+++ b/2016/20161108__ks__general__pratt__precinct.csv
@@ -1,613 +1,613 @@
-county,precinct,office,district,candidate,party,votes
-Pratt,Pratt Ward 1,President,,"Stein, Jill  ",independent,9
-Pratt,Pratt Ward 1,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 1,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 1,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 1,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 1,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 1,President,,"McMullin, Evan  ",write - in,2
-Pratt,Pratt Ward 1,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 1,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 1,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 1,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,93
-Pratt,Pratt Ward 1,President,,"Johnson, Gary  ",Libertarian,10
-Pratt,Pratt Ward 1,President,,"Trump, Donald J. ",Republican,368
-Pratt,Pratt Ward 2,President,,"Stein, Jill  ",independent,7
-Pratt,Pratt Ward 2,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 2,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 2,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 2,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 2,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 2,President,,"McMullin, Evan  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 2,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 2,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 2,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,58
-Pratt,Pratt Ward 2,President,,"Johnson, Gary  ",Libertarian,27
-Pratt,Pratt Ward 2,President,,"Trump, Donald J. ",Republican,220
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Stein, Jill  ",independent,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"McMullin, Evan  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Clinton, Hillary Rodham ",Democratic,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Johnson, Gary  ",Libertarian,0
-Pratt,Pratt Ward 2 Exclave Airport,President,,"Trump, Donald J. ",Republican,0
-Pratt,Pratt Ward 3,President,,"Stein, Jill  ",independent,7
-Pratt,Pratt Ward 3,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 3,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 3,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 3,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 3,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 3,President,,"McMullin, Evan  ",write - in,1
-Pratt,Pratt Ward 3,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 3,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 3,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 3,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,161
-Pratt,Pratt Ward 3,President,,"Johnson, Gary  ",Libertarian,25
-Pratt,Pratt Ward 3,President,,"Trump, Donald J. ",Republican,497
-Pratt,Pratt Ward 4,President,,"Stein, Jill  ",independent,6
-Pratt,Pratt Ward 4,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 4,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 4,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 4,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 4,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 4,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 4,President,,"McMullin, Evan  ",write - in,1
-Pratt,Pratt Ward 4,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 4,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 4,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 4,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 4,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 4,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 4,President,,"Clinton, Hillary Rodham ",Democratic,142
-Pratt,Pratt Ward 4,President,,"Johnson, Gary  ",Libertarian,32
-Pratt,Pratt Ward 4,President,,"Trump, Donald J. ",Republican,357
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Stein, Jill  ",independent,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"McMullin, Evan  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Clinton, Hillary Rodham ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Johnson, Gary  ",Libertarian,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,President,,"Trump, Donald J. ",Republican,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Stein, Jill  ",independent,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"McMullin, Evan  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Clinton, Hillary Rodham ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Johnson, Gary  ",Libertarian,0
-Pratt,Pratt Ward 4 Exclave Withers,President,,"Trump, Donald J. ",Republican,0
-Pratt,Pratt Ward 5,President,,"Stein, Jill  ",independent,6
-Pratt,Pratt Ward 5,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward 5,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward 5,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward 5,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward 5,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward 5,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward 5,President,,"McMullin, Evan  ",write - in,3
-Pratt,Pratt Ward 5,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward 5,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward 5,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward 5,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward 5,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward 5,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward 5,President,,"Clinton, Hillary Rodham ",Democratic,103
-Pratt,Pratt Ward 5,President,,"Johnson, Gary  ",Libertarian,26
-Pratt,Pratt Ward 5,President,,"Trump, Donald J. ",Republican,358
-Pratt,Pratt Ward Exclave Pratt College,President,,"Stein, Jill  ",independent,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Castle, Darrell L ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Hedges, James A ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Maturen, Michael A ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"McMullin, Evan  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Perry, Darryl  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Schriner, Joe C ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Smith, Mike  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Sood, Ajay  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Clinton, Hillary Rodham ",Democratic,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Johnson, Gary  ",Libertarian,0
-Pratt,Pratt Ward Exclave Pratt College,President,,"Trump, Donald J. ",Republican,0
-Pratt,Township 6,President,,"Stein, Jill  ",independent,2
-Pratt,Township 6,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 6,President,,"Castle, Darrell L ",write - in,2
-Pratt,Township 6,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 6,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 6,President,,"Hedges, James A ",write - in,0
-Pratt,Township 6,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 6,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 6,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 6,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 6,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 6,President,,"McMullin, Evan  ",write - in,3
-Pratt,Township 6,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 6,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 6,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 6,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 6,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 6,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 6,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 6,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 6,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 6,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 6,President,,"Clinton, Hillary Rodham ",Democratic,41
-Pratt,Township 6,President,,"Johnson, Gary  ",Libertarian,9
-Pratt,Township 6,President,,"Trump, Donald J. ",Republican,190
-Pratt,Township 7,President,,"Stein, Jill  ",independent,0
-Pratt,Township 7,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 7,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 7,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 7,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 7,President,,"Hedges, James A ",write - in,0
-Pratt,Township 7,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 7,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 7,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 7,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 7,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 7,President,,"McMullin, Evan  ",write - in,1
-Pratt,Township 7,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 7,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 7,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 7,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 7,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 7,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 7,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 7,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 7,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 7,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 7,President,,"Clinton, Hillary Rodham ",Democratic,24
-Pratt,Township 7,President,,"Johnson, Gary  ",Libertarian,3
-Pratt,Township 7,President,,"Trump, Donald J. ",Republican,112
-Pratt,Township 8,President,,"Stein, Jill  ",independent,1
-Pratt,Township 8,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 8,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 8,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 8,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 8,President,,"Hedges, James A ",write - in,0
-Pratt,Township 8,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 8,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 8,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 8,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 8,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 8,President,,"McMullin, Evan  ",write - in,0
-Pratt,Township 8,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 8,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 8,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 8,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 8,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 8,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 8,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 8,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 8,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 8,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 8,President,,"Clinton, Hillary Rodham ",Democratic,15
-Pratt,Township 8,President,,"Johnson, Gary  ",Libertarian,1
-Pratt,Township 8,President,,"Trump, Donald J. ",Republican,43
-Pratt,Township 9,President,,"Stein, Jill  ",independent,1
-Pratt,Township 9,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 9,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 9,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 9,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 9,President,,"Hedges, James A ",write - in,0
-Pratt,Township 9,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 9,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 9,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 9,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 9,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 9,President,,"McMullin, Evan  ",write - in,0
-Pratt,Township 9,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 9,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 9,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 9,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 9,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 9,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 9,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 9,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 9,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 9,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 9,President,,"Clinton, Hillary Rodham ",Democratic,24
-Pratt,Township 9,President,,"Johnson, Gary  ",Libertarian,5
-Pratt,Township 9,President,,"Trump, Donald J. ",Republican,104
-Pratt,Township 10,President,,"Stein, Jill  ",independent,0
-Pratt,Township 10,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 10,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 10,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 10,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 10,President,,"Hedges, James A ",write - in,0
-Pratt,Township 10,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 10,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 10,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 10,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 10,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 10,President,,"McMullin, Evan  ",write - in,0
-Pratt,Township 10,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 10,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 10,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 10,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 10,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 10,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 10,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 10,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 10,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 10,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 10,President,,"Clinton, Hillary Rodham ",Democratic,6
-Pratt,Township 10,President,,"Johnson, Gary  ",Libertarian,1
-Pratt,Township 10,President,,"Trump, Donald J. ",Republican,41
-Pratt,Township 11,President,,"Stein, Jill  ",independent,2
-Pratt,Township 11,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 11,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 11,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 11,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 11,President,,"Hedges, James A ",write - in,0
-Pratt,Township 11,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 11,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 11,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 11,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 11,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 11,President,,"McMullin, Evan  ",write - in,1
-Pratt,Township 11,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 11,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 11,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 11,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 11,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 11,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 11,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 11,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 11,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 11,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 11,President,,"Clinton, Hillary Rodham ",Democratic,23
-Pratt,Township 11,President,,"Johnson, Gary  ",Libertarian,5
-Pratt,Township 11,President,,"Trump, Donald J. ",Republican,114
-Pratt,Township 12,President,,"Stein, Jill  ",independent,9
-Pratt,Township 12,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 12,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 12,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 12,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 12,President,,"Hedges, James A ",write - in,0
-Pratt,Township 12,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 12,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 12,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 12,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 12,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 12,President,,"McMullin, Evan  ",write - in,4
-Pratt,Township 12,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 12,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 12,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 12,President,,"Schriner, Joe C ",write - in,1
-Pratt,Township 12,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 12,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 12,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 12,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 12,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 12,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 12,President,,"Clinton, Hillary Rodham ",Democratic,81
-Pratt,Township 12,President,,"Johnson, Gary  ",Libertarian,20
-Pratt,Township 12,President,,"Trump, Donald J. ",Republican,434
-Pratt,Township 12 Enclave,President,,"Stein, Jill  ",independent,0
-Pratt,Township 12 Enclave,President,,"Basiago, Andrew D. ",write - in,0
-Pratt,Township 12 Enclave,President,,"Castle, Darrell L ",write - in,0
-Pratt,Township 12 Enclave,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Giordani, Rocky  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Hedges, James A ",write - in,0
-Pratt,Township 12 Enclave,President,,"Hoefling, Tom  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Kahn, Lynn  ",write - in,0
-Pratt,Township 12 Enclave,President,,"La Riva, Gloria  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Levinson, Michael S. ",write - in,0
-Pratt,Township 12 Enclave,President,,"Maturen, Michael A ",write - in,0
-Pratt,Township 12 Enclave,President,,"McMullin, Evan  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Moorehead, Monica G. ",write - in,0
-Pratt,Township 12 Enclave,President,,"Perry, Darryl  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Schoenke, Marshall R. ",write - in,0
-Pratt,Township 12 Enclave,President,,"Schriner, Joe C ",write - in,0
-Pratt,Township 12 Enclave,President,,"Smith, Mike  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Sood, Ajay  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Sterling, Shawna  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Valdivia, Anthony J ",write - in,0
-Pratt,Township 12 Enclave,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Pratt,Township 12 Enclave,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Pratt,Township 12 Enclave,President,,"Clinton, Hillary Rodham ",Democratic,0
-Pratt,Township 12 Enclave,President,,"Johnson, Gary  ",Libertarian,0
-Pratt,Township 12 Enclave,President,,"Trump, Donald J. ",Republican,0
-Pratt,Pratt Ward 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,88
-Pratt,Pratt Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,24
-Pratt,Pratt Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,364
-Pratt,Pratt Ward 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,52
-Pratt,Pratt Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,26
-Pratt,Pratt Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,234
-Pratt,Pratt Ward 2 Exclave Airport,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 2 Exclave Airport,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Pratt,Pratt Ward 2 Exclave Airport,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Pratt,Pratt Ward 2 Exclave Airport,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Pratt,Pratt Ward 3,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,124
-Pratt,Pratt Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,42
-Pratt,Pratt Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,523
-Pratt,Pratt Ward 4,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 4,U.S. Senate,,"Wiesner, Patrick  ",Democratic,109
-Pratt,Pratt Ward 4,U.S. Senate,,"Garrard, Robert D. ",Libertarian,26
-Pratt,Pratt Ward 4,U.S. Senate,,"Moran, Jerry  ",Republican,405
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Pratt,Pratt Ward 5,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward 5,U.S. Senate,,"Wiesner, Patrick  ",Democratic,72
-Pratt,Pratt Ward 5,U.S. Senate,,"Garrard, Robert D. ",Libertarian,31
-Pratt,Pratt Ward 5,U.S. Senate,,"Moran, Jerry  ",Republican,399
-Pratt,Pratt Ward Exclave Pratt College,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Pratt Ward Exclave Pratt College,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Pratt,Pratt Ward Exclave Pratt College,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Pratt,Pratt Ward Exclave Pratt College,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Pratt,Township 6,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 6,U.S. Senate,,"Wiesner, Patrick  ",Democratic,32
-Pratt,Township 6,U.S. Senate,,"Garrard, Robert D. ",Libertarian,8
-Pratt,Township 6,U.S. Senate,,"Moran, Jerry  ",Republican,203
-Pratt,Township 7,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 7,U.S. Senate,,"Wiesner, Patrick  ",Democratic,22
-Pratt,Township 7,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Pratt,Township 7,U.S. Senate,,"Moran, Jerry  ",Republican,107
-Pratt,Township 8,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 8,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Pratt,Township 8,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Pratt,Township 8,U.S. Senate,,"Moran, Jerry  ",Republican,56
-Pratt,Township 9,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 9,U.S. Senate,,"Wiesner, Patrick  ",Democratic,14
-Pratt,Township 9,U.S. Senate,,"Garrard, Robert D. ",Libertarian,7
-Pratt,Township 9,U.S. Senate,,"Moran, Jerry  ",Republican,115
-Pratt,Township 10,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 10,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Pratt,Township 10,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Pratt,Township 10,U.S. Senate,,"Moran, Jerry  ",Republican,39
-Pratt,Township 11,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 11,U.S. Senate,,"Wiesner, Patrick  ",Democratic,15
-Pratt,Township 11,U.S. Senate,,"Garrard, Robert D. ",Libertarian,14
-Pratt,Township 11,U.S. Senate,,"Moran, Jerry  ",Republican,113
-Pratt,Township 12,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 12,U.S. Senate,,"Wiesner, Patrick  ",Democratic,65
-Pratt,Township 12,U.S. Senate,,"Garrard, Robert D. ",Libertarian,24
-Pratt,Township 12,U.S. Senate,,"Moran, Jerry  ",Republican,461
-Pratt,Township 12 Enclave,U.S. Senate,,"Smith, DJ  ",write - in,0
-Pratt,Township 12 Enclave,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Pratt,Township 12 Enclave,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Pratt,Township 12 Enclave,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Pratt,Pratt Ward 1,U.S. House,4,"Allen, Miranda  ",independent,47
-Pratt,Pratt Ward 1,U.S. House,4,"Giroux, Daniel B. ",Democratic,73
-Pratt,Pratt Ward 1,U.S. House,4,"Bakken, Gorden J. ",Libertarian,14
-Pratt,Pratt Ward 1,U.S. House,4,"Pompeo, Michael  ",Republican,346
-Pratt,Pratt Ward 2,U.S. House,4,"Allen, Miranda  ",independent,39
-Pratt,Pratt Ward 2,U.S. House,4,"Giroux, Daniel B. ",Democratic,48
-Pratt,Pratt Ward 2,U.S. House,4,"Bakken, Gorden J. ",Libertarian,6
-Pratt,Pratt Ward 2,U.S. House,4,"Pompeo, Michael  ",Republican,221
-Pratt,Pratt Ward 2 Exclave Airport,U.S. House,4,"Allen, Miranda  ",independent,0
-Pratt,Pratt Ward 2 Exclave Airport,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Pratt,Pratt Ward 2 Exclave Airport,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Pratt,Pratt Ward 2 Exclave Airport,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Pratt,Pratt Ward 3,U.S. House,4,"Allen, Miranda  ",independent,69
-Pratt,Pratt Ward 3,U.S. House,4,"Giroux, Daniel B. ",Democratic,130
-Pratt,Pratt Ward 3,U.S. House,4,"Bakken, Gorden J. ",Libertarian,12
-Pratt,Pratt Ward 3,U.S. House,4,"Pompeo, Michael  ",Republican,481
-Pratt,Pratt Ward 4,U.S. House,4,"Allen, Miranda  ",independent,71
-Pratt,Pratt Ward 4,U.S. House,4,"Giroux, Daniel B. ",Democratic,103
-Pratt,Pratt Ward 4,U.S. House,4,"Bakken, Gorden J. ",Libertarian,14
-Pratt,Pratt Ward 4,U.S. House,4,"Pompeo, Michael  ",Republican,348
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. House,4,"Allen, Miranda  ",independent,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. House,4,"Allen, Miranda  ",independent,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Pratt,Pratt Ward 4 Exclave Withers,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Pratt,Pratt Ward 5,U.S. House,4,"Allen, Miranda  ",independent,57
-Pratt,Pratt Ward 5,U.S. House,4,"Giroux, Daniel B. ",Democratic,84
-Pratt,Pratt Ward 5,U.S. House,4,"Bakken, Gorden J. ",Libertarian,11
-Pratt,Pratt Ward 5,U.S. House,4,"Pompeo, Michael  ",Republican,350
-Pratt,Pratt Ward Exclave Pratt College,U.S. House,4,"Allen, Miranda  ",independent,0
-Pratt,Pratt Ward Exclave Pratt College,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Pratt,Pratt Ward Exclave Pratt College,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Pratt,Pratt Ward Exclave Pratt College,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Pratt,Township 6,U.S. House,4,"Allen, Miranda  ",independent,19
-Pratt,Township 6,U.S. House,4,"Giroux, Daniel B. ",Democratic,33
-Pratt,Township 6,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Pratt,Township 6,U.S. House,4,"Pompeo, Michael  ",Republican,193
-Pratt,Township 7,U.S. House,4,"Allen, Miranda  ",independent,13
-Pratt,Township 7,U.S. House,4,"Giroux, Daniel B. ",Democratic,23
-Pratt,Township 7,U.S. House,4,"Bakken, Gorden J. ",Libertarian,5
-Pratt,Township 7,U.S. House,4,"Pompeo, Michael  ",Republican,100
-Pratt,Township 8,U.S. House,4,"Allen, Miranda  ",independent,5
-Pratt,Township 8,U.S. House,4,"Giroux, Daniel B. ",Democratic,5
-Pratt,Township 8,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Pratt,Township 8,U.S. House,4,"Pompeo, Michael  ",Republican,48
-Pratt,Township 9,U.S. House,4,"Allen, Miranda  ",independent,12
-Pratt,Township 9,U.S. House,4,"Giroux, Daniel B. ",Democratic,19
-Pratt,Township 9,U.S. House,4,"Bakken, Gorden J. ",Libertarian,1
-Pratt,Township 9,U.S. House,4,"Pompeo, Michael  ",Republican,105
-Pratt,Township 10,U.S. House,4,"Allen, Miranda  ",independent,3
-Pratt,Township 10,U.S. House,4,"Giroux, Daniel B. ",Democratic,4
-Pratt,Township 10,U.S. House,4,"Bakken, Gorden J. ",Libertarian,2
-Pratt,Township 10,U.S. House,4,"Pompeo, Michael  ",Republican,38
-Pratt,Township 11,U.S. House,4,"Allen, Miranda  ",independent,20
-Pratt,Township 11,U.S. House,4,"Giroux, Daniel B. ",Democratic,17
-Pratt,Township 11,U.S. House,4,"Bakken, Gorden J. ",Libertarian,4
-Pratt,Township 11,U.S. House,4,"Pompeo, Michael  ",Republican,101
-Pratt,Township 12,U.S. House,4,"Allen, Miranda  ",independent,51
-Pratt,Township 12,U.S. House,4,"Giroux, Daniel B. ",Democratic,63
-Pratt,Township 12,U.S. House,4,"Bakken, Gorden J. ",Libertarian,8
-Pratt,Township 12,U.S. House,4,"Pompeo, Michael  ",Republican,426
-Pratt,Township 12 Enclave,U.S. House,4,"Allen, Miranda  ",independent,0
-Pratt,Township 12 Enclave,U.S. House,4,"Giroux, Daniel B. ",Democratic,0
-Pratt,Township 12 Enclave,U.S. House,4,"Bakken, Gorden J. ",Libertarian,0
-Pratt,Township 12 Enclave,U.S. House,4,"Pompeo, Michael  ",Republican,0
-Pratt,Pratt Ward 1,State Senate,33,"Bristow, Matt  ",Democratic,90
-Pratt,Pratt Ward 1,State Senate,33,"Taylor, Mary Jo ",Republican,379
-Pratt,Pratt Ward 2,State Senate,33,"Bristow, Matt  ",Democratic,64
-Pratt,Pratt Ward 2,State Senate,33,"Taylor, Mary Jo ",Republican,245
-Pratt,Pratt Ward 2 Exclave Airport,State Senate,33,"Bristow, Matt  ",Democratic,0
-Pratt,Pratt Ward 2 Exclave Airport,State Senate,33,"Taylor, Mary Jo ",Republican,0
-Pratt,Pratt Ward 3,State Senate,33,"Bristow, Matt  ",Democratic,113
-Pratt,Pratt Ward 3,State Senate,33,"Taylor, Mary Jo ",Republican,557
-Pratt,Pratt Ward 4,State Senate,33,"Bristow, Matt  ",Democratic,102
-Pratt,Pratt Ward 4,State Senate,33,"Taylor, Mary Jo ",Republican,413
-Pratt,Pratt Ward 4 Exclave Sewer Plant,State Senate,33,"Bristow, Matt  ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Sewer Plant,State Senate,33,"Taylor, Mary Jo ",Republican,0
-Pratt,Pratt Ward 4 Exclave Withers,State Senate,33,"Bristow, Matt  ",Democratic,0
-Pratt,Pratt Ward 4 Exclave Withers,State Senate,33,"Taylor, Mary Jo ",Republican,0
-Pratt,Pratt Ward 5,State Senate,33,"Bristow, Matt  ",Democratic,76
-Pratt,Pratt Ward 5,State Senate,33,"Taylor, Mary Jo ",Republican,412
-Pratt,Pratt Ward Exclave Pratt College,State Senate,33,"Bristow, Matt  ",Democratic,0
-Pratt,Pratt Ward Exclave Pratt College,State Senate,33,"Taylor, Mary Jo ",Republican,0
-Pratt,Township 6,State Senate,33,"Bristow, Matt  ",Democratic,33
-Pratt,Township 6,State Senate,33,"Taylor, Mary Jo ",Republican,200
-Pratt,Township 7,State Senate,33,"Bristow, Matt  ",Democratic,23
-Pratt,Township 7,State Senate,33,"Taylor, Mary Jo ",Republican,115
-Pratt,Township 8,State Senate,33,"Bristow, Matt  ",Democratic,7
-Pratt,Township 8,State Senate,33,"Taylor, Mary Jo ",Republican,48
-Pratt,Township 9,State Senate,33,"Bristow, Matt  ",Democratic,16
-Pratt,Township 9,State Senate,33,"Taylor, Mary Jo ",Republican,118
-Pratt,Township 10,State Senate,33,"Bristow, Matt  ",Democratic,5
-Pratt,Township 10,State Senate,33,"Taylor, Mary Jo ",Republican,40
-Pratt,Township 11,State Senate,33,"Bristow, Matt  ",Democratic,19
-Pratt,Township 11,State Senate,33,"Taylor, Mary Jo ",Republican,118
-Pratt,Township 12,State Senate,33,"Bristow, Matt  ",Democratic,69
-Pratt,Township 12,State Senate,33,"Taylor, Mary Jo ",Republican,468
-Pratt,Township 12 Enclave,State Senate,33,"Bristow, Matt  ",Democratic,0
-Pratt,Township 12 Enclave,State Senate,33,"Taylor, Mary Jo ",Republican,0
-Pratt,Pratt Ward 1,State House,113,"Lewis, Greg  ",Republican,439
-Pratt,Pratt Ward 2,State House,113,"Lewis, Greg  ",Republican,279
-Pratt,Pratt Ward 2 Exclave Airport,State House,113,"Lewis, Greg  ",Republican,0
-Pratt,Pratt Ward 3,State House,113,"Lewis, Greg  ",Republican,626
-Pratt,Pratt Ward 4,State House,113,"Lewis, Greg  ",Republican,477
-Pratt,Pratt Ward 4 Exclave Sewer Plant,State House,113,"Lewis, Greg  ",Republican,0
-Pratt,Pratt Ward 4 Exclave Withers,State House,113,"Lewis, Greg  ",Republican,0
-Pratt,Pratt Ward 5,State House,113,"Lewis, Greg  ",Republican,448
-Pratt,Pratt Ward Exclave Pratt College,State House,113,"Lewis, Greg  ",Republican,0
-Pratt,Township 6,State House,113,"Lewis, Greg  ",Republican,222
-Pratt,Township 7,State House,113,"Lewis, Greg  ",Republican,128
-Pratt,Township 8,State House,113,"Lewis, Greg  ",Republican,53
-Pratt,Township 9,State House,113,"Lewis, Greg  ",Republican,123
-Pratt,Township 10,State House,113,"Lewis, Greg  ",Republican,42
-Pratt,Township 11,State House,113,"Lewis, Greg  ",Republican,133
-Pratt,Township 12,State House,113,"Lewis, Greg  ",Republican,501
-Pratt,Township 12 Enclave,State House,113,"Lewis, Greg  ",Republican,0
+county,precinct,office,district,party,candidate,votes,vtd
+PRATT,Pratt Ward 1,Kansas House of Representatives,113,Republican,"Lewis, Greg",439,00001A
+PRATT,Pratt Ward 2,Kansas House of Representatives,113,Republican,"Lewis, Greg",279,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Kansas House of Representatives,113,Republican,"Lewis, Greg",0,00002B
+PRATT,Pratt Ward 3,Kansas House of Representatives,113,Republican,"Lewis, Greg",626,000030
+PRATT,Pratt Ward 4,Kansas House of Representatives,113,Republican,"Lewis, Greg",477,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Kansas House of Representatives,113,Republican,"Lewis, Greg",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Kansas House of Representatives,113,Republican,"Lewis, Greg",0,00004C
+PRATT,Pratt Ward 5,Kansas House of Representatives,113,Republican,"Lewis, Greg",448,00005A
+PRATT,Pratt Ward Exclave Pratt College,Kansas House of Representatives,113,Republican,"Lewis, Greg",0,00005B
+PRATT,Township 6,Kansas House of Representatives,113,Republican,"Lewis, Greg",222,000060
+PRATT,Township 7,Kansas House of Representatives,113,Republican,"Lewis, Greg",128,000070
+PRATT,Township 8,Kansas House of Representatives,113,Republican,"Lewis, Greg",53,000080
+PRATT,Township 9,Kansas House of Representatives,113,Republican,"Lewis, Greg",123,000090
+PRATT,Township 10,Kansas House of Representatives,113,Republican,"Lewis, Greg",42,000100
+PRATT,Township 11,Kansas House of Representatives,113,Republican,"Lewis, Greg",133,000110
+PRATT,Township 12,Kansas House of Representatives,113,Republican,"Lewis, Greg",501,00012A
+PRATT,Township 12 Enclave,Kansas House of Representatives,113,Republican,"Lewis, Greg",0,00012B
+PRATT,Pratt Ward 1,Kansas Senate,33,Democratic,"Bristow, Matt",90,00001A
+PRATT,Pratt Ward 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",379,00001A
+PRATT,Pratt Ward 2,Kansas Senate,33,Democratic,"Bristow, Matt",64,00002A
+PRATT,Pratt Ward 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",245,00002A
+PRATT,Pratt Ward 2 Exclave Airport,Kansas Senate,33,Democratic,"Bristow, Matt",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00002B
+PRATT,Pratt Ward 3,Kansas Senate,33,Democratic,"Bristow, Matt",113,000030
+PRATT,Pratt Ward 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",557,000030
+PRATT,Pratt Ward 4,Kansas Senate,33,Democratic,"Bristow, Matt",102,00004A
+PRATT,Pratt Ward 4,Kansas Senate,33,Republican,"Taylor, Mary Jo",413,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Kansas Senate,33,Democratic,"Bristow, Matt",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,Kansas Senate,33,Democratic,"Bristow, Matt",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00004C
+PRATT,Pratt Ward 5,Kansas Senate,33,Democratic,"Bristow, Matt",76,00005A
+PRATT,Pratt Ward 5,Kansas Senate,33,Republican,"Taylor, Mary Jo",412,00005A
+PRATT,Pratt Ward Exclave Pratt College,Kansas Senate,33,Democratic,"Bristow, Matt",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00005B
+PRATT,Township 6,Kansas Senate,33,Democratic,"Bristow, Matt",33,000060
+PRATT,Township 6,Kansas Senate,33,Republican,"Taylor, Mary Jo",200,000060
+PRATT,Township 7,Kansas Senate,33,Democratic,"Bristow, Matt",23,000070
+PRATT,Township 7,Kansas Senate,33,Republican,"Taylor, Mary Jo",115,000070
+PRATT,Township 8,Kansas Senate,33,Democratic,"Bristow, Matt",7,000080
+PRATT,Township 8,Kansas Senate,33,Republican,"Taylor, Mary Jo",48,000080
+PRATT,Township 9,Kansas Senate,33,Democratic,"Bristow, Matt",16,000090
+PRATT,Township 9,Kansas Senate,33,Republican,"Taylor, Mary Jo",118,000090
+PRATT,Township 10,Kansas Senate,33,Democratic,"Bristow, Matt",5,000100
+PRATT,Township 10,Kansas Senate,33,Republican,"Taylor, Mary Jo",40,000100
+PRATT,Township 11,Kansas Senate,33,Democratic,"Bristow, Matt",19,000110
+PRATT,Township 11,Kansas Senate,33,Republican,"Taylor, Mary Jo",118,000110
+PRATT,Township 12,Kansas Senate,33,Democratic,"Bristow, Matt",69,00012A
+PRATT,Township 12,Kansas Senate,33,Republican,"Taylor, Mary Jo",468,00012A
+PRATT,Township 12 Enclave,Kansas Senate,33,Democratic,"Bristow, Matt",0,00012B
+PRATT,Township 12 Enclave,Kansas Senate,33,Republican,"Taylor, Mary Jo",0,00012B
+PRATT,Pratt Ward 1,President / Vice President,,independent,"Stein, Jill",9,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",93,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",10,00001A
+PRATT,Pratt Ward 1,President / Vice President,,Republican,"Trump, Donald J.",368,00001A
+PRATT,Pratt Ward 2,President / Vice President,,independent,"Stein, Jill",7,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",27,00002A
+PRATT,Pratt Ward 2,President / Vice President,,Republican,"Trump, Donald J.",220,00002A
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,independent,"Stein, Jill",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Castle, Darrell L",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Giordani, Rocky",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Hedges, James A",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Kahn, Lynn",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"La Riva, Gloria",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Maturen, Michael A",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"McMullin, Evan",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Perry, Darryl",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Schriner, Joe C",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Smith, Mike",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Sood, Ajay",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Sterling, Shawna",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,President / Vice President,,Republican,"Trump, Donald J.",0,00002B
+PRATT,Pratt Ward 3,President / Vice President,,independent,"Stein, Jill",7,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+PRATT,Pratt Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",161,000030
+PRATT,Pratt Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",25,000030
+PRATT,Pratt Ward 3,President / Vice President,,Republican,"Trump, Donald J.",497,000030
+PRATT,Pratt Ward 4,President / Vice President,,independent,"Stein, Jill",6,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",142,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",32,00004A
+PRATT,Pratt Ward 4,President / Vice President,,Republican,"Trump, Donald J.",357,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,independent,"Stein, Jill",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Castle, Darrell L",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Giordani, Rocky",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Hedges, James A",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Kahn, Lynn",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"La Riva, Gloria",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Levinson, Michael S.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Maturen, Michael A",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"McMullin, Evan",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Perry, Darryl",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Schriner, Joe C",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Smith, Mike",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Sood, Ajay",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Sterling, Shawna",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,President / Vice President,,Republican,"Trump, Donald J.",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,independent,"Stein, Jill",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Castle, Darrell L",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Giordani, Rocky",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Hedges, James A",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Hoefling, Tom",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Kahn, Lynn",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"La Riva, Gloria",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Levinson, Michael S.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Maturen, Michael A",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"McMullin, Evan",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Perry, Darryl",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Schriner, Joe C",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Smith, Mike",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Sood, Ajay",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Sterling, Shawna",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,Libertarian,"Johnson, Gary",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,President / Vice President,,Republican,"Trump, Donald J.",0,00004C
+PRATT,Pratt Ward 5,President / Vice President,,independent,"Stein, Jill",6,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Hedges, James A",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"McMullin, Evan",3,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Smith, Mike",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",26,00005A
+PRATT,Pratt Ward 5,President / Vice President,,Republican,"Trump, Donald J.",358,00005A
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,independent,"Stein, Jill",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Hedges, James A",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Smith, Mike",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+PRATT,Township 6,President / Vice President,,independent,"Stein, Jill",2,000060
+PRATT,Township 6,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Castle, Darrell L",2,000060
+PRATT,Township 6,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Hedges, James A",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"McMullin, Evan",3,000060
+PRATT,Township 6,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Perry, Darryl",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Smith, Mike",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Sood, Ajay",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+PRATT,Township 6,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+PRATT,Township 6,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000060
+PRATT,Township 6,President / Vice President,,Libertarian,"Johnson, Gary",9,000060
+PRATT,Township 6,President / Vice President,,Republican,"Trump, Donald J.",190,000060
+PRATT,Township 7,President / Vice President,,independent,"Stein, Jill",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Hedges, James A",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"McMullin, Evan",1,000070
+PRATT,Township 7,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Perry, Darryl",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Smith, Mike",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Sood, Ajay",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+PRATT,Township 7,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+PRATT,Township 7,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000070
+PRATT,Township 7,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+PRATT,Township 7,President / Vice President,,Republican,"Trump, Donald J.",112,000070
+PRATT,Township 8,President / Vice President,,independent,"Stein, Jill",1,000080
+PRATT,Township 8,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Hedges, James A",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"McMullin, Evan",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Perry, Darryl",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Smith, Mike",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Sood, Ajay",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+PRATT,Township 8,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+PRATT,Township 8,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000080
+PRATT,Township 8,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+PRATT,Township 8,President / Vice President,,Republican,"Trump, Donald J.",43,000080
+PRATT,Township 9,President / Vice President,,independent,"Stein, Jill",1,000090
+PRATT,Township 9,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Hedges, James A",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"McMullin, Evan",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Perry, Darryl",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Smith, Mike",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Sood, Ajay",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+PRATT,Township 9,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+PRATT,Township 9,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000090
+PRATT,Township 9,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+PRATT,Township 9,President / Vice President,,Republican,"Trump, Donald J.",104,000090
+PRATT,Township 10,President / Vice President,,independent,"Stein, Jill",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Hedges, James A",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"McMullin, Evan",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Perry, Darryl",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Smith, Mike",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Sood, Ajay",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+PRATT,Township 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+PRATT,Township 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000100
+PRATT,Township 10,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+PRATT,Township 10,President / Vice President,,Republican,"Trump, Donald J.",41,000100
+PRATT,Township 11,President / Vice President,,independent,"Stein, Jill",2,000110
+PRATT,Township 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Hedges, James A",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"McMullin, Evan",1,000110
+PRATT,Township 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Perry, Darryl",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Smith, Mike",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Sood, Ajay",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+PRATT,Township 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+PRATT,Township 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000110
+PRATT,Township 11,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+PRATT,Township 11,President / Vice President,,Republican,"Trump, Donald J.",114,000110
+PRATT,Township 12,President / Vice President,,independent,"Stein, Jill",9,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Hedges, James A",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"McMullin, Evan",4,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Schriner, Joe C",1,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Smith, Mike",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+PRATT,Township 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+PRATT,Township 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,00012A
+PRATT,Township 12,President / Vice President,,Libertarian,"Johnson, Gary",20,00012A
+PRATT,Township 12,President / Vice President,,Republican,"Trump, Donald J.",434,00012A
+PRATT,Township 12 Enclave,President / Vice President,,independent,"Stein, Jill",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Hedges, James A",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Smith, Mike",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+PRATT,Township 12 Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00012B
+PRATT,Pratt Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",47,00001A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",73,00001A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,00001A
+PRATT,Pratt Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",346,00001A
+PRATT,Pratt Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",39,00002A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",48,00002A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,00002A
+PRATT,Pratt Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",221,00002A
+PRATT,Pratt Ward 2 Exclave Airport,United States House of Representatives,4,independent,"Allen, Miranda",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00002B
+PRATT,Pratt Ward 3,United States House of Representatives,4,independent,"Allen, Miranda",69,000030
+PRATT,Pratt Ward 3,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",130,000030
+PRATT,Pratt Ward 3,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",12,000030
+PRATT,Pratt Ward 3,United States House of Representatives,4,Republican,"Pompeo, Michael",481,000030
+PRATT,Pratt Ward 4,United States House of Representatives,4,independent,"Allen, Miranda",71,00004A
+PRATT,Pratt Ward 4,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",103,00004A
+PRATT,Pratt Ward 4,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",14,00004A
+PRATT,Pratt Ward 4,United States House of Representatives,4,Republican,"Pompeo, Michael",348,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States House of Representatives,4,independent,"Allen, Miranda",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,United States House of Representatives,4,independent,"Allen, Miranda",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00004C
+PRATT,Pratt Ward 5,United States House of Representatives,4,independent,"Allen, Miranda",57,00005A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",84,00005A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",11,00005A
+PRATT,Pratt Ward 5,United States House of Representatives,4,Republican,"Pompeo, Michael",350,00005A
+PRATT,Pratt Ward Exclave Pratt College,United States House of Representatives,4,independent,"Allen, Miranda",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00005B
+PRATT,Township 6,United States House of Representatives,4,independent,"Allen, Miranda",19,000060
+PRATT,Township 6,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",33,000060
+PRATT,Township 6,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000060
+PRATT,Township 6,United States House of Representatives,4,Republican,"Pompeo, Michael",193,000060
+PRATT,Township 7,United States House of Representatives,4,independent,"Allen, Miranda",13,000070
+PRATT,Township 7,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,000070
+PRATT,Township 7,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000070
+PRATT,Township 7,United States House of Representatives,4,Republican,"Pompeo, Michael",100,000070
+PRATT,Township 8,United States House of Representatives,4,independent,"Allen, Miranda",5,000080
+PRATT,Township 8,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000080
+PRATT,Township 8,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000080
+PRATT,Township 8,United States House of Representatives,4,Republican,"Pompeo, Michael",48,000080
+PRATT,Township 9,United States House of Representatives,4,independent,"Allen, Miranda",12,000090
+PRATT,Township 9,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,000090
+PRATT,Township 9,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000090
+PRATT,Township 9,United States House of Representatives,4,Republican,"Pompeo, Michael",105,000090
+PRATT,Township 10,United States House of Representatives,4,independent,"Allen, Miranda",3,000100
+PRATT,Township 10,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000100
+PRATT,Township 10,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000100
+PRATT,Township 10,United States House of Representatives,4,Republican,"Pompeo, Michael",38,000100
+PRATT,Township 11,United States House of Representatives,4,independent,"Allen, Miranda",20,000110
+PRATT,Township 11,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",17,000110
+PRATT,Township 11,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000110
+PRATT,Township 11,United States House of Representatives,4,Republican,"Pompeo, Michael",101,000110
+PRATT,Township 12,United States House of Representatives,4,independent,"Allen, Miranda",51,00012A
+PRATT,Township 12,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",63,00012A
+PRATT,Township 12,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,00012A
+PRATT,Township 12,United States House of Representatives,4,Republican,"Pompeo, Michael",426,00012A
+PRATT,Township 12 Enclave,United States House of Representatives,4,independent,"Allen, Miranda",0,00012B
+PRATT,Township 12 Enclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,00012B
+PRATT,Township 12 Enclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,00012B
+PRATT,Township 12 Enclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,00012B
+PRATT,Pratt Ward 1,United States Senate,,write - in,"Smith, DJ",0,00001A
+PRATT,Pratt Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",88,00001A
+PRATT,Pratt Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",24,00001A
+PRATT,Pratt Ward 1,United States Senate,,Republican,"Moran, Jerry",364,00001A
+PRATT,Pratt Ward 2,United States Senate,,write - in,"Smith, DJ",0,00002A
+PRATT,Pratt Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",52,00002A
+PRATT,Pratt Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",26,00002A
+PRATT,Pratt Ward 2,United States Senate,,Republican,"Moran, Jerry",234,00002A
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,write - in,"Smith, DJ",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,00002B
+PRATT,Pratt Ward 2 Exclave Airport,United States Senate,,Republican,"Moran, Jerry",0,00002B
+PRATT,Pratt Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+PRATT,Pratt Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",124,000030
+PRATT,Pratt Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",42,000030
+PRATT,Pratt Ward 3,United States Senate,,Republican,"Moran, Jerry",523,000030
+PRATT,Pratt Ward 4,United States Senate,,write - in,"Smith, DJ",0,00004A
+PRATT,Pratt Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",109,00004A
+PRATT,Pratt Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",26,00004A
+PRATT,Pratt Ward 4,United States Senate,,Republican,"Moran, Jerry",405,00004A
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,write - in,"Smith, DJ",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,Democratic,"Wiesner, Patrick",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004B
+PRATT,Pratt Ward 4 Exclave Sewer Plant,United States Senate,,Republican,"Moran, Jerry",0,00004B
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,write - in,"Smith, DJ",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,Democratic,"Wiesner, Patrick",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004C
+PRATT,Pratt Ward 4 Exclave Withers,United States Senate,,Republican,"Moran, Jerry",0,00004C
+PRATT,Pratt Ward 5,United States Senate,,write - in,"Smith, DJ",0,00005A
+PRATT,Pratt Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",72,00005A
+PRATT,Pratt Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",31,00005A
+PRATT,Pratt Ward 5,United States Senate,,Republican,"Moran, Jerry",399,00005A
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,write - in,"Smith, DJ",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+PRATT,Pratt Ward Exclave Pratt College,United States Senate,,Republican,"Moran, Jerry",0,00005B
+PRATT,Township 6,United States Senate,,write - in,"Smith, DJ",0,000060
+PRATT,Township 6,United States Senate,,Democratic,"Wiesner, Patrick",32,000060
+PRATT,Township 6,United States Senate,,Libertarian,"Garrard, Robert D.",8,000060
+PRATT,Township 6,United States Senate,,Republican,"Moran, Jerry",203,000060
+PRATT,Township 7,United States Senate,,write - in,"Smith, DJ",0,000070
+PRATT,Township 7,United States Senate,,Democratic,"Wiesner, Patrick",22,000070
+PRATT,Township 7,United States Senate,,Libertarian,"Garrard, Robert D.",12,000070
+PRATT,Township 7,United States Senate,,Republican,"Moran, Jerry",107,000070
+PRATT,Township 8,United States Senate,,write - in,"Smith, DJ",0,000080
+PRATT,Township 8,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+PRATT,Township 8,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+PRATT,Township 8,United States Senate,,Republican,"Moran, Jerry",56,000080
+PRATT,Township 9,United States Senate,,write - in,"Smith, DJ",0,000090
+PRATT,Township 9,United States Senate,,Democratic,"Wiesner, Patrick",14,000090
+PRATT,Township 9,United States Senate,,Libertarian,"Garrard, Robert D.",7,000090
+PRATT,Township 9,United States Senate,,Republican,"Moran, Jerry",115,000090
+PRATT,Township 10,United States Senate,,write - in,"Smith, DJ",0,000100
+PRATT,Township 10,United States Senate,,Democratic,"Wiesner, Patrick",5,000100
+PRATT,Township 10,United States Senate,,Libertarian,"Garrard, Robert D.",2,000100
+PRATT,Township 10,United States Senate,,Republican,"Moran, Jerry",39,000100
+PRATT,Township 11,United States Senate,,write - in,"Smith, DJ",0,000110
+PRATT,Township 11,United States Senate,,Democratic,"Wiesner, Patrick",15,000110
+PRATT,Township 11,United States Senate,,Libertarian,"Garrard, Robert D.",14,000110
+PRATT,Township 11,United States Senate,,Republican,"Moran, Jerry",113,000110
+PRATT,Township 12,United States Senate,,write - in,"Smith, DJ",0,00012A
+PRATT,Township 12,United States Senate,,Democratic,"Wiesner, Patrick",65,00012A
+PRATT,Township 12,United States Senate,,Libertarian,"Garrard, Robert D.",24,00012A
+PRATT,Township 12,United States Senate,,Republican,"Moran, Jerry",461,00012A
+PRATT,Township 12 Enclave,United States Senate,,write - in,"Smith, DJ",0,00012B
+PRATT,Township 12 Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00012B
+PRATT,Township 12 Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00012B
+PRATT,Township 12 Enclave,United States Senate,,Republican,"Moran, Jerry",0,00012B

--- a/2016/20161108__ks__general__rawlins__precinct.csv
+++ b/2016/20161108__ks__general__rawlins__precinct.csv
@@ -1,183 +1,667 @@
-county,precinct,office,district,candidate,party,votes
-Rawlins,Atwood City,State House,120,Adam Smith,R,470
-Rawlins,Herndon,State House,120,Adam Smith,R,48
-Rawlins,McDonald,State House,120,Adam Smith,R,56
-Rawlins,Achilles,State House,120,Adam Smith,R,20
-Rawlins,Atwood,State House,120,Adam Smith,R,11
-Rawlins,Driftwood,State House,120,Adam Smith,R,36
-Rawlins,Center,State House,120,Adam Smith,R,137
-Rawlins,Herl,State House,120,Adam Smith,R,68
-Rawlins,Jefferson,State House,120,Adam Smith,R,20
-Rawlins,Ludell,State House,120,Adam Smith,R,44
-Rawlins,Mirage,State House,120,Adam Smith,R,25
-Rawlins,Rocewood,State House,120,Adam Smith,R,121
-Rawlins,Union,State House,120,Adam Smith,R,19
-Rawlins,Atwood City,U.S. House,1,Alan LaPolice,i,79
-Rawlins,Herndon,U.S. House,1,Alan LaPolice,i,13
-Rawlins,McDonald,U.S. House,1,Alan LaPolice,i,5
-Rawlins,Achilles,U.S. House,1,Alan LaPolice,i,1
-Rawlins,Atwood,U.S. House,1,Alan LaPolice,i,0
-Rawlins,Driftwood,U.S. House,1,Alan LaPolice,i,2
-Rawlins,Center,U.S. House,1,Alan LaPolice,i,12
-Rawlins,Herl,U.S. House,1,Alan LaPolice,i,6
-Rawlins,Jefferson,U.S. House,1,Alan LaPolice,i,3
-Rawlins,Ludell,U.S. House,1,Alan LaPolice,i,14
-Rawlins,Mirage,U.S. House,1,Alan LaPolice,i,3
-Rawlins,Rocewood,U.S. House,1,Alan LaPolice,i,9
-Rawlins,Union,U.S. House,1,Alan LaPolice,i,2
-Rawlins,Atwood City,State Senate,40,Alex Herman,D,103
-Rawlins,Herndon,State Senate,40,Alex Herman,D,19
-Rawlins,McDonald,State Senate,40,Alex Herman,D,5
-Rawlins,Achilles,State Senate,40,Alex Herman,D,2
-Rawlins,Atwood,State Senate,40,Alex Herman,D,1
-Rawlins,Driftwood,State Senate,40,Alex Herman,D,7
-Rawlins,Center,State Senate,40,Alex Herman,D,24
-Rawlins,Herl,State Senate,40,Alex Herman,D,4
-Rawlins,Jefferson,State Senate,40,Alex Herman,D,2
-Rawlins,Ludell,State Senate,40,Alex Herman,D,19
-Rawlins,Mirage,State Senate,40,Alex Herman,D,0
-Rawlins,Rocewood,State Senate,40,Alex Herman,D,8
-Rawlins,Union,State Senate,40,Alex Herman,D,3
-Rawlins,Atwood City,State House,120,Bonita L. Peterson,D,145
-Rawlins,Herndon,State House,120,Bonita L. Peterson,D,31
-Rawlins,McDonald,State House,120,Bonita L. Peterson,D,11
-Rawlins,Achilles,State House,120,Bonita L. Peterson,D,6
-Rawlins,Atwood,State House,120,Bonita L. Peterson,D,1
-Rawlins,Driftwood,State House,120,Bonita L. Peterson,D,8
-Rawlins,Center,State House,120,Bonita L. Peterson,D,31
-Rawlins,Herl,State House,120,Bonita L. Peterson,D,18
-Rawlins,Jefferson,State House,120,Bonita L. Peterson,D,0
-Rawlins,Ludell,State House,120,Bonita L. Peterson,D,20
-Rawlins,Mirage,State House,120,Bonita L. Peterson,D,1
-Rawlins,Rocewood,State House,120,Bonita L. Peterson,D,18
-Rawlins,Union,State House,120,Bonita L. Peterson,D,2
-Rawlins,Atwood City,President,,Clinton & Kaine,D,81
-Rawlins,Herndon,President,,Clinton & Kaine,D,19
-Rawlins,McDonald,President,,Clinton & Kaine,D,9
-Rawlins,Achilles,President,,Clinton & Kaine,D,2
-Rawlins,Atwood,President,,Clinton & Kaine,D,1
-Rawlins,Driftwood,President,,Clinton & Kaine,D,4
-Rawlins,Center,President,,Clinton & Kaine,D,17
-Rawlins,Herl,President,,Clinton & Kaine,D,10
-Rawlins,Jefferson,President,,Clinton & Kaine,D,1
-Rawlins,Ludell,President,,Clinton & Kaine,D,9
-Rawlins,Mirage,President,,Clinton & Kaine,D,1
-Rawlins,Rocewood,President,,Clinton & Kaine,D,7
-Rawlins,Union,President,,Clinton & Kaine,D,2
-Rawlins,Atwood City,U.S. Senate,,Jerry Moran,R,521
-Rawlins,Herndon,U.S. Senate,,Jerry Moran,R,74
-Rawlins,McDonald,U.S. Senate,,Jerry Moran,R,72
-Rawlins,Achilles,U.S. Senate,,Jerry Moran,R,24
-Rawlins,Atwood,U.S. Senate,,Jerry Moran,R,13
-Rawlins,Driftwood,U.S. Senate,,Jerry Moran,R,43
-Rawlins,Center,U.S. Senate,,Jerry Moran,R,149
-Rawlins,Herl,U.S. Senate,,Jerry Moran,R,95
-Rawlins,Jefferson,U.S. Senate,,Jerry Moran,R,22
-Rawlins,Ludell,U.S. Senate,,Jerry Moran,R,50
-Rawlins,Mirage,U.S. Senate,,Jerry Moran,R,28
-Rawlins,Rocewood,U.S. Senate,,Jerry Moran,R,151
-Rawlins,Union,U.S. Senate,,Jerry Moran,R,21
-Rawlins,Atwood City,President,,Johnson & Weld,L,29
-Rawlins,Herndon,President,,Johnson & Weld,L,7
-Rawlins,McDonald,President,,Johnson & Weld,L,1
-Rawlins,Achilles,President,,Johnson & Weld,L,1
-Rawlins,Atwood,President,,Johnson & Weld,L,0
-Rawlins,Driftwood,President,,Johnson & Weld,L,6
-Rawlins,Center,President,,Johnson & Weld,L,4
-Rawlins,Herl,President,,Johnson & Weld,L,3
-Rawlins,Jefferson,President,,Johnson & Weld,L,0
-Rawlins,Ludell,President,,Johnson & Weld,L,2
-Rawlins,Mirage,President,,Johnson & Weld,L,0
-Rawlins,Rocewood,President,,Johnson & Weld,L,2
-Rawlins,Union,President,,Johnson & Weld,L,0
-Rawlins,Atwood City,U.S. House,1,Kerry Burt,L,41
-Rawlins,Herndon,U.S. House,1,Kerry Burt,L,10
-Rawlins,McDonald,U.S. House,1,Kerry Burt,L,0
-Rawlins,Achilles,U.S. House,1,Kerry Burt,L,0
-Rawlins,Atwood,U.S. House,1,Kerry Burt,L,0
-Rawlins,Driftwood,U.S. House,1,Kerry Burt,L,2
-Rawlins,Center,U.S. House,1,Kerry Burt,L,12
-Rawlins,Herl,U.S. House,1,Kerry Burt,L,3
-Rawlins,Jefferson,U.S. House,1,Kerry Burt,L,3
-Rawlins,Ludell,U.S. House,1,Kerry Burt,L,6
-Rawlins,Mirage,U.S. House,1,Kerry Burt,L,0
-Rawlins,Rocewood,U.S. House,1,Kerry Burt,L,4
-Rawlins,Union,U.S. House,1,Kerry Burt,L,1
-Rawlins,Atwood City,U.S. Senate,,Patrick Wiesner,D,64
-Rawlins,Herndon,U.S. Senate,,Patrick Wiesner,D,15
-Rawlins,McDonald,U.S. Senate,,Patrick Wiesner,D,3
-Rawlins,Achilles,U.S. Senate,,Patrick Wiesner,D,2
-Rawlins,Atwood,U.S. Senate,,Patrick Wiesner,D,0
-Rawlins,Driftwood,U.S. Senate,,Patrick Wiesner,D,3
-Rawlins,Center,U.S. Senate,,Patrick Wiesner,D,12
-Rawlins,Herl,U.S. Senate,,Patrick Wiesner,D,5
-Rawlins,Jefferson,U.S. Senate,,Patrick Wiesner,D,0
-Rawlins,Ludell,U.S. Senate,,Patrick Wiesner,D,14
-Rawlins,Mirage,U.S. Senate,,Patrick Wiesner,D,0
-Rawlins,Rocewood,U.S. Senate,,Patrick Wiesner,D,6
-Rawlins,Union,U.S. Senate,,Patrick Wiesner,D,2
-Rawlins,Atwood City,State House,120,Rick Billinger,R,515
-Rawlins,Herndon,State House,120,Rick Billinger,R,63
-Rawlins,McDonald,State House,120,Rick Billinger,R,65
-Rawlins,Achilles,State House,120,Rick Billinger,R,25
-Rawlins,Atwood,State House,120,Rick Billinger,R,12
-Rawlins,Driftwood,State House,120,Rick Billinger,R,41
-Rawlins,Center,State House,120,Rick Billinger,R,142
-Rawlins,Herl,State House,120,Rick Billinger,R,83
-Rawlins,Jefferson,State House,120,Rick Billinger,R,19
-Rawlins,Ludell,State House,120,Rick Billinger,R,45
-Rawlins,Mirage,State House,120,Rick Billinger,R,26
-Rawlins,Rocewood,State House,120,Rick Billinger,R,131
-Rawlins,Union,State House,120,Rick Billinger,R,19
-Rawlins,Atwood City,U.S. Senate,,Robert D. Garrard,L,52
-Rawlins,Herndon,U.S. Senate,,Robert D. Garrard,L,4
-Rawlins,McDonald,U.S. Senate,,Robert D. Garrard,L,2
-Rawlins,Achilles,U.S. Senate,,Robert D. Garrard,L,0
-Rawlins,Atwood,U.S. Senate,,Robert D. Garrard,L,0
-Rawlins,Driftwood,U.S. Senate,,Robert D. Garrard,L,2
-Rawlins,Center,U.S. Senate,,Robert D. Garrard,L,10
-Rawlins,Herl,U.S. Senate,,Robert D. Garrard,L,2
-Rawlins,Jefferson,U.S. Senate,,Robert D. Garrard,L,0
-Rawlins,Ludell,U.S. Senate,,Robert D. Garrard,L,3
-Rawlins,Mirage,U.S. Senate,,Robert D. Garrard,L,0
-Rawlins,Rocewood,U.S. Senate,,Robert D. Garrard,L,6
-Rawlins,Union,U.S. Senate,,Robert D. Garrard,L,0
-Rawlins,Atwood City,U.S. House,1,Roger Marshall,R,506
-Rawlins,Herndon,U.S. House,1,Roger Marshall,R,68
-Rawlins,McDonald,U.S. House,1,Roger Marshall,R,68
-Rawlins,Achilles,U.S. House,1,Roger Marshall,R,23
-Rawlins,Atwood,U.S. House,1,Roger Marshall,R,12
-Rawlins,Driftwood,U.S. House,1,Roger Marshall,R,41
-Rawlins,Center,U.S. House,1,Roger Marshall,R,148
-Rawlins,Herl,U.S. House,1,Roger Marshall,R,88
-Rawlins,Jefferson,U.S. House,1,Roger Marshall,R,16
-Rawlins,Ludell,U.S. House,1,Roger Marshall,R,46
-Rawlins,Mirage,U.S. House,1,Roger Marshall,R,24
-Rawlins,Rocewood,U.S. House,1,Roger Marshall,R,148
-Rawlins,Union,U.S. House,1,Roger Marshall,R,19
-Rawlins,Atwood City,President,,Stein & Baraka,i,15
-Rawlins,Herndon,President,,Stein & Baraka,i,0
-Rawlins,McDonald,President,,Stein & Baraka,i,1
-Rawlins,Achilles,President,,Stein & Baraka,i,0
-Rawlins,Atwood,President,,Stein & Baraka,i,0
-Rawlins,Driftwood,President,,Stein & Baraka,i,0
-Rawlins,Center,President,,Stein & Baraka,i,4
-Rawlins,Herl,President,,Stein & Baraka,i,1
-Rawlins,Jefferson,President,,Stein & Baraka,i,0
-Rawlins,Ludell,President,,Stein & Baraka,i,5
-Rawlins,Mirage,President,,Stein & Baraka,i,0
-Rawlins,Rocewood,President,,Stein & Baraka,i,0
-Rawlins,Union,President,,Stein & Baraka,i,0
-Rawlins,Atwood City,President,,Trump & Pence,R,500
-Rawlins,Herndon,President,,Trump & Pence,R,66
-Rawlins,McDonald,President,,Trump & Pence,R,65
-Rawlins,Achilles,President,,Trump & Pence,R,24
-Rawlins,Atwood,President,,Trump & Pence,R,12
-Rawlins,Driftwood,President,,Trump & Pence,R,38
-Rawlins,Center,President,,Trump & Pence,R,151
-Rawlins,Herl,President,,Trump & Pence,R,88
-Rawlins,Jefferson,President,,Trump & Pence,R,21
-Rawlins,Ludell,President,,Trump & Pence,R,51
-Rawlins,Mirage,President,,Trump & Pence,R,28
-Rawlins,Rocewood,President,,Trump & Pence,R,155
-Rawlins,Union,President,,Trump & Pence,R,21
+county,precinct,office,district,party,candidate,votes,vtd
+RAWLINS,Achilles Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",6,000010
+RAWLINS,Achilles Township,Kansas House of Representatives,120,Republican,"Smith, Adam",20,000010
+RAWLINS,Atwood City Precinct 1 East,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",29,000020
+RAWLINS,Atwood City Precinct 1 East,Kansas House of Representatives,120,Republican,"Smith, Adam",115,000020
+RAWLINS,Atwood City Precinct 1 North,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",17,000030
+RAWLINS,Atwood City Precinct 1 North,Kansas House of Representatives,120,Republican,"Smith, Adam",47,000030
+RAWLINS,Atwood City Precinct 1 West,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",22,000040
+RAWLINS,Atwood City Precinct 1 West,Kansas House of Representatives,120,Republican,"Smith, Adam",47,000040
+RAWLINS,Atwood City Precinct 2,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",77,000050
+RAWLINS,Atwood City Precinct 2,Kansas House of Representatives,120,Republican,"Smith, Adam",261,000050
+RAWLINS,Atwood Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000060
+RAWLINS,Atwood Township,Kansas House of Representatives,120,Republican,"Smith, Adam",11,000060
+RAWLINS,Driftwood Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",8,000070
+RAWLINS,Driftwood Township,Kansas House of Representatives,120,Republican,"Smith, Adam",36,000070
+RAWLINS,East Center,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",10,000080
+RAWLINS,East Center,Kansas House of Representatives,120,Republican,"Smith, Adam",48,000080
+RAWLINS,Herl Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",18,00009A
+RAWLINS,Herl Township,Kansas House of Representatives,120,Republican,"Smith, Adam",68,00009A
+RAWLINS,Herl Township South,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,00009B
+RAWLINS,Herl Township South,Kansas House of Representatives,120,Republican,"Smith, Adam",0,00009B
+RAWLINS,Herndon City,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",31,000100
+RAWLINS,Herndon City,Kansas House of Representatives,120,Republican,"Smith, Adam",48,000100
+RAWLINS,Jefferson Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000110
+RAWLINS,Jefferson Township,Kansas House of Representatives,120,Republican,"Smith, Adam",20,000110
+RAWLINS,Ludell Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",20,000120
+RAWLINS,Ludell Township,Kansas House of Representatives,120,Republican,"Smith, Adam",44,000120
+RAWLINS,McDonald City,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",11,000130
+RAWLINS,McDonald City,Kansas House of Representatives,120,Republican,"Smith, Adam",56,000130
+RAWLINS,Mirage Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000140
+RAWLINS,Mirage Township,Kansas House of Representatives,120,Republican,"Smith, Adam",25,000140
+RAWLINS,Rocewood Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",18,000150
+RAWLINS,Rocewood Township,Kansas House of Representatives,120,Republican,"Smith, Adam",121,000150
+RAWLINS,Union Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000160
+RAWLINS,Union Township,Kansas House of Representatives,120,Republican,"Smith, Adam",19,000160
+RAWLINS,West Center,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",21,000170
+RAWLINS,West Center,Kansas House of Representatives,120,Republican,"Smith, Adam",89,000170
+RAWLINS,Achilles Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000010
+RAWLINS,Achilles Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",25,000010
+RAWLINS,Atwood City Precinct 1 East,Kansas Senate,40,Democratic,"Herman, Alex",20,000020
+RAWLINS,Atwood City Precinct 1 East,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",124,000020
+RAWLINS,Atwood City Precinct 1 North,Kansas Senate,40,Democratic,"Herman, Alex",10,000030
+RAWLINS,Atwood City Precinct 1 North,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",53,000030
+RAWLINS,Atwood City Precinct 1 West,Kansas Senate,40,Democratic,"Herman, Alex",16,000040
+RAWLINS,Atwood City Precinct 1 West,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",52,000040
+RAWLINS,Atwood City Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",57,000050
+RAWLINS,Atwood City Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",286,000050
+RAWLINS,Atwood Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000060
+RAWLINS,Atwood Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",12,000060
+RAWLINS,Driftwood Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000070
+RAWLINS,Driftwood Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",41,000070
+RAWLINS,East Center,Kansas Senate,40,Democratic,"Herman, Alex",8,000080
+RAWLINS,East Center,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",50,000080
+RAWLINS,Herl Township,Kansas Senate,40,Democratic,"Herman, Alex",4,00009A
+RAWLINS,Herl Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",83,00009A
+RAWLINS,Herl Township South,Kansas Senate,40,Democratic,"Herman, Alex",0,00009B
+RAWLINS,Herl Township South,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,00009B
+RAWLINS,Herndon City,Kansas Senate,40,Democratic,"Herman, Alex",19,000100
+RAWLINS,Herndon City,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",63,000100
+RAWLINS,Jefferson Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000110
+RAWLINS,Jefferson Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",19,000110
+RAWLINS,Ludell Township,Kansas Senate,40,Democratic,"Herman, Alex",19,000120
+RAWLINS,Ludell Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",45,000120
+RAWLINS,McDonald City,Kansas Senate,40,Democratic,"Herman, Alex",5,000130
+RAWLINS,McDonald City,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",65,000130
+RAWLINS,Mirage Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000140
+RAWLINS,Mirage Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",26,000140
+RAWLINS,Rocewood Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000150
+RAWLINS,Rocewood Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",131,000150
+RAWLINS,Union Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000160
+RAWLINS,Union Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",19,000160
+RAWLINS,West Center,Kansas Senate,40,Democratic,"Herman, Alex",16,000170
+RAWLINS,West Center,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",92,000170
+RAWLINS,Achilles Township,President / Vice President,,independent,"Stein, Jill",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+RAWLINS,Achilles Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+RAWLINS,Achilles Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+RAWLINS,Achilles Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+RAWLINS,Achilles Township,President / Vice President,,Republican,"Trump, Donald J.",24,000010
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,independent,"Stein, Jill",1,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Hedges, James A",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"McMullin, Evan",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Perry, Darryl",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Smith, Mike",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Sood, Ajay",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+RAWLINS,Atwood City Precinct 1 East,President / Vice President,,Republican,"Trump, Donald J.",122,000020
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,independent,"Stein, Jill",1,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Hedges, James A",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"McMullin, Evan",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Perry, Darryl",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Smith, Mike",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Sood, Ajay",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+RAWLINS,Atwood City Precinct 1 North,President / Vice President,,Republican,"Trump, Donald J.",56,000030
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,independent,"Stein, Jill",5,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Hedges, James A",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"McMullin, Evan",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Perry, Darryl",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Smith, Mike",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Sood, Ajay",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Libertarian,"Johnson, Gary",3,000040
+RAWLINS,Atwood City Precinct 1 West,President / Vice President,,Republican,"Trump, Donald J.",52,000040
+RAWLINS,Atwood City Precinct 2,President / Vice President,,independent,"Stein, Jill",8,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",5,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",21,000050
+RAWLINS,Atwood City Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",270,000050
+RAWLINS,Atwood Township,President / Vice President,,independent,"Stein, Jill",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+RAWLINS,Atwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+RAWLINS,Atwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000060
+RAWLINS,Atwood Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+RAWLINS,Atwood Township,President / Vice President,,Republican,"Trump, Donald J.",12,000060
+RAWLINS,Driftwood Township,President / Vice President,,independent,"Stein, Jill",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+RAWLINS,Driftwood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000070
+RAWLINS,Driftwood Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+RAWLINS,Driftwood Township,President / Vice President,,Republican,"Trump, Donald J.",38,000070
+RAWLINS,East Center,President / Vice President,,independent,"Stein, Jill",2,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Hedges, James A",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"McMullin, Evan",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Perry, Darryl",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Smith, Mike",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Sood, Ajay",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+RAWLINS,East Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+RAWLINS,East Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000080
+RAWLINS,East Center,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+RAWLINS,East Center,President / Vice President,,Republican,"Trump, Donald J.",53,000080
+RAWLINS,Herl Township,President / Vice President,,independent,"Stein, Jill",1,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Castle, Darrell L",1,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Giordani, Rocky",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Hedges, James A",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Hoefling, Tom",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Kahn, Lynn",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"La Riva, Gloria",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Maturen, Michael A",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"McMullin, Evan",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Perry, Darryl",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Schriner, Joe C",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Smith, Mike",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Sood, Ajay",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Sterling, Shawna",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009A
+RAWLINS,Herl Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009A
+RAWLINS,Herl Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,00009A
+RAWLINS,Herl Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00009A
+RAWLINS,Herl Township,President / Vice President,,Republican,"Trump, Donald J.",88,00009A
+RAWLINS,Herl Township South,President / Vice President,,independent,"Stein, Jill",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Basiago, Andrew D.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Castle, Darrell L",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Giordani, Rocky",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Hedges, James A",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Hoefling, Tom",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Kahn, Lynn",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"La Riva, Gloria",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Levinson, Michael S.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Maturen, Michael A",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"McMullin, Evan",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Moorehead, Monica G.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Perry, Darryl",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Schriner, Joe C",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Smith, Mike",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Sood, Ajay",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Sterling, Shawna",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Valdivia, Anthony J",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Libertarian,"Johnson, Gary",0,00009B
+RAWLINS,Herl Township South,President / Vice President,,Republican,"Trump, Donald J.",0,00009B
+RAWLINS,Herndon City,President / Vice President,,independent,"Stein, Jill",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Hedges, James A",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"McMullin, Evan",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Perry, Darryl",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Smith, Mike",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Sood, Ajay",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+RAWLINS,Herndon City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+RAWLINS,Herndon City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000100
+RAWLINS,Herndon City,President / Vice President,,Libertarian,"Johnson, Gary",7,000100
+RAWLINS,Herndon City,President / Vice President,,Republican,"Trump, Donald J.",66,000100
+RAWLINS,Jefferson Township,President / Vice President,,independent,"Stein, Jill",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000110
+RAWLINS,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+RAWLINS,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",21,000110
+RAWLINS,Ludell Township,President / Vice President,,independent,"Stein, Jill",5,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Castle, Darrell L",1,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+RAWLINS,Ludell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+RAWLINS,Ludell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000120
+RAWLINS,Ludell Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+RAWLINS,Ludell Township,President / Vice President,,Republican,"Trump, Donald J.",51,000120
+RAWLINS,McDonald City,President / Vice President,,independent,"Stein, Jill",1,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Basiago, Andrew D.",1,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Hedges, James A",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"McMullin, Evan",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Perry, Darryl",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Smith, Mike",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Sood, Ajay",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+RAWLINS,McDonald City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+RAWLINS,McDonald City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000130
+RAWLINS,McDonald City,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+RAWLINS,McDonald City,President / Vice President,,Republican,"Trump, Donald J.",65,000130
+RAWLINS,Mirage Township,President / Vice President,,independent,"Stein, Jill",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+RAWLINS,Mirage Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+RAWLINS,Mirage Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000140
+RAWLINS,Mirage Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+RAWLINS,Mirage Township,President / Vice President,,Republican,"Trump, Donald J.",28,000140
+RAWLINS,Rocewood Township,President / Vice President,,independent,"Stein, Jill",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+RAWLINS,Rocewood Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000150
+RAWLINS,Rocewood Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+RAWLINS,Rocewood Township,President / Vice President,,Republican,"Trump, Donald J.",155,000150
+RAWLINS,Union Township,President / Vice President,,independent,"Stein, Jill",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+RAWLINS,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+RAWLINS,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000160
+RAWLINS,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+RAWLINS,Union Township,President / Vice President,,Republican,"Trump, Donald J.",21,000160
+RAWLINS,West Center,President / Vice President,,independent,"Stein, Jill",2,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Hedges, James A",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"McMullin, Evan",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Perry, Darryl",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Smith, Mike",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Sood, Ajay",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+RAWLINS,West Center,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+RAWLINS,West Center,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000170
+RAWLINS,West Center,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+RAWLINS,West Center,President / Vice President,,Republican,"Trump, Donald J.",98,000170
+RAWLINS,Achilles Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000010
+RAWLINS,Achilles Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+RAWLINS,Achilles Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+RAWLINS,Achilles Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000010
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,independent,"LaPolice, Alan",13,000020
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000020
+RAWLINS,Atwood City Precinct 1 East,United States House of Representatives,1,Republican,"Marshall, Roger",126,000020
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,independent,"LaPolice, Alan",7,000030
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000030
+RAWLINS,Atwood City Precinct 1 North,United States House of Representatives,1,Republican,"Marshall, Roger",55,000030
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,independent,"LaPolice, Alan",14,000040
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000040
+RAWLINS,Atwood City Precinct 1 West,United States House of Representatives,1,Republican,"Marshall, Roger",51,000040
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",45,000050
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000050
+RAWLINS,Atwood City Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",274,000050
+RAWLINS,Atwood Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000060
+RAWLINS,Atwood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+RAWLINS,Atwood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+RAWLINS,Atwood Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000060
+RAWLINS,Driftwood Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000070
+RAWLINS,Driftwood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+RAWLINS,Driftwood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000070
+RAWLINS,Driftwood Township,United States House of Representatives,1,Republican,"Marshall, Roger",41,000070
+RAWLINS,East Center,United States House of Representatives,1,independent,"LaPolice, Alan",6,000080
+RAWLINS,East Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+RAWLINS,East Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000080
+RAWLINS,East Center,United States House of Representatives,1,Republican,"Marshall, Roger",50,000080
+RAWLINS,Herl Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,00009A
+RAWLINS,Herl Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00009A
+RAWLINS,Herl Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,00009A
+RAWLINS,Herl Township,United States House of Representatives,1,Republican,"Marshall, Roger",88,00009A
+RAWLINS,Herl Township South,United States House of Representatives,1,independent,"LaPolice, Alan",0,00009B
+RAWLINS,Herl Township South,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00009B
+RAWLINS,Herl Township South,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00009B
+RAWLINS,Herl Township South,United States House of Representatives,1,Republican,"Marshall, Roger",0,00009B
+RAWLINS,Herndon City,United States House of Representatives,1,independent,"LaPolice, Alan",13,000100
+RAWLINS,Herndon City,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+RAWLINS,Herndon City,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000100
+RAWLINS,Herndon City,United States House of Representatives,1,Republican,"Marshall, Roger",68,000100
+RAWLINS,Jefferson Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000110
+RAWLINS,Jefferson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+RAWLINS,Jefferson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000110
+RAWLINS,Jefferson Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000110
+RAWLINS,Ludell Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000120
+RAWLINS,Ludell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+RAWLINS,Ludell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000120
+RAWLINS,Ludell Township,United States House of Representatives,1,Republican,"Marshall, Roger",46,000120
+RAWLINS,McDonald City,United States House of Representatives,1,independent,"LaPolice, Alan",5,000130
+RAWLINS,McDonald City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+RAWLINS,McDonald City,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+RAWLINS,McDonald City,United States House of Representatives,1,Republican,"Marshall, Roger",68,000130
+RAWLINS,Mirage Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000140
+RAWLINS,Mirage Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+RAWLINS,Mirage Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+RAWLINS,Mirage Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000140
+RAWLINS,Rocewood Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000150
+RAWLINS,Rocewood Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000150
+RAWLINS,Rocewood Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000150
+RAWLINS,Rocewood Township,United States House of Representatives,1,Republican,"Marshall, Roger",148,000150
+RAWLINS,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000160
+RAWLINS,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+RAWLINS,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+RAWLINS,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000160
+RAWLINS,West Center,United States House of Representatives,1,independent,"LaPolice, Alan",6,000170
+RAWLINS,West Center,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+RAWLINS,West Center,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000170
+RAWLINS,West Center,United States House of Representatives,1,Republican,"Marshall, Roger",98,000170
+RAWLINS,Achilles Township,United States Senate,,write - in,"Smith, DJ",0,000010
+RAWLINS,Achilles Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+RAWLINS,Achilles Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+RAWLINS,Achilles Township,United States Senate,,Republican,"Moran, Jerry",24,000010
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,write - in,"Smith, DJ",0,000020
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,Democratic,"Wiesner, Patrick",12,000020
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,Libertarian,"Garrard, Robert D.",10,000020
+RAWLINS,Atwood City Precinct 1 East,United States Senate,,Republican,"Moran, Jerry",129,000020
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,write - in,"Smith, DJ",0,000030
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,Democratic,"Wiesner, Patrick",10,000030
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+RAWLINS,Atwood City Precinct 1 North,United States Senate,,Republican,"Moran, Jerry",52,000030
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,write - in,"Smith, DJ",0,000040
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,Democratic,"Wiesner, Patrick",10,000040
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,Libertarian,"Garrard, Robert D.",3,000040
+RAWLINS,Atwood City Precinct 1 West,United States Senate,,Republican,"Moran, Jerry",57,000040
+RAWLINS,Atwood City Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000050
+RAWLINS,Atwood City Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",32,000050
+RAWLINS,Atwood City Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",35,000050
+RAWLINS,Atwood City Precinct 2,United States Senate,,Republican,"Moran, Jerry",283,000050
+RAWLINS,Atwood Township,United States Senate,,write - in,"Smith, DJ",0,000060
+RAWLINS,Atwood Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+RAWLINS,Atwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+RAWLINS,Atwood Township,United States Senate,,Republican,"Moran, Jerry",13,000060
+RAWLINS,Driftwood Township,United States Senate,,write - in,"Smith, DJ",0,000070
+RAWLINS,Driftwood Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000070
+RAWLINS,Driftwood Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+RAWLINS,Driftwood Township,United States Senate,,Republican,"Moran, Jerry",43,000070
+RAWLINS,East Center,United States Senate,,write - in,"Smith, DJ",0,000080
+RAWLINS,East Center,United States Senate,,Democratic,"Wiesner, Patrick",3,000080
+RAWLINS,East Center,United States Senate,,Libertarian,"Garrard, Robert D.",5,000080
+RAWLINS,East Center,United States Senate,,Republican,"Moran, Jerry",52,000080
+RAWLINS,Herl Township,United States Senate,,write - in,"Smith, DJ",0,00009A
+RAWLINS,Herl Township,United States Senate,,Democratic,"Wiesner, Patrick",5,00009A
+RAWLINS,Herl Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,00009A
+RAWLINS,Herl Township,United States Senate,,Republican,"Moran, Jerry",95,00009A
+RAWLINS,Herl Township South,United States Senate,,write - in,"Smith, DJ",0,00009B
+RAWLINS,Herl Township South,United States Senate,,Democratic,"Wiesner, Patrick",0,00009B
+RAWLINS,Herl Township South,United States Senate,,Libertarian,"Garrard, Robert D.",0,00009B
+RAWLINS,Herl Township South,United States Senate,,Republican,"Moran, Jerry",0,00009B
+RAWLINS,Herndon City,United States Senate,,write - in,"Smith, DJ",0,000100
+RAWLINS,Herndon City,United States Senate,,Democratic,"Wiesner, Patrick",15,000100
+RAWLINS,Herndon City,United States Senate,,Libertarian,"Garrard, Robert D.",4,000100
+RAWLINS,Herndon City,United States Senate,,Republican,"Moran, Jerry",74,000100
+RAWLINS,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000110
+RAWLINS,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000110
+RAWLINS,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+RAWLINS,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",22,000110
+RAWLINS,Ludell Township,United States Senate,,write - in,"Smith, DJ",0,000120
+RAWLINS,Ludell Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000120
+RAWLINS,Ludell Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000120
+RAWLINS,Ludell Township,United States Senate,,Republican,"Moran, Jerry",50,000120
+RAWLINS,McDonald City,United States Senate,,write - in,"Smith, DJ",0,000130
+RAWLINS,McDonald City,United States Senate,,Democratic,"Wiesner, Patrick",3,000130
+RAWLINS,McDonald City,United States Senate,,Libertarian,"Garrard, Robert D.",2,000130
+RAWLINS,McDonald City,United States Senate,,Republican,"Moran, Jerry",72,000130
+RAWLINS,Mirage Township,United States Senate,,write - in,"Smith, DJ",0,000140
+RAWLINS,Mirage Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000140
+RAWLINS,Mirage Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000140
+RAWLINS,Mirage Township,United States Senate,,Republican,"Moran, Jerry",28,000140
+RAWLINS,Rocewood Township,United States Senate,,write - in,"Smith, DJ",0,000150
+RAWLINS,Rocewood Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000150
+RAWLINS,Rocewood Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000150
+RAWLINS,Rocewood Township,United States Senate,,Republican,"Moran, Jerry",151,000150
+RAWLINS,Union Township,United States Senate,,write - in,"Smith, DJ",0,000160
+RAWLINS,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000160
+RAWLINS,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000160
+RAWLINS,Union Township,United States Senate,,Republican,"Moran, Jerry",21,000160
+RAWLINS,West Center,United States Senate,,write - in,"Smith, DJ",0,000170
+RAWLINS,West Center,United States Senate,,Democratic,"Wiesner, Patrick",9,000170
+RAWLINS,West Center,United States Senate,,Libertarian,"Garrard, Robert D.",5,000170
+RAWLINS,West Center,United States Senate,,Republican,"Moran, Jerry",97,000170

--- a/2016/20161108__ks__general__reno__precinct.csv
+++ b/2016/20161108__ks__general__reno__precinct.csv
@@ -1,1519 +1,2970 @@
-county,precinct,office,district,party,candidate,polling,advance,votes
-Reno,Precinct #1-H102,,,,Registered Voters,,,536
-Reno,Precinct #1-H114,,,,Registered Voters,,,37
-Reno,Precinct #2,,,,Registered Voters,,,615
-Reno,Precinct #3,,,,Registered Voters,,,343
-Reno,Precinct #4,,,,Registered Voters,,,1165
-Reno,Precinct #5,,,,Registered Voters,,,844
-Reno,Precinct #6,,,,Registered Voters,,,692
-Reno,Precinct #7,,,,Registered Voters,,,820
-Reno,Precinct #8,,,,Registered Voters,,,363
-Reno,Precinct #9,,,,Registered Voters,,,993
-Reno,Precinct #10,,,,Registered Voters,,,1052
-Reno,Precinct #11,,,,Registered Voters,,,1019
-Reno,Precinct #12,,,,Registered Voters,,,722
-Reno,Precinct #13,,,,Registered Voters,,,789
-Reno,Precinct #14,,,,Registered Voters,,,723
-Reno,Precinct #15,,,,Registered Voters,,,651
-Reno,Precinct #16,,,,Registered Voters,,,994
-Reno,Precinct #17,,,,Registered Voters,,,882
-Reno,Precinct #18,,,,Registered Voters,,,452
-Reno,Precinct #19,,,,Registered Voters,,,547
-Reno,Precinct #20,,,,Registered Voters,,,762
-Reno,Precinct #21,,,,Registered Voters,,,1405
-Reno,Precinct #22,,,,Registered Voters,,,1081
-Reno,Precinct #23,,,,Registered Voters,,,1300
-Reno,Precinct #23 Exclave,,,,Registered Voters,,,250
-Reno,Precinct #24,,,,Registered Voters,,,866
-Reno,Precinct #25,,,,Registered Voters,,,791
-Reno,Precinct #26,,,,Registered Voters,,,368
-Reno,Precinct #26 Exclave,,,,Registered Voters,,,91
-Reno,Precinct #27,,,,Registered Voters,,,640
-Reno,Precinct #28,,,,Registered Voters,,,1213
-Reno,Precinct #28 Exclave,,,,Registered Voters,,,530
-Reno,Precinct #29,,,,Registered Voters,,,604
-Reno,Precinct #30,,,,Registered Voters,,,449
-Reno,Precinct #31,,,,Registered Voters,,,647
-Reno,Precinct #32,,,,Registered Voters,,,161
-Reno,Precinct #33,,,,Registered Voters,,,257
-Reno,Precinct #34,,,,Registered Voters,,,131
-Reno,Precinct #34 Exclave,,,,Registered Voters,,,1
-Reno,Precinct #35,,,,Registered Voters,,,354
-Reno,Albion Township,,,,Registered Voters,,,596
-Reno,Arlington Township,,,,Registered Voters,,,387
-Reno,Bell Township,,,,Registered Voters,,,47
-Reno,Castleton Township,,,,Registered Voters,,,201
-Reno,Center Township,,,,Registered Voters,,,307
-Reno,Clay North Township,,,,Registered Voters,,,679
-Reno,Clay South H101,,,,Registered Voters,,,775
-Reno,Clay South H102A,,,,Registered Voters,,,4
-Reno,Enterprise Township,,,,Registered Voters,,,94
-Reno,Grant Township,,,,Registered Voters,,,1080
-Reno,Grove 310,,,,Registered Voters,,,40
-Reno,Haven Township,,,,Registered Voters,,,1154
-Reno,Hayes Township,,,,Registered Voters,,,49
-Reno,Huntsville Township,,,,Registered Voters,,,78
-Reno,Langdon 310,,,,Registered Voters,,,100
-Reno,Lincoln Township,,,,Registered Voters,,,355
-Reno,Little River Township,,,,Registered Voters,,,1282
-Reno,Loda Township,,,,Registered Voters,,,61
-Reno,Medford Township,,,,Registered Voters,,,100
-Reno,Medora Township,,,,Registered Voters,,,1179
-Reno,Miami 310,,,,Registered Voters,,,296
-Reno,Ninnescah Township,,,,Registered Voters,,,162
-Reno,Plevna 310,,,,Registered Voters,,,166
-Reno,Reno North Township,,,,Registered Voters,,,1082
-Reno,Reno South Township,,,,Registered Voters,,,177
-Reno,Roscoe Township,,,,Registered Voters,,,75
-Reno,Salt Creek Township,,,,Registered Voters,,,263
-Reno,Sumner Township,,,,Registered Voters,,,410
-Reno,Sylvia 310,,,,Registered Voters,,,193
-Reno,Troy Township,,,,Registered Voters,,,76
-Reno,Valley Township,,,,Registered Voters,,,608
-Reno,Walnut Township,,,,Registered Voters,,,79
-Reno,Westminster 310,,,,Registered Voters,,,154
-Reno,Yoder Township,,,,Registered Voters,,,408
-Reno,South Hutchinson #1,,,,Registered Voters,,,510
-Reno,South Hutchinson #2,,,,Registered Voters,,,668
-Reno,South Hutchinson #3,,,,Registered Voters,,,458
-Reno,Nickerson Ward #1,,,,Registered Voters,,,273
-Reno,Nickerson Ward #2,,,,Registered Voters,,,174
-Reno,Nickerson Ward #3,,,,Registered Voters,,,194
-Reno,Total,,,,Registered Voters,,,41134
-Reno,Precinct #1-H102,,,,Ballots Cast,,,217
-Reno,Precinct #1-H114,,,,Ballots Cast,,,15
-Reno,Precinct #2,,,,Ballots Cast,,,227
-Reno,Precinct #3,,,,Ballots Cast,,,135
-Reno,Precinct #4,,,,Ballots Cast,,,845
-Reno,Precinct #5,,,,Ballots Cast,,,345
-Reno,Precinct #6,,,,Ballots Cast,,,358
-Reno,Precinct #7,,,,Ballots Cast,,,437
-Reno,Precinct #8,,,,Ballots Cast,,,218
-Reno,Precinct #9,,,,Ballots Cast,,,613
-Reno,Precinct #10,,,,Ballots Cast,,,745
-Reno,Precinct #11,,,,Ballots Cast,,,709
-Reno,Precinct #12,,,,Ballots Cast,,,441
-Reno,Precinct #13,,,,Ballots Cast,,,499
-Reno,Precinct #14,,,,Ballots Cast,,,414
-Reno,Precinct #15,,,,Ballots Cast,,,236
-Reno,Precinct #16,,,,Ballots Cast,,,490
-Reno,Precinct #17,,,,Ballots Cast,,,550
-Reno,Precinct #18,,,,Ballots Cast,,,200
-Reno,Precinct #19,,,,Ballots Cast,,,227
-Reno,Precinct #20,,,,Ballots Cast,,,364
-Reno,Precinct #21,,,,Ballots Cast,,,312
-Reno,Precinct #22,,,,Ballots Cast,,,672
-Reno,Precinct #23,,,,Ballots Cast,,,821
-Reno,Precinct #23 Exclave,,,,Ballots Cast,,,207
-Reno,Precinct #24,,,,Ballots Cast,,,569
-Reno,Precinct #25,,,,Ballots Cast,,,291
-Reno,Precinct #26,,,,Ballots Cast,,,206
-Reno,Precinct #26 Exclave,,,,Ballots Cast,,,22
-Reno,Precinct #27,,,,Ballots Cast,,,431
-Reno,Precinct #28,,,,Ballots Cast,,,889
-Reno,Precinct #28 Exclave,,,,Ballots Cast,,,416
-Reno,Precinct #29,,,,Ballots Cast,,,406
-Reno,Precinct #30,,,,Ballots Cast,,,216
-Reno,Precinct #31,,,,Ballots Cast,,,358
-Reno,Precinct #32,,,,Ballots Cast,,,126
-Reno,Precinct #33,,,,Ballots Cast,,,197
-Reno,Precinct #34,,,,Ballots Cast,,,66
-Reno,Precinct #34 Exclave,,,,Ballots Cast,,,1
-Reno,Precinct #35,,,,Ballots Cast,,,207
-Reno,Albion Township,,,,Ballots Cast,,,401
-Reno,Arlington Township,,,,Ballots Cast,,,257
-Reno,Bell Township,,,,Ballots Cast,,,35
-Reno,Castleton Township,,,,Ballots Cast,,,153
-Reno,Center Township,,,,Ballots Cast,,,191
-Reno,Clay North Township,,,,Ballots Cast,,,479
-Reno,Clay South H101,,,,Ballots Cast,,,524
-Reno,Clay South H102A,,,,Ballots Cast,,,3
-Reno,Enterprise Township,,,,Ballots Cast,,,71
-Reno,Grant Township,,,,Ballots Cast,,,804
-Reno,Grove 310,,,,Ballots Cast,,,32
-Reno,Haven Township,,,,Ballots Cast,,,756
-Reno,Hayes Township,,,,Ballots Cast,,,33
-Reno,Huntsville Township,,,,Ballots Cast,,,56
-Reno,Langdon 310,,,,Ballots Cast,,,64
-Reno,Lincoln Township,,,,Ballots Cast,,,198
-Reno,Little River Township,,,,Ballots Cast,,,941
-Reno,Loda Township,,,,Ballots Cast,,,44
-Reno,Medford Township,,,,Ballots Cast,,,77
-Reno,Medora Township,,,,Ballots Cast,,,866
-Reno,Miami 310,,,,Ballots Cast,,,152
-Reno,Ninnescah Township,,,,Ballots Cast,,,108
-Reno,Plevna 310,,,,Ballots Cast,,,121
-Reno,Reno North Township,,,,Ballots Cast,,,698
-Reno,Reno South Township,,,,Ballots Cast,,,117
-Reno,Roscoe Township,,,,Ballots Cast,,,57
-Reno,Salt Creek Township,,,,Ballots Cast,,,182
-Reno,Sumner Township,,,,Ballots Cast,,,300
-Reno,Sylvia 310,,,,Ballots Cast,,,131
-Reno,Troy Township,,,,Ballots Cast,,,54
-Reno,Valley Township,,,,Ballots Cast,,,435
-Reno,Walnut Township,,,,Ballots Cast,,,65
-Reno,Westminster 310,,,,Ballots Cast,,,105
-Reno,Yoder Township,,,,Ballots Cast,,,254
-Reno,South Hutchinson #1,,,,Ballots Cast,,,243
-Reno,South Hutchinson #2,,,,Ballots Cast,,,448
-Reno,South Hutchinson #3,,,,Ballots Cast,,,324
-Reno,Nickerson Ward #1,,,,Ballots Cast,,,169
-Reno,Nickerson Ward #2,,,,Ballots Cast,,,93
-Reno,Nickerson Ward #3,,,,Ballots Cast,,,110
-Reno,Total,,,,Ballots Cast,,,24849
-Reno,Precinct #1-H102,President,,R,Trump and Pence,68,38,106
-Reno,Precinct #1-H114,President,,R,Trump and Pence,3,3,6
-Reno,Precinct #2,President,,R,Trump and Pence,62,44,106
-Reno,Precinct #3,President,,R,Trump and Pence,30,16,46
-Reno,Precinct #4,President,,R,Trump and Pence,297,236,533
-Reno,Precinct #5,President,,R,Trump and Pence,94,85,179
-Reno,Precinct #6,President,,R,Trump and Pence,98,74,172
-Reno,Precinct #7,President,,R,Trump and Pence,125,105,230
-Reno,Precinct #8,President,,R,Trump and Pence,75,48,123
-Reno,Precinct #9,President,,R,Trump and Pence,176,169,345
-Reno,Precinct #10,President,,R,Trump and Pence,206,249,455
-Reno,Precinct #11,President,,R,Trump and Pence,230,205,435
-Reno,Precinct #12,President,,R,Trump and Pence,131,92,223
-Reno,Precinct #13,President,,R,Trump and Pence,171,86,257
-Reno,Precinct #14,President,,R,Trump and Pence,140,66,206
-Reno,Precinct #15,President,,R,Trump and Pence,65,42,107
-Reno,Precinct #16,President,,R,Trump and Pence,129,79,208
-Reno,Precinct #17,President,,R,Trump and Pence,197,126,323
-Reno,Precinct #18,President,,R,Trump and Pence,57,54,111
-Reno,Precinct #19,President,,R,Trump and Pence,65,42,107
-Reno,Precinct #20,President,,R,Trump and Pence,130,87,217
-Reno,Precinct #21,President,,R,Trump and Pence,92,64,156
-Reno,Precinct #22,President,,R,Trump and Pence,226,150,376
-Reno,Precinct #23,President,,R,Trump and Pence,233,237,470
-Reno,Precinct #23 Exclave,President,,R,Trump and Pence,76,68,144
-Reno,Precinct #24,President,,R,Trump and Pence,224,127,351
-Reno,Precinct #25,President,,R,Trump and Pence,87,67,154
-Reno,Precinct #26,President,,R,Trump and Pence,70,46,116
-Reno,Precinct #26 Exclave,President,,R,Trump and Pence,8,3,11
-Reno,Precinct #27,President,,R,Trump and Pence,155,103,258
-Reno,Precinct #28,President,,R,Trump and Pence,343,221,564
-Reno,Precinct #28 Exclave,President,,R,Trump and Pence,158,126,284
-Reno,Precinct #29,President,,R,Trump and Pence,125,103,228
-Reno,Precinct #30,President,,R,Trump and Pence,79,51,130
-Reno,Precinct #31,President,,R,Trump and Pence,108,81,189
-Reno,Precinct #32,President,,R,Trump and Pence,44,37,81
-Reno,Precinct #33,President,,R,Trump and Pence,88,42,130
-Reno,Precinct #34,President,,R,Trump and Pence,27,20,47
-Reno,Precinct #34 Exclave,President,,R,Trump and Pence,1,0,1
-Reno,Precinct #35,President,,R,Trump and Pence,73,42,115
-Reno,Albion Township,President,,R,Trump and Pence,246,32,278
-Reno,Arlington Township,President,,R,Trump and Pence,137,31,168
-Reno,Bell Township,President,,R,Trump and Pence,24,6,30
-Reno,Castleton Township,President,,R,Trump and Pence,98,16,114
-Reno,Center Township,President,,R,Trump and Pence,114,20,134
-Reno,Clay North Township,President,,R,Trump and Pence,235,111,346
-Reno,Clay South H101,President,,R,Trump and Pence,310,83,393
-Reno,Clay South H102A,President,,R,Trump and Pence,0,2,2
-Reno,Enterprise Township,President,,R,Trump and Pence,48,10,58
-Reno,Grant Township,President,,R,Trump and Pence,424,159,583
-Reno,Grove 310,President,,R,Trump and Pence,21,5,26
-Reno,Haven Township,President,,R,Trump and Pence,419,74,493
-Reno,Hayes Township,President,,R,Trump and Pence,17,8,25
-Reno,Huntsville Township,President,,R,Trump and Pence,42,6,48
-Reno,Langdon 310,President,,R,Trump and Pence,44,7,51
-Reno,Lincoln Township,President,,R,Trump and Pence,146,21,167
-Reno,Little River Township,President,,R,Trump and Pence,530,129,659
-Reno,Loda Township,President,,R,Trump and Pence,30,4,34
-Reno,Medford Township,President,,R,Trump and Pence,55,6,61
-Reno,Medora Township,President,,R,Trump and Pence,456,165,621
-Reno,Miami 310,President,,R,Trump and Pence,114,4,118
-Reno,Ninnescah Township,President,,R,Trump and Pence,58,13,71
-Reno,Plevna 310,President,,R,Trump and Pence,85,10,95
-Reno,Reno North Township,President,,R,Trump and Pence,330,156,486
-Reno,Reno South Township,President,,R,Trump and Pence,74,19,93
-Reno,Roscoe Township,President,,R,Trump and Pence,35,6,41
-Reno,Salt Creek Township,President,,R,Trump and Pence,131,21,152
-Reno,Sumner Township,President,,R,Trump and Pence,205,25,230
-Reno,Sylvia 310,President,,R,Trump and Pence,83,9,92
-Reno,Troy Township,President,,R,Trump and Pence,38,4,42
-Reno,Valley Township,President,,R,Trump and Pence,219,85,304
-Reno,Walnut Township,President,,R,Trump and Pence,43,7,50
-Reno,Westminster 310,President,,R,Trump and Pence,65,13,78
-Reno,Yoder Township,President,,R,Trump and Pence,152,29,181
-Reno,South Hutchinson #1,President,,R,Trump and Pence,94,44,138
-Reno,South Hutchinson #2,President,,R,Trump and Pence,228,83,311
-Reno,South Hutchinson #3,President,,R,Trump and Pence,161,32,193
-Reno,Nickerson Ward #1,President,,R,Trump and Pence,87,21,108
-Reno,Nickerson Ward #2,President,,R,Trump and Pence,52,11,63
-Reno,Nickerson Ward #3,President,,R,Trump and Pence,69,7,76
-Reno,Total,President,,R,Trump and Pence,10485,5028,15513
-Reno,Precinct #1-H102,President,,D,Clinton and Kaine,58,24,82
-Reno,Precinct #1-H114,President,,D,Clinton and Kaine,1,6,7
-Reno,Precinct #2,President,,D,Clinton and Kaine,45,50,95
-Reno,Precinct #3,President,,D,Clinton and Kaine,52,25,77
-Reno,Precinct #4,President,,D,Clinton and Kaine,92,128,220
-Reno,Precinct #5,President,,D,Clinton and Kaine,67,51,118
-Reno,Precinct #6,President,,D,Clinton and Kaine,69,72,141
-Reno,Precinct #7,President,,D,Clinton and Kaine,84,75,159
-Reno,Precinct #8,President,,D,Clinton and Kaine,36,38,74
-Reno,Precinct #9,President,,D,Clinton and Kaine,87,108,195
-Reno,Precinct #10,President,,D,Clinton and Kaine,71,135,206
-Reno,Precinct #11,President,,D,Clinton and Kaine,84,116,200
-Reno,Precinct #12,President,,D,Clinton and Kaine,76,86,162
-Reno,Precinct #13,President,,D,Clinton and Kaine,92,91,183
-Reno,Precinct #14,President,,D,Clinton and Kaine,78,83,161
-Reno,Precinct #15,President,,D,Clinton and Kaine,56,42,98
-Reno,Precinct #16,President,,D,Clinton and Kaine,128,98,226
-Reno,Precinct #17,President,,D,Clinton and Kaine,90,89,179
-Reno,Precinct #18,President,,D,Clinton and Kaine,34,28,62
-Reno,Precinct #19,President,,D,Clinton and Kaine,46,39,85
-Reno,Precinct #20,President,,D,Clinton and Kaine,57,53,110
-Reno,Precinct #21,President,,D,Clinton and Kaine,55,59,114
-Reno,Precinct #22,President,,D,Clinton and Kaine,110,109,219
-Reno,Precinct #23,President,,D,Clinton and Kaine,111,154,265
-Reno,Precinct #23 Exclave,President,,D,Clinton and Kaine,14,28,42
-Reno,Precinct #24,President,,D,Clinton and Kaine,64,98,162
-Reno,Precinct #25,President,,D,Clinton and Kaine,53,48,101
-Reno,Precinct #26,President,,D,Clinton and Kaine,33,30,63
-Reno,Precinct #26 Exclave,President,,D,Clinton and Kaine,2,4,6
-Reno,Precinct #27,President,,D,Clinton and Kaine,63,62,125
-Reno,Precinct #28,President,,D,Clinton and Kaine,112,128,240
-Reno,Precinct #28 Exclave,President,,D,Clinton and Kaine,34,77,111
-Reno,Precinct #29,President,,D,Clinton and Kaine,70,64,134
-Reno,Precinct #30,President,,D,Clinton and Kaine,27,42,69
-Reno,Precinct #31,President,,D,Clinton and Kaine,56,71,127
-Reno,Precinct #32,President,,D,Clinton and Kaine,14,23,37
-Reno,Precinct #33,President,,D,Clinton and Kaine,33,21,54
-Reno,Precinct #34,President,,D,Clinton and Kaine,11,3,14
-Reno,Precinct #34 Exclave,President,,D,Clinton and Kaine,0,0,0
-Reno,Precinct #35,President,,D,Clinton and Kaine,32,35,67
-Reno,Albion Township,President,,D,Clinton and Kaine,64,19,83
-Reno,Arlington Township,President,,D,Clinton and Kaine,50,8,58
-Reno,Bell Township,President,,D,Clinton and Kaine,1,2,3
-Reno,Castleton Township,President,,D,Clinton and Kaine,20,8,28
-Reno,Center Township,President,,D,Clinton and Kaine,24,12,36
-Reno,Clay North Township,President,,D,Clinton and Kaine,44,55,99
-Reno,Clay South H101,President,,D,Clinton and Kaine,62,28,90
-Reno,Clay South H102A,President,,D,Clinton and Kaine,0,0,0
-Reno,Enterprise Township,President,,D,Clinton and Kaine,5,3,8
-Reno,Grant Township,President,,D,Clinton and Kaine,103,46,149
-Reno,Grove 310,President,,D,Clinton and Kaine,5,0,5
-Reno,Haven Township,President,,D,Clinton and Kaine,153,23,176
-Reno,Hayes Township,President,,D,Clinton and Kaine,2,3,5
-Reno,Huntsville Township,President,,D,Clinton and Kaine,5,1,6
-Reno,Langdon 310,President,,D,Clinton and Kaine,9,0,9
-Reno,Lincoln Township,President,,D,Clinton and Kaine,17,5,22
-Reno,Little River Township,President,,D,Clinton and Kaine,142,55,197
-Reno,Loda Township,President,,D,Clinton and Kaine,6,2,8
-Reno,Medford Township,President,,D,Clinton and Kaine,7,5,12
-Reno,Medora Township,President,,D,Clinton and Kaine,110,67,177
-Reno,Miami 310,President,,D,Clinton and Kaine,25,4,29
-Reno,Ninnescah Township,President,,D,Clinton and Kaine,19,6,25
-Reno,Plevna 310,President,,D,Clinton and Kaine,15,4,19
-Reno,Reno North Township,President,,D,Clinton and Kaine,93,70,163
-Reno,Reno South Township,President,,D,Clinton and Kaine,12,4,16
-Reno,Roscoe Township,President,,D,Clinton and Kaine,13,2,15
-Reno,Salt Creek Township,President,,D,Clinton and Kaine,15,3,18
-Reno,Sumner Township,President,,D,Clinton and Kaine,43,2,45
-Reno,Sylvia 310,President,,D,Clinton and Kaine,16,2,18
-Reno,Troy Township,President,,D,Clinton and Kaine,9,1,10
-Reno,Valley Township,President,,D,Clinton and Kaine,51,25,76
-Reno,Walnut Township,President,,D,Clinton and Kaine,4,4,8
-Reno,Westminster 310,President,,D,Clinton and Kaine,15,1,16
-Reno,Yoder Township,President,,D,Clinton and Kaine,40,10,50
-Reno,South Hutchinson #1,President,,D,Clinton and Kaine,56,27,83
-Reno,South Hutchinson #2,President,,D,Clinton and Kaine,64,40,104
-Reno,South Hutchinson #3,President,,D,Clinton and Kaine,73,28,101
-Reno,Nickerson Ward #1,President,,D,Clinton and Kaine,21,15,36
-Reno,Nickerson Ward #2,President,,D,Clinton and Kaine,20,1,21
-Reno,Nickerson Ward #3,President,,D,Clinton and Kaine,19,4,23
-Reno,Total,President,,D,Clinton and Kaine,3749,3088,6837
-Reno,Precinct #1-H102,President,,L,Johnson and Weld,6,7,13
-Reno,Precinct #1-H114,President,,L,Johnson and Weld,0,0,0
-Reno,Precinct #2,President,,L,Johnson and Weld,7,6,13
-Reno,Precinct #3,President,,L,Johnson and Weld,3,0,3
-Reno,Precinct #4,President,,L,Johnson and Weld,22,20,42
-Reno,Precinct #5,President,,L,Johnson and Weld,12,10,22
-Reno,Precinct #6,President,,L,Johnson and Weld,16,4,20
-Reno,Precinct #7,President,,L,Johnson and Weld,18,13,31
-Reno,Precinct #8,President,,L,Johnson and Weld,7,4,11
-Reno,Precinct #9,President,,L,Johnson and Weld,27,15,42
-Reno,Precinct #10,President,,L,Johnson and Weld,22,22,44
-Reno,Precinct #11,President,,L,Johnson and Weld,24,8,32
-Reno,Precinct #12,President,,L,Johnson and Weld,23,8,31
-Reno,Precinct #13,President,,L,Johnson and Weld,23,9,32
-Reno,Precinct #14,President,,L,Johnson and Weld,19,9,28
-Reno,Precinct #15,President,,L,Johnson and Weld,13,8,21
-Reno,Precinct #16,President,,L,Johnson and Weld,19,7,26
-Reno,Precinct #17,President,,L,Johnson and Weld,14,3,17
-Reno,Precinct #18,President,,L,Johnson and Weld,5,6,11
-Reno,Precinct #19,President,,L,Johnson and Weld,8,11,19
-Reno,Precinct #20,President,,L,Johnson and Weld,14,6,20
-Reno,Precinct #21,President,,L,Johnson and Weld,15,8,23
-Reno,Precinct #22,President,,L,Johnson and Weld,23,12,35
-Reno,Precinct #23,President,,L,Johnson and Weld,21,19,40
-Reno,Precinct #23 Exclave,President,,L,Johnson and Weld,3,3,6
-Reno,Precinct #24,President,,L,Johnson and Weld,23,9,32
-Reno,Precinct #25,President,,L,Johnson and Weld,13,12,25
-Reno,Precinct #26,President,,L,Johnson and Weld,11,2,13
-Reno,Precinct #26 Exclave,President,,L,Johnson and Weld,3,0,3
-Reno,Precinct #27,President,,L,Johnson and Weld,23,5,28
-Reno,Precinct #28,President,,L,Johnson and Weld,31,18,49
-Reno,Precinct #28 Exclave,President,,L,Johnson and Weld,8,3,11
-Reno,Precinct #29,President,,L,Johnson and Weld,14,6,20
-Reno,Precinct #30,President,,L,Johnson and Weld,3,6,9
-Reno,Precinct #31,President,,L,Johnson and Weld,9,9,18
-Reno,Precinct #32,President,,L,Johnson and Weld,1,3,4
-Reno,Precinct #33,President,,L,Johnson and Weld,5,1,6
-Reno,Precinct #34,President,,L,Johnson and Weld,1,2,3
-Reno,Precinct #34 Exclave,President,,L,Johnson and Weld,0,0,0
-Reno,Precinct #35,President,,L,Johnson and Weld,8,2,10
-Reno,Albion Township,President,,L,Johnson and Weld,20,3,23
-Reno,Arlington Township,President,,L,Johnson and Weld,14,6,20
-Reno,Bell Township,President,,L,Johnson and Weld,1,0,1
-Reno,Castleton Township,President,,L,Johnson and Weld,4,0,4
-Reno,Center Township,President,,L,Johnson and Weld,5,2,7
-Reno,Clay North Township,President,,L,Johnson and Weld,10,7,17
-Reno,Clay South H101,President,,L,Johnson and Weld,17,9,26
-Reno,Clay South H102A,President,,L,Johnson and Weld,0,0,0
-Reno,Enterprise Township,President,,L,Johnson and Weld,1,0,1
-Reno,Grant Township,President,,L,Johnson and Weld,26,9,35
-Reno,Grove 310,President,,L,Johnson and Weld,1,0,1
-Reno,Haven Township,President,,L,Johnson and Weld,40,6,46
-Reno,Hayes Township,President,,L,Johnson and Weld,1,0,1
-Reno,Huntsville Township,President,,L,Johnson and Weld,1,0,1
-Reno,Langdon 310,President,,L,Johnson and Weld,2,1,3
-Reno,Lincoln Township,President,,L,Johnson and Weld,4,1,5
-Reno,Little River Township,President,,L,Johnson and Weld,33,4,37
-Reno,Loda Township,President,,L,Johnson and Weld,1,0,1
-Reno,Medford Township,President,,L,Johnson and Weld,2,0,2
-Reno,Medora Township,President,,L,Johnson and Weld,32,6,38
-Reno,Miami 310,President,,L,Johnson and Weld,5,0,5
-Reno,Ninnescah Township,President,,L,Johnson and Weld,7,0,7
-Reno,Plevna 310,President,,L,Johnson and Weld,1,1,2
-Reno,Reno North Township,President,,L,Johnson and Weld,21,7,28
-Reno,Reno South Township,President,,L,Johnson and Weld,3,1,4
-Reno,Roscoe Township,President,,L,Johnson and Weld,1,0,1
-Reno,Salt Creek Township,President,,L,Johnson and Weld,6,0,6
-Reno,Sumner Township,President,,L,Johnson and Weld,11,0,11
-Reno,Sylvia 310,President,,L,Johnson and Weld,10,2,12
-Reno,Troy Township,President,,L,Johnson and Weld,1,0,1
-Reno,Valley Township,President,,L,Johnson and Weld,20,10,30
-Reno,Walnut Township,President,,L,Johnson and Weld,1,0,1
-Reno,Westminster 310,President,,L,Johnson and Weld,8,2,10
-Reno,Yoder Township,President,,L,Johnson and Weld,7,2,9
-Reno,South Hutchinson #1,President,,L,Johnson and Weld,10,6,16
-Reno,South Hutchinson #2,President,,L,Johnson and Weld,13,1,14
-Reno,South Hutchinson #3,President,,L,Johnson and Weld,14,3,17
-Reno,Nickerson Ward #1,President,,L,Johnson and Weld,12,1,13
-Reno,Nickerson Ward #2,President,,L,Johnson and Weld,3,1,4
-Reno,Nickerson Ward #3,President,,L,Johnson and Weld,4,3,7
-Reno,Total,President,,L,Johnson and Weld,890,390,1280
-Reno,Precinct #1-H102,President,,I,Stein and Baraka,7,0,7
-Reno,Precinct #1-H114,President,,I,Stein and Baraka,0,1,1
-Reno,Precinct #2,President,,I,Stein and Baraka,1,3,4
-Reno,Precinct #3,President,,I,Stein and Baraka,5,1,6
-Reno,Precinct #4,President,,I,Stein and Baraka,5,5,10
-Reno,Precinct #5,President,,I,Stein and Baraka,11,5,16
-Reno,Precinct #6,President,,I,Stein and Baraka,3,5,8
-Reno,Precinct #7,President,,I,Stein and Baraka,9,2,11
-Reno,Precinct #8,President,,I,Stein and Baraka,5,0,5
-Reno,Precinct #9,President,,I,Stein and Baraka,9,7,16
-Reno,Precinct #10,President,,I,Stein and Baraka,3,7,10
-Reno,Precinct #11,President,,I,Stein and Baraka,7,4,11
-Reno,Precinct #12,President,,I,Stein and Baraka,6,1,7
-Reno,Precinct #13,President,,I,Stein and Baraka,9,3,12
-Reno,Precinct #14,President,,I,Stein and Baraka,4,5,9
-Reno,Precinct #15,President,,I,Stein and Baraka,2,2,4
-Reno,Precinct #16,President,,I,Stein and Baraka,10,1,11
-Reno,Precinct #17,President,,I,Stein and Baraka,9,4,13
-Reno,Precinct #18,President,,I,Stein and Baraka,5,3,8
-Reno,Precinct #19,President,,I,Stein and Baraka,7,2,9
-Reno,Precinct #20,President,,I,Stein and Baraka,6,3,9
-Reno,Precinct #21,President,,I,Stein and Baraka,5,1,6
-Reno,Precinct #22,President,,I,Stein and Baraka,12,4,16
-Reno,Precinct #23,President,,I,Stein and Baraka,8,4,12
-Reno,Precinct #23 Exclave,President,,I,Stein and Baraka,2,3,5
-Reno,Precinct #24,President,,I,Stein and Baraka,4,4,8
-Reno,Precinct #25,President,,I,Stein and Baraka,5,3,8
-Reno,Precinct #26,President,,I,Stein and Baraka,7,1,8
-Reno,Precinct #26 Exclave,President,,I,Stein and Baraka,0,1,1
-Reno,Precinct #27,President,,I,Stein and Baraka,3,3,6
-Reno,Precinct #28,President,,I,Stein and Baraka,9,3,12
-Reno,Precinct #28 Exclave,President,,I,Stein and Baraka,0,1,1
-Reno,Precinct #29,President,,I,Stein and Baraka,7,1,8
-Reno,Precinct #30,President,,I,Stein and Baraka,3,2,5
-Reno,Precinct #31,President,,I,Stein and Baraka,5,4,9
-Reno,Precinct #32,President,,I,Stein and Baraka,1,0,1
-Reno,Precinct #33,President,,I,Stein and Baraka,1,0,1
-Reno,Precinct #34,President,,I,Stein and Baraka,0,0,0
-Reno,Precinct #34 Exclave,President,,I,Stein and Baraka,0,0,0
-Reno,Precinct #35,President,,I,Stein and Baraka,6,4,10
-Reno,Albion Township,President,,I,Stein and Baraka,3,1,4
-Reno,Arlington Township,President,,I,Stein and Baraka,5,1,6
-Reno,Bell Township,President,,I,Stein and Baraka,0,0,0
-Reno,Castleton Township,President,,I,Stein and Baraka,1,0,1
-Reno,Center Township,President,,I,Stein and Baraka,3,1,4
-Reno,Clay North Township,President,,I,Stein and Baraka,5,3,8
-Reno,Clay South H101,President,,I,Stein and Baraka,5,0,5
-Reno,Clay South H102A,President,,I,Stein and Baraka,0,0,0
-Reno,Enterprise Township,President,,I,Stein and Baraka,0,0,0
-Reno,Grant Township,President,,I,Stein and Baraka,7,4,11
-Reno,Grove 310,President,,I,Stein and Baraka,0,0,0
-Reno,Haven Township,President,,I,Stein and Baraka,15,2,17
-Reno,Hayes Township,President,,I,Stein and Baraka,0,0,0
-Reno,Huntsville Township,President,,I,Stein and Baraka,1,0,1
-Reno,Langdon 310,President,,I,Stein and Baraka,0,0,0
-Reno,Lincoln Township,President,,I,Stein and Baraka,0,0,0
-Reno,Little River Township,President,,I,Stein and Baraka,14,2,16
-Reno,Loda Township,President,,I,Stein and Baraka,1,0,1
-Reno,Medford Township,President,,I,Stein and Baraka,0,0,0
-Reno,Medora Township,President,,I,Stein and Baraka,9,3,12
-Reno,Miami 310,President,,I,Stein and Baraka,0,0,0
-Reno,Ninnescah Township,President,,I,Stein and Baraka,3,0,3
-Reno,Plevna 310,President,,I,Stein and Baraka,1,0,1
-Reno,Reno North Township,President,,I,Stein and Baraka,3,3,6
-Reno,Reno South Township,President,,I,Stein and Baraka,3,0,3
-Reno,Roscoe Township,President,,I,Stein and Baraka,0,0,0
-Reno,Salt Creek Township,President,,I,Stein and Baraka,2,2,4
-Reno,Sumner Township,President,,I,Stein and Baraka,3,2,5
-Reno,Sylvia 310,President,,I,Stein and Baraka,5,0,5
-Reno,Troy Township,President,,I,Stein and Baraka,0,0,0
-Reno,Valley Township,President,,I,Stein and Baraka,5,1,6
-Reno,Walnut Township,President,,I,Stein and Baraka,1,0,1
-Reno,Westminster 310,President,,I,Stein and Baraka,0,0,0
-Reno,Yoder Township,President,,I,Stein and Baraka,9,1,10
-Reno,South Hutchinson #1,President,,I,Stein and Baraka,3,1,4
-Reno,South Hutchinson #2,President,,I,Stein and Baraka,5,0,5
-Reno,South Hutchinson #3,President,,I,Stein and Baraka,2,0,2
-Reno,Nickerson Ward #1,President,,I,Stein and Baraka,5,0,5
-Reno,Nickerson Ward #2,President,,I,Stein and Baraka,3,0,3
-Reno,Nickerson Ward #3,President,,I,Stein and Baraka,2,1,3
-Reno,Total,President,,I,Stein and Baraka,325,131,456
-Reno,Precinct #1-H102,President,,,Write-ins,3,2,5
-Reno,Precinct #1-H114,President,,,Write-ins,1,0,1
-Reno,Precinct #2,President,,,Write-ins,4,0,4
-Reno,Precinct #3,President,,,Write-ins,2,0,2
-Reno,Precinct #4,President,,,Write-ins,14,9,23
-Reno,Precinct #5,President,,,Write-ins,5,3,8
-Reno,Precinct #6,President,,,Write-ins,10,2,12
-Reno,Precinct #7,President,,,Write-ins,2,1,3
-Reno,Precinct #8,President,,,Write-ins,3,1,4
-Reno,Precinct #9,President,,,Write-ins,5,4,9
-Reno,Precinct #10,President,,,Write-ins,2,8,10
-Reno,Precinct #11,President,,,Write-ins,8,7,15
-Reno,Precinct #12,President,,,Write-ins,9,5,14
-Reno,Precinct #13,President,,,Write-ins,6,5,11
-Reno,Precinct #14,President,,,Write-ins,6,2,8
-Reno,Precinct #15,President,,,Write-ins,4,1,5
-Reno,Precinct #16,President,,,Write-ins,9,2,11
-Reno,Precinct #17,President,,,Write-ins,8,1,9
-Reno,Precinct #18,President,,,Write-ins,3,3,6
-Reno,Precinct #19,President,,,Write-ins,2,2,4
-Reno,Precinct #20,President,,,Write-ins,7,1,8
-Reno,Precinct #21,President,,,Write-ins,4,3,7
-Reno,Precinct #22,President,,,Write-ins,5,8,13
-Reno,Precinct #23,President,,,Write-ins,9,13,22
-Reno,Precinct #23 Exclave,President,,,Write-ins,5,2,7
-Reno,Precinct #24,President,,,Write-ins,4,4,8
-Reno,Precinct #25,President,,,Write-ins,1,0,1
-Reno,Precinct #26,President,,,Write-ins,3,1,4
-Reno,Precinct #26 Exclave,President,,,Write-ins,0,0,0
-Reno,Precinct #27,President,,,Write-ins,2,5,7
-Reno,Precinct #28,President,,,Write-ins,7,5,12
-Reno,Precinct #28 Exclave,President,,,Write-ins,3,3,6
-Reno,Precinct #29,President,,,Write-ins,6,4,10
-Reno,Precinct #30,President,,,Write-ins,1,0,1
-Reno,Precinct #31,President,,,Write-ins,10,0,10
-Reno,Precinct #32,President,,,Write-ins,1,0,1
-Reno,Precinct #33,President,,,Write-ins,5,1,6
-Reno,Precinct #34,President,,,Write-ins,0,0,0
-Reno,Precinct #34 Exclave,President,,,Write-ins,0,0,0
-Reno,Precinct #35,President,,,Write-ins,2,1,3
-Reno,Albion Township,President,,,Write-ins,5,0,5
-Reno,Arlington Township,President,,,Write-ins,1,0,1
-Reno,Bell Township,President,,,Write-ins,0,0,0
-Reno,Castleton Township,President,,,Write-ins,5,0,5
-Reno,Center Township,President,,,Write-ins,5,1,6
-Reno,Clay North Township,President,,,Write-ins,3,2,5
-Reno,Clay South H101,President,,,Write-ins,5,1,6
-Reno,Clay South H102A,President,,,Write-ins,0,0,0
-Reno,Enterprise Township,President,,,Write-ins,1,0,1
-Reno,Grant Township,President,,,Write-ins,11,6,17
-Reno,Grove 310,President,,,Write-ins,0,0,0
-Reno,Haven Township,President,,,Write-ins,12,2,14
-Reno,Hayes Township,President,,,Write-ins,0,0,0
-Reno,Huntsville Township,President,,,Write-ins,0,0,0
-Reno,Langdon 310,President,,,Write-ins,0,0,0
-Reno,Lincoln Township,President,,,Write-ins,0,1,1
-Reno,Little River Township,President,,,Write-ins,18,3,21
-Reno,Loda Township,President,,,Write-ins,0,0,0
-Reno,Medford Township,President,,,Write-ins,2,0,2
-Reno,Medora Township,President,,,Write-ins,9,1,10
-Reno,Miami 310,President,,,Write-ins,0,0,0
-Reno,Ninnescah Township,President,,,Write-ins,0,0,0
-Reno,Plevna 310,President,,,Write-ins,3,0,3
-Reno,Reno North Township,President,,,Write-ins,6,4,10
-Reno,Reno South Township,President,,,Write-ins,1,0,1
-Reno,Roscoe Township,President,,,Write-ins,0,0,0
-Reno,Salt Creek Township,President,,,Write-ins,1,1,2
-Reno,Sumner Township,President,,,Write-ins,3,2,5
-Reno,Sylvia 310,President,,,Write-ins,1,2,3
-Reno,Troy Township,President,,,Write-ins,1,0,1
-Reno,Valley Township,President,,,Write-ins,5,9,14
-Reno,Walnut Township,President,,,Write-ins,1,2,3
-Reno,Westminster 310,President,,,Write-ins,1,0,1
-Reno,Yoder Township,President,,,Write-ins,3,0,3
-Reno,South Hutchinson #1,President,,,Write-ins,1,0,1
-Reno,South Hutchinson #2,President,,,Write-ins,6,2,8
-Reno,South Hutchinson #3,President,,,Write-ins,2,0,2
-Reno,Nickerson Ward #1,President,,,Write-ins,4,2,6
-Reno,Nickerson Ward #2,President,,,Write-ins,1,1,2
-Reno,Nickerson Ward #3,President,,,Write-ins,1,0,1
-Reno,Total,President,,,Write-ins,299,151,450
-Reno,Precinct #1-H102,U.S. Senate,,D,Patrick Wiesner,51,25,76
-Reno,Precinct #1-H114,U.S. Senate,,D,Patrick Wiesner,0,5,5
-Reno,Precinct #2,U.S. Senate,,D,Patrick Wiesner,38,48,86
-Reno,Precinct #3,U.S. Senate,,D,Patrick Wiesner,38,21,59
-Reno,Precinct #4,U.S. Senate,,D,Patrick Wiesner,58,86,144
-Reno,Precinct #5,U.S. Senate,,D,Patrick Wiesner,59,49,108
-Reno,Precinct #6,U.S. Senate,,D,Patrick Wiesner,64,62,126
-Reno,Precinct #7,U.S. Senate,,D,Patrick Wiesner,78,73,151
-Reno,Precinct #8,U.S. Senate,,D,Patrick Wiesner,35,28,63
-Reno,Precinct #9,U.S. Senate,,D,Patrick Wiesner,71,86,157
-Reno,Precinct #10,U.S. Senate,,D,Patrick Wiesner,49,91,140
-Reno,Precinct #11,U.S. Senate,,D,Patrick Wiesner,71,81,152
-Reno,Precinct #12,U.S. Senate,,D,Patrick Wiesner,55,61,116
-Reno,Precinct #13,U.S. Senate,,D,Patrick Wiesner,75,70,145
-Reno,Precinct #14,U.S. Senate,,D,Patrick Wiesner,68,70,138
-Reno,Precinct #15,U.S. Senate,,D,Patrick Wiesner,50,37,87
-Reno,Precinct #16,U.S. Senate,,D,Patrick Wiesner,108,81,189
-Reno,Precinct #17,U.S. Senate,,D,Patrick Wiesner,70,67,137
-Reno,Precinct #18,U.S. Senate,,D,Patrick Wiesner,30,32,62
-Reno,Precinct #19,U.S. Senate,,D,Patrick Wiesner,46,29,75
-Reno,Precinct #20,U.S. Senate,,D,Patrick Wiesner,59,42,101
-Reno,Precinct #21,U.S. Senate,,D,Patrick Wiesner,50,54,104
-Reno,Precinct #22,U.S. Senate,,D,Patrick Wiesner,81,86,167
-Reno,Precinct #23,U.S. Senate,,D,Patrick Wiesner,89,114,203
-Reno,Precinct #23 Exclave,U.S. Senate,,D,Patrick Wiesner,9,26,35
-Reno,Precinct #24,U.S. Senate,,D,Patrick Wiesner,59,83,142
-Reno,Precinct #25,U.S. Senate,,D,Patrick Wiesner,43,48,91
-Reno,Precinct #26,U.S. Senate,,D,Patrick Wiesner,32,27,59
-Reno,Precinct #26 Exclave,U.S. Senate,,D,Patrick Wiesner,2,1,3
-Reno,Precinct #27,U.S. Senate,,D,Patrick Wiesner,52,43,95
-Reno,Precinct #28,U.S. Senate,,D,Patrick Wiesner,84,103,187
-Reno,Precinct #28 Exclave,U.S. Senate,,D,Patrick Wiesner,13,42,55
-Reno,Precinct #29,U.S. Senate,,D,Patrick Wiesner,60,54,114
-Reno,Precinct #30,U.S. Senate,,D,Patrick Wiesner,29,36,65
-Reno,Precinct #31,U.S. Senate,,D,Patrick Wiesner,54,58,112
-Reno,Precinct #32,U.S. Senate,,D,Patrick Wiesner,8,14,22
-Reno,Precinct #33,U.S. Senate,,D,Patrick Wiesner,19,20,39
-Reno,Precinct #34,U.S. Senate,,D,Patrick Wiesner,11,5,16
-Reno,Precinct #34 Exclave,U.S. Senate,,D,Patrick Wiesner,0,0,0
-Reno,Precinct #35,U.S. Senate,,D,Patrick Wiesner,29,29,58
-Reno,Albion Township,U.S. Senate,,D,Patrick Wiesner,44,12,56
-Reno,Arlington Township,U.S. Senate,,D,Patrick Wiesner,51,7,58
-Reno,Bell Township,U.S. Senate,,D,Patrick Wiesner,5,1,6
-Reno,Castleton Township,U.S. Senate,,D,Patrick Wiesner,11,6,17
-Reno,Center Township,U.S. Senate,,D,Patrick Wiesner,19,10,29
-Reno,Clay North Township,U.S. Senate,,D,Patrick Wiesner,31,38,69
-Reno,Clay South H101,U.S. Senate,,D,Patrick Wiesner,62,32,94
-Reno,Clay South H102A,U.S. Senate,,D,Patrick Wiesner,0,0,0
-Reno,Enterprise Township,U.S. Senate,,D,Patrick Wiesner,6,3,9
-Reno,Grant Township,U.S. Senate,,D,Patrick Wiesner,67,32,99
-Reno,Grove 310,U.S. Senate,,D,Patrick Wiesner,4,1,5
-Reno,Haven Township,U.S. Senate,,D,Patrick Wiesner,125,21,146
-Reno,Hayes Township,U.S. Senate,,D,Patrick Wiesner,2,0,2
-Reno,Huntsville Township,U.S. Senate,,D,Patrick Wiesner,3,1,4
-Reno,Langdon 310,U.S. Senate,,D,Patrick Wiesner,11,1,12
-Reno,Lincoln Township,U.S. Senate,,D,Patrick Wiesner,22,3,25
-Reno,Little River Township,U.S. Senate,,D,Patrick Wiesner,94,35,129
-Reno,Loda Township,U.S. Senate,,D,Patrick Wiesner,5,3,8
-Reno,Medford Township,U.S. Senate,,D,Patrick Wiesner,4,3,7
-Reno,Medora Township,U.S. Senate,,D,Patrick Wiesner,97,52,149
-Reno,Miami 310,U.S. Senate,,D,Patrick Wiesner,19,4,23
-Reno,Ninnescah Township,U.S. Senate,,D,Patrick Wiesner,14,5,19
-Reno,Plevna 310,U.S. Senate,,D,Patrick Wiesner,16,1,17
-Reno,Reno North Township,U.S. Senate,,D,Patrick Wiesner,79,59,138
-Reno,Reno South Township,U.S. Senate,,D,Patrick Wiesner,7,4,11
-Reno,Roscoe Township,U.S. Senate,,D,Patrick Wiesner,7,1,8
-Reno,Salt Creek Township,U.S. Senate,,D,Patrick Wiesner,14,5,19
-Reno,Sumner Township,U.S. Senate,,D,Patrick Wiesner,43,6,49
-Reno,Sylvia 310,U.S. Senate,,D,Patrick Wiesner,17,2,19
-Reno,Troy Township,U.S. Senate,,D,Patrick Wiesner,6,1,7
-Reno,Valley Township,U.S. Senate,,D,Patrick Wiesner,50,21,71
-Reno,Walnut Township,U.S. Senate,,D,Patrick Wiesner,4,2,6
-Reno,Westminster 310,U.S. Senate,,D,Patrick Wiesner,16,0,16
-Reno,Yoder Township,U.S. Senate,,D,Patrick Wiesner,34,6,40
-Reno,South Hutchinson #1,U.S. Senate,,D,Patrick Wiesner,36,22,58
-Reno,South Hutchinson #2,U.S. Senate,,D,Patrick Wiesner,59,28,87
-Reno,South Hutchinson #3,U.S. Senate,,D,Patrick Wiesner,46,18,64
-Reno,Nickerson Ward #1,U.S. Senate,,D,Patrick Wiesner,23,12,35
-Reno,Nickerson Ward #2,U.S. Senate,,D,Patrick Wiesner,14,2,16
-Reno,Nickerson Ward #3,U.S. Senate,,D,Patrick Wiesner,16,5,21
-Reno,Total,U.S. Senate,,D,Patrick Wiesner,3080,2452,5532
-Reno,Precinct #1-H102,U.S. Senate,,L,Robert D. Garrard,20,12,32
-Reno,Precinct #1-H114,U.S. Senate,,L,Robert D. Garrard,0,1,1
-Reno,Precinct #2,U.S. Senate,,L,Robert D. Garrard,16,6,22
-Reno,Precinct #3,U.S. Senate,,L,Robert D. Garrard,14,2,16
-Reno,Precinct #4,U.S. Senate,,L,Robert D. Garrard,20,14,34
-Reno,Precinct #5,U.S. Senate,,L,Robert D. Garrard,24,12,36
-Reno,Precinct #6,U.S. Senate,,L,Robert D. Garrard,20,10,30
-Reno,Precinct #7,U.S. Senate,,L,Robert D. Garrard,15,11,26
-Reno,Precinct #8,U.S. Senate,,L,Robert D. Garrard,9,6,15
-Reno,Precinct #9,U.S. Senate,,L,Robert D. Garrard,28,15,43
-Reno,Precinct #10,U.S. Senate,,L,Robert D. Garrard,17,14,31
-Reno,Precinct #11,U.S. Senate,,L,Robert D. Garrard,19,12,31
-Reno,Precinct #12,U.S. Senate,,L,Robert D. Garrard,17,4,21
-Reno,Precinct #13,U.S. Senate,,L,Robert D. Garrard,26,6,32
-Reno,Precinct #14,U.S. Senate,,L,Robert D. Garrard,15,11,26
-Reno,Precinct #15,U.S. Senate,,L,Robert D. Garrard,18,8,26
-Reno,Precinct #16,U.S. Senate,,L,Robert D. Garrard,35,5,40
-Reno,Precinct #17,U.S. Senate,,L,Robert D. Garrard,22,11,33
-Reno,Precinct #18,U.S. Senate,,L,Robert D. Garrard,10,12,22
-Reno,Precinct #19,U.S. Senate,,L,Robert D. Garrard,12,13,25
-Reno,Precinct #20,U.S. Senate,,L,Robert D. Garrard,19,8,27
-Reno,Precinct #21,U.S. Senate,,L,Robert D. Garrard,15,4,19
-Reno,Precinct #22,U.S. Senate,,L,Robert D. Garrard,29,16,45
-Reno,Precinct #23,U.S. Senate,,L,Robert D. Garrard,20,16,36
-Reno,Precinct #23 Exclave,U.S. Senate,,L,Robert D. Garrard,6,7,13
-Reno,Precinct #24,U.S. Senate,,L,Robert D. Garrard,23,9,32
-Reno,Precinct #25,U.S. Senate,,L,Robert D. Garrard,24,18,42
-Reno,Precinct #26,U.S. Senate,,L,Robert D. Garrard,13,5,18
-Reno,Precinct #26 Exclave,U.S. Senate,,L,Robert D. Garrard,1,1,2
-Reno,Precinct #27,U.S. Senate,,L,Robert D. Garrard,17,8,25
-Reno,Precinct #28,U.S. Senate,,L,Robert D. Garrard,26,13,39
-Reno,Precinct #28 Exclave,U.S. Senate,,L,Robert D. Garrard,9,7,16
-Reno,Precinct #29,U.S. Senate,,L,Robert D. Garrard,16,9,25
-Reno,Precinct #30,U.S. Senate,,L,Robert D. Garrard,17,9,26
-Reno,Precinct #31,U.S. Senate,,L,Robert D. Garrard,12,7,19
-Reno,Precinct #32,U.S. Senate,,L,Robert D. Garrard,4,1,5
-Reno,Precinct #33,U.S. Senate,,L,Robert D. Garrard,8,1,9
-Reno,Precinct #34,U.S. Senate,,L,Robert D. Garrard,2,1,3
-Reno,Precinct #34 Exclave,U.S. Senate,,L,Robert D. Garrard,0,0,0
-Reno,Precinct #35,U.S. Senate,,L,Robert D. Garrard,5,4,9
-Reno,Albion Township,U.S. Senate,,L,Robert D. Garrard,17,6,23
-Reno,Arlington Township,U.S. Senate,,L,Robert D. Garrard,16,9,25
-Reno,Bell Township,U.S. Senate,,L,Robert D. Garrard,2,0,2
-Reno,Castleton Township,U.S. Senate,,L,Robert D. Garrard,4,4,8
-Reno,Center Township,U.S. Senate,,L,Robert D. Garrard,8,2,10
-Reno,Clay North Township,U.S. Senate,,L,Robert D. Garrard,11,4,15
-Reno,Clay South H101,U.S. Senate,,L,Robert D. Garrard,25,5,30
-Reno,Clay South H102A,U.S. Senate,,L,Robert D. Garrard,0,0,0
-Reno,Enterprise Township,U.S. Senate,,L,Robert D. Garrard,0,1,1
-Reno,Grant Township,U.S. Senate,,L,Robert D. Garrard,40,11,51
-Reno,Grove 310,U.S. Senate,,L,Robert D. Garrard,0,0,0
-Reno,Haven Township,U.S. Senate,,L,Robert D. Garrard,31,5,36
-Reno,Hayes Township,U.S. Senate,,L,Robert D. Garrard,2,0,2
-Reno,Huntsville Township,U.S. Senate,,L,Robert D. Garrard,4,0,4
-Reno,Langdon 310,U.S. Senate,,L,Robert D. Garrard,5,0,5
-Reno,Lincoln Township,U.S. Senate,,L,Robert D. Garrard,6,2,8
-Reno,Little River Township,U.S. Senate,,L,Robert D. Garrard,28,5,33
-Reno,Loda Township,U.S. Senate,,L,Robert D. Garrard,1,0,1
-Reno,Medford Township,U.S. Senate,,L,Robert D. Garrard,3,0,3
-Reno,Medora Township,U.S. Senate,,L,Robert D. Garrard,48,15,63
-Reno,Miami 310,U.S. Senate,,L,Robert D. Garrard,11,1,12
-Reno,Ninnescah Township,U.S. Senate,,L,Robert D. Garrard,10,0,10
-Reno,Plevna 310,U.S. Senate,,L,Robert D. Garrard,5,2,7
-Reno,Reno North Township,U.S. Senate,,L,Robert D. Garrard,32,10,42
-Reno,Reno South Township,U.S. Senate,,L,Robert D. Garrard,2,0,2
-Reno,Roscoe Township,U.S. Senate,,L,Robert D. Garrard,2,0,2
-Reno,Salt Creek Township,U.S. Senate,,L,Robert D. Garrard,13,2,15
-Reno,Sumner Township,U.S. Senate,,L,Robert D. Garrard,17,3,20
-Reno,Sylvia 310,U.S. Senate,,L,Robert D. Garrard,14,1,15
-Reno,Troy Township,U.S. Senate,,L,Robert D. Garrard,2,1,3
-Reno,Valley Township,U.S. Senate,,L,Robert D. Garrard,19,9,28
-Reno,Walnut Township,U.S. Senate,,L,Robert D. Garrard,2,0,2
-Reno,Westminster 310,U.S. Senate,,L,Robert D. Garrard,5,3,8
-Reno,Yoder Township,U.S. Senate,,L,Robert D. Garrard,7,3,10
-Reno,South Hutchinson #1,U.S. Senate,,L,Robert D. Garrard,11,6,17
-Reno,South Hutchinson #2,U.S. Senate,,L,Robert D. Garrard,22,11,33
-Reno,South Hutchinson #3,U.S. Senate,,L,Robert D. Garrard,11,3,14
-Reno,Nickerson Ward #1,U.S. Senate,,L,Robert D. Garrard,11,0,11
-Reno,Nickerson Ward #2,U.S. Senate,,L,Robert D. Garrard,10,1,11
-Reno,Nickerson Ward #3,U.S. Senate,,L,Robert D. Garrard,13,0,13
-Reno,Total,U.S. Senate,,L,Robert D. Garrard,1093,454,1547
-Reno,Precinct #1-H102,U.S. House,1,I,Alan LaPolice,44,22,66
-Reno,Precinct #1-H114,U.S. House,1,I,Alan LaPolice,0,2,2
-Reno,Precinct #2,U.S. House,1,I,Alan LaPolice,35,37,72
-Reno,Precinct #3,U.S. House,1,I,Alan LaPolice,23,15,38
-Reno,Precinct #4,U.S. House,1,I,Alan LaPolice,102,97,199
-Reno,Precinct #5,U.S. House,1,I,Alan LaPolice,59,47,106
-Reno,Precinct #6,U.S. House,1,I,Alan LaPolice,54,42,96
-Reno,Precinct #7,U.S. House,1,I,Alan LaPolice,56,63,119
-Reno,Precinct #8,U.S. House,1,I,Alan LaPolice,34,29,63
-Reno,Precinct #9,U.S. House,1,I,Alan LaPolice,79,89,168
-Reno,Precinct #10,U.S. House,1,I,Alan LaPolice,55,110,165
-Reno,Precinct #11,U.S. House,1,I,Alan LaPolice,93,86,179
-Reno,Precinct #12,U.S. House,1,I,Alan LaPolice,70,64,134
-Reno,Precinct #13,U.S. House,1,I,Alan LaPolice,75,65,140
-Reno,Precinct #14,U.S. House,1,I,Alan LaPolice,61,57,118
-Reno,Precinct #15,U.S. House,1,I,Alan LaPolice,27,23,50
-Reno,Precinct #16,U.S. House,1,I,Alan LaPolice,89,68,157
-Reno,Precinct #17,U.S. House,1,I,Alan LaPolice,79,65,144
-Reno,Precinct #18,U.S. House,1,I,Alan LaPolice,30,28,58
-Reno,Precinct #19,U.S. House,1,I,Alan LaPolice,36,27,63
-Reno,Precinct #20,U.S. House,1,I,Alan LaPolice,52,31,83
-Reno,Precinct #21,U.S. House,1,I,Alan LaPolice,30,47,77
-Reno,Precinct #22,U.S. House,1,I,Alan LaPolice,94,95,189
-Reno,Precinct #23,U.S. House,1,I,Alan LaPolice,85,115,200
-Reno,Precinct #23 Exclave,U.S. House,1,I,Alan LaPolice,20,30,50
-Reno,Precinct #24,U.S. House,1,I,Alan LaPolice,68,68,136
-Reno,Precinct #25,U.S. House,1,I,Alan LaPolice,48,26,74
-Reno,Precinct #26,U.S. House,1,I,Alan LaPolice,33,24,57
-Reno,Precinct #26 Exclave,U.S. House,1,I,Alan LaPolice,4,0,4
-Reno,Precinct #27,U.S. House,1,I,Alan LaPolice,61,43,104
-Reno,Precinct #28,U.S. House,1,I,Alan LaPolice,120,110,230
-Reno,Precinct #28 Exclave,U.S. House,1,I,Alan LaPolice,29,41,70
-Reno,Precinct #29,U.S. House,1,I,Alan LaPolice,58,61,119
-Reno,Precinct #30,U.S. House,1,I,Alan LaPolice,29,28,57
-Reno,Precinct #31,U.S. House,1,I,Alan LaPolice,47,53,100
-Reno,Precinct #32,U.S. House,1,I,Alan LaPolice,11,13,24
-Reno,Precinct #33,U.S. House,1,I,Alan LaPolice,28,17,45
-Reno,Precinct #34,U.S. House,1,I,Alan LaPolice,11,3,14
-Reno,Precinct #34 Exclave,U.S. House,1,I,Alan LaPolice,0,0,0
-Reno,Precinct #35,U.S. House,1,I,Alan LaPolice,23,22,45
-Reno,Albion Township,U.S. House,1,I,Alan LaPolice,74,15,89
-Reno,Arlington Township,U.S. House,1,I,Alan LaPolice,55,9,64
-Reno,Bell Township,U.S. House,1,I,Alan LaPolice,6,2,8
-Reno,Castleton Township,U.S. House,1,I,Alan LaPolice,27,11,38
-Reno,Center Township,U.S. House,1,I,Alan LaPolice,31,10,41
-Reno,Clay North Township,U.S. House,1,I,Alan LaPolice,47,47,94
-Reno,Clay South H101,U.S. House,1,I,Alan LaPolice,84,34,118
-Reno,Clay South H102A,U.S. House,1,I,Alan LaPolice,0,1,1
-Reno,Enterprise Township,U.S. House,1,I,Alan LaPolice,10,5,15
-Reno,Grant Township,U.S. House,1,I,Alan LaPolice,101,45,146
-Reno,Grove 310,U.S. House,1,I,Alan LaPolice,6,1,7
-Reno,Haven Township,U.S. House,1,I,Alan LaPolice,131,17,148
-Reno,Hayes Township,U.S. House,1,I,Alan LaPolice,5,3,8
-Reno,Huntsville Township,U.S. House,1,I,Alan LaPolice,9,1,10
-Reno,Langdon 310,U.S. House,1,I,Alan LaPolice,10,0,10
-Reno,Lincoln Township,U.S. House,1,I,Alan LaPolice,27,4,31
-Reno,Little River Township,U.S. House,1,I,Alan LaPolice,121,47,168
-Reno,Loda Township,U.S. House,1,I,Alan LaPolice,6,2,8
-Reno,Medford Township,U.S. House,1,I,Alan LaPolice,12,1,13
-Reno,Medora Township,U.S. House,1,I,Alan LaPolice,140,61,201
-Reno,Miami 310,U.S. House,1,I,Alan LaPolice,26,2,28
-Reno,Ninnescah Township,U.S. House,1,I,Alan LaPolice,23,7,30
-Reno,Plevna 310,U.S. House,1,I,Alan LaPolice,18,3,21
-Reno,Reno North Township,U.S. House,1,I,Alan LaPolice,99,67,166
-Reno,Reno South Township,U.S. House,1,I,Alan LaPolice,25,7,32
-Reno,Roscoe Township,U.S. House,1,I,Alan LaPolice,12,3,15
-Reno,Salt Creek Township,U.S. House,1,I,Alan LaPolice,26,8,34
-Reno,Sumner Township,U.S. House,1,I,Alan LaPolice,45,9,54
-Reno,Sylvia 310,U.S. House,1,I,Alan LaPolice,23,2,25
-Reno,Troy Township,U.S. House,1,I,Alan LaPolice,11,0,11
-Reno,Valley Township,U.S. House,1,I,Alan LaPolice,59,24,83
-Reno,Walnut Township,U.S. House,1,I,Alan LaPolice,8,6,14
-Reno,Westminster 310,U.S. House,1,I,Alan LaPolice,17,2,19
-Reno,Yoder Township,U.S. House,1,I,Alan LaPolice,54,12,66
-Reno,South Hutchinson #1,U.S. House,1,I,Alan LaPolice,40,20,60
-Reno,South Hutchinson #2,U.S. House,1,I,Alan LaPolice,65,32,97
-Reno,South Hutchinson #3,U.S. House,1,I,Alan LaPolice,63,21,84
-Reno,Nickerson Ward #1,U.S. House,1,I,Alan LaPolice,27,8,35
-Reno,Nickerson Ward #2,U.S. House,1,I,Alan LaPolice,17,2,19
-Reno,Nickerson Ward #3,U.S. House,1,I,Alan LaPolice,17,3,20
-Reno,Total,U.S. House,1,I,Alan LaPolice,3529,2417,5946
-Reno,Precinct #1-H102,U.S. House,1,R,Roger Marshall,57,31,88
-Reno,Precinct #1-H114,U.S. House,1,R,Roger Marshall,3,4,7
-Reno,Precinct #2,U.S. House,1,R,Roger Marshall,54,44,98
-Reno,Precinct #3,U.S. House,1,R,Roger Marshall,37,14,51
-Reno,Precinct #4,U.S. House,1,R,Roger Marshall,285,264,549
-Reno,Precinct #5,U.S. House,1,R,Roger Marshall,86,74,160
-Reno,Precinct #6,U.S. House,1,R,Roger Marshall,91,74,165
-Reno,Precinct #7,U.S. House,1,R,Roger Marshall,125,98,223
-Reno,Precinct #8,U.S. House,1,R,Roger Marshall,70,45,115
-Reno,Precinct #9,U.S. House,1,R,Roger Marshall,174,165,339
-Reno,Precinct #10,U.S. House,1,R,Roger Marshall,201,269,470
-Reno,Precinct #11,U.S. House,1,R,Roger Marshall,239,219,458
-Reno,Precinct #12,U.S. House,1,R,Roger Marshall,135,107,242
-Reno,Precinct #13,U.S. House,1,R,Roger Marshall,172,97,269
-Reno,Precinct #14,U.S. House,1,R,Roger Marshall,129,71,200
-Reno,Precinct #15,U.S. House,1,R,Roger Marshall,64,47,111
-Reno,Precinct #16,U.S. House,1,R,Roger Marshall,136,83,219
-Reno,Precinct #17,U.S. House,1,R,Roger Marshall,192,126,318
-Reno,Precinct #18,U.S. House,1,R,Roger Marshall,51,38,89
-Reno,Precinct #19,U.S. House,1,R,Roger Marshall,59,48,107
-Reno,Precinct #20,U.S. House,1,R,Roger Marshall,113,89,202
-Reno,Precinct #21,U.S. House,1,R,Roger Marshall,85,60,145
-Reno,Precinct #22,U.S. House,1,R,Roger Marshall,238,151,389
-Reno,Precinct #23,U.S. House,1,R,Roger Marshall,229,256,485
-Reno,Precinct #23 Exclave,U.S. House,1,R,Roger Marshall,72,66,138
-Reno,Precinct #24,U.S. House,1,R,Roger Marshall,202,131,333
-Reno,Precinct #25,U.S. House,1,R,Roger Marshall,80,64,144
-Reno,Precinct #26,U.S. House,1,R,Roger Marshall,61,42,103
-Reno,Precinct #26 Exclave,U.S. House,1,R,Roger Marshall,6,5,11
-Reno,Precinct #27,U.S. House,1,R,Roger Marshall,157,107,264
-Reno,Precinct #28,U.S. House,1,R,Roger Marshall,325,227,552
-Reno,Precinct #28 Exclave,U.S. House,1,R,Roger Marshall,155,151,306
-Reno,Precinct #29,U.S. House,1,R,Roger Marshall,128,93,221
-Reno,Precinct #30,U.S. House,1,R,Roger Marshall,66,49,115
-Reno,Precinct #31,U.S. House,1,R,Roger Marshall,108,88,196
-Reno,Precinct #32,U.S. House,1,R,Roger Marshall,41,44,85
-Reno,Precinct #33,U.S. House,1,R,Roger Marshall,96,38,134
-Reno,Precinct #34,U.S. House,1,R,Roger Marshall,20,17,37
-Reno,Precinct #34 Exclave,U.S. House,1,R,Roger Marshall,1,0,1
-Reno,Precinct #35,U.S. House,1,R,Roger Marshall,78,42,120
-Reno,Albion Township,U.S. House,1,R,Roger Marshall,231,34,265
-Reno,Arlington Township,U.S. House,1,R,Roger Marshall,120,27,147
-Reno,Bell Township,U.S. House,1,R,Roger Marshall,13,6,19
-Reno,Castleton Township,U.S. House,1,R,Roger Marshall,85,13,98
-Reno,Center Township,U.S. House,1,R,Roger Marshall,98,23,121
-Reno,Clay North Township,U.S. House,1,R,Roger Marshall,219,123,342
-Reno,Clay South H101,U.S. House,1,R,Roger Marshall,263,70,333
-Reno,Clay South H102A,U.S. House,1,R,Roger Marshall,0,2,2
-Reno,Enterprise Township,U.S. House,1,R,Roger Marshall,45,6,51
-Reno,Grant Township,U.S. House,1,R,Roger Marshall,400,152,552
-Reno,Grove 310,U.S. House,1,R,Roger Marshall,20,4,24
-Reno,Haven Township,U.S. House,1,R,Roger Marshall,425,67,492
-Reno,Hayes Township,U.S. House,1,R,Roger Marshall,15,8,23
-Reno,Huntsville Township,U.S. House,1,R,Roger Marshall,35,3,38
-Reno,Langdon 310,U.S. House,1,R,Roger Marshall,39,8,47
-Reno,Lincoln Township,U.S. House,1,R,Roger Marshall,127,19,146
-Reno,Little River Township,U.S. House,1,R,Roger Marshall,533,130,663
-Reno,Loda Township,U.S. House,1,R,Roger Marshall,27,2,29
-Reno,Medford Township,U.S. House,1,R,Roger Marshall,51,8,59
-Reno,Medora Township,U.S. House,1,R,Roger Marshall,391,151,542
-Reno,Miami 310,U.S. House,1,R,Roger Marshall,92,2,94
-Reno,Ninnescah Township,U.S. House,1,R,Roger Marshall,49,9,58
-Reno,Plevna 310,U.S. House,1,R,Roger Marshall,74,11,85
-Reno,Reno North Township,U.S. House,1,R,Roger Marshall,285,142,427
-Reno,Reno South Township,U.S. House,1,R,Roger Marshall,62,16,78
-Reno,Roscoe Township,U.S. House,1,R,Roger Marshall,32,5,37
-Reno,Salt Creek Township,U.S. House,1,R,Roger Marshall,104,14,118
-Reno,Sumner Township,U.S. House,1,R,Roger Marshall,185,22,207
-Reno,Sylvia 310,U.S. House,1,R,Roger Marshall,72,7,79
-Reno,Troy Township,U.S. House,1,R,Roger Marshall,37,5,42
-Reno,Valley Township,U.S. House,1,R,Roger Marshall,202,90,292
-Reno,Walnut Township,U.S. House,1,R,Roger Marshall,42,7,49
-Reno,Westminster 310,U.S. House,1,R,Roger Marshall,60,9,69
-Reno,Yoder Township,U.S. House,1,R,Roger Marshall,128,21,149
-Reno,South Hutchinson #1,U.S. House,1,R,Roger Marshall,91,37,128
-Reno,South Hutchinson #2,U.S. House,1,R,Roger Marshall,204,61,265
-Reno,South Hutchinson #3,U.S. House,1,R,Roger Marshall,163,33,196
-Reno,Nickerson Ward #1,U.S. House,1,R,Roger Marshall,80,20,100
-Reno,Nickerson Ward #2,U.S. House,1,R,Roger Marshall,47,10,57
-Reno,Nickerson Ward #3,U.S. House,1,R,Roger Marshall,59,8,67
-Reno,Total,U.S. House,1,R,Roger Marshall,9826,5023,14849
-Reno,Precinct #1-H102,U.S. House,1,L,Kerry Burt,34,20,54
-Reno,Precinct #1-H114,U.S. House,1,L,Kerry Burt,2,4,6
-Reno,Precinct #2,U.S. House,1,L,Kerry Burt,30,17,47
-Reno,Precinct #3,U.S. House,1,L,Kerry Burt,27,10,37
-Reno,Precinct #4,U.S. House,1,L,Kerry Burt,32,35,67
-Reno,Precinct #5,U.S. House,1,L,Kerry Burt,38,28,66
-Reno,Precinct #6,U.S. House,1,L,Kerry Burt,49,35,84
-Reno,Precinct #7,U.S. House,1,L,Kerry Burt,50,23,73
-Reno,Precinct #8,U.S. House,1,L,Kerry Burt,18,15,33
-Reno,Precinct #9,U.S. House,1,L,Kerry Burt,39,39,78
-Reno,Precinct #10,U.S. House,1,L,Kerry Burt,42,38,80
-Reno,Precinct #11,U.S. House,1,L,Kerry Burt,21,27,48
-Reno,Precinct #12,U.S. House,1,L,Kerry Burt,28,17,45
-Reno,Precinct #13,U.S. House,1,L,Kerry Burt,45,21,66
-Reno,Precinct #14,U.S. House,1,L,Kerry Burt,45,31,76
-Reno,Precinct #15,U.S. House,1,L,Kerry Burt,46,19,65
-Reno,Precinct #16,U.S. House,1,L,Kerry Burt,62,31,93
-Reno,Precinct #17,U.S. House,1,L,Kerry Burt,33,27,60
-Reno,Precinct #18,U.S. House,1,L,Kerry Burt,18,24,42
-Reno,Precinct #19,U.S. House,1,L,Kerry Burt,29,18,47
-Reno,Precinct #20,U.S. House,1,L,Kerry Burt,37,22,59
-Reno,Precinct #21,U.S. House,1,L,Kerry Burt,50,20,70
-Reno,Precinct #22,U.S. House,1,L,Kerry Burt,40,31,71
-Reno,Precinct #23,U.S. House,1,L,Kerry Burt,53,44,97
-Reno,Precinct #23 Exclave,U.S. House,1,L,Kerry Burt,8,6,14
-Reno,Precinct #24,U.S. House,1,L,Kerry Burt,46,34,80
-Reno,Precinct #25,U.S. House,1,L,Kerry Burt,31,29,60
-Reno,Precinct #26,U.S. House,1,L,Kerry Burt,23,11,34
-Reno,Precinct #26 Exclave,U.S. House,1,L,Kerry Burt,4,3,7
-Reno,Precinct #27,U.S. House,1,L,Kerry Burt,27,22,49
-Reno,Precinct #28,U.S. House,1,L,Kerry Burt,43,28,71
-Reno,Precinct #28 Exclave,U.S. House,1,L,Kerry Burt,14,14,28
-Reno,Precinct #29,U.S. House,1,L,Kerry Burt,33,17,50
-Reno,Precinct #30,U.S. House,1,L,Kerry Burt,18,21,39
-Reno,Precinct #31,U.S. House,1,L,Kerry Burt,28,23,51
-Reno,Precinct #32,U.S. House,1,L,Kerry Burt,8,3,11
-Reno,Precinct #33,U.S. House,1,L,Kerry Burt,5,9,14
-Reno,Precinct #34,U.S. House,1,L,Kerry Burt,9,5,14
-Reno,Precinct #34 Exclave,U.S. House,1,L,Kerry Burt,0,0,0
-Reno,Precinct #35,U.S. House,1,L,Kerry Burt,18,15,33
-Reno,Albion Township,U.S. House,1,L,Kerry Burt,19,3,22
-Reno,Arlington Township,U.S. House,1,L,Kerry Burt,29,8,37
-Reno,Bell Township,U.S. House,1,L,Kerry Burt,3,0,3
-Reno,Castleton Township,U.S. House,1,L,Kerry Burt,7,1,8
-Reno,Center Township,U.S. House,1,L,Kerry Burt,14,2,16
-Reno,Clay North Township,U.S. House,1,L,Kerry Burt,27,9,36
-Reno,Clay South H101,U.S. House,1,L,Kerry Burt,49,14,63
-Reno,Clay South H102A,U.S. House,1,L,Kerry Burt,0,0,0
-Reno,Enterprise Township,U.S. House,1,L,Kerry Burt,2,0,2
-Reno,Grant Township,U.S. House,1,L,Kerry Burt,61,18,79
-Reno,Grove 310,U.S. House,1,L,Kerry Burt,1,0,1
-Reno,Haven Township,U.S. House,1,L,Kerry Burt,71,19,90
-Reno,Hayes Township,U.S. House,1,L,Kerry Burt,1,0,1
-Reno,Huntsville Township,U.S. House,1,L,Kerry Burt,5,1,6
-Reno,Langdon 310,U.S. House,1,L,Kerry Burt,5,0,5
-Reno,Lincoln Township,U.S. House,1,L,Kerry Burt,12,3,15
-Reno,Little River Township,U.S. House,1,L,Kerry Burt,59,13,72
-Reno,Loda Township,U.S. House,1,L,Kerry Burt,4,1,5
-Reno,Medford Township,U.S. House,1,L,Kerry Burt,2,0,2
-Reno,Medora Township,U.S. House,1,L,Kerry Burt,68,22,90
-Reno,Miami 310,U.S. House,1,L,Kerry Burt,14,2,16
-Reno,Ninnescah Township,U.S. House,1,L,Kerry Burt,10,1,11
-Reno,Plevna 310,U.S. House,1,L,Kerry Burt,12,1,13
-Reno,Reno North Township,U.S. House,1,L,Kerry Burt,55,26,81
-Reno,Reno South Township,U.S. House,1,L,Kerry Burt,6,0,6
-Reno,Roscoe Township,U.S. House,1,L,Kerry Burt,3,0,3
-Reno,Salt Creek Township,U.S. House,1,L,Kerry Burt,19,4,23
-Reno,Sumner Township,U.S. House,1,L,Kerry Burt,23,2,25
-Reno,Sylvia 310,U.S. House,1,L,Kerry Burt,17,2,19
-Reno,Troy Township,U.S. House,1,L,Kerry Burt,0,0,0
-Reno,Valley Township,U.S. House,1,L,Kerry Burt,35,14,49
-Reno,Walnut Township,U.S. House,1,L,Kerry Burt,1,0,1
-Reno,Westminster 310,U.S. House,1,L,Kerry Burt,10,4,14
-Reno,Yoder Township,U.S. House,1,L,Kerry Burt,23,4,27
-Reno,South Hutchinson #1,U.S. House,1,L,Kerry Burt,30,15,45
-Reno,South Hutchinson #2,U.S. House,1,L,Kerry Burt,42,28,70
-Reno,South Hutchinson #3,U.S. House,1,L,Kerry Burt,21,5,26
-Reno,Nickerson Ward #1,U.S. House,1,L,Kerry Burt,17,8,25
-Reno,Nickerson Ward #2,U.S. House,1,L,Kerry Burt,12,2,14
-Reno,Nickerson Ward #3,U.S. House,1,L,Kerry Burt,15,4,19
-Reno,Total,U.S. House,1,L,Kerry Burt,1987,1072,3059
-Reno,Precinct #1-H102,U.S. House,1,,Write-ins,2,0,2
-Reno,Precinct #1-H114,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #2,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #3,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #4,U.S. House,1,,Write-ins,7,2,9
-Reno,Precinct #5,U.S. House,1,,Write-ins,1,1,2
-Reno,Precinct #6,U.S. House,1,,Write-ins,1,2,3
-Reno,Precinct #7,U.S. House,1,,Write-ins,1,0,1
-Reno,Precinct #8,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #9,U.S. House,1,,Write-ins,3,2,5
-Reno,Precinct #10,U.S. House,1,,Write-ins,2,0,2
-Reno,Precinct #11,U.S. House,1,,Write-ins,1,5,6
-Reno,Precinct #12,U.S. House,1,,Write-ins,3,0,3
-Reno,Precinct #13,U.S. House,1,,Write-ins,4,1,5
-Reno,Precinct #14,U.S. House,1,,Write-ins,4,1,5
-Reno,Precinct #15,U.S. House,1,,Write-ins,0,1,1
-Reno,Precinct #16,U.S. House,1,,Write-ins,1,0,1
-Reno,Precinct #17,U.S. House,1,,Write-ins,3,2,5
-Reno,Precinct #18,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #19,U.S. House,1,,Write-ins,1,1,2
-Reno,Precinct #20,U.S. House,1,,Write-ins,2,1,3
-Reno,Precinct #21,U.S. House,1,,Write-ins,0,2,2
-Reno,Precinct #22,U.S. House,1,,Write-ins,0,2,2
-Reno,Precinct #23,U.S. House,1,,Write-ins,3,2,5
-Reno,Precinct #23 Exclave,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #24,U.S. House,1,,Write-ins,3,1,4
-Reno,Precinct #25,U.S. House,1,,Write-ins,1,1,2
-Reno,Precinct #26,U.S. House,1,,Write-ins,1,0,1
-Reno,Precinct #26 Exclave,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #27,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #28,U.S. House,1,,Write-ins,3,1,4
-Reno,Precinct #28 Exclave,U.S. House,1,,Write-ins,0,1,1
-Reno,Precinct #29,U.S. House,1,,Write-ins,2,1,3
-Reno,Precinct #30,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #31,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #32,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #33,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #34,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #34 Exclave,U.S. House,1,,Write-ins,0,0,0
-Reno,Precinct #35,U.S. House,1,,Write-ins,0,0,0
-Reno,Albion Township,U.S. House,1,,Write-ins,1,0,1
-Reno,Arlington Township,U.S. House,1,,Write-ins,1,0,1
-Reno,Bell Township,U.S. House,1,,Write-ins,2,0,2
-Reno,Castleton Township,U.S. House,1,,Write-ins,1,0,1
-Reno,Center Township,U.S. House,1,,Write-ins,6,0,6
-Reno,Clay North Township,U.S. House,1,,Write-ins,3,0,3
-Reno,Clay South H101,U.S. House,1,,Write-ins,1,0,1
-Reno,Clay South H102A,U.S. House,1,,Write-ins,0,0,0
-Reno,Enterprise Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Grant Township,U.S. House,1,,Write-ins,3,3,6
-Reno,Grove 310,U.S. House,1,,Write-ins,0,0,0
-Reno,Haven Township,U.S. House,1,,Write-ins,0,1,1
-Reno,Hayes Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Huntsville Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Langdon 310,U.S. House,1,,Write-ins,0,0,0
-Reno,Lincoln Township,U.S. House,1,,Write-ins,0,1,1
-Reno,Little River Township,U.S. House,1,,Write-ins,7,1,8
-Reno,Loda Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Medford Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Medora Township,U.S. House,1,,Write-ins,5,2,7
-Reno,Miami 310,U.S. House,1,,Write-ins,2,1,3
-Reno,Ninnescah Township,U.S. House,1,,Write-ins,2,0,2
-Reno,Plevna 310,U.S. House,1,,Write-ins,0,0,0
-Reno,Reno North Township,U.S. House,1,,Write-ins,1,2,3
-Reno,Reno South Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Roscoe Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Salt Creek Township,U.S. House,1,,Write-ins,2,1,3
-Reno,Sumner Township,U.S. House,1,,Write-ins,3,0,3
-Reno,Sylvia 310,U.S. House,1,,Write-ins,1,1,2
-Reno,Troy Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Valley Township,U.S. House,1,,Write-ins,1,0,1
-Reno,Walnut Township,U.S. House,1,,Write-ins,0,0,0
-Reno,Westminster 310,U.S. House,1,,Write-ins,1,0,1
-Reno,Yoder Township,U.S. House,1,,Write-ins,2,3,5
-Reno,South Hutchinson #1,U.S. House,1,,Write-ins,0,1,1
-Reno,South Hutchinson #2,U.S. House,1,,Write-ins,2,0,2
-Reno,South Hutchinson #3,U.S. House,1,,Write-ins,1,2,3
-Reno,Nickerson Ward #1,U.S. House,1,,Write-ins,1,1,2
-Reno,Nickerson Ward #2,U.S. House,1,,Write-ins,0,0,0
-Reno,Nickerson Ward #3,U.S. House,1,,Write-ins,0,0,0
-Reno,Total,U.S. House,1,,Write-ins,98,50,148
-Reno,Precinct #1-H102,State Senate,34,R,Edward E. Berger,79,47,126
-Reno,Precinct #1-H114,State Senate,34,R,Edward E. Berger,4,6,10
-Reno,Precinct #2,State Senate,34,R,Edward E. Berger,75,71,146
-Reno,Precinct #3,State Senate,34,R,Edward E. Berger,61,25,86
-Reno,Precinct #4,State Senate,34,R,Edward E. Berger,372,362,734
-Reno,Precinct #5,State Senate,34,R,Edward E. Berger,125,100,225
-Reno,Precinct #6,State Senate,34,R,Edward E. Berger,139,102,241
-Reno,Precinct #7,State Senate,34,R,Edward E. Berger,163,141,304
-Reno,Precinct #8,State Senate,34,R,Edward E. Berger,96,63,159
-Reno,Precinct #9,State Senate,34,R,Edward E. Berger,231,246,477
-Reno,Precinct #10,State Senate,34,R,Edward E. Berger,260,373,633
-Reno,Precinct #11,State Senate,34,R,Edward E. Berger,317,286,603
-Reno,Precinct #12,State Senate,34,R,Edward E. Berger,207,156,363
-Reno,Precinct #13,State Senate,34,R,Edward E. Berger,243,150,393
-Reno,Precinct #14,State Senate,34,R,Edward E. Berger,182,103,285
-Reno,Precinct #15,State Senate,34,R,Edward E. Berger,83,62,145
-Reno,Precinct #16,State Senate,34,R,Edward E. Berger,198,137,335
-Reno,Precinct #17,State Senate,34,R,Edward E. Berger,250,170,420
-Reno,Precinct #18,State Senate,34,R,Edward E. Berger,75,60,135
-Reno,Precinct #19,State Senate,34,R,Edward E. Berger,77,67,144
-Reno,Precinct #20,State Senate,34,R,Edward E. Berger,153,113,266
-Reno,Precinct #21,State Senate,34,R,Edward E. Berger,121,98,219
-Reno,Precinct #22,State Senate,34,R,Edward E. Berger,329,227,556
-Reno,Precinct #23,State Senate,34,R,Edward E. Berger,319,326,645
-Reno,Precinct #23 Exclave,State Senate,34,R,Edward E. Berger,90,88,178
-Reno,Precinct #24,State Senate,34,R,Edward E. Berger,287,194,481
-Reno,Precinct #25,State Senate,34,R,Edward E. Berger,104,76,180
-Reno,Precinct #26,State Senate,34,R,Edward E. Berger,84,53,137
-Reno,Precinct #26 Exclave,State Senate,34,R,Edward E. Berger,10,5,15
-Reno,Precinct #27,State Senate,34,R,Edward E. Berger,218,146,364
-Reno,Precinct #28,State Senate,34,R,Edward E. Berger,433,314,747
-Reno,Precinct #28 Exclave,State Senate,34,R,Edward E. Berger,182,197,379
-Reno,Precinct #29,State Senate,34,R,Edward E. Berger,171,140,311
-Reno,Precinct #30,State Senate,34,R,Edward E. Berger,86,65,151
-Reno,Precinct #31,State Senate,34,R,Edward E. Berger,150,123,273
-Reno,Precinct #32,State Senate,34,R,Edward E. Berger,51,55,106
-Reno,Precinct #33,State Senate,34,R,Edward E. Berger,118,59,177
-Reno,Precinct #34,State Senate,34,R,Edward E. Berger,31,18,49
-Reno,Precinct #34 Exclave,State Senate,34,R,Edward E. Berger,1,0,1
-Reno,Precinct #35,State Senate,34,R,Edward E. Berger,103,65,168
-Reno,Albion Township,State Senate,34,R,Edward E. Berger,278,46,324
-Reno,Arlington Township,State Senate,34,R,Edward E. Berger,166,37,203
-Reno,Bell Township,State Senate,34,R,Edward E. Berger,22,5,27
-Reno,Castleton Township,State Senate,34,R,Edward E. Berger,102,18,120
-Reno,Center Township,State Senate,34,R,Edward E. Berger,118,31,149
-Reno,Clay North Township,State Senate,34,R,Edward E. Berger,263,154,417
-Reno,Clay South H101,State Senate,34,R,Edward E. Berger,337,96,433
-Reno,Clay South H102A,State Senate,34,R,Edward E. Berger,0,3,3
-Reno,Enterprise Township,State Senate,34,R,Edward E. Berger,49,7,56
-Reno,Grant Township,State Senate,34,R,Edward E. Berger,491,200,691
-Reno,Grove 310,State Senate,34,R,Edward E. Berger,25,4,29
-Reno,Haven Township,State Senate,34,R,Edward E. Berger,525,88,613
-Reno,Hayes Township,State Senate,34,R,Edward E. Berger,18,10,28
-Reno,Huntsville Township,State Senate,34,R,Edward E. Berger,38,4,42
-Reno,Langdon 310,State Senate,34,R,Edward E. Berger,48,8,56
-Reno,Lincoln Township,State Senate,34,R,Edward E. Berger,150,23,173
-Reno,Little River Township,State Senate,34,R,Edward E. Berger,646,160,806
-Reno,Loda Township,State Senate,34,R,Edward E. Berger,30,3,33
-Reno,Medford Township,State Senate,34,R,Edward E. Berger,61,8,69
-Reno,Medora Township,State Senate,34,R,Edward E. Berger,514,207,721
-Reno,Miami 310,State Senate,34,R,Edward E. Berger,103,3,106
-Reno,Ninnescah Township,State Senate,34,R,Edward E. Berger,64,12,76
-Reno,Plevna 310,State Senate,34,R,Edward E. Berger,78,12,90
-Reno,Reno North Township,State Senate,34,R,Edward E. Berger,367,195,562
-Reno,Reno South Township,State Senate,34,R,Edward E. Berger,79,19,98
-Reno,Roscoe Township,State Senate,34,R,Edward E. Berger,41,5,46
-Reno,Salt Creek Township,State Senate,34,R,Edward E. Berger,117,23,140
-Reno,Sumner Township,State Senate,34,R,Edward E. Berger,200,29,229
-Reno,Sylvia 310,State Senate,34,R,Edward E. Berger,88,8,96
-Reno,Troy Township,State Senate,34,R,Edward E. Berger,43,4,47
-Reno,Valley Township,State Senate,34,R,Edward E. Berger,233,100,333
-Reno,Walnut Township,State Senate,34,R,Edward E. Berger,42,11,53
-Reno,Westminster 310,State Senate,34,R,Edward E. Berger,71,14,85
-Reno,Yoder Township,State Senate,34,R,Edward E. Berger,175,29,204
-Reno,South Hutchinson #1,State Senate,34,R,Edward E. Berger,124,51,175
-Reno,South Hutchinson #2,State Senate,34,R,Edward E. Berger,261,89,350
-Reno,South Hutchinson #3,State Senate,34,R,Edward E. Berger,207,48,255
-Reno,Nickerson Ward #1,State Senate,34,R,Edward E. Berger,104,26,130
-Reno,Nickerson Ward #2,State Senate,34,R,Edward E. Berger,61,11,72
-Reno,Nickerson Ward #3,State Senate,34,R,Edward E. Berger,71,10,81
-Reno,Total,State Senate,34,R,Edward E. Berger,12688,6900,19588
-Reno,Precinct #1-H102,State Senate,34,D,Homer L. Gilson,56,25,81
-Reno,Precinct #1-H114,State Senate,34,D,Homer L. Gilson,1,4,5
-Reno,Precinct #2,State Senate,34,D,Homer L. Gilson,40,29,69
-Reno,Precinct #3,State Senate,34,D,Homer L. Gilson,29,16,45
-Reno,Precinct #4,State Senate,34,D,Homer L. Gilson,46,31,77
-Reno,Precinct #5,State Senate,34,D,Homer L. Gilson,60,49,109
-Reno,Precinct #6,State Senate,34,D,Homer L. Gilson,52,51,103
-Reno,Precinct #7,State Senate,34,D,Homer L. Gilson,66,51,117
-Reno,Precinct #8,State Senate,34,D,Homer L. Gilson,27,23,50
-Reno,Precinct #9,State Senate,34,D,Homer L. Gilson,59,50,109
-Reno,Precinct #10,State Senate,34,D,Homer L. Gilson,40,49,89
-Reno,Precinct #11,State Senate,34,D,Homer L. Gilson,36,46,82
-Reno,Precinct #12,State Senate,34,D,Homer L. Gilson,28,30,58
-Reno,Precinct #13,State Senate,34,D,Homer L. Gilson,53,38,91
-Reno,Precinct #14,State Senate,34,D,Homer L. Gilson,57,58,115
-Reno,Precinct #15,State Senate,34,D,Homer L. Gilson,52,31,83
-Reno,Precinct #16,State Senate,34,D,Homer L. Gilson,90,48,138
-Reno,Precinct #17,State Senate,34,D,Homer L. Gilson,60,49,109
-Reno,Precinct #18,State Senate,34,D,Homer L. Gilson,27,31,58
-Reno,Precinct #19,State Senate,34,D,Homer L. Gilson,51,29,80
-Reno,Precinct #20,State Senate,34,D,Homer L. Gilson,48,33,81
-Reno,Precinct #21,State Senate,34,D,Homer L. Gilson,41,30,71
-Reno,Precinct #22,State Senate,34,D,Homer L. Gilson,39,51,90
-Reno,Precinct #23,State Senate,34,D,Homer L. Gilson,56,89,145
-Reno,Precinct #23 Exclave,State Senate,34,D,Homer L. Gilson,6,14,20
-Reno,Precinct #24,State Senate,34,D,Homer L. Gilson,33,45,78
-Reno,Precinct #25,State Senate,34,D,Homer L. Gilson,51,44,95
-Reno,Precinct #26,State Senate,34,D,Homer L. Gilson,33,25,58
-Reno,Precinct #26 Exclave,State Senate,34,D,Homer L. Gilson,4,3,7
-Reno,Precinct #27,State Senate,34,D,Homer L. Gilson,25,28,53
-Reno,Precinct #28,State Senate,34,D,Homer L. Gilson,61,50,111
-Reno,Precinct #28 Exclave,State Senate,34,D,Homer L. Gilson,10,14,24
-Reno,Precinct #29,State Senate,34,D,Homer L. Gilson,49,34,83
-Reno,Precinct #30,State Senate,34,D,Homer L. Gilson,26,33,59
-Reno,Precinct #31,State Senate,34,D,Homer L. Gilson,32,41,73
-Reno,Precinct #32,State Senate,34,D,Homer L. Gilson,9,9,18
-Reno,Precinct #33,State Senate,34,D,Homer L. Gilson,12,6,18
-Reno,Precinct #34,State Senate,34,D,Homer L. Gilson,8,7,15
-Reno,Precinct #34 Exclave,State Senate,34,D,Homer L. Gilson,0,0,0
-Reno,Precinct #35,State Senate,34,D,Homer L. Gilson,14,17,31
-Reno,Albion Township,State Senate,34,D,Homer L. Gilson,50,9,59
-Reno,Arlington Township,State Senate,34,D,Homer L. Gilson,38,9,47
-Reno,Bell Township,State Senate,34,D,Homer L. Gilson,3,3,6
-Reno,Castleton Township,State Senate,34,D,Homer L. Gilson,15,5,20
-Reno,Center Township,State Senate,34,D,Homer L. Gilson,20,4,24
-Reno,Clay North Township,State Senate,34,D,Homer L. Gilson,27,17,44
-Reno,Clay South H101,State Senate,34,D,Homer L. Gilson,56,22,78
-Reno,Clay South H102A,State Senate,34,D,Homer L. Gilson,0,0,0
-Reno,Enterprise Township,State Senate,34,D,Homer L. Gilson,7,4,11
-Reno,Grant Township,State Senate,34,D,Homer L. Gilson,68,15,83
-Reno,Grove 310,State Senate,34,D,Homer L. Gilson,2,0,2
-Reno,Haven Township,State Senate,34,D,Homer L. Gilson,102,15,117
-Reno,Hayes Township,State Senate,34,D,Homer L. Gilson,2,0,2
-Reno,Huntsville Township,State Senate,34,D,Homer L. Gilson,8,1,9
-Reno,Langdon 310,State Senate,34,D,Homer L. Gilson,7,0,7
-Reno,Lincoln Township,State Senate,34,D,Homer L. Gilson,15,4,19
-Reno,Little River Township,State Senate,34,D,Homer L. Gilson,63,26,89
-Reno,Loda Township,State Senate,34,D,Homer L. Gilson,7,3,10
-Reno,Medford Township,State Senate,34,D,Homer L. Gilson,3,3,6
-Reno,Medora Township,State Senate,34,D,Homer L. Gilson,86,28,114
-Reno,Miami 310,State Senate,34,D,Homer L. Gilson,23,4,27
-Reno,Ninnescah Township,State Senate,34,D,Homer L. Gilson,11,5,16
-Reno,Plevna 310,State Senate,34,D,Homer L. Gilson,21,2,23
-Reno,Reno North Township,State Senate,34,D,Homer L. Gilson,74,38,112
-Reno,Reno South Township,State Senate,34,D,Homer L. Gilson,13,3,16
-Reno,Roscoe Township,State Senate,34,D,Homer L. Gilson,8,3,11
-Reno,Salt Creek Township,State Senate,34,D,Homer L. Gilson,18,3,21
-Reno,Sumner Township,State Senate,34,D,Homer L. Gilson,49,4,53
-Reno,Sylvia 310,State Senate,34,D,Homer L. Gilson,21,4,25
-Reno,Troy Township,State Senate,34,D,Homer L. Gilson,4,1,5
-Reno,Valley Township,State Senate,34,D,Homer L. Gilson,51,25,76
-Reno,Walnut Township,State Senate,34,D,Homer L. Gilson,6,3,9
-Reno,Westminster 310,State Senate,34,D,Homer L. Gilson,9,0,9
-Reno,Yoder Township,State Senate,34,D,Homer L. Gilson,31,6,37
-Reno,South Hutchinson #1,State Senate,34,D,Homer L. Gilson,37,24,61
-Reno,South Hutchinson #2,State Senate,34,D,Homer L. Gilson,53,30,83
-Reno,South Hutchinson #3,State Senate,34,D,Homer L. Gilson,40,15,55
-Reno,Nickerson Ward #1,State Senate,34,D,Homer L. Gilson,21,11,32
-Reno,Nickerson Ward #2,State Senate,34,D,Homer L. Gilson,15,3,18
-Reno,Nickerson Ward #3,State Senate,34,D,Homer L. Gilson,19,5,24
-Reno,Total,State Senate,34,D,Homer L. Gilson,2590,1668,4258
-Reno,Precinct #1-H102,State Senate,34,,Write-ins,2,0,2
-Reno,Precinct #1-H114,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #2,State Senate,34,,Write-ins,2,0,2
-Reno,Precinct #3,State Senate,34,,Write-ins,2,1,3
-Reno,Precinct #4,State Senate,34,,Write-ins,6,3,9
-Reno,Precinct #5,State Senate,34,,Write-ins,0,1,1
-Reno,Precinct #6,State Senate,34,,Write-ins,0,1,1
-Reno,Precinct #7,State Senate,34,,Write-ins,1,2,3
-Reno,Precinct #8,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #9,State Senate,34,,Write-ins,2,2,4
-Reno,Precinct #10,State Senate,34,,Write-ins,1,4,5
-Reno,Precinct #11,State Senate,34,,Write-ins,2,5,7
-Reno,Precinct #12,State Senate,34,,Write-ins,3,0,3
-Reno,Precinct #13,State Senate,34,,Write-ins,2,0,2
-Reno,Precinct #14,State Senate,34,,Write-ins,0,1,1
-Reno,Precinct #15,State Senate,34,,Write-ins,1,0,1
-Reno,Precinct #16,State Senate,34,,Write-ins,4,1,5
-Reno,Precinct #17,State Senate,34,,Write-ins,1,2,3
-Reno,Precinct #18,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #19,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #20,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #21,State Senate,34,,Write-ins,0,2,2
-Reno,Precinct #22,State Senate,34,,Write-ins,1,2,3
-Reno,Precinct #23,State Senate,34,,Write-ins,1,1,2
-Reno,Precinct #23 Exclave,State Senate,34,,Write-ins,3,0,3
-Reno,Precinct #24,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #25,State Senate,34,,Write-ins,2,0,2
-Reno,Precinct #26,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #26 Exclave,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #27,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #28,State Senate,34,,Write-ins,2,3,5
-Reno,Precinct #28 Exclave,State Senate,34,,Write-ins,2,1,3
-Reno,Precinct #29,State Senate,34,,Write-ins,1,1,2
-Reno,Precinct #30,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #31,State Senate,34,,Write-ins,1,0,1
-Reno,Precinct #32,State Senate,34,,Write-ins,1,0,1
-Reno,Precinct #33,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #34,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #34 Exclave,State Senate,34,,Write-ins,0,0,0
-Reno,Precinct #35,State Senate,34,,Write-ins,0,1,1
-Reno,Albion Township,State Senate,34,,Write-ins,5,0,5
-Reno,Arlington Township,State Senate,34,,Write-ins,1,0,1
-Reno,Bell Township,State Senate,34,,Write-ins,0,0,0
-Reno,Castleton Township,State Senate,34,,Write-ins,0,1,1
-Reno,Center Township,State Senate,34,,Write-ins,4,0,4
-Reno,Clay North Township,State Senate,34,,Write-ins,0,2,2
-Reno,Clay South H101,State Senate,34,,Write-ins,0,0,0
-Reno,Clay South H102A,State Senate,34,,Write-ins,0,0,0
-Reno,Enterprise Township,State Senate,34,,Write-ins,0,0,0
-Reno,Grant Township,State Senate,34,,Write-ins,6,2,8
-Reno,Grove 310,State Senate,34,,Write-ins,0,0,0
-Reno,Haven Township,State Senate,34,,Write-ins,7,0,7
-Reno,Hayes Township,State Senate,34,,Write-ins,1,0,1
-Reno,Huntsville Township,State Senate,34,,Write-ins,0,0,0
-Reno,Langdon 310,State Senate,34,,Write-ins,0,0,0
-Reno,Lincoln Township,State Senate,34,,Write-ins,0,0,0
-Reno,Little River Township,State Senate,34,,Write-ins,7,4,11
-Reno,Loda Township,State Senate,34,,Write-ins,0,0,0
-Reno,Medford Township,State Senate,34,,Write-ins,0,0,0
-Reno,Medora Township,State Senate,34,,Write-ins,3,0,3
-Reno,Miami 310,State Senate,34,,Write-ins,2,1,3
-Reno,Ninnescah Township,State Senate,34,,Write-ins,5,0,5
-Reno,Plevna 310,State Senate,34,,Write-ins,0,0,0
-Reno,Reno North Township,State Senate,34,,Write-ins,1,2,3
-Reno,Reno South Township,State Senate,34,,Write-ins,0,0,0
-Reno,Roscoe Township,State Senate,34,,Write-ins,0,0,0
-Reno,Salt Creek Township,State Senate,34,,Write-ins,3,0,3
-Reno,Sumner Township,State Senate,34,,Write-ins,1,0,1
-Reno,Sylvia 310,State Senate,34,,Write-ins,1,1,2
-Reno,Troy Township,State Senate,34,,Write-ins,0,0,0
-Reno,Valley Township,State Senate,34,,Write-ins,2,2,4
-Reno,Walnut Township,State Senate,34,,Write-ins,0,0,0
-Reno,Westminster 310,State Senate,34,,Write-ins,0,0,0
-Reno,Yoder Township,State Senate,34,,Write-ins,2,3,5
-Reno,South Hutchinson #1,State Senate,34,,Write-ins,0,0,0
-Reno,South Hutchinson #2,State Senate,34,,Write-ins,0,3,3
-Reno,South Hutchinson #3,State Senate,34,,Write-ins,0,1,1
-Reno,Nickerson Ward #1,State Senate,34,,Write-ins,2,0,2
-Reno,Nickerson Ward #2,State Senate,34,,Write-ins,2,0,2
-Reno,Nickerson Ward #3,State Senate,34,,Write-ins,0,0,0
-Reno,Albion Township,State House,101,D,Clifton Beck,108,21,129
-Reno,Albion Township,State House,101,R,Joe Seiwert,224,34,258
-Reno,Albion Township,State House,101,,Write-ins,1,0,1
-Reno,Castleton Township,State House,101,D,Clifton Beck,35,11,46
-Reno,Castleton Township,State House,101,R,Joe Seiwert,89,13,102
-Reno,Castleton Township,State House,101,,Write-ins,0,0,0
-Reno,Clay South H101,State House,101,D,Clifton Beck,77,34,111
-Reno,Clay South H101,State House,101,R,Joe Seiwert,320,85,405
-Reno,Clay South H101,State House,101,,Write-ins,1,1,2
-Reno,Haven Township,State House,101,D,Clifton Beck,166,27,193
-Reno,Haven Township,State House,101,R,Joe Seiwert,449,77,526
-Reno,Haven Township,State House,101,,Write-ins,3,0,3
-Reno,Lincoln Township,State House,101,D,Clifton Beck,30,6,36
-Reno,Lincoln Township,State House,101,R,Joe Seiwert,131,21,152
-Reno,Lincoln Township,State House,101,,Write-ins,0,0,0
-Reno,Ninnescah Township,State House,101,D,Clifton Beck,24,9,33
-Reno,Ninnescah Township,State House,101,R,Joe Seiwert,63,9,72
-Reno,Ninnescah Township,State House,101,,Write-ins,0,0,0
-Reno,Roscoe Township,State House,101,D,Clifton Beck,22,2,24
-Reno,Roscoe Township,State House,101,R,Joe Seiwert,26,6,32
-Reno,Roscoe Township,State House,101,,Write-ins,0,0,0
-Reno,Sumner Township,State House,101,D,Clifton Beck,45,6,51
-Reno,Sumner Township,State House,101,R,Joe Seiwert,212,27,239
-Reno,Sumner Township,State House,101,,Write-ins,0,0,0
-Reno,Valley Township,State House,101,D,Clifton Beck,65,31,96
-Reno,Valley Township,State House,101,R,Joe Seiwert,220,92,312
-Reno,Valley Township,State House,101,,Write-ins,0,1,1
-Reno,Yoder Township,State House,101,D,Clifton Beck,41,9,50
-Reno,Yoder Township,State House,101,R,Joe Seiwert,164,32,196
-Reno,Yoder Township,State House,101,,Write-ins,1,0,1
-Reno,Total,State House,101,D,Clifton Beck,156,613,769
-Reno,Total,State House,101,R,Joe Seiwert,396,1898,2294
-Reno,Total,State House,101,,Write-ins,2,6,8
-Reno,Precinct #1-H102,State House,102,R,Jan Pauls,49,28,77
-Reno,Precinct #2,State House,102,R,Jan Pauls,55,36,91
-Reno,Precinct #5,State House,102,R,Jan Pauls,77,75,152
-Reno,Precinct #6,State House,102,R,Jan Pauls,86,60,146
-Reno,Precinct #7,State House,102,R,Jan Pauls,112,82,194
-Reno,Precinct #8,State House,102,R,Jan Pauls,66,37,103
-Reno,Precinct #9,State House,102,R,Jan Pauls,149,135,284
-Reno,Precinct #14,State House,102,R,Jan Pauls,122,67,189
-Reno,Precinct #15,State House,102,R,Jan Pauls,53,37,90
-Reno,Precinct #16,State House,102,R,Jan Pauls,119,77,196
-Reno,Precinct #18,State House,102,R,Jan Pauls,52,35,87
-Reno,Precinct #19,State House,102,R,Jan Pauls,48,28,76
-Reno,Precinct #20,State House,102,R,Jan Pauls,103,75,178
-Reno,Precinct #25,State House,102,R,Jan Pauls,63,47,110
-Reno,Precinct #26,State House,102,R,Jan Pauls,61,27,88
-Reno,Precinct #26 Exclave,State House,102,R,Jan Pauls,8,3,11
-Reno,Precinct #29,State House,102,R,Jan Pauls,110,81,191
-Reno,Precinct #30,State House,102,R,Jan Pauls,60,41,101
-Reno,Precinct #34,State House,102,R,Jan Pauls,24,16,40
-Reno,Precinct #34 Exclave,State House,102,R,Jan Pauls,1,0,1
-Reno,Precinct #35,State House,102,R,Jan Pauls,57,39,96
-Reno,Clay South H102A,State House,102,R,Jan Pauls,0,2,2
-Reno,Total,State House,102,R,Jan Pauls,1475,1028,2503
-Reno,Precinct #1-H102,State House,102,D,Patsy Terrell,86,46,132
-Reno,Precinct #2,State House,102,D,Patsy Terrell,64,63,127
-Reno,Precinct #5,State House,102,D,Patsy Terrell,113,76,189
-Reno,Precinct #6,State House,102,D,Patsy Terrell,112,97,209
-Reno,Precinct #7,State House,102,D,Patsy Terrell,123,114,237
-Reno,Precinct #8,State House,102,D,Patsy Terrell,61,49,110
-Reno,Precinct #9,State House,102,D,Patsy Terrell,147,161,308
-Reno,Precinct #14,State House,102,D,Patsy Terrell,119,95,214
-Reno,Precinct #15,State House,102,D,Patsy Terrell,85,59,144
-Reno,Precinct #16,State House,102,D,Patsy Terrell,175,111,286
-Reno,Precinct #18,State House,102,D,Patsy Terrell,51,58,109
-Reno,Precinct #19,State House,102,D,Patsy Terrell,80,67,147
-Reno,Precinct #20,State House,102,D,Patsy Terrell,103,73,176
-Reno,Precinct #25,State House,102,D,Patsy Terrell,95,79,174
-Reno,Precinct #26,State House,102,D,Patsy Terrell,60,50,110
-Reno,Precinct #26 Exclave,State House,102,D,Patsy Terrell,6,5,11
-Reno,Precinct #29,State House,102,D,Patsy Terrell,112,97,209
-Reno,Precinct #30,State House,102,D,Patsy Terrell,52,60,112
-Reno,Precinct #34,State House,102,D,Patsy Terrell,16,10,26
-Reno,Precinct #34 Exclave,State House,102,D,Patsy Terrell,0,0,0
-Reno,Precinct #35,State House,102,D,Patsy Terrell,60,42,102
-Reno,Clay South H102A,State House,102,D,Patsy Terrell,0,0,0
-Reno,Total,State House,102,D,Patsy Terrell,1720,1412,3132
-Reno,Precinct #1-H102,State House,102,,Write-ins,2,0,2
-Reno,Precinct #2,State House,102,,Write-ins,0,1,1
-Reno,Precinct #5,State House,102,,Write-ins,0,1,1
-Reno,Precinct #6,State House,102,,Write-ins,1,0,1
-Reno,Precinct #7,State House,102,,Write-ins,0,1,1
-Reno,Precinct #8,State House,102,,Write-ins,0,0,0
-Reno,Precinct #9,State House,102,,Write-ins,3,2,5
-Reno,Precinct #14,State House,102,,Write-ins,1,1,2
-Reno,Precinct #15,State House,102,,Write-ins,0,0,0
-Reno,Precinct #16,State House,102,,Write-ins,0,0,0
-Reno,Precinct #18,State House,102,,Write-ins,0,0,0
-Reno,Precinct #19,State House,102,,Write-ins,0,0,0
-Reno,Precinct #20,State House,102,,Write-ins,1,0,1
-Reno,Precinct #25,State House,102,,Write-ins,0,1,1
-Reno,Precinct #26,State House,102,,Write-ins,0,1,1
-Reno,Precinct #26 Exclave,State House,102,,Write-ins,0,0,0
-Reno,Precinct #29,State House,102,,Write-ins,0,1,1
-Reno,Precinct #30,State House,102,,Write-ins,1,0,1
-Reno,Precinct #34,State House,102,,Write-ins,0,0,0
-Reno,Precinct #34 Exclave,State House,102,,Write-ins,0,0,0
-Reno,Precinct #35,State House,102,,Write-ins,0,0,0
-Reno,Clay South H102A,State House,102,,Write-ins,0,0,0
-Reno,Total,State House,102,,Write-ins,9,9,18
-Reno,Precinct #4,State House,104,R,Steven Becker,351,347,698
-Reno,Precinct #10,State House,104,R,Steven Becker,250,338,588
-Reno,Precinct #11,State House,104,R,Steven Becker,299,288,587
-Reno,Precinct #12,State House,104,R,Steven Becker,189,142,331
-Reno,Precinct #13,State House,104,R,Steven Becker,229,138,367
-Reno,Precinct #17,State House,104,R,Steven Becker,244,155,399
-Reno,Precinct #21,State House,104,R,Steven Becker,109,93,202
-Reno,Precinct #22,State House,104,R,Steven Becker,305,200,505
-Reno,Precinct #23,State House,104,R,Steven Becker,292,322,614
-Reno,Precinct #23 Exclave,State House,104,R,Steven Becker,91,93,184
-Reno,Precinct #24,State House,104,R,Steven Becker,261,172,433
-Reno,Precinct #27,State House,104,R,Steven Becker,200,147,347
-Reno,Precinct #28,State House,104,R,Steven Becker,426,292,718
-Reno,Precinct #28 Exclave,State House,104,R,Steven Becker,173,177,350
-Reno,Precinct #31,State House,104,R,Steven Becker,138,118,256
-Reno,Precinct #32,State House,104,R,Steven Becker,47,55,102
-Reno,Precinct #33,State House,104,R,Steven Becker,111,49,160
-Reno,Clay North Township,State House,104,R,Steven Becker,251,151,402
-Reno,Little River Township,State House,104,R,Steven Becker,658,157,815
-Reno,Medora Township,State House,104,R,Steven Becker,504,193,697
-Reno,Total,State House,104,R,Steven Becker,5128,3627,8755
-Reno,Precinct #4,State House,104,D,Betty Taylor,63,50,113
-Reno,Precinct #10,State House,104,D,Betty Taylor,49,86,135
-Reno,Precinct #11,State House,104,D,Betty Taylor,52,46,98
-Reno,Precinct #12,State House,104,D,Betty Taylor,43,46,89
-Reno,Precinct #13,State House,104,D,Betty Taylor,63,45,108
-Reno,Precinct #17,State House,104,D,Betty Taylor,59,65,124
-Reno,Precinct #21,State House,104,D,Betty Taylor,56,39,95
-Reno,Precinct #22,State House,104,D,Betty Taylor,66,79,145
-Reno,Precinct #23,State House,104,D,Betty Taylor,78,100,178
-Reno,Precinct #23 Exclave,State House,104,D,Betty Taylor,7,10,17
-Reno,Precinct #24,State House,104,D,Betty Taylor,53,59,112
-Reno,Precinct #27,State House,104,D,Betty Taylor,40,31,71
-Reno,Precinct #28,State House,104,D,Betty Taylor,71,70,141
-Reno,Precinct #28 Exclave,State House,104,D,Betty Taylor,19,31,50
-Reno,Precinct #31,State House,104,D,Betty Taylor,43,44,87
-Reno,Precinct #32,State House,104,D,Betty Taylor,11,7,18
-Reno,Precinct #33,State House,104,D,Betty Taylor,16,14,30
-Reno,Clay North Township,State House,104,D,Betty Taylor,42,24,66
-Reno,Little River Township,State House,104,D,Betty Taylor,56,33,89
-Reno,Medora Township,State House,104,D,Betty Taylor,97,35,132
-Reno,Total,State House,104,D,Betty Taylor,984,914,1898
-Reno,Precinct #4,State House,104,,Write-ins,6,1,7
-Reno,Precinct #10,State House,104,,Write-ins,3,2,5
-Reno,Precinct #11,State House,104,,Write-ins,0,6,6
-Reno,Precinct #12,State House,104,,Write-ins,2,0,2
-Reno,Precinct #13,State House,104,,Write-ins,2,1,3
-Reno,Precinct #17,State House,104,,Write-ins,0,2,2
-Reno,Precinct #21,State House,104,,Write-ins,0,0,0
-Reno,Precinct #22,State House,104,,Write-ins,0,0,0
-Reno,Precinct #23,State House,104,,Write-ins,3,1,4
-Reno,Precinct #23 Exclave,State House,104,,Write-ins,2,1,3
-Reno,Precinct #24,State House,104,,Write-ins,1,1,2
-Reno,Precinct #27,State House,104,,Write-ins,1,0,1
-Reno,Precinct #28,State House,104,,Write-ins,0,0,0
-Reno,Precinct #28 Exclave,State House,104,,Write-ins,1,1,2
-Reno,Precinct #31,State House,104,,Write-ins,0,0,0
-Reno,Precinct #32,State House,104,,Write-ins,1,1,2
-Reno,Precinct #33,State House,104,,Write-ins,0,1,1
-Reno,Clay North Township,State House,104,,Write-ins,1,1,2
-Reno,Little River Township,State House,104,,Write-ins,6,3,9
-Reno,Medora Township,State House,104,,Write-ins,2,2,4
-Reno,Total,State House,104,,Write-ins,31,24,55
-Reno,Precinct #1-H114,State House,114,R,Jack Thimesch,4,9,13
-Reno,Precinct #3,State House,114,R,Jack Thimesch,65,31,96
-Reno,Arlington Township,State House,114,R,Jack Thimesch,177,36,213
-Reno,Bell Township,State House,114,R,Jack Thimesch,22,8,30
-Reno,Center Township,State House,114,R,Jack Thimesch,128,25,153
-Reno,Enterprise Township,State House,114,R,Jack Thimesch,50,9,59
-Reno,Grant Township,State House,114,R,Jack Thimesch,508,195,703
-Reno,Grove 310,State House,114,R,Jack Thimesch,26,3,29
-Reno,Hayes Township,State House,114,R,Jack Thimesch,18,9,27
-Reno,Huntsville Township,State House,114,R,Jack Thimesch,47,5,52
-Reno,Langdon 310,State House,114,R,Jack Thimesch,50,8,58
-Reno,Loda Township,State House,114,R,Jack Thimesch,35,5,40
-Reno,Medford Township,State House,114,R,Jack Thimesch,60,5,65
-Reno,Miami 310,State House,114,R,Jack Thimesch,119,6,125
-Reno,Plevna 310,State House,114,R,Jack Thimesch,94,13,107
-Reno,Reno North Township,State House,114,R,Jack Thimesch,388,194,582
-Reno,Reno South Township,State House,114,R,Jack Thimesch,82,19,101
-Reno,Salt Creek Township,State House,114,R,Jack Thimesch,136,25,161
-Reno,Sylvia 310,State House,114,R,Jack Thimesch,97,12,109
-Reno,Troy Township,State House,114,R,Jack Thimesch,41,5,46
-Reno,Walnut Township,State House,114,R,Jack Thimesch,47,13,60
-Reno,Westminster 310,State House,114,R,Jack Thimesch,76,15,91
-Reno,South Hutchinson #1,State House,114,R,Jack Thimesch,145,56,201
-Reno,South Hutchinson #2,State House,114,R,Jack Thimesch,276,104,380
-Reno,South Hutchinson #3,State House,114,R,Jack Thimesch,210,48,258
-Reno,Nickerson Ward #1,State House,114,R,Jack Thimesch,112,32,144
-Reno,Nickerson Ward #2,State House,114,R,Jack Thimesch,68,14,82
-Reno,Nickerson Ward #3,State House,114,R,Jack Thimesch,80,14,94
-Reno,Total,State House,114,R,Jack Thimesch,3161,918,4079
-Reno,Precinct #1-H114,State House,114,,Write-ins,1,0,1
-Reno,Precinct #3,State House,114,,Write-ins,3,1,4
-Reno,Arlington Township,State House,114,,Write-ins,6,1,7
-Reno,Bell Township,State House,114,,Write-ins,0,0,0
-Reno,Center Township,State House,114,,Write-ins,4,2,6
-Reno,Enterprise Township,State House,114,,Write-ins,0,0,0
-Reno,Grant Township,State House,114,,Write-ins,6,4,10
-Reno,Grove 310,State House,114,,Write-ins,0,0,0
-Reno,Hayes Township,State House,114,,Write-ins,0,2,2
-Reno,Huntsville Township,State House,114,,Write-ins,0,0,0
-Reno,Langdon 310,State House,114,,Write-ins,0,0,0
-Reno,Loda Township,State House,114,,Write-ins,0,0,0
-Reno,Medford Township,State House,114,,Write-ins,1,0,1
-Reno,Miami 310,State House,114,,Write-ins,2,0,2
-Reno,Plevna 310,State House,114,,Write-ins,0,0,0
-Reno,Reno North Township,State House,114,,Write-ins,6,6,12
-Reno,Reno South Township,State House,114,,Write-ins,2,0,2
-Reno,Salt Creek Township,State House,114,,Write-ins,0,0,0
-Reno,Sylvia 310,State House,114,,Write-ins,1,0,1
-Reno,Troy Township,State House,114,,Write-ins,0,0,0
-Reno,Walnut Township,State House,114,,Write-ins,2,0,2
-Reno,Westminster 310,State House,114,,Write-ins,0,0,0
-Reno,South Hutchinson #1,State House,114,,Write-ins,1,5,6
-Reno,South Hutchinson #2,State House,114,,Write-ins,7,0,7
-Reno,South Hutchinson #3,State House,114,,Write-ins,5,0,5
-Reno,Nickerson Ward #1,State House,114,,Write-ins,1,1,2
-Reno,Nickerson Ward #2,State House,114,,Write-ins,1,0,1
-Reno,Nickerson Ward #3,State House,114,,Write-ins,1,0,1
-Reno,Total,State House,114,,Write-ins,50,22,72
+county,precinct,office,district,party,candidate,votes,vtd
+RENO,Albion Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",129,000010
+RENO,Albion Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",258,000010
+RENO,Arlington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",213,000020
+RENO,Bell Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",30,000030
+RENO,Castleton Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",46,000040
+RENO,Castleton Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",102,000040
+RENO,Center Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",153,000050
+RENO,Enterprise Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",59,000060
+RENO,Grant Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",703,000070
+RENO,Grove Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",29,000080
+RENO,Haven Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",193,000090
+RENO,Haven Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",526,000090
+RENO,Hayes Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",27,000100
+RENO,Huntsville Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",52,000110
+RENO,Hutchinson Precinct 02,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",127,000130
+RENO,Hutchinson Precinct 02,Kansas House of Representatives,102,Republican,"Pauls, Jan",91,000130
+RENO,Hutchinson Precinct 03,Kansas House of Representatives,114,Republican,"Thimesch, Jack",96,000140
+RENO,Hutchinson Precinct 04,Kansas House of Representatives,104,Democratic,"Taylor, Betty",113,000150
+RENO,Hutchinson Precinct 04,Kansas House of Representatives,104,Republican,"Becker, Steven R.",698,000150
+RENO,Hutchinson Precinct 05,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",189,000160
+RENO,Hutchinson Precinct 05,Kansas House of Representatives,102,Republican,"Pauls, Jan",152,000160
+RENO,Hutchinson Precinct 06,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",209,000170
+RENO,Hutchinson Precinct 06,Kansas House of Representatives,102,Republican,"Pauls, Jan",146,000170
+RENO,Hutchinson Precinct 07,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",237,000180
+RENO,Hutchinson Precinct 07,Kansas House of Representatives,102,Republican,"Pauls, Jan",194,000180
+RENO,Hutchinson Precinct 09,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",308,000200
+RENO,Hutchinson Precinct 09,Kansas House of Representatives,102,Republican,"Pauls, Jan",284,000200
+RENO,Hutchinson Precinct 10,Kansas House of Representatives,104,Democratic,"Taylor, Betty",135,000210
+RENO,Hutchinson Precinct 10,Kansas House of Representatives,104,Republican,"Becker, Steven R.",588,000210
+RENO,Hutchinson Precinct 11,Kansas House of Representatives,104,Democratic,"Taylor, Betty",98,000220
+RENO,Hutchinson Precinct 11,Kansas House of Representatives,104,Republican,"Becker, Steven R.",587,000220
+RENO,Hutchinson Precinct 12,Kansas House of Representatives,104,Democratic,"Taylor, Betty",89,000230
+RENO,Hutchinson Precinct 12,Kansas House of Representatives,104,Republican,"Becker, Steven R.",331,000230
+RENO,Hutchinson Precinct 13,Kansas House of Representatives,104,Democratic,"Taylor, Betty",108,000240
+RENO,Hutchinson Precinct 13,Kansas House of Representatives,104,Republican,"Becker, Steven R.",367,000240
+RENO,Hutchinson Precinct 14,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",214,000250
+RENO,Hutchinson Precinct 14,Kansas House of Representatives,102,Republican,"Pauls, Jan",189,000250
+RENO,Hutchinson Precinct 15,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",144,000260
+RENO,Hutchinson Precinct 15,Kansas House of Representatives,102,Republican,"Pauls, Jan",90,000260
+RENO,Hutchinson Precinct 16,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",286,000270
+RENO,Hutchinson Precinct 16,Kansas House of Representatives,102,Republican,"Pauls, Jan",196,000270
+RENO,Hutchinson Precinct 17,Kansas House of Representatives,104,Democratic,"Taylor, Betty",124,000280
+RENO,Hutchinson Precinct 17,Kansas House of Representatives,104,Republican,"Becker, Steven R.",399,000280
+RENO,Hutchinson Precinct 18,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",109,000290
+RENO,Hutchinson Precinct 18,Kansas House of Representatives,102,Republican,"Pauls, Jan",87,000290
+RENO,Hutchinson Precinct 19,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",147,000300
+RENO,Hutchinson Precinct 19,Kansas House of Representatives,102,Republican,"Pauls, Jan",76,000300
+RENO,Hutchinson Precinct 20,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",176,000310
+RENO,Hutchinson Precinct 20,Kansas House of Representatives,102,Republican,"Pauls, Jan",178,000310
+RENO,Hutchinson Precinct 21,Kansas House of Representatives,104,Democratic,"Taylor, Betty",95,000320
+RENO,Hutchinson Precinct 21,Kansas House of Representatives,104,Republican,"Becker, Steven R.",202,000320
+RENO,Hutchinson Precinct 22,Kansas House of Representatives,104,Democratic,"Taylor, Betty",145,000330
+RENO,Hutchinson Precinct 22,Kansas House of Representatives,104,Republican,"Becker, Steven R.",505,000330
+RENO,Hutchinson Precinct 24,Kansas House of Representatives,104,Democratic,"Taylor, Betty",112,000350
+RENO,Hutchinson Precinct 24,Kansas House of Representatives,104,Republican,"Becker, Steven R.",433,000350
+RENO,Hutchinson Precinct 25,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",174,000360
+RENO,Hutchinson Precinct 25,Kansas House of Representatives,102,Republican,"Pauls, Jan",110,000360
+RENO,Hutchinson Precinct 26,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",110,00037A
+RENO,Hutchinson Precinct 26,Kansas House of Representatives,102,Republican,"Pauls, Jan",88,00037A
+RENO,Hutchinson Precinct 26 Exclave,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",11,00037B
+RENO,Hutchinson Precinct 26 Exclave,Kansas House of Representatives,102,Republican,"Pauls, Jan",11,00037B
+RENO,Hutchinson Precinct 27,Kansas House of Representatives,104,Democratic,"Taylor, Betty",71,000380
+RENO,Hutchinson Precinct 27,Kansas House of Representatives,104,Republican,"Becker, Steven R.",347,000380
+RENO,Hutchinson Precinct 28,Kansas House of Representatives,104,Democratic,"Taylor, Betty",141,00039A
+RENO,Hutchinson Precinct 28,Kansas House of Representatives,104,Republican,"Becker, Steven R.",718,00039A
+RENO,Hutchinson Precinct 28 Exclave,Kansas House of Representatives,104,Democratic,"Taylor, Betty",50,00039B
+RENO,Hutchinson Precinct 28 Exclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",350,00039B
+RENO,Hutchinson Precinct 29,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",209,000400
+RENO,Hutchinson Precinct 29,Kansas House of Representatives,102,Republican,"Pauls, Jan",191,000400
+RENO,Hutchinson Precinct 30,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",112,000410
+RENO,Hutchinson Precinct 30,Kansas House of Representatives,102,Republican,"Pauls, Jan",101,000410
+RENO,Hutchinson Precinct 31,Kansas House of Representatives,104,Democratic,"Taylor, Betty",87,000420
+RENO,Hutchinson Precinct 31,Kansas House of Representatives,104,Republican,"Becker, Steven R.",256,000420
+RENO,Hutchinson Precinct 32,Kansas House of Representatives,104,Democratic,"Taylor, Betty",18,000430
+RENO,Hutchinson Precinct 32,Kansas House of Representatives,104,Republican,"Becker, Steven R.",102,000430
+RENO,Langdon Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",58,000440
+RENO,Lincoln Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",36,000450
+RENO,Lincoln Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",152,000450
+RENO,Little River Township,Kansas House of Representatives,104,Democratic,"Taylor, Betty",89,000460
+RENO,Little River Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",815,000460
+RENO,Loda Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",40,000470
+RENO,Medford Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",65,000480
+RENO,Medora Township,Kansas House of Representatives,104,Democratic,"Taylor, Betty",132,000490
+RENO,Medora Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",697,000490
+RENO,Miami Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",125,000500
+RENO,Nickerson Ward 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",144,000510
+RENO,Nickerson Ward 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",82,000520
+RENO,Nickerson Ward 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",94,000530
+RENO,Ninnescah Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",33,000540
+RENO,Ninnescah Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",72,000540
+RENO,North Clay Township,Kansas House of Representatives,104,Democratic,"Taylor, Betty",66,00055A
+RENO,North Clay Township,Kansas House of Representatives,104,Republican,"Becker, Steven R.",402,00055A
+RENO,North Reno Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",582,000560
+RENO,Plevna Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",107,000570
+RENO,Roscoe Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",24,000580
+RENO,Roscoe Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",32,000580
+RENO,Salt Creek Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",161,000590
+RENO,South Hutchinson Precinct 1,Kansas House of Representatives,114,Republican,"Thimesch, Jack",201,000610
+RENO,South Hutchinson Precinct 2,Kansas House of Representatives,114,Republican,"Thimesch, Jack",380,000620
+RENO,South Hutchinson Precinct 3,Kansas House of Representatives,114,Republican,"Thimesch, Jack",258,000630
+RENO,South Reno Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",101,000640
+RENO,Sumner Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",51,000650
+RENO,Sumner Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",239,000650
+RENO,Sylvia Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",109,000660
+RENO,Troy Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",46,000670
+RENO,Valley Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",96,000680
+RENO,Valley Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",312,000680
+RENO,Walnut Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",60,000690
+RENO,Westminister Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",91,000700
+RENO,Yoder Township,Kansas House of Representatives,101,Democratic,"Beck, Clifton",50,000710
+RENO,Yoder Township,Kansas House of Representatives,101,Republican,"Seiwert, Joe",196,000710
+RENO,Hutchinson Precinct 01 H102,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",132,120020
+RENO,Hutchinson Precinct 01 H102,Kansas House of Representatives,102,Republican,"Pauls, Jan",77,120020
+RENO,Hutchinson Precinct 01 H114,Kansas House of Representatives,114,Republican,"Thimesch, Jack",13,120030
+RENO,South Clay Township H101,Kansas House of Representatives,101,Democratic,"Beck, Clifton",111,120040
+RENO,South Clay Township H101,Kansas House of Representatives,101,Republican,"Seiwert, Joe",405,120040
+RENO,South Clay Township Clay H102 A,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",0,12005A
+RENO,South Clay Township Clay H102 A,Kansas House of Representatives,102,Republican,"Pauls, Jan",2,12005A
+RENO,Hutchinson Precinct 34 Exclave,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Kansas House of Representatives,102,Republican,"Pauls, Jan",1,120060
+RENO,Hutchinson Precinct 36,Kansas House of Representatives,104,Democratic,"Taylor, Betty",0,120070
+RENO,Hutchinson Precinct 36,Kansas House of Representatives,104,Republican,"Becker, Steven R.",0,120070
+RENO,Hutchinson Precinct 08 H101,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",110,200010
+RENO,Hutchinson Precinct 08 H101,Kansas House of Representatives,102,Republican,"Pauls, Jan",103,200010
+RENO,Hutchinson Precinct 35,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",102,200020
+RENO,Hutchinson Precinct 35,Kansas House of Representatives,102,Republican,"Pauls, Jan",96,200020
+RENO,Hutchinson Precinct 23 Exclave,Kansas House of Representatives,104,Democratic,"Taylor, Betty",17,200030
+RENO,Hutchinson Precinct 23 Exclave,Kansas House of Representatives,104,Republican,"Becker, Steven R.",184,200030
+RENO,Hutchinson Precinct 23 H104,Kansas House of Representatives,104,Democratic,"Taylor, Betty",178,200040
+RENO,Hutchinson Precinct 23 H104,Kansas House of Representatives,104,Republican,"Becker, Steven R.",614,200040
+RENO,Hutchinson Precinct 33,Kansas House of Representatives,104,Democratic,"Taylor, Betty",30,200050
+RENO,Hutchinson Precinct 33,Kansas House of Representatives,104,Republican,"Becker, Steven R.",160,200050
+RENO,Hutchinson Precinct 34,Kansas House of Representatives,102,Democratic,"Terrell, Patsy",26,200060
+RENO,Hutchinson Precinct 34,Kansas House of Representatives,102,Republican,"Pauls, Jan",40,200060
+RENO,Albion Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",59,000010
+RENO,Albion Township,Kansas Senate,34,Republican,"Berger, Edward E.",324,000010
+RENO,Arlington Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",47,000020
+RENO,Arlington Township,Kansas Senate,34,Republican,"Berger, Edward E.",203,000020
+RENO,Bell Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",6,000030
+RENO,Bell Township,Kansas Senate,34,Republican,"Berger, Edward E.",27,000030
+RENO,Castleton Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",20,000040
+RENO,Castleton Township,Kansas Senate,34,Republican,"Berger, Edward E.",120,000040
+RENO,Center Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",24,000050
+RENO,Center Township,Kansas Senate,34,Republican,"Berger, Edward E.",149,000050
+RENO,Enterprise Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",11,000060
+RENO,Enterprise Township,Kansas Senate,34,Republican,"Berger, Edward E.",56,000060
+RENO,Grant Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",83,000070
+RENO,Grant Township,Kansas Senate,34,Republican,"Berger, Edward E.",691,000070
+RENO,Grove Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",2,000080
+RENO,Grove Township,Kansas Senate,34,Republican,"Berger, Edward E.",29,000080
+RENO,Haven Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",117,000090
+RENO,Haven Township,Kansas Senate,34,Republican,"Berger, Edward E.",613,000090
+RENO,Hayes Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",2,000100
+RENO,Hayes Township,Kansas Senate,34,Republican,"Berger, Edward E.",28,000100
+RENO,Huntsville Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",9,000110
+RENO,Huntsville Township,Kansas Senate,34,Republican,"Berger, Edward E.",42,000110
+RENO,Hutchinson Precinct 02,Kansas Senate,34,Democratic,"Gilson, Homer L.",69,000130
+RENO,Hutchinson Precinct 02,Kansas Senate,34,Republican,"Berger, Edward E.",146,000130
+RENO,Hutchinson Precinct 03,Kansas Senate,34,Democratic,"Gilson, Homer L.",45,000140
+RENO,Hutchinson Precinct 03,Kansas Senate,34,Republican,"Berger, Edward E.",86,000140
+RENO,Hutchinson Precinct 04,Kansas Senate,34,Democratic,"Gilson, Homer L.",77,000150
+RENO,Hutchinson Precinct 04,Kansas Senate,34,Republican,"Berger, Edward E.",734,000150
+RENO,Hutchinson Precinct 05,Kansas Senate,34,Democratic,"Gilson, Homer L.",109,000160
+RENO,Hutchinson Precinct 05,Kansas Senate,34,Republican,"Berger, Edward E.",225,000160
+RENO,Hutchinson Precinct 06,Kansas Senate,34,Democratic,"Gilson, Homer L.",103,000170
+RENO,Hutchinson Precinct 06,Kansas Senate,34,Republican,"Berger, Edward E.",241,000170
+RENO,Hutchinson Precinct 07,Kansas Senate,34,Democratic,"Gilson, Homer L.",117,000180
+RENO,Hutchinson Precinct 07,Kansas Senate,34,Republican,"Berger, Edward E.",304,000180
+RENO,Hutchinson Precinct 09,Kansas Senate,34,Democratic,"Gilson, Homer L.",109,000200
+RENO,Hutchinson Precinct 09,Kansas Senate,34,Republican,"Berger, Edward E.",477,000200
+RENO,Hutchinson Precinct 10,Kansas Senate,34,Democratic,"Gilson, Homer L.",89,000210
+RENO,Hutchinson Precinct 10,Kansas Senate,34,Republican,"Berger, Edward E.",633,000210
+RENO,Hutchinson Precinct 11,Kansas Senate,34,Democratic,"Gilson, Homer L.",82,000220
+RENO,Hutchinson Precinct 11,Kansas Senate,34,Republican,"Berger, Edward E.",603,000220
+RENO,Hutchinson Precinct 12,Kansas Senate,34,Democratic,"Gilson, Homer L.",58,000230
+RENO,Hutchinson Precinct 12,Kansas Senate,34,Republican,"Berger, Edward E.",363,000230
+RENO,Hutchinson Precinct 13,Kansas Senate,34,Democratic,"Gilson, Homer L.",91,000240
+RENO,Hutchinson Precinct 13,Kansas Senate,34,Republican,"Berger, Edward E.",393,000240
+RENO,Hutchinson Precinct 14,Kansas Senate,34,Democratic,"Gilson, Homer L.",115,000250
+RENO,Hutchinson Precinct 14,Kansas Senate,34,Republican,"Berger, Edward E.",285,000250
+RENO,Hutchinson Precinct 15,Kansas Senate,34,Democratic,"Gilson, Homer L.",83,000260
+RENO,Hutchinson Precinct 15,Kansas Senate,34,Republican,"Berger, Edward E.",145,000260
+RENO,Hutchinson Precinct 16,Kansas Senate,34,Democratic,"Gilson, Homer L.",138,000270
+RENO,Hutchinson Precinct 16,Kansas Senate,34,Republican,"Berger, Edward E.",335,000270
+RENO,Hutchinson Precinct 17,Kansas Senate,34,Democratic,"Gilson, Homer L.",109,000280
+RENO,Hutchinson Precinct 17,Kansas Senate,34,Republican,"Berger, Edward E.",420,000280
+RENO,Hutchinson Precinct 18,Kansas Senate,34,Democratic,"Gilson, Homer L.",58,000290
+RENO,Hutchinson Precinct 18,Kansas Senate,34,Republican,"Berger, Edward E.",135,000290
+RENO,Hutchinson Precinct 19,Kansas Senate,34,Democratic,"Gilson, Homer L.",80,000300
+RENO,Hutchinson Precinct 19,Kansas Senate,34,Republican,"Berger, Edward E.",144,000300
+RENO,Hutchinson Precinct 20,Kansas Senate,34,Democratic,"Gilson, Homer L.",81,000310
+RENO,Hutchinson Precinct 20,Kansas Senate,34,Republican,"Berger, Edward E.",266,000310
+RENO,Hutchinson Precinct 21,Kansas Senate,34,Democratic,"Gilson, Homer L.",71,000320
+RENO,Hutchinson Precinct 21,Kansas Senate,34,Republican,"Berger, Edward E.",219,000320
+RENO,Hutchinson Precinct 22,Kansas Senate,34,Democratic,"Gilson, Homer L.",90,000330
+RENO,Hutchinson Precinct 22,Kansas Senate,34,Republican,"Berger, Edward E.",556,000330
+RENO,Hutchinson Precinct 24,Kansas Senate,34,Democratic,"Gilson, Homer L.",78,000350
+RENO,Hutchinson Precinct 24,Kansas Senate,34,Republican,"Berger, Edward E.",481,000350
+RENO,Hutchinson Precinct 25,Kansas Senate,34,Democratic,"Gilson, Homer L.",95,000360
+RENO,Hutchinson Precinct 25,Kansas Senate,34,Republican,"Berger, Edward E.",180,000360
+RENO,Hutchinson Precinct 26,Kansas Senate,34,Democratic,"Gilson, Homer L.",58,00037A
+RENO,Hutchinson Precinct 26,Kansas Senate,34,Republican,"Berger, Edward E.",137,00037A
+RENO,Hutchinson Precinct 26 Exclave,Kansas Senate,34,Democratic,"Gilson, Homer L.",7,00037B
+RENO,Hutchinson Precinct 26 Exclave,Kansas Senate,34,Republican,"Berger, Edward E.",15,00037B
+RENO,Hutchinson Precinct 27,Kansas Senate,34,Democratic,"Gilson, Homer L.",53,000380
+RENO,Hutchinson Precinct 27,Kansas Senate,34,Republican,"Berger, Edward E.",364,000380
+RENO,Hutchinson Precinct 28,Kansas Senate,34,Democratic,"Gilson, Homer L.",111,00039A
+RENO,Hutchinson Precinct 28,Kansas Senate,34,Republican,"Berger, Edward E.",747,00039A
+RENO,Hutchinson Precinct 28 Exclave,Kansas Senate,34,Democratic,"Gilson, Homer L.",24,00039B
+RENO,Hutchinson Precinct 28 Exclave,Kansas Senate,34,Republican,"Berger, Edward E.",379,00039B
+RENO,Hutchinson Precinct 29,Kansas Senate,34,Democratic,"Gilson, Homer L.",83,000400
+RENO,Hutchinson Precinct 29,Kansas Senate,34,Republican,"Berger, Edward E.",311,000400
+RENO,Hutchinson Precinct 30,Kansas Senate,34,Democratic,"Gilson, Homer L.",59,000410
+RENO,Hutchinson Precinct 30,Kansas Senate,34,Republican,"Berger, Edward E.",151,000410
+RENO,Hutchinson Precinct 31,Kansas Senate,34,Democratic,"Gilson, Homer L.",73,000420
+RENO,Hutchinson Precinct 31,Kansas Senate,34,Republican,"Berger, Edward E.",273,000420
+RENO,Hutchinson Precinct 32,Kansas Senate,34,Democratic,"Gilson, Homer L.",18,000430
+RENO,Hutchinson Precinct 32,Kansas Senate,34,Republican,"Berger, Edward E.",106,000430
+RENO,Langdon Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",7,000440
+RENO,Langdon Township,Kansas Senate,34,Republican,"Berger, Edward E.",56,000440
+RENO,Lincoln Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",19,000450
+RENO,Lincoln Township,Kansas Senate,34,Republican,"Berger, Edward E.",173,000450
+RENO,Little River Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",89,000460
+RENO,Little River Township,Kansas Senate,34,Republican,"Berger, Edward E.",806,000460
+RENO,Loda Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",10,000470
+RENO,Loda Township,Kansas Senate,34,Republican,"Berger, Edward E.",33,000470
+RENO,Medford Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",6,000480
+RENO,Medford Township,Kansas Senate,34,Republican,"Berger, Edward E.",69,000480
+RENO,Medora Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",114,000490
+RENO,Medora Township,Kansas Senate,34,Republican,"Berger, Edward E.",721,000490
+RENO,Miami Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",27,000500
+RENO,Miami Township,Kansas Senate,34,Republican,"Berger, Edward E.",106,000500
+RENO,Nickerson Ward 1,Kansas Senate,34,Democratic,"Gilson, Homer L.",32,000510
+RENO,Nickerson Ward 1,Kansas Senate,34,Republican,"Berger, Edward E.",130,000510
+RENO,Nickerson Ward 2,Kansas Senate,34,Democratic,"Gilson, Homer L.",18,000520
+RENO,Nickerson Ward 2,Kansas Senate,34,Republican,"Berger, Edward E.",72,000520
+RENO,Nickerson Ward 3,Kansas Senate,34,Democratic,"Gilson, Homer L.",24,000530
+RENO,Nickerson Ward 3,Kansas Senate,34,Republican,"Berger, Edward E.",81,000530
+RENO,Ninnescah Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",16,000540
+RENO,Ninnescah Township,Kansas Senate,34,Republican,"Berger, Edward E.",76,000540
+RENO,North Clay Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",44,00055A
+RENO,North Clay Township,Kansas Senate,34,Republican,"Berger, Edward E.",417,00055A
+RENO,North Reno Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",112,000560
+RENO,North Reno Township,Kansas Senate,34,Republican,"Berger, Edward E.",562,000560
+RENO,Plevna Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",23,000570
+RENO,Plevna Township,Kansas Senate,34,Republican,"Berger, Edward E.",90,000570
+RENO,Roscoe Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",11,000580
+RENO,Roscoe Township,Kansas Senate,34,Republican,"Berger, Edward E.",46,000580
+RENO,Salt Creek Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",21,000590
+RENO,Salt Creek Township,Kansas Senate,34,Republican,"Berger, Edward E.",140,000590
+RENO,South Hutchinson Precinct 1,Kansas Senate,34,Democratic,"Gilson, Homer L.",61,000610
+RENO,South Hutchinson Precinct 1,Kansas Senate,34,Republican,"Berger, Edward E.",175,000610
+RENO,South Hutchinson Precinct 2,Kansas Senate,34,Democratic,"Gilson, Homer L.",83,000620
+RENO,South Hutchinson Precinct 2,Kansas Senate,34,Republican,"Berger, Edward E.",350,000620
+RENO,South Hutchinson Precinct 3,Kansas Senate,34,Democratic,"Gilson, Homer L.",55,000630
+RENO,South Hutchinson Precinct 3,Kansas Senate,34,Republican,"Berger, Edward E.",255,000630
+RENO,South Reno Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",16,000640
+RENO,South Reno Township,Kansas Senate,34,Republican,"Berger, Edward E.",98,000640
+RENO,Sumner Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",53,000650
+RENO,Sumner Township,Kansas Senate,34,Republican,"Berger, Edward E.",229,000650
+RENO,Sylvia Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",25,000660
+RENO,Sylvia Township,Kansas Senate,34,Republican,"Berger, Edward E.",96,000660
+RENO,Troy Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",5,000670
+RENO,Troy Township,Kansas Senate,34,Republican,"Berger, Edward E.",47,000670
+RENO,Valley Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",76,000680
+RENO,Valley Township,Kansas Senate,34,Republican,"Berger, Edward E.",333,000680
+RENO,Walnut Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",9,000690
+RENO,Walnut Township,Kansas Senate,34,Republican,"Berger, Edward E.",53,000690
+RENO,Westminister Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",9,000700
+RENO,Westminister Township,Kansas Senate,34,Republican,"Berger, Edward E.",85,000700
+RENO,Yoder Township,Kansas Senate,34,Democratic,"Gilson, Homer L.",37,000710
+RENO,Yoder Township,Kansas Senate,34,Republican,"Berger, Edward E.",204,000710
+RENO,Hutchinson Precinct 01 H102,Kansas Senate,34,Democratic,"Gilson, Homer L.",81,120020
+RENO,Hutchinson Precinct 01 H102,Kansas Senate,34,Republican,"Berger, Edward E.",126,120020
+RENO,Hutchinson Precinct 01 H114,Kansas Senate,34,Democratic,"Gilson, Homer L.",5,120030
+RENO,Hutchinson Precinct 01 H114,Kansas Senate,34,Republican,"Berger, Edward E.",10,120030
+RENO,South Clay Township H101,Kansas Senate,34,Democratic,"Gilson, Homer L.",78,120040
+RENO,South Clay Township H101,Kansas Senate,34,Republican,"Berger, Edward E.",433,120040
+RENO,South Clay Township Clay H102 A,Kansas Senate,34,Democratic,"Gilson, Homer L.",0,12005A
+RENO,South Clay Township Clay H102 A,Kansas Senate,34,Republican,"Berger, Edward E.",3,12005A
+RENO,Hutchinson Precinct 34 Exclave,Kansas Senate,34,Democratic,"Gilson, Homer L.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,Kansas Senate,34,Republican,"Berger, Edward E.",1,120060
+RENO,Hutchinson Precinct 36,Kansas Senate,34,Democratic,"Gilson, Homer L.",0,120070
+RENO,Hutchinson Precinct 36,Kansas Senate,34,Republican,"Berger, Edward E.",0,120070
+RENO,Hutchinson Precinct 08 H101,Kansas Senate,34,Democratic,"Gilson, Homer L.",50,200010
+RENO,Hutchinson Precinct 08 H101,Kansas Senate,34,Republican,"Berger, Edward E.",159,200010
+RENO,Hutchinson Precinct 35,Kansas Senate,34,Democratic,"Gilson, Homer L.",31,200020
+RENO,Hutchinson Precinct 35,Kansas Senate,34,Republican,"Berger, Edward E.",168,200020
+RENO,Hutchinson Precinct 23 Exclave,Kansas Senate,34,Democratic,"Gilson, Homer L.",20,200030
+RENO,Hutchinson Precinct 23 Exclave,Kansas Senate,34,Republican,"Berger, Edward E.",178,200030
+RENO,Hutchinson Precinct 23 H104,Kansas Senate,34,Democratic,"Gilson, Homer L.",145,200040
+RENO,Hutchinson Precinct 23 H104,Kansas Senate,34,Republican,"Berger, Edward E.",645,200040
+RENO,Hutchinson Precinct 33,Kansas Senate,34,Democratic,"Gilson, Homer L.",18,200050
+RENO,Hutchinson Precinct 33,Kansas Senate,34,Republican,"Berger, Edward E.",177,200050
+RENO,Hutchinson Precinct 34,Kansas Senate,34,Democratic,"Gilson, Homer L.",15,200060
+RENO,Hutchinson Precinct 34,Kansas Senate,34,Republican,"Berger, Edward E.",49,200060
+RENO,Albion Township,President / Vice President,,independent,"Stein, Jill",4,000010
+RENO,Albion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"McMullin, Evan",2,000010
+RENO,Albion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+RENO,Albion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+RENO,Albion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000010
+RENO,Albion Township,President / Vice President,,Libertarian,"Johnson, Gary",23,000010
+RENO,Albion Township,President / Vice President,,Republican,"Trump, Donald J.",278,000010
+RENO,Arlington Township,President / Vice President,,independent,"Stein, Jill",6,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+RENO,Arlington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+RENO,Arlington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,000020
+RENO,Arlington Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000020
+RENO,Arlington Township,President / Vice President,,Republican,"Trump, Donald J.",168,000020
+RENO,Bell Township,President / Vice President,,independent,"Stein, Jill",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+RENO,Bell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+RENO,Bell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+RENO,Bell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+RENO,Bell Township,President / Vice President,,Republican,"Trump, Donald J.",30,000030
+RENO,Castleton Township,President / Vice President,,independent,"Stein, Jill",1,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"McMullin, Evan",2,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+RENO,Castleton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+RENO,Castleton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000040
+RENO,Castleton Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+RENO,Castleton Township,President / Vice President,,Republican,"Trump, Donald J.",114,000040
+RENO,Center Township,President / Vice President,,independent,"Stein, Jill",4,000050
+RENO,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+RENO,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+RENO,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+RENO,Center Township,President / Vice President,,write - in,"McMullin, Evan",2,000050
+RENO,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+RENO,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+RENO,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,000050
+RENO,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+RENO,Center Township,President / Vice President,,Republican,"Trump, Donald J.",134,000050
+RENO,Enterprise Township,President / Vice President,,independent,"Stein, Jill",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+RENO,Enterprise Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+RENO,Enterprise Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000060
+RENO,Enterprise Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+RENO,Enterprise Township,President / Vice President,,Republican,"Trump, Donald J.",58,000060
+RENO,Grant Township,President / Vice President,,independent,"Stein, Jill",11,000070
+RENO,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"McMullin, Evan",4,000070
+RENO,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+RENO,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+RENO,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",149,000070
+RENO,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",35,000070
+RENO,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",583,000070
+RENO,Grove Township,President / Vice President,,independent,"Stein, Jill",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+RENO,Grove Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+RENO,Grove Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000080
+RENO,Grove Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+RENO,Grove Township,President / Vice President,,Republican,"Trump, Donald J.",26,000080
+RENO,Haven Township,President / Vice President,,independent,"Stein, Jill",17,000090
+RENO,Haven Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Castle, Darrell L",3,000090
+RENO,Haven Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"McMullin, Evan",1,000090
+RENO,Haven Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+RENO,Haven Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+RENO,Haven Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",176,000090
+RENO,Haven Township,President / Vice President,,Libertarian,"Johnson, Gary",46,000090
+RENO,Haven Township,President / Vice President,,Republican,"Trump, Donald J.",493,000090
+RENO,Hayes Township,President / Vice President,,independent,"Stein, Jill",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+RENO,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+RENO,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000100
+RENO,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+RENO,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",25,000100
+RENO,Huntsville Township,President / Vice President,,independent,"Stein, Jill",1,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+RENO,Huntsville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+RENO,Huntsville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000110
+RENO,Huntsville Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+RENO,Huntsville Township,President / Vice President,,Republican,"Trump, Donald J.",48,000110
+RENO,Hutchinson Precinct 02,President / Vice President,,independent,"Stein, Jill",4,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"McMullin, Evan",1,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",95,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",13,000130
+RENO,Hutchinson Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",106,000130
+RENO,Hutchinson Precinct 03,President / Vice President,,independent,"Stein, Jill",6,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"McMullin, Evan",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+RENO,Hutchinson Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",46,000140
+RENO,Hutchinson Precinct 04,President / Vice President,,independent,"Stein, Jill",10,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"McMullin, Evan",7,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",220,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",42,000150
+RENO,Hutchinson Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",533,000150
+RENO,Hutchinson Precinct 05,President / Vice President,,independent,"Stein, Jill",16,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"McMullin, Evan",1,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",118,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",22,000160
+RENO,Hutchinson Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",179,000160
+RENO,Hutchinson Precinct 06,President / Vice President,,independent,"Stein, Jill",8,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"McMullin, Evan",5,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",141,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",20,000170
+RENO,Hutchinson Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",172,000170
+RENO,Hutchinson Precinct 07,President / Vice President,,independent,"Stein, Jill",11,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"McMullin, Evan",1,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",159,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",31,000180
+RENO,Hutchinson Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",230,000180
+RENO,Hutchinson Precinct 09,President / Vice President,,independent,"Stein, Jill",16,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"McMullin, Evan",1,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",195,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",42,000200
+RENO,Hutchinson Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",345,000200
+RENO,Hutchinson Precinct 10,President / Vice President,,independent,"Stein, Jill",10,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"McMullin, Evan",3,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",206,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",44,000210
+RENO,Hutchinson Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",455,000210
+RENO,Hutchinson Precinct 11,President / Vice President,,independent,"Stein, Jill",11,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Hedges, James A",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"McMullin, Evan",3,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Perry, Darryl",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Smith, Mike",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Sood, Ajay",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",200,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",32,000220
+RENO,Hutchinson Precinct 11,President / Vice President,,Republican,"Trump, Donald J.",435,000220
+RENO,Hutchinson Precinct 12,President / Vice President,,independent,"Stein, Jill",7,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Hedges, James A",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"McMullin, Evan",4,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Perry, Darryl",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Smith, Mike",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Sood, Ajay",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",162,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",31,000230
+RENO,Hutchinson Precinct 12,President / Vice President,,Republican,"Trump, Donald J.",223,000230
+RENO,Hutchinson Precinct 13,President / Vice President,,independent,"Stein, Jill",12,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Castle, Darrell L",2,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Hedges, James A",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"McMullin, Evan",3,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Perry, Darryl",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Smith, Mike",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Sood, Ajay",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",183,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",32,000240
+RENO,Hutchinson Precinct 13,President / Vice President,,Republican,"Trump, Donald J.",257,000240
+RENO,Hutchinson Precinct 14,President / Vice President,,independent,"Stein, Jill",9,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Hedges, James A",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"McMullin, Evan",2,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Perry, Darryl",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Smith, Mike",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Sood, Ajay",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Democratic,"Clinton, Hillary Rodham",161,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Libertarian,"Johnson, Gary",28,000250
+RENO,Hutchinson Precinct 14,President / Vice President,,Republican,"Trump, Donald J.",206,000250
+RENO,Hutchinson Precinct 15,President / Vice President,,independent,"Stein, Jill",4,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Hedges, James A",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"McMullin, Evan",2,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Perry, Darryl",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Smith, Mike",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Sood, Ajay",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Democratic,"Clinton, Hillary Rodham",98,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Libertarian,"Johnson, Gary",21,000260
+RENO,Hutchinson Precinct 15,President / Vice President,,Republican,"Trump, Donald J.",107,000260
+RENO,Hutchinson Precinct 16,President / Vice President,,independent,"Stein, Jill",11,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Hedges, James A",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"McMullin, Evan",5,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Perry, Darryl",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Smith, Mike",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Sood, Ajay",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Democratic,"Clinton, Hillary Rodham",226,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",26,000270
+RENO,Hutchinson Precinct 16,President / Vice President,,Republican,"Trump, Donald J.",208,000270
+RENO,Hutchinson Precinct 17,President / Vice President,,independent,"Stein, Jill",13,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Hedges, James A",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"McMullin, Evan",1,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Perry, Darryl",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Smith, Mike",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Sood, Ajay",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",179,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",17,000280
+RENO,Hutchinson Precinct 17,President / Vice President,,Republican,"Trump, Donald J.",323,000280
+RENO,Hutchinson Precinct 18,President / Vice President,,independent,"Stein, Jill",8,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Hedges, James A",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"McMullin, Evan",3,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Perry, Darryl",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Smith, Mike",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Sood, Ajay",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",11,000290
+RENO,Hutchinson Precinct 18,President / Vice President,,Republican,"Trump, Donald J.",111,000290
+RENO,Hutchinson Precinct 19,President / Vice President,,independent,"Stein, Jill",9,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Hedges, James A",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"McMullin, Evan",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Perry, Darryl",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Schriner, Joe C",1,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Smith, Mike",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Sood, Ajay",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",85,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",19,000300
+RENO,Hutchinson Precinct 19,President / Vice President,,Republican,"Trump, Donald J.",107,000300
+RENO,Hutchinson Precinct 20,President / Vice President,,independent,"Stein, Jill",9,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Hedges, James A",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"McMullin, Evan",1,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Perry, Darryl",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Smith, Mike",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Sood, Ajay",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Democratic,"Clinton, Hillary Rodham",110,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Libertarian,"Johnson, Gary",20,000310
+RENO,Hutchinson Precinct 20,President / Vice President,,Republican,"Trump, Donald J.",217,000310
+RENO,Hutchinson Precinct 21,President / Vice President,,independent,"Stein, Jill",6,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Hedges, James A",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"McMullin, Evan",4,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Perry, Darryl",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Smith, Mike",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Sood, Ajay",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Democratic,"Clinton, Hillary Rodham",114,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Libertarian,"Johnson, Gary",23,000320
+RENO,Hutchinson Precinct 21,President / Vice President,,Republican,"Trump, Donald J.",156,000320
+RENO,Hutchinson Precinct 22,President / Vice President,,independent,"Stein, Jill",16,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Hedges, James A",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"McMullin, Evan",1,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Perry, Darryl",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Smith, Mike",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Sood, Ajay",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Democratic,"Clinton, Hillary Rodham",219,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Libertarian,"Johnson, Gary",35,000330
+RENO,Hutchinson Precinct 22,President / Vice President,,Republican,"Trump, Donald J.",376,000330
+RENO,Hutchinson Precinct 24,President / Vice President,,independent,"Stein, Jill",8,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Hedges, James A",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"McMullin, Evan",4,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Perry, Darryl",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Smith, Mike",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Sood, Ajay",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Democratic,"Clinton, Hillary Rodham",162,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",32,000350
+RENO,Hutchinson Precinct 24,President / Vice President,,Republican,"Trump, Donald J.",351,000350
+RENO,Hutchinson Precinct 25,President / Vice President,,independent,"Stein, Jill",8,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Hedges, James A",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"McMullin, Evan",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Perry, Darryl",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Smith, Mike",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Sood, Ajay",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",25,000360
+RENO,Hutchinson Precinct 25,President / Vice President,,Republican,"Trump, Donald J.",154,000360
+RENO,Hutchinson Precinct 26,President / Vice President,,independent,"Stein, Jill",8,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Basiago, Andrew D.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Castle, Darrell L",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Giordani, Rocky",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Hedges, James A",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Kahn, Lynn",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"La Riva, Gloria",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Levinson, Michael S.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Maturen, Michael A",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"McMullin, Evan",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Moorehead, Monica G.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Perry, Darryl",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Schriner, Joe C",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Smith, Mike",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Sood, Ajay",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Sterling, Shawna",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Valdivia, Anthony J",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",13,00037A
+RENO,Hutchinson Precinct 26,President / Vice President,,Republican,"Trump, Donald J.",116,00037A
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,independent,"Stein, Jill",1,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",3,00037B
+RENO,Hutchinson Precinct 26 Exclave,President / Vice President,,Republican,"Trump, Donald J.",11,00037B
+RENO,Hutchinson Precinct 27,President / Vice President,,independent,"Stein, Jill",6,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Hedges, James A",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"McMullin, Evan",2,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Perry, Darryl",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Smith, Mike",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Sood, Ajay",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Democratic,"Clinton, Hillary Rodham",125,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",28,000380
+RENO,Hutchinson Precinct 27,President / Vice President,,Republican,"Trump, Donald J.",258,000380
+RENO,Hutchinson Precinct 28,President / Vice President,,independent,"Stein, Jill",12,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Castle, Darrell L",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Giordani, Rocky",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Hedges, James A",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Kahn, Lynn",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"La Riva, Gloria",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Levinson, Michael S.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Maturen, Michael A",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"McMullin, Evan",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Perry, Darryl",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Schriner, Joe C",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Smith, Mike",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Sood, Ajay",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Sterling, Shawna",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Democratic,"Clinton, Hillary Rodham",240,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",49,00039A
+RENO,Hutchinson Precinct 28,President / Vice President,,Republican,"Trump, Donald J.",564,00039A
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,independent,"Stein, Jill",1,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",111,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",11,00039B
+RENO,Hutchinson Precinct 28 Exclave,President / Vice President,,Republican,"Trump, Donald J.",284,00039B
+RENO,Hutchinson Precinct 29,President / Vice President,,independent,"Stein, Jill",8,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Hedges, James A",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"McMullin, Evan",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Perry, Darryl",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Smith, Mike",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Sood, Ajay",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Democratic,"Clinton, Hillary Rodham",134,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",20,000400
+RENO,Hutchinson Precinct 29,President / Vice President,,Republican,"Trump, Donald J.",228,000400
+RENO,Hutchinson Precinct 30,President / Vice President,,independent,"Stein, Jill",5,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Castle, Darrell L",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Hedges, James A",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"McMullin, Evan",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Perry, Darryl",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Smith, Mike",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Sood, Ajay",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Libertarian,"Johnson, Gary",9,000410
+RENO,Hutchinson Precinct 30,President / Vice President,,Republican,"Trump, Donald J.",130,000410
+RENO,Hutchinson Precinct 31,President / Vice President,,independent,"Stein, Jill",9,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Basiago, Andrew D.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Castle, Darrell L",2,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Giordani, Rocky",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Hedges, James A",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Hoefling, Tom",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Kahn, Lynn",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"La Riva, Gloria",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Levinson, Michael S.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Maturen, Michael A",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"McMullin, Evan",2,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Moorehead, Monica G.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Perry, Darryl",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Schriner, Joe C",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Smith, Mike",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Sood, Ajay",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Sterling, Shawna",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Valdivia, Anthony J",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Democratic,"Clinton, Hillary Rodham",127,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Libertarian,"Johnson, Gary",18,000420
+RENO,Hutchinson Precinct 31,President / Vice President,,Republican,"Trump, Donald J.",189,000420
+RENO,Hutchinson Precinct 32,President / Vice President,,independent,"Stein, Jill",1,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Hedges, James A",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"McMullin, Evan",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Perry, Darryl",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Smith, Mike",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Sood, Ajay",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",4,000430
+RENO,Hutchinson Precinct 32,President / Vice President,,Republican,"Trump, Donald J.",81,000430
+RENO,Langdon Township,President / Vice President,,independent,"Stein, Jill",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Hedges, James A",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"McMullin, Evan",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Perry, Darryl",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Smith, Mike",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Sood, Ajay",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000440
+RENO,Langdon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000440
+RENO,Langdon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000440
+RENO,Langdon Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000440
+RENO,Langdon Township,President / Vice President,,Republican,"Trump, Donald J.",51,000440
+RENO,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+RENO,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+RENO,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000450
+RENO,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000450
+RENO,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",167,000450
+RENO,Little River Township,President / Vice President,,independent,"Stein, Jill",16,000460
+RENO,Little River Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Castle, Darrell L",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Giordani, Rocky",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Hedges, James A",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Kahn, Lynn",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"La Riva, Gloria",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Maturen, Michael A",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"McMullin, Evan",7,000460
+RENO,Little River Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Perry, Darryl",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Schriner, Joe C",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Smith, Mike",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Sood, Ajay",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Sterling, Shawna",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000460
+RENO,Little River Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000460
+RENO,Little River Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",197,000460
+RENO,Little River Township,President / Vice President,,Libertarian,"Johnson, Gary",37,000460
+RENO,Little River Township,President / Vice President,,Republican,"Trump, Donald J.",659,000460
+RENO,Loda Township,President / Vice President,,independent,"Stein, Jill",1,000470
+RENO,Loda Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Castle, Darrell L",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Giordani, Rocky",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Hedges, James A",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Hoefling, Tom",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Kahn, Lynn",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"La Riva, Gloria",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Maturen, Michael A",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"McMullin, Evan",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Perry, Darryl",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Schriner, Joe C",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Smith, Mike",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Sood, Ajay",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Sterling, Shawna",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000470
+RENO,Loda Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000470
+RENO,Loda Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000470
+RENO,Loda Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000470
+RENO,Loda Township,President / Vice President,,Republican,"Trump, Donald J.",34,000470
+RENO,Medford Township,President / Vice President,,independent,"Stein, Jill",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Castle, Darrell L",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Hedges, James A",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"McMullin, Evan",2,000480
+RENO,Medford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Perry, Darryl",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Smith, Mike",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Sood, Ajay",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000480
+RENO,Medford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000480
+RENO,Medford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000480
+RENO,Medford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000480
+RENO,Medford Township,President / Vice President,,Republican,"Trump, Donald J.",61,000480
+RENO,Medora Township,President / Vice President,,independent,"Stein, Jill",12,000490
+RENO,Medora Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Castle, Darrell L",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Giordani, Rocky",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Hedges, James A",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Kahn, Lynn",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"La Riva, Gloria",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Maturen, Michael A",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"McMullin, Evan",5,000490
+RENO,Medora Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Perry, Darryl",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Schriner, Joe C",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Smith, Mike",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Sood, Ajay",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Sterling, Shawna",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000490
+RENO,Medora Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000490
+RENO,Medora Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",177,000490
+RENO,Medora Township,President / Vice President,,Libertarian,"Johnson, Gary",38,000490
+RENO,Medora Township,President / Vice President,,Republican,"Trump, Donald J.",621,000490
+RENO,Miami Township,President / Vice President,,independent,"Stein, Jill",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Castle, Darrell L",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Giordani, Rocky",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Hedges, James A",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Kahn, Lynn",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"La Riva, Gloria",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Maturen, Michael A",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"McMullin, Evan",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Perry, Darryl",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Schriner, Joe C",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Smith, Mike",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Sood, Ajay",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Sterling, Shawna",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000500
+RENO,Miami Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000500
+RENO,Miami Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000500
+RENO,Miami Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000500
+RENO,Miami Township,President / Vice President,,Republican,"Trump, Donald J.",118,000500
+RENO,Nickerson Ward 1,President / Vice President,,independent,"Stein, Jill",5,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"McMullin, Evan",4,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000510
+RENO,Nickerson Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,000510
+RENO,Nickerson Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000510
+RENO,Nickerson Ward 1,President / Vice President,,Republican,"Trump, Donald J.",108,000510
+RENO,Nickerson Ward 2,President / Vice President,,independent,"Stein, Jill",3,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000520
+RENO,Nickerson Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000520
+RENO,Nickerson Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",4,000520
+RENO,Nickerson Ward 2,President / Vice President,,Republican,"Trump, Donald J.",63,000520
+RENO,Nickerson Ward 3,President / Vice President,,independent,"Stein, Jill",3,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000530
+RENO,Nickerson Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000530
+RENO,Nickerson Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000530
+RENO,Nickerson Ward 3,President / Vice President,,Republican,"Trump, Donald J.",76,000530
+RENO,Ninnescah Township,President / Vice President,,independent,"Stein, Jill",3,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Castle, Darrell L",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Giordani, Rocky",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Hedges, James A",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Kahn, Lynn",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"La Riva, Gloria",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Maturen, Michael A",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"McMullin, Evan",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Perry, Darryl",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Schriner, Joe C",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Smith, Mike",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Sood, Ajay",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Sterling, Shawna",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000540
+RENO,Ninnescah Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000540
+RENO,Ninnescah Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000540
+RENO,Ninnescah Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000540
+RENO,Ninnescah Township,President / Vice President,,Republican,"Trump, Donald J.",71,000540
+RENO,North Clay Township,President / Vice President,,independent,"Stein, Jill",8,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Castle, Darrell L",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Giordani, Rocky",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Hedges, James A",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Hoefling, Tom",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Kahn, Lynn",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"La Riva, Gloria",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Maturen, Michael A",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"McMullin, Evan",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Perry, Darryl",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Schriner, Joe C",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Smith, Mike",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Sood, Ajay",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Sterling, Shawna",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00055A
+RENO,North Clay Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00055A
+RENO,North Clay Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",99,00055A
+RENO,North Clay Township,President / Vice President,,Libertarian,"Johnson, Gary",17,00055A
+RENO,North Clay Township,President / Vice President,,Republican,"Trump, Donald J.",346,00055A
+RENO,North Reno Township,President / Vice President,,independent,"Stein, Jill",6,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Castle, Darrell L",2,000560
+RENO,North Reno Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Giordani, Rocky",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Hedges, James A",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Hoefling, Tom",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Kahn, Lynn",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"La Riva, Gloria",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Maturen, Michael A",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"McMullin, Evan",1,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Perry, Darryl",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Schriner, Joe C",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Smith, Mike",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Sood, Ajay",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Sterling, Shawna",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000560
+RENO,North Reno Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000560
+RENO,North Reno Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",163,000560
+RENO,North Reno Township,President / Vice President,,Libertarian,"Johnson, Gary",28,000560
+RENO,North Reno Township,President / Vice President,,Republican,"Trump, Donald J.",486,000560
+RENO,Plevna Township,President / Vice President,,independent,"Stein, Jill",1,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Castle, Darrell L",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Giordani, Rocky",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Hedges, James A",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Hoefling, Tom",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Kahn, Lynn",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"La Riva, Gloria",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Maturen, Michael A",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"McMullin, Evan",1,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Perry, Darryl",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Schriner, Joe C",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Smith, Mike",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Sood, Ajay",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Sterling, Shawna",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000570
+RENO,Plevna Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000570
+RENO,Plevna Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000570
+RENO,Plevna Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000570
+RENO,Plevna Township,President / Vice President,,Republican,"Trump, Donald J.",95,000570
+RENO,Roscoe Township,President / Vice President,,independent,"Stein, Jill",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Castle, Darrell L",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Giordani, Rocky",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Hedges, James A",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Kahn, Lynn",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"La Riva, Gloria",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Maturen, Michael A",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"McMullin, Evan",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Perry, Darryl",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Schriner, Joe C",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Smith, Mike",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Sood, Ajay",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Sterling, Shawna",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000580
+RENO,Roscoe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000580
+RENO,Roscoe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000580
+RENO,Roscoe Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000580
+RENO,Roscoe Township,President / Vice President,,Republican,"Trump, Donald J.",41,000580
+RENO,Salt Creek Township,President / Vice President,,independent,"Stein, Jill",4,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000590
+RENO,Salt Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000590
+RENO,Salt Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000590
+RENO,Salt Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000590
+RENO,Salt Creek Township,President / Vice President,,Republican,"Trump, Donald J.",152,000590
+RENO,South Hutchinson Precinct 1,President / Vice President,,independent,"Stein, Jill",4,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",16,000610
+RENO,South Hutchinson Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",138,000610
+RENO,South Hutchinson Precinct 2,President / Vice President,,independent,"Stein, Jill",5,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",104,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000620
+RENO,South Hutchinson Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",311,000620
+RENO,South Hutchinson Precinct 3,President / Vice President,,independent,"Stein, Jill",2,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"McMullin, Evan",2,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",17,000630
+RENO,South Hutchinson Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",193,000630
+RENO,South Reno Township,President / Vice President,,independent,"Stein, Jill",3,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Castle, Darrell L",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Giordani, Rocky",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Hedges, James A",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Hoefling, Tom",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Kahn, Lynn",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"La Riva, Gloria",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Maturen, Michael A",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"McMullin, Evan",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Perry, Darryl",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Schriner, Joe C",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Smith, Mike",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Sood, Ajay",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Sterling, Shawna",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000640
+RENO,South Reno Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000640
+RENO,South Reno Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000640
+RENO,South Reno Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000640
+RENO,South Reno Township,President / Vice President,,Republican,"Trump, Donald J.",93,000640
+RENO,Sumner Township,President / Vice President,,independent,"Stein, Jill",5,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Castle, Darrell L",1,000650
+RENO,Sumner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Hedges, James A",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"McMullin, Evan",1,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Perry, Darryl",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Smith, Mike",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Sood, Ajay",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000650
+RENO,Sumner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000650
+RENO,Sumner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000650
+RENO,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000650
+RENO,Sumner Township,President / Vice President,,Republican,"Trump, Donald J.",230,000650
+RENO,Sylvia Township,President / Vice President,,independent,"Stein, Jill",5,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Hedges, James A",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"McMullin, Evan",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Perry, Darryl",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Smith, Mike",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Sood, Ajay",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000660
+RENO,Sylvia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000660
+RENO,Sylvia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000660
+RENO,Sylvia Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000660
+RENO,Sylvia Township,President / Vice President,,Republican,"Trump, Donald J.",92,000660
+RENO,Troy Township,President / Vice President,,independent,"Stein, Jill",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Castle, Darrell L",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Giordani, Rocky",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Hedges, James A",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Hoefling, Tom",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Kahn, Lynn",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"La Riva, Gloria",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Maturen, Michael A",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"McMullin, Evan",1,000670
+RENO,Troy Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Perry, Darryl",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Schriner, Joe C",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Smith, Mike",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Sood, Ajay",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Sterling, Shawna",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000670
+RENO,Troy Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000670
+RENO,Troy Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000670
+RENO,Troy Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000670
+RENO,Troy Township,President / Vice President,,Republican,"Trump, Donald J.",42,000670
+RENO,Valley Township,President / Vice President,,independent,"Stein, Jill",6,000680
+RENO,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",1,000680
+RENO,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"McMullin, Evan",3,000680
+RENO,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000680
+RENO,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000680
+RENO,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,000680
+RENO,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000680
+RENO,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",304,000680
+RENO,Walnut Township,President / Vice President,,independent,"Stein, Jill",1,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",2,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000690
+RENO,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000690
+RENO,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000690
+RENO,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000690
+RENO,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",50,000690
+RENO,Westminister Township,President / Vice President,,independent,"Stein, Jill",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Castle, Darrell L",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Giordani, Rocky",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Hedges, James A",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Hoefling, Tom",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Kahn, Lynn",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"La Riva, Gloria",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Maturen, Michael A",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"McMullin, Evan",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Perry, Darryl",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Schriner, Joe C",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Smith, Mike",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Sood, Ajay",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Sterling, Shawna",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000700
+RENO,Westminister Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000700
+RENO,Westminister Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000700
+RENO,Westminister Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000700
+RENO,Westminister Township,President / Vice President,,Republican,"Trump, Donald J.",78,000700
+RENO,Yoder Township,President / Vice President,,independent,"Stein, Jill",10,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Castle, Darrell L",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Giordani, Rocky",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Hedges, James A",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Hoefling, Tom",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Kahn, Lynn",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"La Riva, Gloria",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Maturen, Michael A",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"McMullin, Evan",2,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Perry, Darryl",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Schriner, Joe C",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Smith, Mike",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Sood, Ajay",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Sterling, Shawna",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000710
+RENO,Yoder Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000710
+RENO,Yoder Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,000710
+RENO,Yoder Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000710
+RENO,Yoder Township,President / Vice President,,Republican,"Trump, Donald J.",181,000710
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,independent,"Stein, Jill",7,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Hedges, James A",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"McMullin, Evan",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Perry, Darryl",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Smith, Mike",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Sood, Ajay",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Democratic,"Clinton, Hillary Rodham",82,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Libertarian,"Johnson, Gary",13,120020
+RENO,Hutchinson Precinct 01 H102,President / Vice President,,Republican,"Trump, Donald J.",106,120020
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,independent,"Stein, Jill",1,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Hedges, James A",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"McMullin, Evan",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Perry, Darryl",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Smith, Mike",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Sood, Ajay",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+RENO,Hutchinson Precinct 01 H114,President / Vice President,,Republican,"Trump, Donald J.",6,120030
+RENO,South Clay Township H101,President / Vice President,,independent,"Stein, Jill",5,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Hedges, James A",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"McMullin, Evan",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Perry, Darryl",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Smith, Mike",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Sood, Ajay",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+RENO,South Clay Township H101,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+RENO,South Clay Township H101,President / Vice President,,Democratic,"Clinton, Hillary Rodham",90,120040
+RENO,South Clay Township H101,President / Vice President,,Libertarian,"Johnson, Gary",26,120040
+RENO,South Clay Township H101,President / Vice President,,Republican,"Trump, Donald J.",393,120040
+RENO,South Clay Township Clay H102 A,President / Vice President,,independent,"Stein, Jill",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Castle, Darrell L",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Giordani, Rocky",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Hedges, James A",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Hoefling, Tom",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Kahn, Lynn",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"La Riva, Gloria",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Maturen, Michael A",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"McMullin, Evan",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Perry, Darryl",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Schriner, Joe C",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Smith, Mike",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Sood, Ajay",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Sterling, Shawna",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12005A
+RENO,South Clay Township Clay H102 A,President / Vice President,,Republican,"Trump, Donald J.",2,12005A
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,independent,"Stein, Jill",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Hedges, James A",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Smith, Mike",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,120060
+RENO,Hutchinson Precinct 34 Exclave,President / Vice President,,Republican,"Trump, Donald J.",1,120060
+RENO,Hutchinson Precinct 36,President / Vice President,,independent,"Stein, Jill",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Hedges, James A",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"McMullin, Evan",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Perry, Darryl",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Smith, Mike",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Sood, Ajay",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+RENO,Hutchinson Precinct 36,President / Vice President,,Republican,"Trump, Donald J.",0,120070
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,independent,"Stein, Jill",5,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Basiago, Andrew D.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Castle, Darrell L",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Giordani, Rocky",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Hedges, James A",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Hoefling, Tom",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Kahn, Lynn",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"La Riva, Gloria",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Levinson, Michael S.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Maturen, Michael A",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"McMullin, Evan",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Moorehead, Monica G.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Perry, Darryl",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Schriner, Joe C",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Smith, Mike",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Sood, Ajay",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Sterling, Shawna",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Valdivia, Anthony J",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Democratic,"Clinton, Hillary Rodham",74,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Libertarian,"Johnson, Gary",11,200010
+RENO,Hutchinson Precinct 08 H101,President / Vice President,,Republican,"Trump, Donald J.",123,200010
+RENO,Hutchinson Precinct 35,President / Vice President,,independent,"Stein, Jill",10,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Basiago, Andrew D.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Castle, Darrell L",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Giordani, Rocky",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Hedges, James A",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Hoefling, Tom",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Kahn, Lynn",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"La Riva, Gloria",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Levinson, Michael S.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Maturen, Michael A",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"McMullin, Evan",2,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Moorehead, Monica G.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Perry, Darryl",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Schriner, Joe C",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Smith, Mike",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Sood, Ajay",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Sterling, Shawna",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Valdivia, Anthony J",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Libertarian,"Johnson, Gary",10,200020
+RENO,Hutchinson Precinct 35,President / Vice President,,Republican,"Trump, Donald J.",115,200020
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,independent,"Stein, Jill",5,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Hedges, James A",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"McMullin, Evan",1,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Smith, Mike",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",6,200030
+RENO,Hutchinson Precinct 23 Exclave,President / Vice President,,Republican,"Trump, Donald J.",144,200030
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,independent,"Stein, Jill",12,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Basiago, Andrew D.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Castle, Darrell L",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Giordani, Rocky",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Hedges, James A",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Hoefling, Tom",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Kahn, Lynn",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"La Riva, Gloria",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Levinson, Michael S.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Maturen, Michael A",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"McMullin, Evan",8,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Moorehead, Monica G.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Perry, Darryl",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Schriner, Joe C",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Smith, Mike",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Sood, Ajay",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Sterling, Shawna",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Valdivia, Anthony J",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Democratic,"Clinton, Hillary Rodham",265,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Libertarian,"Johnson, Gary",40,200040
+RENO,Hutchinson Precinct 23 H104,President / Vice President,,Republican,"Trump, Donald J.",470,200040
+RENO,Hutchinson Precinct 33,President / Vice President,,independent,"Stein, Jill",1,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Basiago, Andrew D.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Castle, Darrell L",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Giordani, Rocky",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Hedges, James A",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Hoefling, Tom",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Kahn, Lynn",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"La Riva, Gloria",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Levinson, Michael S.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Maturen, Michael A",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"McMullin, Evan",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Moorehead, Monica G.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Perry, Darryl",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Schriner, Joe C",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Smith, Mike",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Sood, Ajay",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Sterling, Shawna",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Valdivia, Anthony J",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Libertarian,"Johnson, Gary",6,200050
+RENO,Hutchinson Precinct 33,President / Vice President,,Republican,"Trump, Donald J.",130,200050
+RENO,Hutchinson Precinct 34,President / Vice President,,independent,"Stein, Jill",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Basiago, Andrew D.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Castle, Darrell L",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Giordani, Rocky",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Hedges, James A",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Hoefling, Tom",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Kahn, Lynn",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"La Riva, Gloria",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Levinson, Michael S.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Maturen, Michael A",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"McMullin, Evan",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Moorehead, Monica G.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Perry, Darryl",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Schoenke, Marshall R.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Schriner, Joe C",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Smith, Mike",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Sood, Ajay",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Sterling, Shawna",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Valdivia, Anthony J",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Libertarian,"Johnson, Gary",3,200060
+RENO,Hutchinson Precinct 34,President / Vice President,,Republican,"Trump, Donald J.",47,200060
+RENO,Albion Township,United States House of Representatives,1,independent,"LaPolice, Alan",89,000010
+RENO,Albion Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+RENO,Albion Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000010
+RENO,Albion Township,United States House of Representatives,1,Republican,"Marshall, Roger",265,000010
+RENO,Arlington Township,United States House of Representatives,1,independent,"LaPolice, Alan",64,000020
+RENO,Arlington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+RENO,Arlington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",37,000020
+RENO,Arlington Township,United States House of Representatives,1,Republican,"Marshall, Roger",147,000020
+RENO,Bell Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000030
+RENO,Bell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000030
+RENO,Bell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000030
+RENO,Bell Township,United States House of Representatives,1,Republican,"Marshall, Roger",19,000030
+RENO,Castleton Township,United States House of Representatives,1,independent,"LaPolice, Alan",38,000040
+RENO,Castleton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+RENO,Castleton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000040
+RENO,Castleton Township,United States House of Representatives,1,Republican,"Marshall, Roger",98,000040
+RENO,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",41,000050
+RENO,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",7,000050
+RENO,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000050
+RENO,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",121,000050
+RENO,Enterprise Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000060
+RENO,Enterprise Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+RENO,Enterprise Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000060
+RENO,Enterprise Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000060
+RENO,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",146,000070
+RENO,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000070
+RENO,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",79,000070
+RENO,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",552,000070
+RENO,Grove Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000080
+RENO,Grove Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+RENO,Grove Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+RENO,Grove Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000080
+RENO,Haven Township,United States House of Representatives,1,independent,"LaPolice, Alan",148,000090
+RENO,Haven Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000090
+RENO,Haven Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",90,000090
+RENO,Haven Township,United States House of Representatives,1,Republican,"Marshall, Roger",492,000090
+RENO,Hayes Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000100
+RENO,Hayes Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+RENO,Hayes Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+RENO,Hayes Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000100
+RENO,Huntsville Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000110
+RENO,Huntsville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+RENO,Huntsville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000110
+RENO,Huntsville Township,United States House of Representatives,1,Republican,"Marshall, Roger",38,000110
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",72,000130
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",47,000130
+RENO,Hutchinson Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",98,000130
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",38,000140
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",37,000140
+RENO,Hutchinson Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",51,000140
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,independent,"LaPolice, Alan",199,000150
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",9,000150
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",67,000150
+RENO,Hutchinson Precinct 04,United States House of Representatives,1,Republican,"Marshall, Roger",549,000150
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",106,000160
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",66,000160
+RENO,Hutchinson Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",160,000160
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,independent,"LaPolice, Alan",96,000170
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000170
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,Libertarian,"Burt, Kerry",84,000170
+RENO,Hutchinson Precinct 06,United States House of Representatives,1,Republican,"Marshall, Roger",165,000170
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,independent,"LaPolice, Alan",119,000180
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000180
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",73,000180
+RENO,Hutchinson Precinct 07,United States House of Representatives,1,Republican,"Marshall, Roger",223,000180
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,independent,"LaPolice, Alan",168,000200
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000200
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,Libertarian,"Burt, Kerry",78,000200
+RENO,Hutchinson Precinct 09,United States House of Representatives,1,Republican,"Marshall, Roger",339,000200
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,independent,"LaPolice, Alan",165,000210
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000210
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",80,000210
+RENO,Hutchinson Precinct 10,United States House of Representatives,1,Republican,"Marshall, Roger",470,000210
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,independent,"LaPolice, Alan",179,000220
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,000220
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,Libertarian,"Burt, Kerry",48,000220
+RENO,Hutchinson Precinct 11,United States House of Representatives,1,Republican,"Marshall, Roger",458,000220
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,independent,"LaPolice, Alan",134,000230
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000230
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,000230
+RENO,Hutchinson Precinct 12,United States House of Representatives,1,Republican,"Marshall, Roger",242,000230
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,independent,"LaPolice, Alan",140,000240
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,000240
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,Libertarian,"Burt, Kerry",66,000240
+RENO,Hutchinson Precinct 13,United States House of Representatives,1,Republican,"Marshall, Roger",269,000240
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,independent,"LaPolice, Alan",118,000250
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000250
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,Libertarian,"Burt, Kerry",76,000250
+RENO,Hutchinson Precinct 14,United States House of Representatives,1,Republican,"Marshall, Roger",200,000250
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,independent,"LaPolice, Alan",50,000260
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,Libertarian,"Burt, Kerry",65,000260
+RENO,Hutchinson Precinct 15,United States House of Representatives,1,Republican,"Marshall, Roger",111,000260
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,independent,"LaPolice, Alan",157,000270
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000270
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,Libertarian,"Burt, Kerry",93,000270
+RENO,Hutchinson Precinct 16,United States House of Representatives,1,Republican,"Marshall, Roger",219,000270
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,independent,"LaPolice, Alan",144,000280
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000280
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,Libertarian,"Burt, Kerry",60,000280
+RENO,Hutchinson Precinct 17,United States House of Representatives,1,Republican,"Marshall, Roger",318,000280
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,independent,"LaPolice, Alan",58,000290
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,Libertarian,"Burt, Kerry",42,000290
+RENO,Hutchinson Precinct 18,United States House of Representatives,1,Republican,"Marshall, Roger",89,000290
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,independent,"LaPolice, Alan",63,000300
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000300
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,Libertarian,"Burt, Kerry",47,000300
+RENO,Hutchinson Precinct 19,United States House of Representatives,1,Republican,"Marshall, Roger",107,000300
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,independent,"LaPolice, Alan",83,000310
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,Libertarian,"Burt, Kerry",59,000310
+RENO,Hutchinson Precinct 20,United States House of Representatives,1,Republican,"Marshall, Roger",202,000310
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,independent,"LaPolice, Alan",77,000320
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000320
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,Libertarian,"Burt, Kerry",70,000320
+RENO,Hutchinson Precinct 21,United States House of Representatives,1,Republican,"Marshall, Roger",145,000320
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,independent,"LaPolice, Alan",189,000330
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000330
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,Libertarian,"Burt, Kerry",71,000330
+RENO,Hutchinson Precinct 22,United States House of Representatives,1,Republican,"Marshall, Roger",389,000330
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,independent,"LaPolice, Alan",136,000350
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000350
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,Libertarian,"Burt, Kerry",80,000350
+RENO,Hutchinson Precinct 24,United States House of Representatives,1,Republican,"Marshall, Roger",333,000350
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,independent,"LaPolice, Alan",74,000360
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000360
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,Libertarian,"Burt, Kerry",60,000360
+RENO,Hutchinson Precinct 25,United States House of Representatives,1,Republican,"Marshall, Roger",144,000360
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,independent,"LaPolice, Alan",57,00037A
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00037A
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,00037A
+RENO,Hutchinson Precinct 26,United States House of Representatives,1,Republican,"Marshall, Roger",103,00037A
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",4,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",11,00037B
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,independent,"LaPolice, Alan",104,000380
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000380
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,000380
+RENO,Hutchinson Precinct 27,United States House of Representatives,1,Republican,"Marshall, Roger",264,000380
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,independent,"LaPolice, Alan",230,00039A
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,00039A
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,Libertarian,"Burt, Kerry",71,00039A
+RENO,Hutchinson Precinct 28,United States House of Representatives,1,Republican,"Marshall, Roger",552,00039A
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",70,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",306,00039B
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,independent,"LaPolice, Alan",119,000400
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000400
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,Libertarian,"Burt, Kerry",50,000400
+RENO,Hutchinson Precinct 29,United States House of Representatives,1,Republican,"Marshall, Roger",221,000400
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,independent,"LaPolice, Alan",57,000410
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000410
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,Libertarian,"Burt, Kerry",39,000410
+RENO,Hutchinson Precinct 30,United States House of Representatives,1,Republican,"Marshall, Roger",115,000410
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,independent,"LaPolice, Alan",100,000420
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000420
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,000420
+RENO,Hutchinson Precinct 31,United States House of Representatives,1,Republican,"Marshall, Roger",196,000420
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,independent,"LaPolice, Alan",24,000430
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000430
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000430
+RENO,Hutchinson Precinct 32,United States House of Representatives,1,Republican,"Marshall, Roger",85,000430
+RENO,Langdon Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000440
+RENO,Langdon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000440
+RENO,Langdon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000440
+RENO,Langdon Township,United States House of Representatives,1,Republican,"Marshall, Roger",47,000440
+RENO,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000450
+RENO,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000450
+RENO,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000450
+RENO,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",146,000450
+RENO,Little River Township,United States House of Representatives,1,independent,"LaPolice, Alan",168,000460
+RENO,Little River Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",7,000460
+RENO,Little River Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",72,000460
+RENO,Little River Township,United States House of Representatives,1,Republican,"Marshall, Roger",663,000460
+RENO,Loda Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000470
+RENO,Loda Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000470
+RENO,Loda Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000470
+RENO,Loda Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000470
+RENO,Medford Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000480
+RENO,Medford Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000480
+RENO,Medford Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000480
+RENO,Medford Township,United States House of Representatives,1,Republican,"Marshall, Roger",59,000480
+RENO,Medora Township,United States House of Representatives,1,independent,"LaPolice, Alan",201,000490
+RENO,Medora Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",8,000490
+RENO,Medora Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",90,000490
+RENO,Medora Township,United States House of Representatives,1,Republican,"Marshall, Roger",542,000490
+RENO,Miami Township,United States House of Representatives,1,independent,"LaPolice, Alan",28,000500
+RENO,Miami Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000500
+RENO,Miami Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000500
+RENO,Miami Township,United States House of Representatives,1,Republican,"Marshall, Roger",94,000500
+RENO,Nickerson Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",35,000510
+RENO,Nickerson Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000510
+RENO,Nickerson Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000510
+RENO,Nickerson Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",100,000510
+RENO,Nickerson Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",19,000520
+RENO,Nickerson Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000520
+RENO,Nickerson Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000520
+RENO,Nickerson Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",57,000520
+RENO,Nickerson Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",20,000530
+RENO,Nickerson Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000530
+RENO,Nickerson Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000530
+RENO,Nickerson Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",67,000530
+RENO,Ninnescah Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000540
+RENO,Ninnescah Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000540
+RENO,Ninnescah Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000540
+RENO,Ninnescah Township,United States House of Representatives,1,Republican,"Marshall, Roger",58,000540
+RENO,North Clay Township,United States House of Representatives,1,independent,"LaPolice, Alan",94,00055A
+RENO,North Clay Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,00055A
+RENO,North Clay Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",36,00055A
+RENO,North Clay Township,United States House of Representatives,1,Republican,"Marshall, Roger",342,00055A
+RENO,North Reno Township,United States House of Representatives,1,independent,"LaPolice, Alan",166,000560
+RENO,North Reno Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000560
+RENO,North Reno Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",81,000560
+RENO,North Reno Township,United States House of Representatives,1,Republican,"Marshall, Roger",427,000560
+RENO,Plevna Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000570
+RENO,Plevna Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000570
+RENO,Plevna Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000570
+RENO,Plevna Township,United States House of Representatives,1,Republican,"Marshall, Roger",85,000570
+RENO,Roscoe Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000580
+RENO,Roscoe Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000580
+RENO,Roscoe Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000580
+RENO,Roscoe Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000580
+RENO,Salt Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",34,000590
+RENO,Salt Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000590
+RENO,Salt Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,000590
+RENO,Salt Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",118,000590
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",60,000610
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000610
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",45,000610
+RENO,South Hutchinson Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",128,000610
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",97,000620
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000620
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",70,000620
+RENO,South Hutchinson Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",265,000620
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",84,000630
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000630
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",26,000630
+RENO,South Hutchinson Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",196,000630
+RENO,South Reno Township,United States House of Representatives,1,independent,"LaPolice, Alan",32,000640
+RENO,South Reno Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000640
+RENO,South Reno Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000640
+RENO,South Reno Township,United States House of Representatives,1,Republican,"Marshall, Roger",78,000640
+RENO,Sumner Township,United States House of Representatives,1,independent,"LaPolice, Alan",54,000650
+RENO,Sumner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000650
+RENO,Sumner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000650
+RENO,Sumner Township,United States House of Representatives,1,Republican,"Marshall, Roger",207,000650
+RENO,Sylvia Township,United States House of Representatives,1,independent,"LaPolice, Alan",25,000660
+RENO,Sylvia Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000660
+RENO,Sylvia Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000660
+RENO,Sylvia Township,United States House of Representatives,1,Republican,"Marshall, Roger",79,000660
+RENO,Troy Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000670
+RENO,Troy Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000670
+RENO,Troy Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000670
+RENO,Troy Township,United States House of Representatives,1,Republican,"Marshall, Roger",42,000670
+RENO,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",83,000680
+RENO,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000680
+RENO,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,000680
+RENO,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",292,000680
+RENO,Walnut Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000690
+RENO,Walnut Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000690
+RENO,Walnut Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000690
+RENO,Walnut Township,United States House of Representatives,1,Republican,"Marshall, Roger",49,000690
+RENO,Westminister Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000700
+RENO,Westminister Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000700
+RENO,Westminister Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000700
+RENO,Westminister Township,United States House of Representatives,1,Republican,"Marshall, Roger",69,000700
+RENO,Yoder Township,United States House of Representatives,1,independent,"LaPolice, Alan",66,000710
+RENO,Yoder Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000710
+RENO,Yoder Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000710
+RENO,Yoder Township,United States House of Representatives,1,Republican,"Marshall, Roger",149,000710
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,independent,"LaPolice, Alan",66,120020
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,Libertarian,"Burt, Kerry",54,120020
+RENO,Hutchinson Precinct 01 H102,United States House of Representatives,1,Republican,"Marshall, Roger",88,120020
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,independent,"LaPolice, Alan",2,120030
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,120030
+RENO,Hutchinson Precinct 01 H114,United States House of Representatives,1,Republican,"Marshall, Roger",7,120030
+RENO,South Clay Township H101,United States House of Representatives,1,independent,"LaPolice, Alan",118,120040
+RENO,South Clay Township H101,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+RENO,South Clay Township H101,United States House of Representatives,1,Libertarian,"Burt, Kerry",63,120040
+RENO,South Clay Township H101,United States House of Representatives,1,Republican,"Marshall, Roger",333,120040
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,independent,"LaPolice, Alan",1,12005A
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,12005A
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,12005A
+RENO,South Clay Township Clay H102 A,United States House of Representatives,1,Republican,"Marshall, Roger",2,12005A
+RENO,Hutchinson Precinct 34 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",1,120060
+RENO,Hutchinson Precinct 36,United States House of Representatives,1,independent,"LaPolice, Alan",0,120070
+RENO,Hutchinson Precinct 36,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120070
+RENO,Hutchinson Precinct 36,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120070
+RENO,Hutchinson Precinct 36,United States House of Representatives,1,Republican,"Marshall, Roger",0,120070
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,independent,"LaPolice, Alan",63,200010
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,200010
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,200010
+RENO,Hutchinson Precinct 08 H101,United States House of Representatives,1,Republican,"Marshall, Roger",115,200010
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,independent,"LaPolice, Alan",45,200020
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,200020
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,200020
+RENO,Hutchinson Precinct 35,United States House of Representatives,1,Republican,"Marshall, Roger",120,200020
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",50,200030
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,200030
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,200030
+RENO,Hutchinson Precinct 23 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",138,200030
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,independent,"LaPolice, Alan",200,200040
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,200040
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,Libertarian,"Burt, Kerry",97,200040
+RENO,Hutchinson Precinct 23 H104,United States House of Representatives,1,Republican,"Marshall, Roger",485,200040
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,independent,"LaPolice, Alan",45,200050
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,200050
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,200050
+RENO,Hutchinson Precinct 33,United States House of Representatives,1,Republican,"Marshall, Roger",134,200050
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,independent,"LaPolice, Alan",14,200060
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,200060
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,200060
+RENO,Hutchinson Precinct 34,United States House of Representatives,1,Republican,"Marshall, Roger",37,200060
+RENO,Albion Township,United States Senate,,write - in,"Smith, DJ",0,000010
+RENO,Albion Township,United States Senate,,Democratic,"Wiesner, Patrick",56,000010
+RENO,Albion Township,United States Senate,,Libertarian,"Garrard, Robert D.",23,000010
+RENO,Albion Township,United States Senate,,Republican,"Moran, Jerry",311,000010
+RENO,Arlington Township,United States Senate,,write - in,"Smith, DJ",0,000020
+RENO,Arlington Township,United States Senate,,Democratic,"Wiesner, Patrick",58,000020
+RENO,Arlington Township,United States Senate,,Libertarian,"Garrard, Robert D.",25,000020
+RENO,Arlington Township,United States Senate,,Republican,"Moran, Jerry",169,000020
+RENO,Bell Township,United States Senate,,write - in,"Smith, DJ",0,000030
+RENO,Bell Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000030
+RENO,Bell Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+RENO,Bell Township,United States Senate,,Republican,"Moran, Jerry",26,000030
+RENO,Castleton Township,United States Senate,,write - in,"Smith, DJ",0,000040
+RENO,Castleton Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000040
+RENO,Castleton Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000040
+RENO,Castleton Township,United States Senate,,Republican,"Moran, Jerry",124,000040
+RENO,Center Township,United States Senate,,write - in,"Smith, DJ",0,000050
+RENO,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000050
+RENO,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000050
+RENO,Center Township,United States Senate,,Republican,"Moran, Jerry",144,000050
+RENO,Enterprise Township,United States Senate,,write - in,"Smith, DJ",0,000060
+RENO,Enterprise Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000060
+RENO,Enterprise Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+RENO,Enterprise Township,United States Senate,,Republican,"Moran, Jerry",59,000060
+RENO,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000070
+RENO,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",99,000070
+RENO,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",51,000070
+RENO,Grant Township,United States Senate,,Republican,"Moran, Jerry",631,000070
+RENO,Grove Township,United States Senate,,write - in,"Smith, DJ",0,000080
+RENO,Grove Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000080
+RENO,Grove Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+RENO,Grove Township,United States Senate,,Republican,"Moran, Jerry",27,000080
+RENO,Haven Township,United States Senate,,write - in,"Smith, DJ",0,000090
+RENO,Haven Township,United States Senate,,Democratic,"Wiesner, Patrick",146,000090
+RENO,Haven Township,United States Senate,,Libertarian,"Garrard, Robert D.",36,000090
+RENO,Haven Township,United States Senate,,Republican,"Moran, Jerry",564,000090
+RENO,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000100
+RENO,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+RENO,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000100
+RENO,Hayes Township,United States Senate,,Republican,"Moran, Jerry",28,000100
+RENO,Huntsville Township,United States Senate,,write - in,"Smith, DJ",0,000110
+RENO,Huntsville Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000110
+RENO,Huntsville Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000110
+RENO,Huntsville Township,United States Senate,,Republican,"Moran, Jerry",48,000110
+RENO,Hutchinson Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000130
+RENO,Hutchinson Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",86,000130
+RENO,Hutchinson Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",22,000130
+RENO,Hutchinson Precinct 02,United States Senate,,Republican,"Moran, Jerry",110,000130
+RENO,Hutchinson Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000140
+RENO,Hutchinson Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",59,000140
+RENO,Hutchinson Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",16,000140
+RENO,Hutchinson Precinct 03,United States Senate,,Republican,"Moran, Jerry",58,000140
+RENO,Hutchinson Precinct 04,United States Senate,,write - in,"Smith, DJ",0,000150
+RENO,Hutchinson Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",144,000150
+RENO,Hutchinson Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",34,000150
+RENO,Hutchinson Precinct 04,United States Senate,,Republican,"Moran, Jerry",647,000150
+RENO,Hutchinson Precinct 05,United States Senate,,write - in,"Smith, DJ",0,000160
+RENO,Hutchinson Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",108,000160
+RENO,Hutchinson Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",36,000160
+RENO,Hutchinson Precinct 05,United States Senate,,Republican,"Moran, Jerry",193,000160
+RENO,Hutchinson Precinct 06,United States Senate,,write - in,"Smith, DJ",0,000170
+RENO,Hutchinson Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",126,000170
+RENO,Hutchinson Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",30,000170
+RENO,Hutchinson Precinct 06,United States Senate,,Republican,"Moran, Jerry",196,000170
+RENO,Hutchinson Precinct 07,United States Senate,,write - in,"Smith, DJ",0,000180
+RENO,Hutchinson Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",151,000180
+RENO,Hutchinson Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",26,000180
+RENO,Hutchinson Precinct 07,United States Senate,,Republican,"Moran, Jerry",252,000180
+RENO,Hutchinson Precinct 09,United States Senate,,write - in,"Smith, DJ",0,000200
+RENO,Hutchinson Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",157,000200
+RENO,Hutchinson Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",43,000200
+RENO,Hutchinson Precinct 09,United States Senate,,Republican,"Moran, Jerry",396,000200
+RENO,Hutchinson Precinct 10,United States Senate,,write - in,"Smith, DJ",0,000210
+RENO,Hutchinson Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",140,000210
+RENO,Hutchinson Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",31,000210
+RENO,Hutchinson Precinct 10,United States Senate,,Republican,"Moran, Jerry",554,000210
+RENO,Hutchinson Precinct 11,United States Senate,,write - in,"Smith, DJ",0,000220
+RENO,Hutchinson Precinct 11,United States Senate,,Democratic,"Wiesner, Patrick",152,000220
+RENO,Hutchinson Precinct 11,United States Senate,,Libertarian,"Garrard, Robert D.",31,000220
+RENO,Hutchinson Precinct 11,United States Senate,,Republican,"Moran, Jerry",511,000220
+RENO,Hutchinson Precinct 12,United States Senate,,write - in,"Smith, DJ",0,000230
+RENO,Hutchinson Precinct 12,United States Senate,,Democratic,"Wiesner, Patrick",116,000230
+RENO,Hutchinson Precinct 12,United States Senate,,Libertarian,"Garrard, Robert D.",21,000230
+RENO,Hutchinson Precinct 12,United States Senate,,Republican,"Moran, Jerry",293,000230
+RENO,Hutchinson Precinct 13,United States Senate,,write - in,"Smith, DJ",0,000240
+RENO,Hutchinson Precinct 13,United States Senate,,Democratic,"Wiesner, Patrick",145,000240
+RENO,Hutchinson Precinct 13,United States Senate,,Libertarian,"Garrard, Robert D.",32,000240
+RENO,Hutchinson Precinct 13,United States Senate,,Republican,"Moran, Jerry",310,000240
+RENO,Hutchinson Precinct 14,United States Senate,,write - in,"Smith, DJ",0,000250
+RENO,Hutchinson Precinct 14,United States Senate,,Democratic,"Wiesner, Patrick",138,000250
+RENO,Hutchinson Precinct 14,United States Senate,,Libertarian,"Garrard, Robert D.",26,000250
+RENO,Hutchinson Precinct 14,United States Senate,,Republican,"Moran, Jerry",246,000250
+RENO,Hutchinson Precinct 15,United States Senate,,write - in,"Smith, DJ",0,000260
+RENO,Hutchinson Precinct 15,United States Senate,,Democratic,"Wiesner, Patrick",87,000260
+RENO,Hutchinson Precinct 15,United States Senate,,Libertarian,"Garrard, Robert D.",26,000260
+RENO,Hutchinson Precinct 15,United States Senate,,Republican,"Moran, Jerry",119,000260
+RENO,Hutchinson Precinct 16,United States Senate,,write - in,"Smith, DJ",0,000270
+RENO,Hutchinson Precinct 16,United States Senate,,Democratic,"Wiesner, Patrick",189,000270
+RENO,Hutchinson Precinct 16,United States Senate,,Libertarian,"Garrard, Robert D.",40,000270
+RENO,Hutchinson Precinct 16,United States Senate,,Republican,"Moran, Jerry",247,000270
+RENO,Hutchinson Precinct 17,United States Senate,,write - in,"Smith, DJ",0,000280
+RENO,Hutchinson Precinct 17,United States Senate,,Democratic,"Wiesner, Patrick",137,000280
+RENO,Hutchinson Precinct 17,United States Senate,,Libertarian,"Garrard, Robert D.",33,000280
+RENO,Hutchinson Precinct 17,United States Senate,,Republican,"Moran, Jerry",367,000280
+RENO,Hutchinson Precinct 18,United States Senate,,write - in,"Smith, DJ",0,000290
+RENO,Hutchinson Precinct 18,United States Senate,,Democratic,"Wiesner, Patrick",62,000290
+RENO,Hutchinson Precinct 18,United States Senate,,Libertarian,"Garrard, Robert D.",22,000290
+RENO,Hutchinson Precinct 18,United States Senate,,Republican,"Moran, Jerry",112,000290
+RENO,Hutchinson Precinct 19,United States Senate,,write - in,"Smith, DJ",0,000300
+RENO,Hutchinson Precinct 19,United States Senate,,Democratic,"Wiesner, Patrick",75,000300
+RENO,Hutchinson Precinct 19,United States Senate,,Libertarian,"Garrard, Robert D.",25,000300
+RENO,Hutchinson Precinct 19,United States Senate,,Republican,"Moran, Jerry",119,000300
+RENO,Hutchinson Precinct 20,United States Senate,,write - in,"Smith, DJ",0,000310
+RENO,Hutchinson Precinct 20,United States Senate,,Democratic,"Wiesner, Patrick",101,000310
+RENO,Hutchinson Precinct 20,United States Senate,,Libertarian,"Garrard, Robert D.",27,000310
+RENO,Hutchinson Precinct 20,United States Senate,,Republican,"Moran, Jerry",224,000310
+RENO,Hutchinson Precinct 21,United States Senate,,write - in,"Smith, DJ",0,000320
+RENO,Hutchinson Precinct 21,United States Senate,,Democratic,"Wiesner, Patrick",104,000320
+RENO,Hutchinson Precinct 21,United States Senate,,Libertarian,"Garrard, Robert D.",19,000320
+RENO,Hutchinson Precinct 21,United States Senate,,Republican,"Moran, Jerry",177,000320
+RENO,Hutchinson Precinct 22,United States Senate,,write - in,"Smith, DJ",0,000330
+RENO,Hutchinson Precinct 22,United States Senate,,Democratic,"Wiesner, Patrick",167,000330
+RENO,Hutchinson Precinct 22,United States Senate,,Libertarian,"Garrard, Robert D.",45,000330
+RENO,Hutchinson Precinct 22,United States Senate,,Republican,"Moran, Jerry",444,000330
+RENO,Hutchinson Precinct 24,United States Senate,,write - in,"Smith, DJ",0,000350
+RENO,Hutchinson Precinct 24,United States Senate,,Democratic,"Wiesner, Patrick",142,000350
+RENO,Hutchinson Precinct 24,United States Senate,,Libertarian,"Garrard, Robert D.",32,000350
+RENO,Hutchinson Precinct 24,United States Senate,,Republican,"Moran, Jerry",391,000350
+RENO,Hutchinson Precinct 25,United States Senate,,write - in,"Smith, DJ",0,000360
+RENO,Hutchinson Precinct 25,United States Senate,,Democratic,"Wiesner, Patrick",91,000360
+RENO,Hutchinson Precinct 25,United States Senate,,Libertarian,"Garrard, Robert D.",42,000360
+RENO,Hutchinson Precinct 25,United States Senate,,Republican,"Moran, Jerry",147,000360
+RENO,Hutchinson Precinct 26,United States Senate,,write - in,"Smith, DJ",0,00037A
+RENO,Hutchinson Precinct 26,United States Senate,,Democratic,"Wiesner, Patrick",59,00037A
+RENO,Hutchinson Precinct 26,United States Senate,,Libertarian,"Garrard, Robert D.",18,00037A
+RENO,Hutchinson Precinct 26,United States Senate,,Republican,"Moran, Jerry",123,00037A
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,write - in,"Smith, DJ",0,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",3,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",2,00037B
+RENO,Hutchinson Precinct 26 Exclave,United States Senate,,Republican,"Moran, Jerry",17,00037B
+RENO,Hutchinson Precinct 27,United States Senate,,write - in,"Smith, DJ",0,000380
+RENO,Hutchinson Precinct 27,United States Senate,,Democratic,"Wiesner, Patrick",95,000380
+RENO,Hutchinson Precinct 27,United States Senate,,Libertarian,"Garrard, Robert D.",25,000380
+RENO,Hutchinson Precinct 27,United States Senate,,Republican,"Moran, Jerry",302,000380
+RENO,Hutchinson Precinct 28,United States Senate,,write - in,"Smith, DJ",0,00039A
+RENO,Hutchinson Precinct 28,United States Senate,,Democratic,"Wiesner, Patrick",187,00039A
+RENO,Hutchinson Precinct 28,United States Senate,,Libertarian,"Garrard, Robert D.",39,00039A
+RENO,Hutchinson Precinct 28,United States Senate,,Republican,"Moran, Jerry",647,00039A
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,write - in,"Smith, DJ",0,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",55,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",16,00039B
+RENO,Hutchinson Precinct 28 Exclave,United States Senate,,Republican,"Moran, Jerry",340,00039B
+RENO,Hutchinson Precinct 29,United States Senate,,write - in,"Smith, DJ",0,000400
+RENO,Hutchinson Precinct 29,United States Senate,,Democratic,"Wiesner, Patrick",114,000400
+RENO,Hutchinson Precinct 29,United States Senate,,Libertarian,"Garrard, Robert D.",25,000400
+RENO,Hutchinson Precinct 29,United States Senate,,Republican,"Moran, Jerry",260,000400
+RENO,Hutchinson Precinct 30,United States Senate,,write - in,"Smith, DJ",0,000410
+RENO,Hutchinson Precinct 30,United States Senate,,Democratic,"Wiesner, Patrick",65,000410
+RENO,Hutchinson Precinct 30,United States Senate,,Libertarian,"Garrard, Robert D.",26,000410
+RENO,Hutchinson Precinct 30,United States Senate,,Republican,"Moran, Jerry",123,000410
+RENO,Hutchinson Precinct 31,United States Senate,,write - in,"Smith, DJ",0,000420
+RENO,Hutchinson Precinct 31,United States Senate,,Democratic,"Wiesner, Patrick",112,000420
+RENO,Hutchinson Precinct 31,United States Senate,,Libertarian,"Garrard, Robert D.",19,000420
+RENO,Hutchinson Precinct 31,United States Senate,,Republican,"Moran, Jerry",217,000420
+RENO,Hutchinson Precinct 32,United States Senate,,write - in,"Smith, DJ",0,000430
+RENO,Hutchinson Precinct 32,United States Senate,,Democratic,"Wiesner, Patrick",22,000430
+RENO,Hutchinson Precinct 32,United States Senate,,Libertarian,"Garrard, Robert D.",5,000430
+RENO,Hutchinson Precinct 32,United States Senate,,Republican,"Moran, Jerry",98,000430
+RENO,Langdon Township,United States Senate,,write - in,"Smith, DJ",0,000440
+RENO,Langdon Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000440
+RENO,Langdon Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000440
+RENO,Langdon Township,United States Senate,,Republican,"Moran, Jerry",46,000440
+RENO,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000450
+RENO,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000450
+RENO,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000450
+RENO,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",162,000450
+RENO,Little River Township,United States Senate,,write - in,"Smith, DJ",0,000460
+RENO,Little River Township,United States Senate,,Democratic,"Wiesner, Patrick",129,000460
+RENO,Little River Township,United States Senate,,Libertarian,"Garrard, Robert D.",33,000460
+RENO,Little River Township,United States Senate,,Republican,"Moran, Jerry",755,000460
+RENO,Loda Township,United States Senate,,write - in,"Smith, DJ",0,000470
+RENO,Loda Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000470
+RENO,Loda Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000470
+RENO,Loda Township,United States Senate,,Republican,"Moran, Jerry",34,000470
+RENO,Medford Township,United States Senate,,write - in,"Smith, DJ",0,000480
+RENO,Medford Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000480
+RENO,Medford Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000480
+RENO,Medford Township,United States Senate,,Republican,"Moran, Jerry",65,000480
+RENO,Medora Township,United States Senate,,write - in,"Smith, DJ",0,000490
+RENO,Medora Township,United States Senate,,Democratic,"Wiesner, Patrick",149,000490
+RENO,Medora Township,United States Senate,,Libertarian,"Garrard, Robert D.",63,000490
+RENO,Medora Township,United States Senate,,Republican,"Moran, Jerry",640,000490
+RENO,Miami Township,United States Senate,,write - in,"Smith, DJ",0,000500
+RENO,Miami Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000500
+RENO,Miami Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000500
+RENO,Miami Township,United States Senate,,Republican,"Moran, Jerry",106,000500
+RENO,Nickerson Ward 1,United States Senate,,write - in,"Smith, DJ",0,000510
+RENO,Nickerson Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",35,000510
+RENO,Nickerson Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000510
+RENO,Nickerson Ward 1,United States Senate,,Republican,"Moran, Jerry",119,000510
+RENO,Nickerson Ward 2,United States Senate,,write - in,"Smith, DJ",0,000520
+RENO,Nickerson Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",16,000520
+RENO,Nickerson Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,000520
+RENO,Nickerson Ward 2,United States Senate,,Republican,"Moran, Jerry",64,000520
+RENO,Nickerson Ward 3,United States Senate,,write - in,"Smith, DJ",0,000530
+RENO,Nickerson Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",21,000530
+RENO,Nickerson Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",13,000530
+RENO,Nickerson Ward 3,United States Senate,,Republican,"Moran, Jerry",74,000530
+RENO,Ninnescah Township,United States Senate,,write - in,"Smith, DJ",0,000540
+RENO,Ninnescah Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000540
+RENO,Ninnescah Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000540
+RENO,Ninnescah Township,United States Senate,,Republican,"Moran, Jerry",73,000540
+RENO,North Clay Township,United States Senate,,write - in,"Smith, DJ",0,00055A
+RENO,North Clay Township,United States Senate,,Democratic,"Wiesner, Patrick",69,00055A
+RENO,North Clay Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,00055A
+RENO,North Clay Township,United States Senate,,Republican,"Moran, Jerry",391,00055A
+RENO,North Reno Township,United States Senate,,write - in,"Smith, DJ",0,000560
+RENO,North Reno Township,United States Senate,,Democratic,"Wiesner, Patrick",138,000560
+RENO,North Reno Township,United States Senate,,Libertarian,"Garrard, Robert D.",42,000560
+RENO,North Reno Township,United States Senate,,Republican,"Moran, Jerry",505,000560
+RENO,Plevna Township,United States Senate,,write - in,"Smith, DJ",0,000570
+RENO,Plevna Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000570
+RENO,Plevna Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000570
+RENO,Plevna Township,United States Senate,,Republican,"Moran, Jerry",96,000570
+RENO,Roscoe Township,United States Senate,,write - in,"Smith, DJ",0,000580
+RENO,Roscoe Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000580
+RENO,Roscoe Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000580
+RENO,Roscoe Township,United States Senate,,Republican,"Moran, Jerry",47,000580
+RENO,Salt Creek Township,United States Senate,,write - in,"Smith, DJ",0,000590
+RENO,Salt Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000590
+RENO,Salt Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000590
+RENO,Salt Creek Township,United States Senate,,Republican,"Moran, Jerry",142,000590
+RENO,South Hutchinson Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000610
+RENO,South Hutchinson Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",58,000610
+RENO,South Hutchinson Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",17,000610
+RENO,South Hutchinson Precinct 1,United States Senate,,Republican,"Moran, Jerry",156,000610
+RENO,South Hutchinson Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000620
+RENO,South Hutchinson Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",87,000620
+RENO,South Hutchinson Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",33,000620
+RENO,South Hutchinson Precinct 2,United States Senate,,Republican,"Moran, Jerry",317,000620
+RENO,South Hutchinson Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000630
+RENO,South Hutchinson Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",64,000630
+RENO,South Hutchinson Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",14,000630
+RENO,South Hutchinson Precinct 3,United States Senate,,Republican,"Moran, Jerry",239,000630
+RENO,South Reno Township,United States Senate,,write - in,"Smith, DJ",0,000640
+RENO,South Reno Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000640
+RENO,South Reno Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000640
+RENO,South Reno Township,United States Senate,,Republican,"Moran, Jerry",104,000640
+RENO,Sumner Township,United States Senate,,write - in,"Smith, DJ",0,000650
+RENO,Sumner Township,United States Senate,,Democratic,"Wiesner, Patrick",49,000650
+RENO,Sumner Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000650
+RENO,Sumner Township,United States Senate,,Republican,"Moran, Jerry",223,000650
+RENO,Sylvia Township,United States Senate,,write - in,"Smith, DJ",0,000660
+RENO,Sylvia Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000660
+RENO,Sylvia Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000660
+RENO,Sylvia Township,United States Senate,,Republican,"Moran, Jerry",95,000660
+RENO,Troy Township,United States Senate,,write - in,"Smith, DJ",0,000670
+RENO,Troy Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000670
+RENO,Troy Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000670
+RENO,Troy Township,United States Senate,,Republican,"Moran, Jerry",44,000670
+RENO,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000680
+RENO,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",71,000680
+RENO,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,000680
+RENO,Valley Township,United States Senate,,Republican,"Moran, Jerry",326,000680
+RENO,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000690
+RENO,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000690
+RENO,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000690
+RENO,Walnut Township,United States Senate,,Republican,"Moran, Jerry",57,000690
+RENO,Westminister Township,United States Senate,,write - in,"Smith, DJ",0,000700
+RENO,Westminister Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000700
+RENO,Westminister Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000700
+RENO,Westminister Township,United States Senate,,Republican,"Moran, Jerry",77,000700
+RENO,Yoder Township,United States Senate,,write - in,"Smith, DJ",0,000710
+RENO,Yoder Township,United States Senate,,Democratic,"Wiesner, Patrick",40,000710
+RENO,Yoder Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000710
+RENO,Yoder Township,United States Senate,,Republican,"Moran, Jerry",202,000710
+RENO,Hutchinson Precinct 01 H102,United States Senate,,write - in,"Smith, DJ",0,120020
+RENO,Hutchinson Precinct 01 H102,United States Senate,,Democratic,"Wiesner, Patrick",76,120020
+RENO,Hutchinson Precinct 01 H102,United States Senate,,Libertarian,"Garrard, Robert D.",32,120020
+RENO,Hutchinson Precinct 01 H102,United States Senate,,Republican,"Moran, Jerry",103,120020
+RENO,Hutchinson Precinct 01 H114,United States Senate,,write - in,"Smith, DJ",0,120030
+RENO,Hutchinson Precinct 01 H114,United States Senate,,Democratic,"Wiesner, Patrick",5,120030
+RENO,Hutchinson Precinct 01 H114,United States Senate,,Libertarian,"Garrard, Robert D.",1,120030
+RENO,Hutchinson Precinct 01 H114,United States Senate,,Republican,"Moran, Jerry",9,120030
+RENO,South Clay Township H101,United States Senate,,write - in,"Smith, DJ",0,120040
+RENO,South Clay Township H101,United States Senate,,Democratic,"Wiesner, Patrick",94,120040
+RENO,South Clay Township H101,United States Senate,,Libertarian,"Garrard, Robert D.",30,120040
+RENO,South Clay Township H101,United States Senate,,Republican,"Moran, Jerry",396,120040
+RENO,South Clay Township Clay H102 A,United States Senate,,write - in,"Smith, DJ",0,12005A
+RENO,South Clay Township Clay H102 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12005A
+RENO,South Clay Township Clay H102 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12005A
+RENO,South Clay Township Clay H102 A,United States Senate,,Republican,"Moran, Jerry",3,12005A
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,write - in,"Smith, DJ",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,120060
+RENO,Hutchinson Precinct 34 Exclave,United States Senate,,Republican,"Moran, Jerry",1,120060
+RENO,Hutchinson Precinct 36,United States Senate,,write - in,"Smith, DJ",0,120070
+RENO,Hutchinson Precinct 36,United States Senate,,Democratic,"Wiesner, Patrick",0,120070
+RENO,Hutchinson Precinct 36,United States Senate,,Libertarian,"Garrard, Robert D.",0,120070
+RENO,Hutchinson Precinct 36,United States Senate,,Republican,"Moran, Jerry",0,120070
+RENO,Hutchinson Precinct 08 H101,United States Senate,,write - in,"Smith, DJ",0,200010
+RENO,Hutchinson Precinct 08 H101,United States Senate,,Democratic,"Wiesner, Patrick",63,200010
+RENO,Hutchinson Precinct 08 H101,United States Senate,,Libertarian,"Garrard, Robert D.",15,200010
+RENO,Hutchinson Precinct 08 H101,United States Senate,,Republican,"Moran, Jerry",135,200010
+RENO,Hutchinson Precinct 35,United States Senate,,write - in,"Smith, DJ",0,200020
+RENO,Hutchinson Precinct 35,United States Senate,,Democratic,"Wiesner, Patrick",58,200020
+RENO,Hutchinson Precinct 35,United States Senate,,Libertarian,"Garrard, Robert D.",9,200020
+RENO,Hutchinson Precinct 35,United States Senate,,Republican,"Moran, Jerry",136,200020
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,write - in,"Smith, DJ",0,200030
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",35,200030
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",13,200030
+RENO,Hutchinson Precinct 23 Exclave,United States Senate,,Republican,"Moran, Jerry",155,200030
+RENO,Hutchinson Precinct 23 H104,United States Senate,,write - in,"Smith, DJ",0,200040
+RENO,Hutchinson Precinct 23 H104,United States Senate,,Democratic,"Wiesner, Patrick",203,200040
+RENO,Hutchinson Precinct 23 H104,United States Senate,,Libertarian,"Garrard, Robert D.",36,200040
+RENO,Hutchinson Precinct 23 H104,United States Senate,,Republican,"Moran, Jerry",557,200040
+RENO,Hutchinson Precinct 33,United States Senate,,write - in,"Smith, DJ",0,200050
+RENO,Hutchinson Precinct 33,United States Senate,,Democratic,"Wiesner, Patrick",39,200050
+RENO,Hutchinson Precinct 33,United States Senate,,Libertarian,"Garrard, Robert D.",9,200050
+RENO,Hutchinson Precinct 33,United States Senate,,Republican,"Moran, Jerry",148,200050
+RENO,Hutchinson Precinct 34,United States Senate,,write - in,"Smith, DJ",0,200060
+RENO,Hutchinson Precinct 34,United States Senate,,Democratic,"Wiesner, Patrick",16,200060
+RENO,Hutchinson Precinct 34,United States Senate,,Libertarian,"Garrard, Robert D.",3,200060
+RENO,Hutchinson Precinct 34,United States Senate,,Republican,"Moran, Jerry",45,200060

--- a/2016/20161108__ks__general__republic__precinct.csv
+++ b/2016/20161108__ks__general__republic__precinct.csv
@@ -1,323 +1,963 @@
-county,precinct,office,district,party,candidate,votes
-Republic,1st Ward,President,,REP,Trump and Pence,245
-Republic,2nd Ward,President,,REP,Trump and Pence,285
-Republic,3rd Ward,President,,REP,Trump and Pence,162
-Republic,Albion,President,,REP,Trump and Pence,57
-Republic,Beaver,President,,REP,Trump and Pence,33
-Republic,Belleville,President,,REP,Trump and Pence,113
-Republic,Big Bend,President,,REP,Trump and Pence,76
-Republic,Courtland,President,,REP,Trump and Pence,162
-Republic,Elk Creek,President,,REP,Trump and Pence,59
-Republic,Fairview,President,,REP,Trump and Pence,72
-Republic,Farmington,President,,REP,Trump and Pence,25
-Republic,Freedom,President,,REP,Trump and Pence,87
-Republic,Grant,President,,REP,Trump and Pence,30
-Republic,Jefferson,President,,REP,Trump and Pence,48
-Republic,Liberty,President,,REP,Trump and Pence,20
-Republic,Lincoln,President,,REP,Trump and Pence,40
-Republic,Norway,President,,REP,Trump and Pence,63
-Republic,Richland,President,,REP,Trump and Pence,111
-Republic,Rose Creek,President,,REP,Trump and Pence,51
-Republic,Scandia,President,,REP,Trump and Pence,188
-Republic,Union,President,,REP,Trump and Pence,14
-Republic,Washington,President,,REP,Trump and Pence,40
-Republic,White Rock,President,,REP,Trump and Pence,43
-Republic,1st Ward,President,,DEM,Clinton and Kaine,67
-Republic,2nd Ward,President,,DEM,Clinton and Kaine,77
-Republic,3rd Ward,President,,DEM,Clinton and Kaine,32
-Republic,Albion,President,,DEM,Clinton and Kaine,7
-Republic,Beaver,President,,DEM,Clinton and Kaine,13
-Republic,Belleville,President,,DEM,Clinton and Kaine,10
-Republic,Big Bend,President,,DEM,Clinton and Kaine,3
-Republic,Courtland,President,,DEM,Clinton and Kaine,26
-Republic,Elk Creek,President,,DEM,Clinton and Kaine,81
-Republic,Fairview,President,,DEM,Clinton and Kaine,11
-Republic,Farmington,President,,DEM,Clinton and Kaine,6
-Republic,Freedom,President,,DEM,Clinton and Kaine,11
-Republic,Grant,President,,DEM,Clinton and Kaine,1
-Republic,Jefferson,President,,DEM,Clinton and Kaine,8
-Republic,Liberty,President,,DEM,Clinton and Kaine,2
-Republic,Lincoln,President,,DEM,Clinton and Kaine,7
-Republic,Norway,President,,DEM,Clinton and Kaine,9
-Republic,Richland,President,,DEM,Clinton and Kaine,16
-Republic,Rose Creek,President,,DEM,Clinton and Kaine,10
-Republic,Scandia,President,,DEM,Clinton and Kaine,33
-Republic,Union,President,,DEM,Clinton and Kaine,6
-Republic,Washington,President,,DEM,Clinton and Kaine,5
-Republic,White Rock,President,,DEM,Clinton and Kaine,7
-Republic,1st Ward,President,,LIB,Johnson and Weld,13
-Republic,2nd Ward,President,,LIB,Johnson and Weld,15
-Republic,3rd Ward,President,,LIB,Johnson and Weld,5
-Republic,Albion,President,,LIB,Johnson and Weld,2
-Republic,Beaver,President,,LIB,Johnson and Weld,3
-Republic,Belleville,President,,LIB,Johnson and Weld,7
-Republic,Big Bend,President,,LIB,Johnson and Weld,5
-Republic,Courtland,President,,LIB,Johnson and Weld,1
-Republic,Elk Creek,President,,LIB,Johnson and Weld,2
-Republic,Fairview,President,,LIB,Johnson and Weld,2
-Republic,Farmington,President,,LIB,Johnson and Weld,0
-Republic,Freedom,President,,LIB,Johnson and Weld,1
-Republic,Grant,President,,LIB,Johnson and Weld,4
-Republic,Jefferson,President,,LIB,Johnson and Weld,1
-Republic,Liberty,President,,LIB,Johnson and Weld,0
-Republic,Lincoln,President,,LIB,Johnson and Weld,1
-Republic,Norway,President,,LIB,Johnson and Weld,2
-Republic,Richland,President,,LIB,Johnson and Weld,7
-Republic,Rose Creek,President,,LIB,Johnson and Weld,1
-Republic,Scandia,President,,LIB,Johnson and Weld,9
-Republic,Union,President,,LIB,Johnson and Weld,1
-Republic,Washington,President,,LIB,Johnson and Weld,0
-Republic,White Rock,President,,LIB,Johnson and Weld,1
-Republic,1st Ward,President,,IND,Stein and Baraka,8
-Republic,2nd Ward,President,,IND,Stein and Baraka,6
-Republic,3rd Ward,President,,IND,Stein and Baraka,5
-Republic,Albion,President,,IND,Stein and Baraka,0
-Republic,Beaver,President,,IND,Stein and Baraka,0
-Republic,Belleville,President,,IND,Stein and Baraka,1
-Republic,Big Bend,President,,IND,Stein and Baraka,4
-Republic,Courtland,President,,IND,Stein and Baraka,1
-Republic,Elk Creek,President,,IND,Stein and Baraka,1
-Republic,Fairview,President,,IND,Stein and Baraka,1
-Republic,Farmington,President,,IND,Stein and Baraka,1
-Republic,Freedom,President,,IND,Stein and Baraka,2
-Republic,Grant,President,,IND,Stein and Baraka,0
-Republic,Jefferson,President,,IND,Stein and Baraka,2
-Republic,Liberty,President,,IND,Stein and Baraka,0
-Republic,Lincoln,President,,IND,Stein and Baraka,0
-Republic,Norway,President,,IND,Stein and Baraka,0
-Republic,Richland,President,,IND,Stein and Baraka,0
-Republic,Rose Creek,President,,IND,Stein and Baraka,2
-Republic,Scandia,President,,IND,Stein and Baraka,9
-Republic,Union,President,,IND,Stein and Baraka,0
-Republic,Washington,President,,IND,Stein and Baraka,0
-Republic,White Rock,President,,IND,Stein and Baraka,0
-Republic,1st Ward,U.S. Senate,,DEM,Patrick Wiesner,49
-Republic,2nd Ward,U.S. Senate,,DEM,Patrick Wiesner,54
-Republic,3rd Ward,U.S. Senate,,DEM,Patrick Wiesner,24
-Republic,Albion,U.S. Senate,,DEM,Patrick Wiesner,4
-Republic,Beaver,U.S. Senate,,DEM,Patrick Wiesner,6
-Republic,Belleville,U.S. Senate,,DEM,Patrick Wiesner,5
-Republic,Big Bend,U.S. Senate,,DEM,Patrick Wiesner,10
-Republic,Courtland,U.S. Senate,,DEM,Patrick Wiesner,23
-Republic,Elk Creek,U.S. Senate,,DEM,Patrick Wiesner,6
-Republic,Fairview,U.S. Senate,,DEM,Patrick Wiesner,14
-Republic,Farmington,U.S. Senate,,DEM,Patrick Wiesner,4
-Republic,Freedom,U.S. Senate,,DEM,Patrick Wiesner,8
-Republic,Grant,U.S. Senate,,DEM,Patrick Wiesner,4
-Republic,Jefferson,U.S. Senate,,DEM,Patrick Wiesner,3
-Republic,Liberty,U.S. Senate,,DEM,Patrick Wiesner,2
-Republic,Lincoln,U.S. Senate,,DEM,Patrick Wiesner,6
-Republic,Norway,U.S. Senate,,DEM,Patrick Wiesner,5
-Republic,Richland,U.S. Senate,,DEM,Patrick Wiesner,7
-Republic,Rose Creek,U.S. Senate,,DEM,Patrick Wiesner,12
-Republic,Scandia,U.S. Senate,,DEM,Patrick Wiesner,18
-Republic,Union,U.S. Senate,,DEM,Patrick Wiesner,2
-Republic,Washington,U.S. Senate,,DEM,Patrick Wiesner,3
-Republic,White Rock,U.S. Senate,,DEM,Patrick Wiesner,5
-Republic,1st Ward,U.S. Senate,,LIB,Robert D. Garrard,18
-Republic,2nd Ward,U.S. Senate,,LIB,Robert D. Garrard,18
-Republic,3rd Ward,U.S. Senate,,LIB,Robert D. Garrard,13
-Republic,Albion,U.S. Senate,,LIB,Robert D. Garrard,4
-Republic,Beaver,U.S. Senate,,LIB,Robert D. Garrard,1
-Republic,Belleville,U.S. Senate,,LIB,Robert D. Garrard,5
-Republic,Big Bend,U.S. Senate,,LIB,Robert D. Garrard,8
-Republic,Courtland,U.S. Senate,,LIB,Robert D. Garrard,7
-Republic,Elk Creek,U.S. Senate,,LIB,Robert D. Garrard,2
-Republic,Fairview,U.S. Senate,,LIB,Robert D. Garrard,1
-Republic,Farmington,U.S. Senate,,LIB,Robert D. Garrard,0
-Republic,Freedom,U.S. Senate,,LIB,Robert D. Garrard,2
-Republic,Grant,U.S. Senate,,LIB,Robert D. Garrard,3
-Republic,Jefferson,U.S. Senate,,LIB,Robert D. Garrard,2
-Republic,Liberty,U.S. Senate,,LIB,Robert D. Garrard,0
-Republic,Lincoln,U.S. Senate,,LIB,Robert D. Garrard,2
-Republic,Norway,U.S. Senate,,LIB,Robert D. Garrard,1
-Republic,Richland,U.S. Senate,,LIB,Robert D. Garrard,6
-Republic,Rose Creek,U.S. Senate,,LIB,Robert D. Garrard,0
-Republic,Scandia,U.S. Senate,,LIB,Robert D. Garrard,16
-Republic,Union,U.S. Senate,,LIB,Robert D. Garrard,0
-Republic,Washington,U.S. Senate,,LIB,Robert D. Garrard,0
-Republic,White Rock,U.S. Senate,,LIB,Robert D. Garrard,1
-Republic,1st Ward,U.S. Senate,,REP,Jerry Moran,255
-Republic,2nd Ward,U.S. Senate,,REP,Jerry Moran,308
-Republic,3rd Ward,U.S. Senate,,REP,Jerry Moran,161
-Republic,Albion,U.S. Senate,,REP,Jerry Moran,57
-Republic,Beaver,U.S. Senate,,REP,Jerry Moran,43
-Republic,Belleville,U.S. Senate,,REP,Jerry Moran,116
-Republic,Big Bend,U.S. Senate,,REP,Jerry Moran,69
-Republic,Courtland,U.S. Senate,,REP,Jerry Moran,161
-Republic,Elk Creek,U.S. Senate,,REP,Jerry Moran,61
-Republic,Fairview,U.S. Senate,,REP,Jerry Moran,70
-Republic,Farmington,U.S. Senate,,REP,Jerry Moran,26
-Republic,Freedom,U.S. Senate,,REP,Jerry Moran,90
-Republic,Grant,U.S. Senate,,REP,Jerry Moran,28
-Republic,Jefferson,U.S. Senate,,REP,Jerry Moran,55
-Republic,Liberty,U.S. Senate,,REP,Jerry Moran,21
-Republic,Lincoln,U.S. Senate,,REP,Jerry Moran,40
-Republic,Norway,U.S. Senate,,REP,Jerry Moran,69
-Republic,Richland,U.S. Senate,,REP,Jerry Moran,118
-Republic,Rose Creek,U.S. Senate,,REP,Jerry Moran,52
-Republic,Scandia,U.S. Senate,,REP,Jerry Moran,209
-Republic,Union,U.S. Senate,,REP,Jerry Moran,19
-Republic,Washington,U.S. Senate,,REP,Jerry Moran,43
-Republic,White Rock,U.S. Senate,,REP,Jerry Moran,46
-Republic,1st Ward,U.S. House,1,REP,Roger Marshall,160
-Republic,2nd Ward,U.S. House,1,REP,Roger Marshall,209
-Republic,3rd Ward,U.S. House,1,REP,Roger Marshall,103
-Republic,Albion,U.S. House,1,REP,Roger Marshall,37
-Republic,Beaver,U.S. House,1,REP,Roger Marshall,24
-Republic,Belleville,U.S. House,1,REP,Roger Marshall,66
-Republic,Big Bend,U.S. House,1,REP,Roger Marshall,51
-Republic,Courtland,U.S. House,1,REP,Roger Marshall,80
-Republic,Elk Creek,U.S. House,1,REP,Roger Marshall,34
-Republic,Fairview,U.S. House,1,REP,Roger Marshall,32
-Republic,Farmington,U.S. House,1,REP,Roger Marshall,12
-Republic,Freedom,U.S. House,1,REP,Roger Marshall,62
-Republic,Grant,U.S. House,1,REP,Roger Marshall,21
-Republic,Jefferson,U.S. House,1,REP,Roger Marshall,29
-Republic,Liberty,U.S. House,1,REP,Roger Marshall,15
-Republic,Lincoln,U.S. House,1,REP,Roger Marshall,20
-Republic,Norway,U.S. House,1,REP,Roger Marshall,40
-Republic,Richland,U.S. House,1,REP,Roger Marshall,58
-Republic,Rose Creek,U.S. House,1,REP,Roger Marshall,31
-Republic,Scandia,U.S. House,1,REP,Roger Marshall,119
-Republic,Union,U.S. House,1,REP,Roger Marshall,13
-Republic,Washington,U.S. House,1,REP,Roger Marshall,35
-Republic,White Rock,U.S. House,1,REP,Roger Marshall,34
-Republic,1st Ward,U.S. House,1,LIB,Kerry Burt,8
-Republic,2nd Ward,U.S. House,1,LIB,Kerry Burt,12
-Republic,3rd Ward,U.S. House,1,LIB,Kerry Burt,11
-Republic,Albion,U.S. House,1,LIB,Kerry Burt,2
-Republic,Beaver,U.S. House,1,LIB,Kerry Burt,2
-Republic,Belleville,U.S. House,1,LIB,Kerry Burt,1
-Republic,Big Bend,U.S. House,1,LIB,Kerry Burt,6
-Republic,Courtland,U.S. House,1,LIB,Kerry Burt,6
-Republic,Elk Creek,U.S. House,1,LIB,Kerry Burt,0
-Republic,Fairview,U.S. House,1,LIB,Kerry Burt,2
-Republic,Farmington,U.S. House,1,LIB,Kerry Burt,1
-Republic,Freedom,U.S. House,1,LIB,Kerry Burt,1
-Republic,Grant,U.S. House,1,LIB,Kerry Burt,0
-Republic,Jefferson,U.S. House,1,LIB,Kerry Burt,4
-Republic,Liberty,U.S. House,1,LIB,Kerry Burt,0
-Republic,Lincoln,U.S. House,1,LIB,Kerry Burt,1
-Republic,Norway,U.S. House,1,LIB,Kerry Burt,0
-Republic,Richland,U.S. House,1,LIB,Kerry Burt,5
-Republic,Rose Creek,U.S. House,1,LIB,Kerry Burt,1
-Republic,Scandia,U.S. House,1,LIB,Kerry Burt,8
-Republic,Union,U.S. House,1,LIB,Kerry Burt,0
-Republic,Washington,U.S. House,1,LIB,Kerry Burt,0
-Republic,White Rock,U.S. House,1,LIB,Kerry Burt,1
-Republic,1st Ward,U.S. House,1,IND,Alan LaPolice,157
-Republic,2nd Ward,U.S. House,1,IND,Alan LaPolice,153
-Republic,3rd Ward,U.S. House,1,IND,Alan LaPolice,87
-Republic,Albion,U.S. House,1,IND,Alan LaPolice,23
-Republic,Beaver,U.S. House,1,IND,Alan LaPolice,23
-Republic,Belleville,U.S. House,1,IND,Alan LaPolice,59
-Republic,Big Bend,U.S. House,1,IND,Alan LaPolice,27
-Republic,Courtland,U.S. House,1,IND,Alan LaPolice,101
-Republic,Elk Creek,U.S. House,1,IND,Alan LaPolice,34
-Republic,Fairview,U.S. House,1,IND,Alan LaPolice,51
-Republic,Farmington,U.S. House,1,IND,Alan LaPolice,18
-Republic,Freedom,U.S. House,1,IND,Alan LaPolice,36
-Republic,Grant,U.S. House,1,IND,Alan LaPolice,14
-Republic,Jefferson,U.S. House,1,IND,Alan LaPolice,27
-Republic,Liberty,U.S. House,1,IND,Alan LaPolice,8
-Republic,Lincoln,U.S. House,1,IND,Alan LaPolice,24
-Republic,Norway,U.S. House,1,IND,Alan LaPolice,34
-Republic,Richland,U.S. House,1,IND,Alan LaPolice,72
-Republic,Rose Creek,U.S. House,1,IND,Alan LaPolice,29
-Republic,Scandia,U.S. House,1,IND,Alan LaPolice,114
-Republic,Union,U.S. House,1,IND,Alan LaPolice,7
-Republic,Washington,U.S. House,1,IND,Alan LaPolice,8
-Republic,White Rock,U.S. House,1,IND,Alan LaPolice,15
-Republic,1st Ward,State Senate,36,REP,Elaine S. Bowers,248
-Republic,2nd Ward,State Senate,36,REP,Elaine S. Bowers,310
-Republic,3rd Ward,State Senate,36,REP,Elaine S. Bowers,160
-Republic,Albion,State Senate,36,REP,Elaine S. Bowers,49
-Republic,Beaver,State Senate,36,REP,Elaine S. Bowers,41
-Republic,Belleville,State Senate,36,REP,Elaine S. Bowers,105
-Republic,Big Bend,State Senate,36,REP,Elaine S. Bowers,75
-Republic,Courtland,State Senate,36,REP,Elaine S. Bowers,153
-Republic,Elk Creek,State Senate,36,REP,Elaine S. Bowers,52
-Republic,Fairview,State Senate,36,REP,Elaine S. Bowers,54
-Republic,Farmington,State Senate,36,REP,Elaine S. Bowers,24
-Republic,Freedom,State Senate,36,REP,Elaine S. Bowers,85
-Republic,Grant,State Senate,36,REP,Elaine S. Bowers,27
-Republic,Jefferson,State Senate,36,REP,Elaine S. Bowers,39
-Republic,Liberty,State Senate,36,REP,Elaine S. Bowers,19
-Republic,Lincoln,State Senate,36,REP,Elaine S. Bowers,40
-Republic,Norway,State Senate,36,REP,Elaine S. Bowers,65
-Republic,Richland,State Senate,36,REP,Elaine S. Bowers,74
-Republic,Rose Creek,State Senate,36,REP,Elaine S. Bowers,46
-Republic,Scandia,State Senate,36,REP,Elaine S. Bowers,195
-Republic,Union,State Senate,36,REP,Elaine S. Bowers,17
-Republic,Washington,State Senate,36,REP,Elaine S. Bowers,43
-Republic,White Rock,State Senate,36,REP,Elaine S. Bowers,47
-Republic,1st Ward,State Senate,36,DEM,Brian G. Angevine,78
-Republic,2nd Ward,State Senate,36,DEM,Brian G. Angevine,71
-Republic,3rd Ward,State Senate,36,DEM,Brian G. Angevine,42
-Republic,Albion,State Senate,36,DEM,Brian G. Angevine,15
-Republic,Beaver,State Senate,36,DEM,Brian G. Angevine,9
-Republic,Belleville,State Senate,36,DEM,Brian G. Angevine,21
-Republic,Big Bend,State Senate,36,DEM,Brian G. Angevine,13
-Republic,Courtland,State Senate,36,DEM,Brian G. Angevine,38
-Republic,Elk Creek,State Senate,36,DEM,Brian G. Angevine,14
-Republic,Fairview,State Senate,36,DEM,Brian G. Angevine,31
-Republic,Farmington,State Senate,36,DEM,Brian G. Angevine,8
-Republic,Freedom,State Senate,36,DEM,Brian G. Angevine,15
-Republic,Grant,State Senate,36,DEM,Brian G. Angevine,8
-Republic,Jefferson,State Senate,36,DEM,Brian G. Angevine,20
-Republic,Liberty,State Senate,36,DEM,Brian G. Angevine,4
-Republic,Lincoln,State Senate,36,DEM,Brian G. Angevine,8
-Republic,Norway,State Senate,36,DEM,Brian G. Angevine,10
-Republic,Richland,State Senate,36,DEM,Brian G. Angevine,59
-Republic,Rose Creek,State Senate,36,DEM,Brian G. Angevine,17
-Republic,Scandia,State Senate,36,DEM,Brian G. Angevine,46
-Republic,Union,State Senate,36,DEM,Brian G. Angevine,4
-Republic,Washington,State Senate,36,DEM,Brian G. Angevine,1
-Republic,White Rock,State Senate,36,DEM,Brian G. Angevine,4
-Republic,1st Ward,State House,106,DEM,Todd E. Frye,76
-Republic,2nd Ward,State House,106,DEM,Todd E. Frye,78
-Republic,3rd Ward,State House,106,DEM,Todd E. Frye,51
-Republic,Albion,State House,106,DEM,Todd E. Frye,13
-Republic,Beaver,State House,106,DEM,Todd E. Frye,25
-Republic,Belleville,State House,106,DEM,Todd E. Frye,29
-Republic,Big Bend,State House,106,DEM,Todd E. Frye,18
-Republic,Courtland,State House,106,DEM,Todd E. Frye,122
-Republic,Elk Creek,State House,106,DEM,Todd E. Frye,11
-Republic,Fairview,State House,106,DEM,Todd E. Frye,32
-Republic,Farmington,State House,106,DEM,Todd E. Frye,7
-Republic,Freedom,State House,106,DEM,Todd E. Frye,19
-Republic,Grant,State House,106,DEM,Todd E. Frye,7
-Republic,Jefferson,State House,106,DEM,Todd E. Frye,17
-Republic,Liberty,State House,106,DEM,Todd E. Frye,6
-Republic,Lincoln,State House,106,DEM,Todd E. Frye,7
-Republic,Norway,State House,106,DEM,Todd E. Frye,19
-Republic,Richland,State House,106,DEM,Todd E. Frye,49
-Republic,Rose Creek,State House,106,DEM,Todd E. Frye,17
-Republic,Scandia,State House,106,DEM,Todd E. Frye,123
-Republic,Union,State House,106,DEM,Todd E. Frye,7
-Republic,Washington,State House,106,DEM,Todd E. Frye,4
-Republic,White Rock,State House,106,DEM,Todd E. Frye,22
-Republic,1st Ward,State House,106,REP,Clay Aurand,250
-Republic,2nd Ward,State House,106,REP,Clay Aurand,303
-Republic,3rd Ward,State House,106,REP,Clay Aurand,151
-Republic,Albion,State House,106,REP,Clay Aurand,53
-Republic,Beaver,State House,106,REP,Clay Aurand,24
-Republic,Belleville,State House,106,REP,Clay Aurand,98
-Republic,Big Bend,State House,106,REP,Clay Aurand,69
-Republic,Courtland,State House,106,REP,Clay Aurand,67
-Republic,Elk Creek,State House,106,REP,Clay Aurand,57
-Republic,Fairview,State House,106,REP,Clay Aurand,55
-Republic,Farmington,State House,106,REP,Clay Aurand,25
-Republic,Freedom,State House,106,REP,Clay Aurand,82
-Republic,Grant,State House,106,REP,Clay Aurand,27
-Republic,Jefferson,State House,106,REP,Clay Aurand,42
-Republic,Liberty,State House,106,REP,Clay Aurand,16
-Republic,Lincoln,State House,106,REP,Clay Aurand,40
-Republic,Norway,State House,106,REP,Clay Aurand,56
-Republic,Richland,State House,106,REP,Clay Aurand,87
-Republic,Rose Creek,State House,106,REP,Clay Aurand,46
-Republic,Scandia,State House,106,REP,Clay Aurand,119
-Republic,Union,State House,106,REP,Clay Aurand,14
-Republic,Washington,State House,106,REP,Clay Aurand,42
-Republic,White Rock,State House,106,REP,Clay Aurand,28
+county,precinct,office,district,party,candidate,votes,vtd
+REPUBLIC,Albion Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",13,000010
+REPUBLIC,Albion Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",53,000010
+REPUBLIC,Beaver Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",25,000020
+REPUBLIC,Beaver Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",24,000020
+REPUBLIC,Belleville Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",29,000030
+REPUBLIC,Belleville Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",98,000030
+REPUBLIC,Belleville Ward 1,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",76,000040
+REPUBLIC,Belleville Ward 1,Kansas House of Representatives,106,Republican,"Aurand, Clay",250,000040
+REPUBLIC,Belleville Ward 2,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",78,00005A
+REPUBLIC,Belleville Ward 2,Kansas House of Representatives,106,Republican,"Aurand, Clay",303,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00005B
+REPUBLIC,Belleville Ward 3,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",51,00006A
+REPUBLIC,Belleville Ward 3,Kansas House of Representatives,106,Republican,"Aurand, Clay",151,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00006B
+REPUBLIC,Big Bend Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",18,000070
+REPUBLIC,Big Bend Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",69,000070
+REPUBLIC,Courtland Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",122,000080
+REPUBLIC,Courtland Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",67,000080
+REPUBLIC,Elk Creek Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",11,000090
+REPUBLIC,Elk Creek Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",57,000090
+REPUBLIC,Fairview Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",32,000100
+REPUBLIC,Fairview Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",55,000100
+REPUBLIC,Farmington Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",7,000110
+REPUBLIC,Farmington Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",25,000110
+REPUBLIC,Freedom Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",19,00012A
+REPUBLIC,Freedom Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",82,00012A
+REPUBLIC,Freedom Township Enclave,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00012B
+REPUBLIC,Freedom Township Enclave,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00012B
+REPUBLIC,Grant Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",7,000130
+REPUBLIC,Grant Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",27,000130
+REPUBLIC,Jefferson Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",17,000140
+REPUBLIC,Jefferson Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",42,000140
+REPUBLIC,Liberty Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",6,000150
+REPUBLIC,Liberty Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",16,000150
+REPUBLIC,Lincoln Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",7,000160
+REPUBLIC,Lincoln Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",40,000160
+REPUBLIC,Norway Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",19,000170
+REPUBLIC,Norway Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",56,000170
+REPUBLIC,Richland Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",49,000180
+REPUBLIC,Richland Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",87,000180
+REPUBLIC,Rose Creek Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",17,000190
+REPUBLIC,Rose Creek Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",46,000190
+REPUBLIC,Scandia Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",123,000200
+REPUBLIC,Scandia Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",119,000200
+REPUBLIC,Union Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",7,000210
+REPUBLIC,Union Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",14,000210
+REPUBLIC,Washington Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",4,000220
+REPUBLIC,Washington Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",42,000220
+REPUBLIC,White Rock Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",22,000230
+REPUBLIC,White Rock Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",28,000230
+REPUBLIC,Albion Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,000010
+REPUBLIC,Albion Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",49,000010
+REPUBLIC,Beaver Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000020
+REPUBLIC,Beaver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000020
+REPUBLIC,Belleville Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",21,000030
+REPUBLIC,Belleville Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",105,000030
+REPUBLIC,Belleville Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",78,000040
+REPUBLIC,Belleville Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",248,000040
+REPUBLIC,Belleville Ward 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",71,00005A
+REPUBLIC,Belleville Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",310,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00005B
+REPUBLIC,Belleville Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",42,00006A
+REPUBLIC,Belleville Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",160,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00006B
+REPUBLIC,Big Bend Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",13,000070
+REPUBLIC,Big Bend Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",75,000070
+REPUBLIC,Courtland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",38,000080
+REPUBLIC,Courtland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",153,000080
+REPUBLIC,Elk Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",14,000090
+REPUBLIC,Elk Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000090
+REPUBLIC,Fairview Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",31,000100
+REPUBLIC,Fairview Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000100
+REPUBLIC,Farmington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000110
+REPUBLIC,Farmington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000110
+REPUBLIC,Freedom Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,00012A
+REPUBLIC,Freedom Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",85,00012A
+REPUBLIC,Freedom Township Enclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00012B
+REPUBLIC,Freedom Township Enclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00012B
+REPUBLIC,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000130
+REPUBLIC,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000130
+REPUBLIC,Jefferson Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000140
+REPUBLIC,Jefferson Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",39,000140
+REPUBLIC,Liberty Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000150
+REPUBLIC,Liberty Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000150
+REPUBLIC,Lincoln Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000160
+REPUBLIC,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,000160
+REPUBLIC,Norway Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000170
+REPUBLIC,Norway Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",65,000170
+REPUBLIC,Richland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",59,000180
+REPUBLIC,Richland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",74,000180
+REPUBLIC,Rose Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",17,000190
+REPUBLIC,Rose Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",46,000190
+REPUBLIC,Scandia Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",46,000200
+REPUBLIC,Scandia Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",195,000200
+REPUBLIC,Union Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000210
+REPUBLIC,Union Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",17,000210
+REPUBLIC,Washington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000220
+REPUBLIC,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",43,000220
+REPUBLIC,White Rock Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000230
+REPUBLIC,White Rock Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",47,000230
+REPUBLIC,Albion Township,President / Vice President,,independent,"Stein, Jill",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+REPUBLIC,Albion Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+REPUBLIC,Albion Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000010
+REPUBLIC,Albion Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+REPUBLIC,Albion Township,President / Vice President,,Republican,"Trump, Donald J.",57,000010
+REPUBLIC,Beaver Township,President / Vice President,,independent,"Stein, Jill",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+REPUBLIC,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000020
+REPUBLIC,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+REPUBLIC,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",33,000020
+REPUBLIC,Belleville Township,President / Vice President,,independent,"Stein, Jill",1,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+REPUBLIC,Belleville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000030
+REPUBLIC,Belleville Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000030
+REPUBLIC,Belleville Township,President / Vice President,,Republican,"Trump, Donald J.",113,000030
+REPUBLIC,Belleville Ward 1,President / Vice President,,independent,"Stein, Jill",8,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000040
+REPUBLIC,Belleville Ward 1,President / Vice President,,Republican,"Trump, Donald J.",245,000040
+REPUBLIC,Belleville Ward 2,President / Vice President,,independent,"Stein, Jill",6,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"McMullin, Evan",1,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,00005A
+REPUBLIC,Belleville Ward 2,President / Vice President,,Republican,"Trump, Donald J.",285,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,independent,"Stein, Jill",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Hedges, James A",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Smith, Mike",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,President / Vice President,,Republican,"Trump, Donald J.",0,00005B
+REPUBLIC,Belleville Ward 3,President / Vice President,,independent,"Stein, Jill",5,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",5,00006A
+REPUBLIC,Belleville Ward 3,President / Vice President,,Republican,"Trump, Donald J.",162,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,independent,"Stein, Jill",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Basiago, Andrew D.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Castle, Darrell L",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Giordani, Rocky",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Hedges, James A",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Hoefling, Tom",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Kahn, Lynn",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"La Riva, Gloria",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Levinson, Michael S.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Maturen, Michael A",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"McMullin, Evan",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Moorehead, Monica G.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Perry, Darryl",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Schriner, Joe C",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Smith, Mike",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Sood, Ajay",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Sterling, Shawna",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Valdivia, Anthony J",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Libertarian,"Johnson, Gary",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,President / Vice President,,Republican,"Trump, Donald J.",0,00006B
+REPUBLIC,Big Bend Township,President / Vice President,,independent,"Stein, Jill",4,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+REPUBLIC,Big Bend Township,President / Vice President,,Republican,"Trump, Donald J.",76,000070
+REPUBLIC,Courtland Township,President / Vice President,,independent,"Stein, Jill",1,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"McMullin, Evan",1,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+REPUBLIC,Courtland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000080
+REPUBLIC,Courtland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+REPUBLIC,Courtland Township,President / Vice President,,Republican,"Trump, Donald J.",162,000080
+REPUBLIC,Elk Creek Township,President / Vice President,,independent,"Stein, Jill",1,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+REPUBLIC,Elk Creek Township,President / Vice President,,Republican,"Trump, Donald J.",59,000090
+REPUBLIC,Fairview Township,President / Vice President,,independent,"Stein, Jill",1,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+REPUBLIC,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000100
+REPUBLIC,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+REPUBLIC,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",72,000100
+REPUBLIC,Farmington Township,President / Vice President,,independent,"Stein, Jill",1,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000110
+REPUBLIC,Farmington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+REPUBLIC,Farmington Township,President / Vice President,,Republican,"Trump, Donald J.",25,000110
+REPUBLIC,Freedom Township,President / Vice President,,independent,"Stein, Jill",2,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Hedges, James A",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Hoefling, Tom",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"McMullin, Evan",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Smith, Mike",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Libertarian,"Johnson, Gary",1,00012A
+REPUBLIC,Freedom Township,President / Vice President,,Republican,"Trump, Donald J.",87,00012A
+REPUBLIC,Freedom Township Enclave,President / Vice President,,independent,"Stein, Jill",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00012B
+REPUBLIC,Freedom Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00012B
+REPUBLIC,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+REPUBLIC,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+REPUBLIC,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000130
+REPUBLIC,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+REPUBLIC,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",30,000130
+REPUBLIC,Jefferson Township,President / Vice President,,independent,"Stein, Jill",2,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+REPUBLIC,Jefferson Township,President / Vice President,,Republican,"Trump, Donald J.",48,000140
+REPUBLIC,Liberty Township,President / Vice President,,independent,"Stein, Jill",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000150
+REPUBLIC,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+REPUBLIC,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",20,000150
+REPUBLIC,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+REPUBLIC,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",40,000160
+REPUBLIC,Norway Township,President / Vice President,,independent,"Stein, Jill",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+REPUBLIC,Norway Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+REPUBLIC,Norway Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000170
+REPUBLIC,Norway Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+REPUBLIC,Norway Township,President / Vice President,,Republican,"Trump, Donald J.",63,000170
+REPUBLIC,Richland Township,President / Vice President,,independent,"Stein, Jill",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+REPUBLIC,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+REPUBLIC,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000180
+REPUBLIC,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000180
+REPUBLIC,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",111,000180
+REPUBLIC,Rose Creek Township,President / Vice President,,independent,"Stein, Jill",2,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000190
+REPUBLIC,Rose Creek Township,President / Vice President,,Republican,"Trump, Donald J.",51,000190
+REPUBLIC,Scandia Township,President / Vice President,,independent,"Stein, Jill",9,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+REPUBLIC,Scandia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000200
+REPUBLIC,Scandia Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000200
+REPUBLIC,Scandia Township,President / Vice President,,Republican,"Trump, Donald J.",188,000200
+REPUBLIC,Union Township,President / Vice President,,independent,"Stein, Jill",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+REPUBLIC,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+REPUBLIC,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000210
+REPUBLIC,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+REPUBLIC,Union Township,President / Vice President,,Republican,"Trump, Donald J.",14,000210
+REPUBLIC,Washington Township,President / Vice President,,independent,"Stein, Jill",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+REPUBLIC,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+REPUBLIC,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000220
+REPUBLIC,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+REPUBLIC,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",40,000220
+REPUBLIC,White Rock Township,President / Vice President,,independent,"Stein, Jill",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+REPUBLIC,White Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000230
+REPUBLIC,White Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000230
+REPUBLIC,White Rock Township,President / Vice President,,Republican,"Trump, Donald J.",43,000230
+REPUBLIC,Albion Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000010
+REPUBLIC,Albion Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+REPUBLIC,Albion Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+REPUBLIC,Albion Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000010
+REPUBLIC,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000020
+REPUBLIC,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+REPUBLIC,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000020
+REPUBLIC,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000020
+REPUBLIC,Belleville Township,United States House of Representatives,1,independent,"LaPolice, Alan",59,000030
+REPUBLIC,Belleville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000030
+REPUBLIC,Belleville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+REPUBLIC,Belleville Township,United States House of Representatives,1,Republican,"Marshall, Roger",66,000030
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",157,000040
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000040
+REPUBLIC,Belleville Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",160,000040
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",153,00005A
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005A
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,00005A
+REPUBLIC,Belleville Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",209,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005B
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",87,00006A
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00006A
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,00006A
+REPUBLIC,Belleville Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",103,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,independent,"LaPolice, Alan",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States House of Representatives,1,Republican,"Marshall, Roger",0,00006B
+REPUBLIC,Big Bend Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000070
+REPUBLIC,Big Bend Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000070
+REPUBLIC,Big Bend Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000070
+REPUBLIC,Big Bend Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000070
+REPUBLIC,Courtland Township,United States House of Representatives,1,independent,"LaPolice, Alan",101,000080
+REPUBLIC,Courtland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000080
+REPUBLIC,Courtland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000080
+REPUBLIC,Courtland Township,United States House of Representatives,1,Republican,"Marshall, Roger",80,000080
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",34,000090
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+REPUBLIC,Elk Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000090
+REPUBLIC,Fairview Township,United States House of Representatives,1,independent,"LaPolice, Alan",51,000100
+REPUBLIC,Fairview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+REPUBLIC,Fairview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000100
+REPUBLIC,Fairview Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000100
+REPUBLIC,Farmington Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,000110
+REPUBLIC,Farmington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+REPUBLIC,Farmington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000110
+REPUBLIC,Farmington Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000110
+REPUBLIC,Freedom Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,00012A
+REPUBLIC,Freedom Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00012A
+REPUBLIC,Freedom Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,00012A
+REPUBLIC,Freedom Township,United States House of Representatives,1,Republican,"Marshall, Roger",62,00012A
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00012B
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00012B
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00012B
+REPUBLIC,Freedom Township Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00012B
+REPUBLIC,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000130
+REPUBLIC,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+REPUBLIC,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+REPUBLIC,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000130
+REPUBLIC,Jefferson Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000140
+REPUBLIC,Jefferson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+REPUBLIC,Jefferson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000140
+REPUBLIC,Jefferson Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000140
+REPUBLIC,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000150
+REPUBLIC,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+REPUBLIC,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000150
+REPUBLIC,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000150
+REPUBLIC,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000160
+REPUBLIC,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+REPUBLIC,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+REPUBLIC,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000160
+REPUBLIC,Norway Township,United States House of Representatives,1,independent,"LaPolice, Alan",34,000170
+REPUBLIC,Norway Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+REPUBLIC,Norway Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+REPUBLIC,Norway Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000170
+REPUBLIC,Richland Township,United States House of Representatives,1,independent,"LaPolice, Alan",72,000180
+REPUBLIC,Richland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+REPUBLIC,Richland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000180
+REPUBLIC,Richland Township,United States House of Representatives,1,Republican,"Marshall, Roger",58,000180
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000190
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000190
+REPUBLIC,Rose Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000190
+REPUBLIC,Scandia Township,United States House of Representatives,1,independent,"LaPolice, Alan",114,000200
+REPUBLIC,Scandia Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+REPUBLIC,Scandia Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000200
+REPUBLIC,Scandia Township,United States House of Representatives,1,Republican,"Marshall, Roger",119,000200
+REPUBLIC,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000210
+REPUBLIC,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+REPUBLIC,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000210
+REPUBLIC,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000210
+REPUBLIC,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000220
+REPUBLIC,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000220
+REPUBLIC,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000220
+REPUBLIC,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000220
+REPUBLIC,White Rock Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000230
+REPUBLIC,White Rock Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+REPUBLIC,White Rock Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000230
+REPUBLIC,White Rock Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000230
+REPUBLIC,Albion Township,United States Senate,,write - in,"Smith, DJ",0,000010
+REPUBLIC,Albion Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000010
+REPUBLIC,Albion Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+REPUBLIC,Albion Township,United States Senate,,Republican,"Moran, Jerry",57,000010
+REPUBLIC,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000020
+REPUBLIC,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000020
+REPUBLIC,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+REPUBLIC,Beaver Township,United States Senate,,Republican,"Moran, Jerry",43,000020
+REPUBLIC,Belleville Township,United States Senate,,write - in,"Smith, DJ",0,000030
+REPUBLIC,Belleville Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000030
+REPUBLIC,Belleville Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000030
+REPUBLIC,Belleville Township,United States Senate,,Republican,"Moran, Jerry",116,000030
+REPUBLIC,Belleville Ward 1,United States Senate,,write - in,"Smith, DJ",0,000040
+REPUBLIC,Belleville Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",49,000040
+REPUBLIC,Belleville Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",18,000040
+REPUBLIC,Belleville Ward 1,United States Senate,,Republican,"Moran, Jerry",255,000040
+REPUBLIC,Belleville Ward 2,United States Senate,,write - in,"Smith, DJ",0,00005A
+REPUBLIC,Belleville Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",54,00005A
+REPUBLIC,Belleville Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,00005A
+REPUBLIC,Belleville Ward 2,United States Senate,,Republican,"Moran, Jerry",308,00005A
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,write - in,"Smith, DJ",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+REPUBLIC,Belleville Ward 2 Exclave Airport,United States Senate,,Republican,"Moran, Jerry",0,00005B
+REPUBLIC,Belleville Ward 3,United States Senate,,write - in,"Smith, DJ",0,00006A
+REPUBLIC,Belleville Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",24,00006A
+REPUBLIC,Belleville Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",13,00006A
+REPUBLIC,Belleville Ward 3,United States Senate,,Republican,"Moran, Jerry",161,00006A
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,write - in,"Smith, DJ",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,Democratic,"Wiesner, Patrick",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,Libertarian,"Garrard, Robert D.",0,00006B
+REPUBLIC,Belleville Ward 3 Exclave Cemetery,United States Senate,,Republican,"Moran, Jerry",0,00006B
+REPUBLIC,Big Bend Township,United States Senate,,write - in,"Smith, DJ",0,000070
+REPUBLIC,Big Bend Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000070
+REPUBLIC,Big Bend Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000070
+REPUBLIC,Big Bend Township,United States Senate,,Republican,"Moran, Jerry",69,000070
+REPUBLIC,Courtland Township,United States Senate,,write - in,"Smith, DJ",0,000080
+REPUBLIC,Courtland Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000080
+REPUBLIC,Courtland Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000080
+REPUBLIC,Courtland Township,United States Senate,,Republican,"Moran, Jerry",161,000080
+REPUBLIC,Elk Creek Township,United States Senate,,write - in,"Smith, DJ",0,000090
+REPUBLIC,Elk Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000090
+REPUBLIC,Elk Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000090
+REPUBLIC,Elk Creek Township,United States Senate,,Republican,"Moran, Jerry",61,000090
+REPUBLIC,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000100
+REPUBLIC,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000100
+REPUBLIC,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+REPUBLIC,Fairview Township,United States Senate,,Republican,"Moran, Jerry",70,000100
+REPUBLIC,Farmington Township,United States Senate,,write - in,"Smith, DJ",0,000110
+REPUBLIC,Farmington Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000110
+REPUBLIC,Farmington Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+REPUBLIC,Farmington Township,United States Senate,,Republican,"Moran, Jerry",26,000110
+REPUBLIC,Freedom Township,United States Senate,,write - in,"Smith, DJ",0,00012A
+REPUBLIC,Freedom Township,United States Senate,,Democratic,"Wiesner, Patrick",8,00012A
+REPUBLIC,Freedom Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,00012A
+REPUBLIC,Freedom Township,United States Senate,,Republican,"Moran, Jerry",90,00012A
+REPUBLIC,Freedom Township Enclave,United States Senate,,write - in,"Smith, DJ",0,00012B
+REPUBLIC,Freedom Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00012B
+REPUBLIC,Freedom Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00012B
+REPUBLIC,Freedom Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,00012B
+REPUBLIC,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000130
+REPUBLIC,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000130
+REPUBLIC,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000130
+REPUBLIC,Grant Township,United States Senate,,Republican,"Moran, Jerry",28,000130
+REPUBLIC,Jefferson Township,United States Senate,,write - in,"Smith, DJ",0,000140
+REPUBLIC,Jefferson Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000140
+REPUBLIC,Jefferson Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000140
+REPUBLIC,Jefferson Township,United States Senate,,Republican,"Moran, Jerry",55,000140
+REPUBLIC,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000150
+REPUBLIC,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000150
+REPUBLIC,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+REPUBLIC,Liberty Township,United States Senate,,Republican,"Moran, Jerry",21,000150
+REPUBLIC,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000160
+REPUBLIC,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000160
+REPUBLIC,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000160
+REPUBLIC,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",40,000160
+REPUBLIC,Norway Township,United States Senate,,write - in,"Smith, DJ",0,000170
+REPUBLIC,Norway Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000170
+REPUBLIC,Norway Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000170
+REPUBLIC,Norway Township,United States Senate,,Republican,"Moran, Jerry",69,000170
+REPUBLIC,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000180
+REPUBLIC,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000180
+REPUBLIC,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000180
+REPUBLIC,Richland Township,United States Senate,,Republican,"Moran, Jerry",118,000180
+REPUBLIC,Rose Creek Township,United States Senate,,write - in,"Smith, DJ",0,000190
+REPUBLIC,Rose Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000190
+REPUBLIC,Rose Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000190
+REPUBLIC,Rose Creek Township,United States Senate,,Republican,"Moran, Jerry",52,000190
+REPUBLIC,Scandia Township,United States Senate,,write - in,"Smith, DJ",0,000200
+REPUBLIC,Scandia Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000200
+REPUBLIC,Scandia Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000200
+REPUBLIC,Scandia Township,United States Senate,,Republican,"Moran, Jerry",209,000200
+REPUBLIC,Union Township,United States Senate,,write - in,"Smith, DJ",0,000210
+REPUBLIC,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000210
+REPUBLIC,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000210
+REPUBLIC,Union Township,United States Senate,,Republican,"Moran, Jerry",19,000210
+REPUBLIC,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000220
+REPUBLIC,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000220
+REPUBLIC,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000220
+REPUBLIC,Washington Township,United States Senate,,Republican,"Moran, Jerry",43,000220
+REPUBLIC,White Rock Township,United States Senate,,write - in,"Smith, DJ",0,000230
+REPUBLIC,White Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000230
+REPUBLIC,White Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000230
+REPUBLIC,White Rock Township,United States Senate,,Republican,"Moran, Jerry",46,000230

--- a/2016/20161108__ks__general__rice__precinct.csv
+++ b/2016/20161108__ks__general__rice__precinct.csv
@@ -1,408 +1,1016 @@
-county,precinct,office,district,party,candidate,votes
-Rice,Atlanta,President,,D,Hillary Clinton,4
-Rice,Bell,President,,D,Hillary Clinton,1
-Rice,Center,President,,D,Hillary Clinton,1
-Rice,Eureka,President,,D,Hillary Clinton,0
-Rice,Farmer,President,,D,Hillary Clinton,4
-Rice,Galt,President,,D,Hillary Clinton,6
-Rice,Harrison,President,,D,Hillary Clinton,1
-Rice,Lincoln,President,,D,Hillary Clinton,19
-Rice,Mitchell,President,,D,Hillary Clinton,9
-Rice,Odessa,President,,D,Hillary Clinton,5
-Rice,Pioneer,President,,D,Hillary Clinton,0
-Rice,Raymond,President,,D,Hillary Clinton,4
-Rice,Rockville,President,,D,Hillary Clinton,14
-Rice,Stevens,President,,D,Hillary Clinton,5
-Rice,Union,President,,D,Hillary Clinton,29
-Rice,Valley,President,,D,Hillary Clinton,9
-Rice,Victory,President,,D,Hillary Clinton,13
-Rice,E Wash,President,,D,Hillary Clinton,11
-Rice,W Wash,President,,D,Hillary Clinton,5
-Rice,Wilson,President,,D,Hillary Clinton,5
-Rice,Lyons 1,President,,D,Hillary Clinton,24
-Rice,Lyons 2,President,,D,Hillary Clinton,28
-Rice,Lyons 3,President,,D,Hillary Clinton,25
-Rice,Lyons 4,President,,D,Hillary Clinton,25
-Rice,Sterling E,President,,D,Hillary Clinton,49
-Rice,Sterling W,President,,D,Hillary Clinton,32
-Rice,Prov,President,,D,Hillary Clinton,12
-Rice,Advance,President,,D,Hillary Clinton,355
-Rice,Total,President,,D,Hillary Clinton,695
-Rice,Atlanta,President,,LBT,Gary Johnson,0
-Rice,Bell,President,,LBT,Gary Johnson,0
-Rice,Center,President,,LBT,Gary Johnson,1
-Rice,Eureka,President,,LBT,Gary Johnson,0
-Rice,Farmer,President,,LBT,Gary Johnson,6
-Rice,Galt,President,,LBT,Gary Johnson,1
-Rice,Harrison,President,,LBT,Gary Johnson,0
-Rice,Lincoln,President,,LBT,Gary Johnson,0
-Rice,Mitchell,President,,LBT,Gary Johnson,0
-Rice,Odessa,President,,LBT,Gary Johnson,2
-Rice,Pioneer,President,,LBT,Gary Johnson,0
-Rice,Raymond,President,,LBT,Gary Johnson,1
-Rice,Rockville,President,,LBT,Gary Johnson,1
-Rice,Stevens,President,,LBT,Gary Johnson,1
-Rice,Union,President,,LBT,Gary Johnson,11
-Rice,Valley,President,,LBT,Gary Johnson,3
-Rice,Victory,President,,LBT,Gary Johnson,9
-Rice,E Wash,President,,LBT,Gary Johnson,1
-Rice,W Wash,President,,LBT,Gary Johnson,0
-Rice,Wilson,President,,LBT,Gary Johnson,2
-Rice,Lyons 1,President,,LBT,Gary Johnson,9
-Rice,Lyons 2,President,,LBT,Gary Johnson,13
-Rice,Lyons 3,President,,LBT,Gary Johnson,12
-Rice,Lyons 4,President,,LBT,Gary Johnson,11
-Rice,Sterling E,President,,LBT,Gary Johnson,18
-Rice,Sterling W,President,,LBT,Gary Johnson,14
-Rice,Prov,President,,LBT,Gary Johnson,5
-Rice,Advance,President,,LBT,Gary Johnson,73
-Rice,Total,President,,LBT,Gary Johnson,194
-Rice,Atlanta,President,,IND,Jill Stein,0
-Rice,Bell,President,,IND,Jill Stein,0
-Rice,Center,President,,IND,Jill Stein,0
-Rice,Eureka,President,,IND,Jill Stein,0
-Rice,Farmer,President,,IND,Jill Stein,4
-Rice,Galt,President,,IND,Jill Stein,1
-Rice,Harrison,President,,IND,Jill Stein,0
-Rice,Lincoln,President,,IND,Jill Stein,1
-Rice,Mitchell,President,,IND,Jill Stein,1
-Rice,Odessa,President,,IND,Jill Stein,0
-Rice,Pioneer,President,,IND,Jill Stein,0
-Rice,Raymond,President,,IND,Jill Stein,1
-Rice,Rockville,President,,IND,Jill Stein,0
-Rice,Stevens,President,,IND,Jill Stein,1
-Rice,Union,President,,IND,Jill Stein,6
-Rice,Valley,President,,IND,Jill Stein,0
-Rice,Victory,President,,IND,Jill Stein,2
-Rice,E Wash,President,,IND,Jill Stein,0
-Rice,W Wash,President,,IND,Jill Stein,0
-Rice,Wilson,President,,IND,Jill Stein,1
-Rice,Lyons 1,President,,IND,Jill Stein,2
-Rice,Lyons 2,President,,IND,Jill Stein,5
-Rice,Lyons 3,President,,IND,Jill Stein,3
-Rice,Lyons 4,President,,IND,Jill Stein,2
-Rice,Sterling E,President,,IND,Jill Stein,10
-Rice,Sterling W,President,,IND,Jill Stein,5
-Rice,Prov,President,,IND,Jill Stein,1
-Rice,Advance,President,,IND,Jill Stein,23
-Rice,Total,President,,IND,Jill Stein,69
-Rice,Atlanta,President,,R,Donald Trump,23
-Rice,Bell,President,,R,Donald Trump,4
-Rice,Center,President,,R,Donald Trump,30
-Rice,Eureka,President,,R,Donald Trump,11
-Rice,Farmer,President,,R,Donald Trump,90
-Rice,Galt,President,,R,Donald Trump,26
-Rice,Harrison,President,,R,Donald Trump,44
-Rice,Lincoln,President,,R,Donald Trump,118
-Rice,Mitchell,President,,R,Donald Trump,25
-Rice,Odessa,President,,R,Donald Trump,15
-Rice,Pioneer,President,,R,Donald Trump,22
-Rice,Raymond,President,,R,Donald Trump,45
-Rice,Rockville,President,,R,Donald Trump,31
-Rice,Stevens,President,,R,Donald Trump,36
-Rice,Union,President,,R,Donald Trump,176
-Rice,Valley,President,,R,Donald Trump,45
-Rice,Victory,President,,R,Donald Trump,91
-Rice,E Wash,President,,R,Donald Trump,30
-Rice,W Wash,President,,R,Donald Trump,30
-Rice,Wilson,President,,R,Donald Trump,26
-Rice,Lyons 1,President,,R,Donald Trump,95
-Rice,Lyons 2,President,,R,Donald Trump,73
-Rice,Lyons 3,President,,R,Donald Trump,65
-Rice,Lyons 4,President,,R,Donald Trump,84
-Rice,Sterling E,President,,R,Donald Trump,238
-Rice,Sterling W,President,,R,Donald Trump,152
-Rice,Prov,President,,R,Donald Trump,40
-Rice,Advance,President,,R,Donald Trump,1172
-Rice,Total,President,,R,Donald Trump,2837
-Rice,Odessa,President,,CON,Darrell Castle,2
-Rice,Union,President,,CON,Darrell Castle,1
-Rice,Lyons 3,President,,CON,Darrell Castle,1
-Rice,Lyons 1,President,,wri,Evan McMullin,1
-Rice,Sterling E,President,,wri,Evan McMullin,17
-Rice,Sterling W,President,,wri,Evan McMullin,2
-Rice,Advance,President,,wri,Evan McMullin,2
-Rice,Prov,President,,wri,Mike Maturen,1
-Rice,Atlanta,U.S. Senate,,LBT,Robert Garrard,2
-Rice,Bell,U.S. Senate,,LBT,Robert Garrard,0
-Rice,Center,U.S. Senate,,LBT,Robert Garrard,1
-Rice,Eureka,U.S. Senate,,LBT,Robert Garrard,0
-Rice,Farmer,U.S. Senate,,LBT,Robert Garrard,4
-Rice,Galt,U.S. Senate,,LBT,Robert Garrard,4
-Rice,Harrison,U.S. Senate,,LBT,Robert Garrard,1
-Rice,Lincoln,U.S. Senate,,LBT,Robert Garrard,9
-Rice,Mitchell,U.S. Senate,,LBT,Robert Garrard,1
-Rice,Odessa,U.S. Senate,,LBT,Robert Garrard,2
-Rice,Pioneer,U.S. Senate,,LBT,Robert Garrard,2
-Rice,Raymond,U.S. Senate,,LBT,Robert Garrard,2
-Rice,Rockville,U.S. Senate,,LBT,Robert Garrard,2
-Rice,Stevens,U.S. Senate,,LBT,Robert Garrard,3
-Rice,Union,U.S. Senate,,LBT,Robert Garrard,11
-Rice,Valley,U.S. Senate,,LBT,Robert Garrard,2
-Rice,Victory,U.S. Senate,,LBT,Robert Garrard,7
-Rice,E Wash,U.S. Senate,,LBT,Robert Garrard,1
-Rice,W Wash,U.S. Senate,,LBT,Robert Garrard,1
-Rice,Wilson,U.S. Senate,,LBT,Robert Garrard,4
-Rice,Lyons 1,U.S. Senate,,LBT,Robert Garrard,9
-Rice,Lyons 2,U.S. Senate,,LBT,Robert Garrard,10
-Rice,Lyons 3,U.S. Senate,,LBT,Robert Garrard,14
-Rice,Lyons 4,U.S. Senate,,LBT,Robert Garrard,6
-Rice,Sterling E,U.S. Senate,,LBT,Robert Garrard,19
-Rice,Sterling W,U.S. Senate,,LBT,Robert Garrard,18
-Rice,Prov,U.S. Senate,,LBT,Robert Garrard,6
-Rice,Advance,U.S. Senate,,LBT,Robert Garrard,89
-Rice,Total,U.S. Senate,,LBT,Robert Garrard,230
-Rice,Atlanta,U.S. Senate,,R,Jerry Moran,21
-Rice,Bell,U.S. Senate,,R,Jerry Moran,4
-Rice,Center,U.S. Senate,,R,Jerry Moran,29
-Rice,Eureka,U.S. Senate,,R,Jerry Moran,12
-Rice,Farmer,U.S. Senate,,R,Jerry Moran,93
-Rice,Galt,U.S. Senate,,R,Jerry Moran,27
-Rice,Harrison,U.S. Senate,,R,Jerry Moran,45
-Rice,Lincoln,U.S. Senate,,R,Jerry Moran,105
-Rice,Mitchell,U.S. Senate,,R,Jerry Moran,27
-Rice,Odessa,U.S. Senate,,R,Jerry Moran,17
-Rice,Pioneer,U.S. Senate,,R,Jerry Moran,19
-Rice,Raymond,U.S. Senate,,R,Jerry Moran,46
-Rice,Rockville,U.S. Senate,,R,Jerry Moran,33
-Rice,Stevens,U.S. Senate,,R,Jerry Moran,40
-Rice,Union,U.S. Senate,,R,Jerry Moran,181
-Rice,Valley,U.S. Senate,,R,Jerry Moran,41
-Rice,Victory,U.S. Senate,,R,Jerry Moran,91
-Rice,E Wash,U.S. Senate,,R,Jerry Moran,30
-Rice,W Wash,U.S. Senate,,R,Jerry Moran,30
-Rice,Wilson,U.S. Senate,,R,Jerry Moran,24
-Rice,Lyons 1,U.S. Senate,,R,Jerry Moran,103
-Rice,Lyons 2,U.S. Senate,,R,Jerry Moran,86
-Rice,Lyons 3,U.S. Senate,,R,Jerry Moran,70
-Rice,Lyons 4,U.S. Senate,,R,Jerry Moran,90
-Rice,Sterling E,U.S. Senate,,R,Jerry Moran,272
-Rice,Sterling W,U.S. Senate,,R,Jerry Moran,163
-Rice,Prov,U.S. Senate,,R,Jerry Moran,44
-Rice,Advance,U.S. Senate,,R,Jerry Moran,1237
-Rice,Total,U.S. Senate,,R,Jerry Moran,2980
-Rice,Atlanta,U.S. Senate,,D,Patrick Wiesner,3
-Rice,Bell,U.S. Senate,,D,Patrick Wiesner,1
-Rice,Center,U.S. Senate,,D,Patrick Wiesner,1
-Rice,Eureka,U.S. Senate,,D,Patrick Wiesner,0
-Rice,Farmer,U.S. Senate,,D,Patrick Wiesner,6
-Rice,Galt,U.S. Senate,,D,Patrick Wiesner,3
-Rice,Harrison,U.S. Senate,,D,Patrick Wiesner,0
-Rice,Lincoln,U.S. Senate,,D,Patrick Wiesner,21
-Rice,Mitchell,U.S. Senate,,D,Patrick Wiesner,6
-Rice,Odessa,U.S. Senate,,D,Patrick Wiesner,5
-Rice,Pioneer,U.S. Senate,,D,Patrick Wiesner,0
-Rice,Raymond,U.S. Senate,,D,Patrick Wiesner,4
-Rice,Rockville,U.S. Senate,,D,Patrick Wiesner,11
-Rice,Stevens,U.S. Senate,,D,Patrick Wiesner,1
-Rice,Union,U.S. Senate,,D,Patrick Wiesner,33
-Rice,Valley,U.S. Senate,,D,Patrick Wiesner,12
-Rice,Victory,U.S. Senate,,D,Patrick Wiesner,17
-Rice,E Wash,U.S. Senate,,D,Patrick Wiesner,9
-Rice,W Wash,U.S. Senate,,D,Patrick Wiesner,4
-Rice,Wilson,U.S. Senate,,D,Patrick Wiesner,6
-Rice,Lyons 1,U.S. Senate,,D,Patrick Wiesner,19
-Rice,Lyons 2,U.S. Senate,,D,Patrick Wiesner,28
-Rice,Lyons 3,U.S. Senate,,D,Patrick Wiesner,19
-Rice,Lyons 4,U.S. Senate,,D,Patrick Wiesner,23
-Rice,Sterling E,U.S. Senate,,D,Patrick Wiesner,37
-Rice,Sterling W,U.S. Senate,,D,Patrick Wiesner,29
-Rice,Prov,U.S. Senate,,D,Patrick Wiesner,11
-Rice,Advance,U.S. Senate,,D,Patrick Wiesner,302
-Rice,Total,U.S. Senate,,D,Patrick Wiesner,611
-Rice,Atlanta,U.S. House,1,LBT,Kerry Burt,1
-Rice,Bell,U.S. House,1,LBT,Kerry Burt,0
-Rice,Center,U.S. House,1,LBT,Kerry Burt,2
-Rice,Eureka,U.S. House,1,LBT,Kerry Burt,0
-Rice,Farmer,U.S. House,1,LBT,Kerry Burt,12
-Rice,Galt,U.S. House,1,LBT,Kerry Burt,2
-Rice,Harrison,U.S. House,1,LBT,Kerry Burt,2
-Rice,Lincoln,U.S. House,1,LBT,Kerry Burt,5
-Rice,Mitchell,U.S. House,1,LBT,Kerry Burt,1
-Rice,Odessa,U.S. House,1,LBT,Kerry Burt,1
-Rice,Pioneer,U.S. House,1,LBT,Kerry Burt,1
-Rice,Raymond,U.S. House,1,LBT,Kerry Burt,3
-Rice,Rockville,U.S. House,1,LBT,Kerry Burt,3
-Rice,Stevens,U.S. House,1,LBT,Kerry Burt,2
-Rice,Union,U.S. House,1,LBT,Kerry Burt,15
-Rice,Valley,U.S. House,1,LBT,Kerry Burt,3
-Rice,Victory,U.S. House,1,LBT,Kerry Burt,8
-Rice,E Wash,U.S. House,1,LBT,Kerry Burt,3
-Rice,W Wash,U.S. House,1,LBT,Kerry Burt,2
-Rice,Wilson,U.S. House,1,LBT,Kerry Burt,3
-Rice,Lyons 1,U.S. House,1,LBT,Kerry Burt,8
-Rice,Lyons 2,U.S. House,1,LBT,Kerry Burt,9
-Rice,Lyons 3,U.S. House,1,LBT,Kerry Burt,18
-Rice,Lyons 4,U.S. House,1,LBT,Kerry Burt,11
-Rice,Sterling E,U.S. House,1,LBT,Kerry Burt,29
-Rice,Sterling W,U.S. House,1,LBT,Kerry Burt,19
-Rice,Prov,U.S. House,1,LBT,Kerry Burt,6
-Rice,Advance,U.S. House,1,LBT,Kerry Burt,113
-Rice,Total,U.S. House,1,LBT,Kerry Burt,282
-Rice,Atlanta,U.S. House,1,IND,Alan LaPolice,2
-Rice,Bell,U.S. House,1,IND,Alan LaPolice,3
-Rice,Center,U.S. House,1,IND,Alan LaPolice,4
-Rice,Eureka,U.S. House,1,IND,Alan LaPolice,2
-Rice,Farmer,U.S. House,1,IND,Alan LaPolice,16
-Rice,Galt,U.S. House,1,IND,Alan LaPolice,7
-Rice,Harrison,U.S. House,1,IND,Alan LaPolice,4
-Rice,Lincoln,U.S. House,1,IND,Alan LaPolice,21
-Rice,Mitchell,U.S. House,1,IND,Alan LaPolice,6
-Rice,Odessa,U.S. House,1,IND,Alan LaPolice,8
-Rice,Pioneer,U.S. House,1,IND,Alan LaPolice,4
-Rice,Raymond,U.S. House,1,IND,Alan LaPolice,9
-Rice,Rockville,U.S. House,1,IND,Alan LaPolice,14
-Rice,Stevens,U.S. House,1,IND,Alan LaPolice,5
-Rice,Union,U.S. House,1,IND,Alan LaPolice,49
-Rice,Valley,U.S. House,1,IND,Alan LaPolice,9
-Rice,Victory,U.S. House,1,IND,Alan LaPolice,33
-Rice,E Wash,U.S. House,1,IND,Alan LaPolice,11
-Rice,W Wash,U.S. House,1,IND,Alan LaPolice,8
-Rice,Wilson,U.S. House,1,IND,Alan LaPolice,7
-Rice,Lyons 1,U.S. House,1,IND,Alan LaPolice,13
-Rice,Lyons 2,U.S. House,1,IND,Alan LaPolice,22
-Rice,Lyons 3,U.S. House,1,IND,Alan LaPolice,17
-Rice,Lyons 4,U.S. House,1,IND,Alan LaPolice,21
-Rice,Sterling E,U.S. House,1,IND,Alan LaPolice,59
-Rice,Sterling W,U.S. House,1,IND,Alan LaPolice,36
-Rice,Prov,U.S. House,1,IND,Alan LaPolice,8
-Rice,Advance,U.S. House,1,IND,Alan LaPolice,340
-Rice,Total,U.S. House,1,IND,Alan LaPolice,738
-Rice,Atlanta,U.S. House,1,R,Roger Marshall,24
-Rice,Bell,U.S. House,1,R,Roger Marshall,3
-Rice,Center,U.S. House,1,R,Roger Marshall,25
-Rice,Eureka,U.S. House,1,R,Roger Marshall,10
-Rice,Farmer,U.S. House,1,R,Roger Marshall,75
-Rice,Galt,U.S. House,1,R,Roger Marshall,21
-Rice,Harrison,U.S. House,1,R,Roger Marshall,40
-Rice,Lincoln,U.S. House,1,R,Roger Marshall,107
-Rice,Mitchell,U.S. House,1,R,Roger Marshall,28
-Rice,Odessa,U.S. House,1,R,Roger Marshall,15
-Rice,Pioneer,U.S. House,1,R,Roger Marshall,16
-Rice,Raymond,U.S. House,1,R,Roger Marshall,41
-Rice,Rockville,U.S. House,1,R,Roger Marshall,30
-Rice,Stevens,U.S. House,1,R,Roger Marshall,37
-Rice,Union,U.S. House,1,R,Roger Marshall,159
-Rice,Valley,U.S. House,1,R,Roger Marshall,44
-Rice,Victory,U.S. House,1,R,Roger Marshall,74
-Rice,E Wash,U.S. House,1,R,Roger Marshall,26
-Rice,W Wash,U.S. House,1,R,Roger Marshall,25
-Rice,Wilson,U.S. House,1,R,Roger Marshall,23
-Rice,Lyons 1,U.S. House,1,R,Roger Marshall,107
-Rice,Lyons 2,U.S. House,1,R,Roger Marshall,90
-Rice,Lyons 3,U.S. House,1,R,Roger Marshall,70
-Rice,Lyons 4,U.S. House,1,R,Roger Marshall,87
-Rice,Sterling E,U.S. House,1,R,Roger Marshall,243
-Rice,Sterling W,U.S. House,1,R,Roger Marshall,149
-Rice,Prov,U.S. House,1,R,Roger Marshall,42
-Rice,Advance,U.S. House,1,R,Roger Marshall,1153
-Rice,Total,U.S. House,1,R,Roger Marshall,2764
-Rice,Atlanta,State Senate,35,D,Levi Morris,3
-Rice,Bell,State Senate,33,D,Matt Bristow,1
-Rice,Center,State Senate,33,D,Matt Bristow,5
-Rice,Eureka,State Senate,33,D,Matt Bristow,2
-Rice,Farmer,State Senate,33,D,Matt Bristow,25
-Rice,Galt,State Senate,35,D,Levi Morris,8
-Rice,Harrison,State Senate,35,D,Levi Morris,9
-Rice,Lincoln,State Senate,33,D,Matt Bristow,50
-Rice,Mitchell,State Senate,35,D,Levi Morris,11
-Rice,Odessa,State Senate,35,D,Levi Morris,9
-Rice,Pioneer,State Senate,33,D,Matt Bristow,3
-Rice,Raymond,State Senate,33,D,Matt Bristow,12
-Rice,Rockville,State Senate,35,D,Levi Morris,15
-Rice,Stevens,State Senate,35,D,Levi Morris,11
-Rice,Union,State Senate,35,D,Levi Morris,56
-Rice,Valley,State Senate,33,D,Matt Bristow,19
-Rice,Victory,State Senate,35,D,Levi Morris,40
-Rice,E Wash,State Senate,35,D,Levi Morris,10
-Rice,W Wash,State Senate,35,D,Levi Morris,9
-Rice,Wilson,State Senate,35,D,Levi Morris,12
-Rice,Lyons 1,State Senate,35,D,Levi Morris,52
-Rice,Lyons 2,State Senate,35,D,Levi Morris,63
-Rice,Lyons 3,State Senate,35,D,Levi Morris,51
-Rice,Lyons 4,State Senate,35,D,Levi Morris,50
-Rice,Sterling E,State Senate,35,D,Levi Morris,85
-Rice,Sterling W,State Senate,35,D,Levi Morris,66
-Rice,Prov,State Senate,33,D,Matt Bristow,2
-Rice,Advance,State Senate,33,D,Matt Bristow,66
-Rice,Total,State Senate,33,D,Matt Bristow,185
-Rice,Prov,State Senate,35,D,Levi Morris,22
-Rice,Advance,State Senate,35,D,Levi Morris,492
-Rice,Total,State Senate,35,D,Levi Morris,1074
-Rice,Atlanta,State Senate,35,R,Richard Willborn,24
-Rice,Bell,State Senate,33,R,Mary Jo Taylor,4
-Rice,Center,State Senate,33,R,Mary Jo Taylor,26
-Rice,Eureka,State Senate,33,R,Mary Jo Taylor,10
-Rice,Farmer,State Senate,33,R,Mary Jo Taylor,79
-Rice,Galt,State Senate,35,R,Richard Willborn,25
-Rice,Harrison,State Senate,35,R,Richard Willborn,37
-Rice,Lincoln,State Senate,33,R,Mary Jo Taylor,84
-Rice,Mitchell,State Senate,35,R,Richard Willborn,23
-Rice,Odessa,State Senate,35,R,Richard Willborn,14
-Rice,Pioneer,State Senate,33,R,Mary Jo Taylor,17
-Rice,Raymond,State Senate,33,R,Mary Jo Taylor,40
-Rice,Rockville,State Senate,35,R,Richard Willborn,31
-Rice,Stevens,State Senate,35,R,Richard Willborn,33
-Rice,Union,State Senate,35,R,Richard Willborn,163
-Rice,Valley,State Senate,33,R,Mary Jo Taylor,37
-Rice,Victory,State Senate,35,R,Richard Willborn,75
-Rice,E Wash,State Senate,35,R,Richard Willborn,28
-Rice,W Wash,State Senate,35,R,Richard Willborn,25
-Rice,Wilson,State Senate,35,R,Richard Willborn,22
-Rice,Lyons 1,State Senate,35,R,Richard Willborn,78
-Rice,Lyons 2,State Senate,35,R,Richard Willborn,57
-Rice,Lyons 3,State Senate,35,R,Richard Willborn,51
-Rice,Lyons 4,State Senate,35,R,Richard Willborn,68
-Rice,Sterling E,State Senate,35,R,Richard Willborn,234
-Rice,Sterling W,State Senate,35,R,Richard Willborn,135
-Rice,Prov,State Senate,33,R,Mary Jo Taylor,8
-Rice,Advance,State Senate,33,R,Mary Jo Taylor,146
-Rice,Total,State Senate,33,R,Mary Jo Taylor,451
-Rice,Prov,State Senate,35,R,Richard Willborn,26
-Rice,Advance,State Senate,35,R,Richard Willborn,897
-Rice,Total,State Senate,35,R,Richard Willborn,2046
-Rice,Eureka,State House,108,D,Kelley Menke,2
-Rice,Farmer,State House,108,D,Kelley Menke,19
-Rice,Galt,State House,108,D,Kelley Menke,6
-Rice,Mitchell,State House,108,D,Kelley Menke,8
-Rice,Odessa,State House,108,D,Kelley Menke,9
-Rice,Union,State House,108,D,Kelley Menke,60
-Rice,Victory,State House,108,D,Kelley Menke,31
-Rice,Prov,State House,108,D,Kelley Menke,5
-Rice,Advance,State House,108,D,Kelley Menke,77
-Rice,Total,State House,108,D,Kelley Menke,217
-Rice,Atlanta,State House,113,R,Greg Lewis,26
-Rice,Bell,State House,113,R,Greg Lewis,5
-Rice,Center,State House,113,R,Greg Lewis,28
-Rice,Eureka,State House,108,R,Steven Johnson,10
-Rice,Farmer,State House,108,R,Steven Johnson,85
-Rice,Galt,State House,108,R,Steven Johnson,28
-Rice,Harrison,State House,113,R,Greg Lewis,44
-Rice,Lincoln,State House,113,R,Greg Lewis,122
-Rice,Mitchell,State House,108,R,Steven Johnson,25
-Rice,Odessa,State House,108,R,Steven Johnson,14
-Rice,Pioneer,State House,113,R,Greg Lewis,19
-Rice,Raymond,State House,113,R,Greg Lewis,51
-Rice,Rockville,State House,114,R,Jack Thimesch,40
-Rice,Stevens,State House,114,R,Jack Thimesch,37
-Rice,Union,State House,108,R,Steven Johnson,158
-Rice,Valley,State House,113,R,Greg Lewis,53
-Rice,Victory,State House,108,R,Steven Johnson,83
-Rice,E Wash,State House,114,R,Jack Thimesch,33
-Rice,W Wash,State House,114,R,Jack Thimesch,30
-Rice,Wilson,State House,114,R,Jack Thimesch,30
-Rice,Lyons 1,State House,113,R,Greg Lewis,123
-Rice,Lyons 2,State House,113,R,Greg Lewis,107
-Rice,Lyons 3,State House,113,R,Greg Lewis,93
-Rice,Lyons 4,State House,113,R,Greg Lewis,109
-Rice,Sterling E,State House,114,R,Jack Thimesch,288
-Rice,Sterling W,State House,114,R,Jack Thimesch,182
-Rice,Prov,State House,108,R,Steven Johnson,8
-Rice,Advance,State House,108,R,Steven Johnson,154
-Rice,Total,State House,108,R,Steven Johnson,565
-Rice,Prov,State House,113,R,Greg Lewis,27
-Rice,Advance,State House,113,R,Greg Lewis,819
-Rice,Total,State House,113,R,Greg Lewis,1626
-Rice,Prov,State House,114,R,Jack Thimesch,14
-Rice,Advance,State House,114,R,Jack Thimesch,395
-Rice,Total,State House,114,R,Jack Thimesch,1049
+county,precinct,office,district,party,candidate,votes,vtd
+RICE,Atlanta Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",64,000010
+RICE,Bell Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",6,000020
+RICE,Center Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",45,000030
+RICE,East Washington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",67,000040
+RICE,Eureka Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",7,000050
+RICE,Eureka Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",18,000050
+RICE,Farmer Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",45,000060
+RICE,Farmer Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",122,000060
+RICE,Galt Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",8,000070
+RICE,Galt Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",35,000070
+RICE,Harrison Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",82,000080
+RICE,Lincoln Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",166,000090
+RICE,Lyons Ward 1,Kansas House of Representatives,113,Republican,"Lewis, Greg",330,000100
+RICE,Lyons Ward 2,Kansas House of Representatives,113,Republican,"Lewis, Greg",256,000110
+RICE,Lyons Ward 3,Kansas House of Representatives,113,Republican,"Lewis, Greg",217,000120
+RICE,Lyons Ward 4,Kansas House of Representatives,113,Republican,"Lewis, Greg",260,000130
+RICE,Mitchell Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",16,000140
+RICE,Mitchell Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",51,000140
+RICE,Odessa Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",9,000150
+RICE,Odessa Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",25,000150
+RICE,Pioneer Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",28,000160
+RICE,Raymond Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",71,000170
+RICE,Rockville Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",61,000180
+RICE,Sterling City East Ward,Kansas House of Representatives,114,Republican,"Thimesch, Jack",461,00019A
+RICE,Sterling City East Ward Exclave A,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00019B
+RICE,Sterling City East Ward Exclave B,Kansas House of Representatives,114,Republican,"Thimesch, Jack",0,00019C
+RICE,Sterling City West Ward,Kansas House of Representatives,114,Republican,"Thimesch, Jack",273,000200
+RICE,Sterling Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",72,000210
+RICE,Union Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",88,000220
+RICE,Union Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",216,000220
+RICE,Valley Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",101,000230
+RICE,Victoria Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",44,000240
+RICE,Victoria Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",98,000240
+RICE,West Washington Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",48,000250
+RICE,Wilson Township,Kansas House of Representatives,114,Republican,"Thimesch, Jack",67,000260
+RICE,Atlanta Township,Kansas Senate,35,Democratic,"Morris, Levi",19,000010
+RICE,Atlanta Township,Kansas Senate,35,Republican,"Wilborn, Richard",50,000010
+RICE,Bell Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000020
+RICE,Bell Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",5,000020
+RICE,Center Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000030
+RICE,Center Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",43,000030
+RICE,East Washington Township,Kansas Senate,35,Democratic,"Morris, Levi",18,000040
+RICE,East Washington Township,Kansas Senate,35,Republican,"Wilborn, Richard",59,000040
+RICE,Eureka Township,Kansas Senate,33,Democratic,"Bristow, Matt",8,000050
+RICE,Eureka Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",17,000050
+RICE,Farmer Township,Kansas Senate,33,Democratic,"Bristow, Matt",51,000060
+RICE,Farmer Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",115,000060
+RICE,Galt Township,Kansas Senate,35,Democratic,"Morris, Levi",12,000070
+RICE,Galt Township,Kansas Senate,35,Republican,"Wilborn, Richard",31,000070
+RICE,Harrison Township,Kansas Senate,35,Democratic,"Morris, Levi",25,000080
+RICE,Harrison Township,Kansas Senate,35,Republican,"Wilborn, Richard",64,000080
+RICE,Lincoln Township,Kansas Senate,33,Democratic,"Bristow, Matt",62,000090
+RICE,Lincoln Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",114,000090
+RICE,Lyons Ward 1,Kansas Senate,35,Democratic,"Morris, Levi",142,000100
+RICE,Lyons Ward 1,Kansas Senate,35,Republican,"Wilborn, Richard",222,000100
+RICE,Lyons Ward 2,Kansas Senate,35,Democratic,"Morris, Levi",128,000110
+RICE,Lyons Ward 2,Kansas Senate,35,Republican,"Wilborn, Richard",158,000110
+RICE,Lyons Ward 3,Kansas Senate,35,Democratic,"Morris, Levi",121,000120
+RICE,Lyons Ward 3,Kansas Senate,35,Republican,"Wilborn, Richard",122,000120
+RICE,Lyons Ward 4,Kansas Senate,35,Democratic,"Morris, Levi",130,000130
+RICE,Lyons Ward 4,Kansas Senate,35,Republican,"Wilborn, Richard",167,000130
+RICE,Mitchell Township,Kansas Senate,35,Democratic,"Morris, Levi",20,000140
+RICE,Mitchell Township,Kansas Senate,35,Republican,"Wilborn, Richard",49,000140
+RICE,Odessa Township,Kansas Senate,35,Democratic,"Morris, Levi",9,000150
+RICE,Odessa Township,Kansas Senate,35,Republican,"Wilborn, Richard",25,000150
+RICE,Pioneer Township,Kansas Senate,33,Democratic,"Bristow, Matt",8,000160
+RICE,Pioneer Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",21,000160
+RICE,Raymond Township,Kansas Senate,33,Democratic,"Bristow, Matt",16,000170
+RICE,Raymond Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",58,000170
+RICE,Rockville Township,Kansas Senate,35,Democratic,"Morris, Levi",24,000180
+RICE,Rockville Township,Kansas Senate,35,Republican,"Wilborn, Richard",47,000180
+RICE,Sterling City East Ward,Kansas Senate,35,Democratic,"Morris, Levi",136,00019A
+RICE,Sterling City East Ward,Kansas Senate,35,Republican,"Wilborn, Richard",380,00019A
+RICE,Sterling City East Ward Exclave A,Kansas Senate,35,Democratic,"Morris, Levi",0,00019B
+RICE,Sterling City East Ward Exclave A,Kansas Senate,35,Republican,"Wilborn, Richard",0,00019B
+RICE,Sterling City East Ward Exclave B,Kansas Senate,35,Democratic,"Morris, Levi",0,00019C
+RICE,Sterling City East Ward Exclave B,Kansas Senate,35,Republican,"Wilborn, Richard",0,00019C
+RICE,Sterling City West Ward,Kansas Senate,35,Democratic,"Morris, Levi",111,000200
+RICE,Sterling City West Ward,Kansas Senate,35,Republican,"Wilborn, Richard",196,000200
+RICE,Sterling Township,Kansas Senate,35,Democratic,"Morris, Levi",20,000210
+RICE,Sterling Township,Kansas Senate,35,Republican,"Wilborn, Richard",63,000210
+RICE,Union Township,Kansas Senate,35,Democratic,"Morris, Levi",77,000220
+RICE,Union Township,Kansas Senate,35,Republican,"Wilborn, Richard",225,000220
+RICE,Valley Township,Kansas Senate,33,Democratic,"Bristow, Matt",33,000230
+RICE,Valley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",78,000230
+RICE,Victoria Township,Kansas Senate,35,Democratic,"Morris, Levi",49,000240
+RICE,Victoria Township,Kansas Senate,35,Republican,"Wilborn, Richard",93,000240
+RICE,West Washington Township,Kansas Senate,35,Democratic,"Morris, Levi",15,000250
+RICE,West Washington Township,Kansas Senate,35,Republican,"Wilborn, Richard",39,000250
+RICE,Wilson Township,Kansas Senate,35,Democratic,"Morris, Levi",18,000260
+RICE,Wilson Township,Kansas Senate,35,Republican,"Wilborn, Richard",56,000260
+RICE,Atlanta Township,President / Vice President,,independent,"Stein, Jill",1,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+RICE,Atlanta Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+RICE,Atlanta Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000010
+RICE,Atlanta Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+RICE,Atlanta Township,President / Vice President,,Republican,"Trump, Donald J.",53,000010
+RICE,Bell Township,President / Vice President,,independent,"Stein, Jill",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+RICE,Bell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+RICE,Bell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+RICE,Bell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+RICE,Bell Township,President / Vice President,,Republican,"Trump, Donald J.",5,000020
+RICE,Center Township,President / Vice President,,independent,"Stein, Jill",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+RICE,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+RICE,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+RICE,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+RICE,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+RICE,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+RICE,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+RICE,Center Township,President / Vice President,,Republican,"Trump, Donald J.",58,000030
+RICE,East Washington Township,President / Vice President,,independent,"Stein, Jill",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+RICE,East Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+RICE,East Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000040
+RICE,East Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+RICE,East Washington Township,President / Vice President,,Republican,"Trump, Donald J.",64,000040
+RICE,Eureka Township,President / Vice President,,independent,"Stein, Jill",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+RICE,Eureka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+RICE,Eureka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000050
+RICE,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+RICE,Eureka Township,President / Vice President,,Republican,"Trump, Donald J.",21,000050
+RICE,Farmer Township,President / Vice President,,independent,"Stein, Jill",4,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+RICE,Farmer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+RICE,Farmer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000060
+RICE,Farmer Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000060
+RICE,Farmer Township,President / Vice President,,Republican,"Trump, Donald J.",142,000060
+RICE,Galt Township,President / Vice President,,independent,"Stein, Jill",1,000070
+RICE,Galt Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+RICE,Galt Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+RICE,Galt Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000070
+RICE,Galt Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+RICE,Galt Township,President / Vice President,,Republican,"Trump, Donald J.",34,000070
+RICE,Harrison Township,President / Vice President,,independent,"Stein, Jill",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+RICE,Harrison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+RICE,Harrison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000080
+RICE,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+RICE,Harrison Township,President / Vice President,,Republican,"Trump, Donald J.",77,000080
+RICE,Lincoln Township,President / Vice President,,independent,"Stein, Jill",1,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+RICE,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+RICE,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000090
+RICE,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+RICE,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",156,000090
+RICE,Lyons Ward 1,President / Vice President,,independent,"Stein, Jill",5,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"McMullin, Evan",1,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+RICE,Lyons Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+RICE,Lyons Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000100
+RICE,Lyons Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",20,000100
+RICE,Lyons Ward 1,President / Vice President,,Republican,"Trump, Donald J.",249,000100
+RICE,Lyons Ward 2,President / Vice President,,independent,"Stein, Jill",11,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+RICE,Lyons Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+RICE,Lyons Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000110
+RICE,Lyons Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",26,000110
+RICE,Lyons Ward 2,President / Vice President,,Republican,"Trump, Donald J.",183,000110
+RICE,Lyons Ward 3,President / Vice President,,independent,"Stein, Jill",3,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Castle, Darrell L",1,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+RICE,Lyons Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+RICE,Lyons Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000120
+RICE,Lyons Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",18,000120
+RICE,Lyons Ward 3,President / Vice President,,Republican,"Trump, Donald J.",159,000120
+RICE,Lyons Ward 4,President / Vice President,,independent,"Stein, Jill",7,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+RICE,Lyons Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+RICE,Lyons Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000130
+RICE,Lyons Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",23,000130
+RICE,Lyons Ward 4,President / Vice President,,Republican,"Trump, Donald J.",218,000130
+RICE,Mitchell Township,President / Vice President,,independent,"Stein, Jill",1,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+RICE,Mitchell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+RICE,Mitchell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000140
+RICE,Mitchell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+RICE,Mitchell Township,President / Vice President,,Republican,"Trump, Donald J.",53,000140
+RICE,Odessa Township,President / Vice President,,independent,"Stein, Jill",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Castle, Darrell L",2,000150
+RICE,Odessa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+RICE,Odessa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+RICE,Odessa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000150
+RICE,Odessa Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+RICE,Odessa Township,President / Vice President,,Republican,"Trump, Donald J.",26,000150
+RICE,Pioneer Township,President / Vice President,,independent,"Stein, Jill",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+RICE,Pioneer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+RICE,Pioneer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000160
+RICE,Pioneer Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+RICE,Pioneer Township,President / Vice President,,Republican,"Trump, Donald J.",27,000160
+RICE,Raymond Township,President / Vice President,,independent,"Stein, Jill",1,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+RICE,Raymond Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+RICE,Raymond Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000170
+RICE,Raymond Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000170
+RICE,Raymond Township,President / Vice President,,Republican,"Trump, Donald J.",66,000170
+RICE,Rockville Township,President / Vice President,,independent,"Stein, Jill",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+RICE,Rockville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+RICE,Rockville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000180
+RICE,Rockville Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+RICE,Rockville Township,President / Vice President,,Republican,"Trump, Donald J.",47,000180
+RICE,Sterling City East Ward,President / Vice President,,independent,"Stein, Jill",14,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Castle, Darrell L",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Giordani, Rocky",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Hedges, James A",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Hoefling, Tom",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Kahn, Lynn",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"La Riva, Gloria",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Levinson, Michael S.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Maturen, Michael A",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"McMullin, Evan",2,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Perry, Darryl",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Schriner, Joe C",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Smith, Mike",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Sood, Ajay",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Sterling, Shawna",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019A
+RICE,Sterling City East Ward,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,00019A
+RICE,Sterling City East Ward,President / Vice President,,Libertarian,"Johnson, Gary",23,00019A
+RICE,Sterling City East Ward,President / Vice President,,Republican,"Trump, Donald J.",377,00019A
+RICE,Sterling City East Ward Exclave A,President / Vice President,,independent,"Stein, Jill",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Hedges, James A",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Smith, Mike",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00019B
+RICE,Sterling City East Ward Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00019B
+RICE,Sterling City East Ward Exclave B,President / Vice President,,independent,"Stein, Jill",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Hedges, James A",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Smith, Mike",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00019C
+RICE,Sterling City East Ward Exclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00019C
+RICE,Sterling City West Ward,President / Vice President,,independent,"Stein, Jill",5,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Hedges, James A",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"McMullin, Evan",2,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Perry, Darryl",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Smith, Mike",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Sood, Ajay",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+RICE,Sterling City West Ward,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+RICE,Sterling City West Ward,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000200
+RICE,Sterling City West Ward,President / Vice President,,Libertarian,"Johnson, Gary",21,000200
+RICE,Sterling City West Ward,President / Vice President,,Republican,"Trump, Donald J.",223,000200
+RICE,Sterling Township,President / Vice President,,independent,"Stein, Jill",1,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+RICE,Sterling Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+RICE,Sterling Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000210
+RICE,Sterling Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+RICE,Sterling Township,President / Vice President,,Republican,"Trump, Donald J.",66,000210
+RICE,Union Township,President / Vice President,,independent,"Stein, Jill",8,000220
+RICE,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Castle, Darrell L",1,000220
+RICE,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+RICE,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+RICE,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+RICE,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+RICE,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000220
+RICE,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",19,000220
+RICE,Union Township,President / Vice President,,Republican,"Trump, Donald J.",234,000220
+RICE,Valley Township,President / Vice President,,independent,"Stein, Jill",3,000230
+RICE,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+RICE,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+RICE,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000230
+RICE,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000230
+RICE,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",82,000230
+RICE,Victoria Township,President / Vice President,,independent,"Stein, Jill",2,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+RICE,Victoria Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+RICE,Victoria Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000240
+RICE,Victoria Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000240
+RICE,Victoria Township,President / Vice President,,Republican,"Trump, Donald J.",112,000240
+RICE,West Washington Township,President / Vice President,,independent,"Stein, Jill",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+RICE,West Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+RICE,West Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000250
+RICE,West Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000250
+RICE,West Washington Township,President / Vice President,,Republican,"Trump, Donald J.",42,000250
+RICE,Wilson Township,President / Vice President,,independent,"Stein, Jill",1,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+RICE,Wilson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+RICE,Wilson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000260
+RICE,Wilson Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+RICE,Wilson Township,President / Vice President,,Republican,"Trump, Donald J.",63,000260
+RICE,Atlanta Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000010
+RICE,Atlanta Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+RICE,Atlanta Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000010
+RICE,Atlanta Township,United States House of Representatives,1,Republican,"Marshall, Roger",57,000010
+RICE,Bell Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000020
+RICE,Bell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+RICE,Bell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+RICE,Bell Township,United States House of Representatives,1,Republican,"Marshall, Roger",3,000020
+RICE,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000030
+RICE,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+RICE,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000030
+RICE,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",36,000030
+RICE,East Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000040
+RICE,East Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+RICE,East Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000040
+RICE,East Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000040
+RICE,Eureka Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000050
+RICE,Eureka Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+RICE,Eureka Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000050
+RICE,Eureka Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000050
+RICE,Farmer Township,United States House of Representatives,1,independent,"LaPolice, Alan",37,000060
+RICE,Farmer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+RICE,Farmer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000060
+RICE,Farmer Township,United States House of Representatives,1,Republican,"Marshall, Roger",109,000060
+RICE,Galt Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000070
+RICE,Galt Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+RICE,Galt Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000070
+RICE,Galt Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000070
+RICE,Harrison Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000080
+RICE,Harrison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+RICE,Harrison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000080
+RICE,Harrison Township,United States House of Representatives,1,Republican,"Marshall, Roger",67,000080
+RICE,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000090
+RICE,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+RICE,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000090
+RICE,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",148,000090
+RICE,Lyons Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",61,000100
+RICE,Lyons Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+RICE,Lyons Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000100
+RICE,Lyons Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",287,000100
+RICE,Lyons Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",53,000110
+RICE,Lyons Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+RICE,Lyons Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000110
+RICE,Lyons Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",209,000110
+RICE,Lyons Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",45,000120
+RICE,Lyons Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+RICE,Lyons Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000120
+RICE,Lyons Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",162,000120
+RICE,Lyons Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",47,000130
+RICE,Lyons Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+RICE,Lyons Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000130
+RICE,Lyons Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",212,000130
+RICE,Mitchell Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000140
+RICE,Mitchell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+RICE,Mitchell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000140
+RICE,Mitchell Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000140
+RICE,Odessa Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000150
+RICE,Odessa Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+RICE,Odessa Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000150
+RICE,Odessa Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000150
+RICE,Pioneer Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000160
+RICE,Pioneer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+RICE,Pioneer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+RICE,Pioneer Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000160
+RICE,Raymond Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000170
+RICE,Raymond Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+RICE,Raymond Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000170
+RICE,Raymond Township,United States House of Representatives,1,Republican,"Marshall, Roger",55,000170
+RICE,Rockville Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000180
+RICE,Rockville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+RICE,Rockville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000180
+RICE,Rockville Township,United States House of Representatives,1,Republican,"Marshall, Roger",49,000180
+RICE,Sterling City East Ward,United States House of Representatives,1,independent,"LaPolice, Alan",102,00019A
+RICE,Sterling City East Ward,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019A
+RICE,Sterling City East Ward,United States House of Representatives,1,Libertarian,"Burt, Kerry",42,00019A
+RICE,Sterling City East Ward,United States House of Representatives,1,Republican,"Marshall, Roger",388,00019A
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00019B
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019B
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00019B
+RICE,Sterling City East Ward Exclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00019B
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00019C
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00019C
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00019C
+RICE,Sterling City East Ward Exclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00019C
+RICE,Sterling City West Ward,United States House of Representatives,1,independent,"LaPolice, Alan",62,000200
+RICE,Sterling City West Ward,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+RICE,Sterling City West Ward,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000200
+RICE,Sterling City West Ward,United States House of Representatives,1,Republican,"Marshall, Roger",226,000200
+RICE,Sterling Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000210
+RICE,Sterling Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+RICE,Sterling Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000210
+RICE,Sterling Township,United States House of Representatives,1,Republican,"Marshall, Roger",68,000210
+RICE,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",71,000220
+RICE,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+RICE,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,000220
+RICE,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",222,000220
+RICE,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",26,000230
+RICE,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+RICE,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000230
+RICE,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",81,000230
+RICE,Victoria Township,United States House of Representatives,1,independent,"LaPolice, Alan",39,000240
+RICE,Victoria Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+RICE,Victoria Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000240
+RICE,Victoria Township,United States House of Representatives,1,Republican,"Marshall, Roger",89,000240
+RICE,West Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000250
+RICE,West Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+RICE,West Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000250
+RICE,West Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000250
+RICE,Wilson Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000260
+RICE,Wilson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+RICE,Wilson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000260
+RICE,Wilson Township,United States House of Representatives,1,Republican,"Marshall, Roger",55,000260
+RICE,Atlanta Township,United States Senate,,write - in,"Smith, DJ",0,000010
+RICE,Atlanta Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000010
+RICE,Atlanta Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000010
+RICE,Atlanta Township,United States Senate,,Republican,"Moran, Jerry",53,000010
+RICE,Bell Township,United States Senate,,write - in,"Smith, DJ",0,000020
+RICE,Bell Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+RICE,Bell Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+RICE,Bell Township,United States Senate,,Republican,"Moran, Jerry",5,000020
+RICE,Center Township,United States Senate,,write - in,"Smith, DJ",0,000030
+RICE,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000030
+RICE,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+RICE,Center Township,United States Senate,,Republican,"Moran, Jerry",45,000030
+RICE,East Washington Township,United States Senate,,write - in,"Smith, DJ",0,000040
+RICE,East Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000040
+RICE,East Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000040
+RICE,East Washington Township,United States Senate,,Republican,"Moran, Jerry",60,000040
+RICE,Eureka Township,United States Senate,,write - in,"Smith, DJ",0,000050
+RICE,Eureka Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000050
+RICE,Eureka Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+RICE,Eureka Township,United States Senate,,Republican,"Moran, Jerry",20,000050
+RICE,Farmer Township,United States Senate,,write - in,"Smith, DJ",0,000060
+RICE,Farmer Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000060
+RICE,Farmer Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000060
+RICE,Farmer Township,United States Senate,,Republican,"Moran, Jerry",143,000060
+RICE,Galt Township,United States Senate,,write - in,"Smith, DJ",0,000070
+RICE,Galt Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000070
+RICE,Galt Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000070
+RICE,Galt Township,United States Senate,,Republican,"Moran, Jerry",38,000070
+RICE,Harrison Township,United States Senate,,write - in,"Smith, DJ",0,000080
+RICE,Harrison Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000080
+RICE,Harrison Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+RICE,Harrison Township,United States Senate,,Republican,"Moran, Jerry",75,000080
+RICE,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000090
+RICE,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000090
+RICE,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000090
+RICE,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",145,000090
+RICE,Lyons Ward 1,United States Senate,,write - in,"Smith, DJ",0,000100
+RICE,Lyons Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",68,000100
+RICE,Lyons Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000100
+RICE,Lyons Ward 1,United States Senate,,Republican,"Moran, Jerry",284,000100
+RICE,Lyons Ward 2,United States Senate,,write - in,"Smith, DJ",0,000110
+RICE,Lyons Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",60,000110
+RICE,Lyons Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",21,000110
+RICE,Lyons Ward 2,United States Senate,,Republican,"Moran, Jerry",211,000110
+RICE,Lyons Ward 3,United States Senate,,write - in,"Smith, DJ",0,000120
+RICE,Lyons Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",60,000120
+RICE,Lyons Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",29,000120
+RICE,Lyons Ward 3,United States Senate,,Republican,"Moran, Jerry",159,000120
+RICE,Lyons Ward 4,United States Senate,,write - in,"Smith, DJ",0,000130
+RICE,Lyons Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",52,000130
+RICE,Lyons Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",16,000130
+RICE,Lyons Ward 4,United States Senate,,Republican,"Moran, Jerry",230,000130
+RICE,Mitchell Township,United States Senate,,write - in,"Smith, DJ",0,000140
+RICE,Mitchell Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000140
+RICE,Mitchell Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+RICE,Mitchell Township,United States Senate,,Republican,"Moran, Jerry",57,000140
+RICE,Odessa Township,United States Senate,,write - in,"Smith, DJ",0,000150
+RICE,Odessa Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000150
+RICE,Odessa Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000150
+RICE,Odessa Township,United States Senate,,Republican,"Moran, Jerry",28,000150
+RICE,Pioneer Township,United States Senate,,write - in,"Smith, DJ",0,000160
+RICE,Pioneer Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000160
+RICE,Pioneer Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000160
+RICE,Pioneer Township,United States Senate,,Republican,"Moran, Jerry",22,000160
+RICE,Raymond Township,United States Senate,,write - in,"Smith, DJ",0,000170
+RICE,Raymond Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000170
+RICE,Raymond Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+RICE,Raymond Township,United States Senate,,Republican,"Moran, Jerry",68,000170
+RICE,Rockville Township,United States Senate,,write - in,"Smith, DJ",0,000180
+RICE,Rockville Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000180
+RICE,Rockville Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000180
+RICE,Rockville Township,United States Senate,,Republican,"Moran, Jerry",52,000180
+RICE,Sterling City East Ward,United States Senate,,write - in,"Smith, DJ",0,00019A
+RICE,Sterling City East Ward,United States Senate,,Democratic,"Wiesner, Patrick",69,00019A
+RICE,Sterling City East Ward,United States Senate,,Libertarian,"Garrard, Robert D.",29,00019A
+RICE,Sterling City East Ward,United States Senate,,Republican,"Moran, Jerry",426,00019A
+RICE,Sterling City East Ward Exclave A,United States Senate,,write - in,"Smith, DJ",0,00019B
+RICE,Sterling City East Ward Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00019B
+RICE,Sterling City East Ward Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00019B
+RICE,Sterling City East Ward Exclave A,United States Senate,,Republican,"Moran, Jerry",0,00019B
+RICE,Sterling City East Ward Exclave B,United States Senate,,write - in,"Smith, DJ",0,00019C
+RICE,Sterling City East Ward Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00019C
+RICE,Sterling City East Ward Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00019C
+RICE,Sterling City East Ward Exclave B,United States Senate,,Republican,"Moran, Jerry",0,00019C
+RICE,Sterling City West Ward,United States Senate,,write - in,"Smith, DJ",0,000200
+RICE,Sterling City West Ward,United States Senate,,Democratic,"Wiesner, Patrick",54,000200
+RICE,Sterling City West Ward,United States Senate,,Libertarian,"Garrard, Robert D.",22,000200
+RICE,Sterling City West Ward,United States Senate,,Republican,"Moran, Jerry",243,000200
+RICE,Sterling Township,United States Senate,,write - in,"Smith, DJ",0,000210
+RICE,Sterling Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000210
+RICE,Sterling Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000210
+RICE,Sterling Township,United States Senate,,Republican,"Moran, Jerry",73,000210
+RICE,Union Township,United States Senate,,write - in,"Smith, DJ",0,000220
+RICE,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",51,000220
+RICE,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000220
+RICE,Union Township,United States Senate,,Republican,"Moran, Jerry",243,000220
+RICE,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000230
+RICE,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000230
+RICE,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000230
+RICE,Valley Township,United States Senate,,Republican,"Moran, Jerry",85,000230
+RICE,Victoria Township,United States Senate,,write - in,"Smith, DJ",0,000240
+RICE,Victoria Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000240
+RICE,Victoria Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000240
+RICE,Victoria Township,United States Senate,,Republican,"Moran, Jerry",110,000240
+RICE,West Washington Township,United States Senate,,write - in,"Smith, DJ",0,000250
+RICE,West Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000250
+RICE,West Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000250
+RICE,West Washington Township,United States Senate,,Republican,"Moran, Jerry",45,000250
+RICE,Wilson Township,United States Senate,,write - in,"Smith, DJ",0,000260
+RICE,Wilson Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000260
+RICE,Wilson Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000260
+RICE,Wilson Township,United States Senate,,Republican,"Moran, Jerry",59,000260

--- a/2016/20161108__ks__general__riley__precinct.csv
+++ b/2016/20161108__ks__general__riley__precinct.csv
@@ -1,1085 +1,2574 @@
-county,precinct,office,district,party,candidate,votes
-Riley,W01P01,Voters,,,Registered,1228
-Riley,W02P01,Voters,,,Registered,1414
-Riley,W02P02,Voters,,,Registered,498
-Riley,W02P03,Voters,,,Registered,1850
-Riley,W02P04,Voters,,,Registered,1095
-Riley,W03P02,Voters,,,Registered,933
-Riley,W03P03,Voters,,,Registered,1490
-Riley,W04P02,Voters,,,Registered,343
-Riley,W04P03,Voters,,,Registered,973
-Riley,W04P04,Voters,,,Registered,1707
-Riley,W04P05,Voters,,,Registered,1021
-Riley,W04P06,Voters,,,Registered,565
-Riley,W04P07,Voters,,,Registered,55
-Riley,W05P02,Voters,,,Registered,1168
-Riley,W05P03,Voters,,,Registered,1466
-Riley,W05P05,Voters,,,Registered,605
-Riley,W05P06,Voters,,,Registered,1042
-Riley,W05P07,Voters,,,Registered,484
-Riley,W05P08,Voters,,,Registered,685
-Riley,W05P09,Voters,,,Registered,1655
-Riley,W05P10,Voters,,,Registered,1892
-Riley,W05P11,Voters,,,Registered,1933
-Riley,W06P01,Voters,,,Registered,40
-Riley,W08P01,Voters,,,Registered,449
-Riley,W08P02,Voters,,,Registered,9
-Riley,W08P03,Voters,,,Registered,716
-Riley,W09P01,Voters,,,Registered,196
-Riley,W09P02,Voters,,,Registered,148
-Riley,W09P03,Voters,,,Registered,76
-Riley,W10P01,Voters,,,Registered,167
-Riley,W11P01,Voters,,,Registered,591
-Riley,W11P03,Voters,,,Registered,77
-Riley,W11P12,Voters,,,Registered,327
-Riley,W01P01,Voters,,,Ballots Cast,713
-Riley,W02P01,Voters,,,Ballots Cast,726
-Riley,W02P02,Voters,,,Ballots Cast,288
-Riley,W02P03,Voters,,,Ballots Cast,1210
-Riley,W02P04,Voters,,,Ballots Cast,676
-Riley,W03P02,Voters,,,Ballots Cast,462
-Riley,W03P03,Voters,,,Ballots Cast,870
-Riley,W04P02,Voters,,,Ballots Cast,257
-Riley,W04P03,Voters,,,Ballots Cast,656
-Riley,W04P04,Voters,,,Ballots Cast,1215
-Riley,W04P05,Voters,,,Ballots Cast,672
-Riley,W04P06,Voters,,,Ballots Cast,413
-Riley,W04P07,Voters,,,Ballots Cast,28
-Riley,W05P02,Voters,,,Ballots Cast,635
-Riley,W05P03,Voters,,,Ballots Cast,833
-Riley,W05P05,Voters,,,Ballots Cast,341
-Riley,W05P06,Voters,,,Ballots Cast,756
-Riley,W05P07,Voters,,,Ballots Cast,332
-Riley,W05P08,Voters,,,Ballots Cast,482
-Riley,W05P09,Voters,,,Ballots Cast,1217
-Riley,W05P10,Voters,,,Ballots Cast,1381
-Riley,W05P11,Voters,,,Ballots Cast,1337
-Riley,W06P01,Voters,,,Ballots Cast,1
-Riley,W08P01,Voters,,,Ballots Cast,218
-Riley,W08P02,Voters,,,Ballots Cast,5
-Riley,W08P03,Voters,,,Ballots Cast,375
-Riley,W09P01,Voters,,,Ballots Cast,118
-Riley,W09P02,Voters,,,Ballots Cast,121
-Riley,W09P03,Voters,,,Ballots Cast,59
-Riley,W10P01,Voters,,,Ballots Cast,130
-Riley,W11P01,Voters,,,Ballots Cast,325
-Riley,W11P03,Voters,,,Ballots Cast,55
-Riley,W11P12,Voters,,,Ballots Cast,213
-Riley,W01P01,President,,Dem,Hillary Clinton,412
-Riley,W02P01,President,,Dem,Hillary Clinton,425
-Riley,W02P02,President,,Dem,Hillary Clinton,154
-Riley,W02P03,President,,Dem,Hillary Clinton,519
-Riley,W02P04,President,,Dem,Hillary Clinton,291
-Riley,W03P02,President,,Dem,Hillary Clinton,248
-Riley,W03P03,President,,Dem,Hillary Clinton,435
-Riley,W04P02,President,,Dem,Hillary Clinton,135
-Riley,W04P03,President,,Dem,Hillary Clinton,350
-Riley,W04P04,President,,Dem,Hillary Clinton,483
-Riley,W04P05,President,,Dem,Hillary Clinton,269
-Riley,W04P06,President,,Dem,Hillary Clinton,160
-Riley,W04P07,President,,Dem,Hillary Clinton,9
-Riley,W05P02,President,,Dem,Hillary Clinton,365
-Riley,W05P03,President,,Dem,Hillary Clinton,413
-Riley,W05P05,President,,Dem,Hillary Clinton,161
-Riley,W05P06,President,,Dem,Hillary Clinton,296
-Riley,W05P07,President,,Dem,Hillary Clinton,158
-Riley,W05P08,President,,Dem,Hillary Clinton,218
-Riley,W05P09,President,,Dem,Hillary Clinton,544
-Riley,W05P10,President,,Dem,Hillary Clinton,610
-Riley,W05P11,President,,Dem,Hillary Clinton,529
-Riley,W06P01,President,,Dem,Hillary Clinton,0
-Riley,W08P01,President,,Dem,Hillary Clinton,93
-Riley,W08P02,President,,Dem,Hillary Clinton,1
-Riley,W08P03,President,,Dem,Hillary Clinton,186
-Riley,W09P01,President,,Dem,Hillary Clinton,56
-Riley,W09P02,President,,Dem,Hillary Clinton,65
-Riley,W09P03,President,,Dem,Hillary Clinton,25
-Riley,W10P01,President,,Dem,Hillary Clinton,57
-Riley,W11P01,President,,Dem,Hillary Clinton,149
-Riley,W11P03,President,,Dem,Hillary Clinton,22
-Riley,W11P12,President,,Dem,Hillary Clinton,74
-Riley,W01P01,President,,Rep,Donald Trump,199
-Riley,W02P01,President,,Rep,Donald Trump,191
-Riley,W02P02,President,,Rep,Donald Trump,87
-Riley,W02P03,President,,Rep,Donald Trump,521
-Riley,W02P04,President,,Rep,Donald Trump,308
-Riley,W03P02,President,,Rep,Donald Trump,143
-Riley,W03P03,President,,Rep,Donald Trump,335
-Riley,W04P02,President,,Rep,Donald Trump,91
-Riley,W04P03,President,,Rep,Donald Trump,228
-Riley,W04P04,President,,Rep,Donald Trump,566
-Riley,W04P05,President,,Rep,Donald Trump,314
-Riley,W04P06,President,,Rep,Donald Trump,218
-Riley,W04P07,President,,Rep,Donald Trump,17
-Riley,W05P02,President,,Rep,Donald Trump,191
-Riley,W05P03,President,,Rep,Donald Trump,285
-Riley,W05P05,President,,Rep,Donald Trump,124
-Riley,W05P06,President,,Rep,Donald Trump,362
-Riley,W05P07,President,,Rep,Donald Trump,127
-Riley,W05P08,President,,Rep,Donald Trump,207
-Riley,W05P09,President,,Rep,Donald Trump,562
-Riley,W05P10,President,,Rep,Donald Trump,616
-Riley,W05P11,President,,Rep,Donald Trump,635
-Riley,W06P01,President,,Rep,Donald Trump,1
-Riley,W08P01,President,,Rep,Donald Trump,99
-Riley,W08P02,President,,Rep,Donald Trump,4
-Riley,W08P03,President,,Rep,Donald Trump,134
-Riley,W09P01,President,,Rep,Donald Trump,53
-Riley,W09P02,President,,Rep,Donald Trump,50
-Riley,W09P03,President,,Rep,Donald Trump,27
-Riley,W10P01,President,,Rep,Donald Trump,64
-Riley,W11P01,President,,Rep,Donald Trump,122
-Riley,W11P03,President,,Rep,Donald Trump,28
-Riley,W11P12,President,,Rep,Donald Trump,110
-Riley,W01P01,President,,LBT,Gary Johnson,47
-Riley,W02P01,President,,LBT,Gary Johnson,69
-Riley,W02P02,President,,LBT,Gary Johnson,25
-Riley,W02P03,President,,LBT,Gary Johnson,100
-Riley,W02P04,President,,LBT,Gary Johnson,42
-Riley,W03P02,President,,LBT,Gary Johnson,39
-Riley,W03P03,President,,LBT,Gary Johnson,57
-Riley,W04P02,President,,LBT,Gary Johnson,9
-Riley,W04P03,President,,LBT,Gary Johnson,34
-Riley,W04P04,President,,LBT,Gary Johnson,89
-Riley,W04P05,President,,LBT,Gary Johnson,41
-Riley,W04P06,President,,LBT,Gary Johnson,19
-Riley,W04P07,President,,LBT,Gary Johnson,2
-Riley,W05P02,President,,LBT,Gary Johnson,44
-Riley,W05P03,President,,LBT,Gary Johnson,88
-Riley,W05P05,President,,LBT,Gary Johnson,26
-Riley,W05P06,President,,LBT,Gary Johnson,45
-Riley,W05P07,President,,LBT,Gary Johnson,22
-Riley,W05P08,President,,LBT,Gary Johnson,28
-Riley,W05P09,President,,LBT,Gary Johnson,43
-Riley,W05P10,President,,LBT,Gary Johnson,87
-Riley,W05P11,President,,LBT,Gary Johnson,101
-Riley,W06P01,President,,LBT,Gary Johnson,0
-Riley,W08P01,President,,LBT,Gary Johnson,11
-Riley,W08P02,President,,LBT,Gary Johnson,0
-Riley,W08P03,President,,LBT,Gary Johnson,36
-Riley,W09P01,President,,LBT,Gary Johnson,4
-Riley,W09P02,President,,LBT,Gary Johnson,3
-Riley,W09P03,President,,LBT,Gary Johnson,4
-Riley,W10P01,President,,LBT,Gary Johnson,5
-Riley,W11P01,President,,LBT,Gary Johnson,35
-Riley,W11P03,President,,LBT,Gary Johnson,4
-Riley,W11P12,President,,LBT,Gary Johnson,20
-Riley,W01P01,President,,IND,Jill Stein,13
-Riley,W02P01,President,,IND,Jill Stein,23
-Riley,W02P02,President,,IND,Jill Stein,10
-Riley,W02P03,President,,IND,Jill Stein,16
-Riley,W02P04,President,,IND,Jill Stein,11
-Riley,W03P02,President,,IND,Jill Stein,13
-Riley,W03P03,President,,IND,Jill Stein,17
-Riley,W04P02,President,,IND,Jill Stein,3
-Riley,W04P03,President,,IND,Jill Stein,18
-Riley,W04P04,President,,IND,Jill Stein,20
-Riley,W04P05,President,,IND,Jill Stein,13
-Riley,W04P06,President,,IND,Jill Stein,4
-Riley,W04P07,President,,IND,Jill Stein,0
-Riley,W05P02,President,,IND,Jill Stein,15
-Riley,W05P03,President,,IND,Jill Stein,22
-Riley,W05P05,President,,IND,Jill Stein,12
-Riley,W05P06,President,,IND,Jill Stein,11
-Riley,W05P07,President,,IND,Jill Stein,4
-Riley,W05P08,President,,IND,Jill Stein,8
-Riley,W05P09,President,,IND,Jill Stein,12
-Riley,W05P10,President,,IND,Jill Stein,17
-Riley,W05P11,President,,IND,Jill Stein,20
-Riley,W06P01,President,,IND,Jill Stein,0
-Riley,W08P01,President,,IND,Jill Stein,12
-Riley,W08P02,President,,IND,Jill Stein,0
-Riley,W08P03,President,,IND,Jill Stein,10
-Riley,W09P01,President,,IND,Jill Stein,1
-Riley,W09P02,President,,IND,Jill Stein,2
-Riley,W09P03,President,,IND,Jill Stein,1
-Riley,W10P01,President,,IND,Jill Stein,2
-Riley,W11P01,President,,IND,Jill Stein,5
-Riley,W11P03,President,,IND,Jill Stein,0
-Riley,W11P12,President,,IND,Jill Stein,2
-Riley,W01P01,President,,,Write-ins,32
-Riley,W02P01,President,,,Write-ins,18
-Riley,W02P02,President,,,Write-ins,10
-Riley,W02P03,President,,,Write-ins,47
-Riley,W02P04,President,,,Write-ins,17
-Riley,W03P02,President,,,Write-ins,16
-Riley,W03P03,President,,,Write-ins,18
-Riley,W04P02,President,,,Write-ins,13
-Riley,W04P03,President,,,Write-ins,21
-Riley,W04P04,President,,,Write-ins,45
-Riley,W04P05,President,,,Write-ins,25
-Riley,W04P06,President,,,Write-ins,9
-Riley,W04P07,President,,,Write-ins,0
-Riley,W05P02,President,,,Write-ins,17
-Riley,W05P03,President,,,Write-ins,23
-Riley,W05P05,President,,,Write-ins,13
-Riley,W05P06,President,,,Write-ins,34
-Riley,W05P07,President,,,Write-ins,14
-Riley,W05P08,President,,,Write-ins,16
-Riley,W05P09,President,,,Write-ins,39
-Riley,W05P10,President,,,Write-ins,42
-Riley,W05P11,President,,,Write-ins,36
-Riley,W06P01,President,,,Write-ins,0
-Riley,W08P01,President,,,Write-ins,3
-Riley,W08P02,President,,,Write-ins,0
-Riley,W08P03,President,,,Write-ins,7
-Riley,W09P01,President,,,Write-ins,0
-Riley,W09P02,President,,,Write-ins,1
-Riley,W09P03,President,,,Write-ins,0
-Riley,W10P01,President,,,Write-ins,2
-Riley,W11P01,President,,,Write-ins,11
-Riley,W11P03,President,,,Write-ins,1
-Riley,W11P12,President,,,Write-ins,7
-Riley,W01P01,U.S. Senate,,Dem,Patrick Wiesner,345
-Riley,W02P01,U.S. Senate,,Dem,Patrick Wiesner,365
-Riley,W02P02,U.S. Senate,,Dem,Patrick Wiesner,134
-Riley,W02P03,U.S. Senate,,Dem,Patrick Wiesner,418
-Riley,W02P04,U.S. Senate,,Dem,Patrick Wiesner,231
-Riley,W03P02,U.S. Senate,,Dem,Patrick Wiesner,197
-Riley,W03P03,U.S. Senate,,Dem,Patrick Wiesner,299
-Riley,W04P02,U.S. Senate,,Dem,Patrick Wiesner,112
-Riley,W04P03,U.S. Senate,,Dem,Patrick Wiesner,281
-Riley,W04P04,U.S. Senate,,Dem,Patrick Wiesner,376
-Riley,W04P05,U.S. Senate,,Dem,Patrick Wiesner,216
-Riley,W04P06,U.S. Senate,,Dem,Patrick Wiesner,96
-Riley,W04P07,U.S. Senate,,Dem,Patrick Wiesner,3
-Riley,W05P02,U.S. Senate,,Dem,Patrick Wiesner,310
-Riley,W05P03,U.S. Senate,,Dem,Patrick Wiesner,356
-Riley,W05P05,U.S. Senate,,Dem,Patrick Wiesner,118
-Riley,W05P06,U.S. Senate,,Dem,Patrick Wiesner,220
-Riley,W05P07,U.S. Senate,,Dem,Patrick Wiesner,117
-Riley,W05P08,U.S. Senate,,Dem,Patrick Wiesner,159
-Riley,W05P09,U.S. Senate,,Dem,Patrick Wiesner,370
-Riley,W05P10,U.S. Senate,,Dem,Patrick Wiesner,429
-Riley,W05P11,U.S. Senate,,Dem,Patrick Wiesner,403
-Riley,W06P01,U.S. Senate,,Dem,Patrick Wiesner,0
-Riley,W08P01,U.S. Senate,,Dem,Patrick Wiesner,65
-Riley,W08P02,U.S. Senate,,Dem,Patrick Wiesner,0
-Riley,W08P03,U.S. Senate,,Dem,Patrick Wiesner,158
-Riley,W09P01,U.S. Senate,,Dem,Patrick Wiesner,39
-Riley,W09P02,U.S. Senate,,Dem,Patrick Wiesner,50
-Riley,W09P03,U.S. Senate,,Dem,Patrick Wiesner,16
-Riley,W10P01,U.S. Senate,,Dem,Patrick Wiesner,43
-Riley,W11P01,U.S. Senate,,Dem,Patrick Wiesner,117
-Riley,W11P03,U.S. Senate,,Dem,Patrick Wiesner,17
-Riley,W11P12,U.S. Senate,,Dem,Patrick Wiesner,51
-Riley,W01P01,U.S. Senate,,Rep,Jerry Moran,294
-Riley,W02P01,U.S. Senate,,Rep,Jerry Moran,280
-Riley,W02P02,U.S. Senate,,Rep,Jerry Moran,127
-Riley,W02P03,U.S. Senate,,Rep,Jerry Moran,690
-Riley,W02P04,U.S. Senate,,Rep,Jerry Moran,394
-Riley,W03P02,U.S. Senate,,Rep,Jerry Moran,202
-Riley,W03P03,U.S. Senate,,Rep,Jerry Moran,478
-Riley,W04P02,U.S. Senate,,Rep,Jerry Moran,135
-Riley,W04P03,U.S. Senate,,Rep,Jerry Moran,331
-Riley,W04P04,U.S. Senate,,Rep,Jerry Moran,759
-Riley,W04P05,U.S. Senate,,Rep,Jerry Moran,416
-Riley,W04P06,U.S. Senate,,Rep,Jerry Moran,291
-Riley,W04P07,U.S. Senate,,Rep,Jerry Moran,24
-Riley,W05P02,U.S. Senate,,Rep,Jerry Moran,276
-Riley,W05P03,U.S. Senate,,Rep,Jerry Moran,403
-Riley,W05P05,U.S. Senate,,Rep,Jerry Moran,188
-Riley,W05P06,U.S. Senate,,Rep,Jerry Moran,499
-Riley,W05P07,U.S. Senate,,Rep,Jerry Moran,190
-Riley,W05P08,U.S. Senate,,Rep,Jerry Moran,292
-Riley,W05P09,U.S. Senate,,Rep,Jerry Moran,809
-Riley,W05P10,U.S. Senate,,Rep,Jerry Moran,897
-Riley,W05P11,U.S. Senate,,Rep,Jerry Moran,858
-Riley,W06P01,U.S. Senate,,Rep,Jerry Moran,1
-Riley,W08P01,U.S. Senate,,Rep,Jerry Moran,128
-Riley,W08P02,U.S. Senate,,Rep,Jerry Moran,4
-Riley,W08P03,U.S. Senate,,Rep,Jerry Moran,194
-Riley,W09P01,U.S. Senate,,Rep,Jerry Moran,74
-Riley,W09P02,U.S. Senate,,Rep,Jerry Moran,71
-Riley,W09P03,U.S. Senate,,Rep,Jerry Moran,41
-Riley,W10P01,U.S. Senate,,Rep,Jerry Moran,82
-Riley,W11P01,U.S. Senate,,Rep,Jerry Moran,172
-Riley,W11P03,U.S. Senate,,Rep,Jerry Moran,38
-Riley,W11P12,U.S. Senate,,Rep,Jerry Moran,144
-Riley,W01P01,U.S. Senate,,LBT,Robert Garrard,40
-Riley,W02P01,U.S. Senate,,LBT,Robert Garrard,55
-Riley,W02P02,U.S. Senate,,LBT,Robert Garrard,16
-Riley,W02P03,U.S. Senate,,LBT,Robert Garrard,74
-Riley,W02P04,U.S. Senate,,LBT,Robert Garrard,36
-Riley,W03P02,U.S. Senate,,LBT,Robert Garrard,35
-Riley,W03P03,U.S. Senate,,LBT,Robert Garrard,52
-Riley,W04P02,U.S. Senate,,LBT,Robert Garrard,9
-Riley,W04P03,U.S. Senate,,LBT,Robert Garrard,31
-Riley,W04P04,U.S. Senate,,LBT,Robert Garrard,56
-Riley,W04P05,U.S. Senate,,LBT,Robert Garrard,24
-Riley,W04P06,U.S. Senate,,LBT,Robert Garrard,21
-Riley,W04P07,U.S. Senate,,LBT,Robert Garrard,1
-Riley,W05P02,U.S. Senate,,LBT,Robert Garrard,33
-Riley,W05P03,U.S. Senate,,LBT,Robert Garrard,43
-Riley,W05P05,U.S. Senate,,LBT,Robert Garrard,22
-Riley,W05P06,U.S. Senate,,LBT,Robert Garrard,27
-Riley,W05P07,U.S. Senate,,LBT,Robert Garrard,20
-Riley,W05P08,U.S. Senate,,LBT,Robert Garrard,16
-Riley,W05P09,U.S. Senate,,LBT,Robert Garrard,20
-Riley,W05P10,U.S. Senate,,LBT,Robert Garrard,35
-Riley,W05P11,U.S. Senate,,LBT,Robert Garrard,42
-Riley,W06P01,U.S. Senate,,LBT,Robert Garrard,0
-Riley,W08P01,U.S. Senate,,LBT,Robert Garrard,18
-Riley,W08P02,U.S. Senate,,LBT,Robert Garrard,0
-Riley,W08P03,U.S. Senate,,LBT,Robert Garrard,15
-Riley,W09P01,U.S. Senate,,LBT,Robert Garrard,3
-Riley,W09P02,U.S. Senate,,LBT,Robert Garrard,0
-Riley,W09P03,U.S. Senate,,LBT,Robert Garrard,1
-Riley,W10P01,U.S. Senate,,LBT,Robert Garrard,3
-Riley,W11P01,U.S. Senate,,LBT,Robert Garrard,24
-Riley,W11P03,U.S. Senate,,LBT,Robert Garrard,0
-Riley,W11P12,U.S. Senate,,LBT,Robert Garrard,11
-Riley,W01P01,U.S. Senate,,,Write-ins,1
-Riley,W02P01,U.S. Senate,,,Write-ins,2
-Riley,W02P02,U.S. Senate,,,Write-ins,2
-Riley,W02P03,U.S. Senate,,,Write-ins,0
-Riley,W02P04,U.S. Senate,,,Write-ins,2
-Riley,W03P02,U.S. Senate,,,Write-ins,2
-Riley,W03P03,U.S. Senate,,,Write-ins,0
-Riley,W04P02,U.S. Senate,,,Write-ins,0
-Riley,W04P03,U.S. Senate,,,Write-ins,4
-Riley,W04P04,U.S. Senate,,,Write-ins,4
-Riley,W04P05,U.S. Senate,,,Write-ins,0
-Riley,W04P06,U.S. Senate,,,Write-ins,0
-Riley,W04P07,U.S. Senate,,,Write-ins,0
-Riley,W05P02,U.S. Senate,,,Write-ins,0
-Riley,W05P03,U.S. Senate,,,Write-ins,0
-Riley,W05P05,U.S. Senate,,,Write-ins,1
-Riley,W05P06,U.S. Senate,,,Write-ins,0
-Riley,W05P07,U.S. Senate,,,Write-ins,0
-Riley,W05P08,U.S. Senate,,,Write-ins,0
-Riley,W05P09,U.S. Senate,,,Write-ins,1
-Riley,W05P10,U.S. Senate,,,Write-ins,2
-Riley,W05P11,U.S. Senate,,,Write-ins,4
-Riley,W06P01,U.S. Senate,,,Write-ins,0
-Riley,W08P01,U.S. Senate,,,Write-ins,0
-Riley,W08P02,U.S. Senate,,,Write-ins,0
-Riley,W08P03,U.S. Senate,,,Write-ins,0
-Riley,W09P01,U.S. Senate,,,Write-ins,0
-Riley,W09P02,U.S. Senate,,,Write-ins,0
-Riley,W09P03,U.S. Senate,,,Write-ins,0
-Riley,W10P01,U.S. Senate,,,Write-ins,0
-Riley,W11P01,U.S. Senate,,,Write-ins,0
-Riley,W11P03,U.S. Senate,,,Write-ins,0
-Riley,W11P12,U.S. Senate,,,Write-ins,0
-Riley,W01P01,U.S. House,1,Rep,Roger Marshall,248
-Riley,W02P01,U.S. House,1,Rep,Roger Marshall,230
-Riley,W02P02,U.S. House,1,Rep,Roger Marshall,99
-Riley,W02P03,U.S. House,1,Rep,Roger Marshall,593
-Riley,W02P04,U.S. House,1,Rep,Roger Marshall,342
-Riley,W03P02,U.S. House,1,Rep,Roger Marshall,185
-Riley,W03P03,U.S. House,1,Rep,Roger Marshall,424
-Riley,W04P02,U.S. House,1,Rep,Roger Marshall,111
-Riley,W04P03,U.S. House,1,Rep,Roger Marshall,287
-Riley,W04P04,U.S. House,1,Rep,Roger Marshall,652
-Riley,W04P05,U.S. House,1,Rep,Roger Marshall,369
-Riley,W04P06,U.S. House,1,Rep,Roger Marshall,270
-Riley,W04P07,U.S. House,1,Rep,Roger Marshall,21
-Riley,W05P02,U.S. House,1,Rep,Roger Marshall,225
-Riley,W05P03,U.S. House,1,Rep,Roger Marshall,376
-Riley,W05P05,U.S. House,1,Rep,Roger Marshall,176
-Riley,W05P06,U.S. House,1,Rep,Roger Marshall,423
-Riley,W05P07,U.S. House,1,Rep,Roger Marshall,158
-Riley,W05P08,U.S. House,1,Rep,Roger Marshall,239
-Riley,W05P09,U.S. House,1,Rep,Roger Marshall,688
-Riley,W05P10,U.S. House,1,Rep,Roger Marshall,799
-Riley,W05P11,U.S. House,1,Rep,Roger Marshall,736
-Riley,W06P01,U.S. House,1,Rep,Roger Marshall,1
-Riley,W08P01,U.S. House,1,Rep,Roger Marshall,119
-Riley,W08P02,U.S. House,1,Rep,Roger Marshall,4
-Riley,W08P03,U.S. House,1,Rep,Roger Marshall,181
-Riley,W09P01,U.S. House,1,Rep,Roger Marshall,63
-Riley,W09P02,U.S. House,1,Rep,Roger Marshall,59
-Riley,W09P03,U.S. House,1,Rep,Roger Marshall,37
-Riley,W10P01,U.S. House,1,Rep,Roger Marshall,74
-Riley,W11P01,U.S. House,1,Rep,Roger Marshall,153
-Riley,W11P03,U.S. House,1,Rep,Roger Marshall,34
-Riley,W11P12,U.S. House,1,Rep,Roger Marshall,124
-Riley,W01P01,U.S. House,1,LBT,Kerry Burt,86
-Riley,W02P01,U.S. House,1,LBT,Kerry Burt,127
-Riley,W02P02,U.S. House,1,LBT,Kerry Burt,53
-Riley,W02P03,U.S. House,1,LBT,Kerry Burt,171
-Riley,W02P04,U.S. House,1,LBT,Kerry Burt,84
-Riley,W03P02,U.S. House,1,LBT,Kerry Burt,99
-Riley,W03P03,U.S. House,1,LBT,Kerry Burt,106
-Riley,W04P02,U.S. House,1,LBT,Kerry Burt,28
-Riley,W04P03,U.S. House,1,LBT,Kerry Burt,71
-Riley,W04P04,U.S. House,1,LBT,Kerry Burt,121
-Riley,W04P05,U.S. House,1,LBT,Kerry Burt,61
-Riley,W04P06,U.S. House,1,LBT,Kerry Burt,29
-Riley,W04P07,U.S. House,1,LBT,Kerry Burt,1
-Riley,W05P02,U.S. House,1,LBT,Kerry Burt,93
-Riley,W05P03,U.S. House,1,LBT,Kerry Burt,120
-Riley,W05P05,U.S. House,1,LBT,Kerry Burt,35
-Riley,W05P06,U.S. House,1,LBT,Kerry Burt,54
-Riley,W05P07,U.S. House,1,LBT,Kerry Burt,33
-Riley,W05P08,U.S. House,1,LBT,Kerry Burt,49
-Riley,W05P09,U.S. House,1,LBT,Kerry Burt,76
-Riley,W05P10,U.S. House,1,LBT,Kerry Burt,100
-Riley,W05P11,U.S. House,1,LBT,Kerry Burt,133
-Riley,W06P01,U.S. House,1,LBT,Kerry Burt,0
-Riley,W08P01,U.S. House,1,LBT,Kerry Burt,28
-Riley,W08P02,U.S. House,1,LBT,Kerry Burt,0
-Riley,W08P03,U.S. House,1,LBT,Kerry Burt,67
-Riley,W09P01,U.S. House,1,LBT,Kerry Burt,6
-Riley,W09P02,U.S. House,1,LBT,Kerry Burt,6
-Riley,W09P03,U.S. House,1,LBT,Kerry Burt,3
-Riley,W10P01,U.S. House,1,LBT,Kerry Burt,14
-Riley,W11P01,U.S. House,1,LBT,Kerry Burt,55
-Riley,W11P03,U.S. House,1,LBT,Kerry Burt,7
-Riley,W11P12,U.S. House,1,LBT,Kerry Burt,30
-Riley,W01P01,U.S. House,1,IND,Alan LaPolice,275
-Riley,W02P01,U.S. House,1,IND,Alan LaPolice,281
-Riley,W02P02,U.S. House,1,IND,Alan LaPolice,98
-Riley,W02P03,U.S. House,1,IND,Alan LaPolice,367
-Riley,W02P04,U.S. House,1,IND,Alan LaPolice,209
-Riley,W03P02,U.S. House,1,IND,Alan LaPolice,124
-Riley,W03P03,U.S. House,1,IND,Alan LaPolice,229
-Riley,W04P02,U.S. House,1,IND,Alan LaPolice,97
-Riley,W04P03,U.S. House,1,IND,Alan LaPolice,238
-Riley,W04P04,U.S. House,1,IND,Alan LaPolice,362
-Riley,W04P05,U.S. House,1,IND,Alan LaPolice,201
-Riley,W04P06,U.S. House,1,IND,Alan LaPolice,87
-Riley,W04P07,U.S. House,1,IND,Alan LaPolice,6
-Riley,W05P02,U.S. House,1,IND,Alan LaPolice,245
-Riley,W05P03,U.S. House,1,IND,Alan LaPolice,247
-Riley,W05P05,U.S. House,1,IND,Alan LaPolice,104
-Riley,W05P06,U.S. House,1,IND,Alan LaPolice,234
-Riley,W05P07,U.S. House,1,IND,Alan LaPolice,124
-Riley,W05P08,U.S. House,1,IND,Alan LaPolice,159
-Riley,W05P09,U.S. House,1,IND,Alan LaPolice,383
-Riley,W05P10,U.S. House,1,IND,Alan LaPolice,381
-Riley,W05P11,U.S. House,1,IND,Alan LaPolice,370
-Riley,W06P01,U.S. House,1,IND,Alan LaPolice,0
-Riley,W08P01,U.S. House,1,IND,Alan LaPolice,56
-Riley,W08P02,U.S. House,1,IND,Alan LaPolice,0
-Riley,W08P03,U.S. House,1,IND,Alan LaPolice,105
-Riley,W09P01,U.S. House,1,IND,Alan LaPolice,39
-Riley,W09P02,U.S. House,1,IND,Alan LaPolice,48
-Riley,W09P03,U.S. House,1,IND,Alan LaPolice,16
-Riley,W10P01,U.S. House,1,IND,Alan LaPolice,27
-Riley,W11P01,U.S. House,1,IND,Alan LaPolice,88
-Riley,W11P03,U.S. House,1,IND,Alan LaPolice,10
-Riley,W11P12,U.S. House,1,IND,Alan LaPolice,42
-Riley,W01P01,U.S. House,1,,Write-ins,19
-Riley,W02P01,U.S. House,1,,Write-ins,2
-Riley,W02P02,U.S. House,1,,Write-ins,5
-Riley,W02P03,U.S. House,1,,Write-ins,6
-Riley,W02P04,U.S. House,1,,Write-ins,5
-Riley,W03P02,U.S. House,1,,Write-ins,5
-Riley,W03P03,U.S. House,1,,Write-ins,6
-Riley,W04P02,U.S. House,1,,Write-ins,1
-Riley,W04P03,U.S. House,1,,Write-ins,8
-Riley,W04P04,U.S. House,1,,Write-ins,3
-Riley,W04P05,U.S. House,1,,Write-ins,3
-Riley,W04P06,U.S. House,1,,Write-ins,1
-Riley,W04P07,U.S. House,1,,Write-ins,0
-Riley,W05P02,U.S. House,1,,Write-ins,7
-Riley,W05P03,U.S. House,1,,Write-ins,4
-Riley,W05P05,U.S. House,1,,Write-ins,3
-Riley,W05P06,U.S. House,1,,Write-ins,6
-Riley,W05P07,U.S. House,1,,Write-ins,2
-Riley,W05P08,U.S. House,1,,Write-ins,4
-Riley,W05P09,U.S. House,1,,Write-ins,6
-Riley,W05P10,U.S. House,1,,Write-ins,6
-Riley,W05P11,U.S. House,1,,Write-ins,9
-Riley,W06P01,U.S. House,1,,Write-ins,0
-Riley,W08P01,U.S. House,1,,Write-ins,0
-Riley,W08P02,U.S. House,1,,Write-ins,0
-Riley,W08P03,U.S. House,1,,Write-ins,0
-Riley,W09P01,U.S. House,1,,Write-ins,0
-Riley,W09P02,U.S. House,1,,Write-ins,0
-Riley,W09P03,U.S. House,1,,Write-ins,0
-Riley,W10P01,U.S. House,1,,Write-ins,1
-Riley,W11P01,U.S. House,1,,Write-ins,2
-Riley,W11P03,U.S. House,1,,Write-ins,0
-Riley,W11P12,U.S. House,1,,Write-ins,1
-Riley,W01P01,State Senate,22,Dem,Tom Hawk,569
-Riley,W02P01,State Senate,22,Dem,Tom Hawk,598
-Riley,W02P02,State Senate,22,Dem,Tom Hawk,232
-Riley,W02P03,State Senate,22,Dem,Tom Hawk,995
-Riley,W02P04,State Senate,22,Dem,Tom Hawk,542
-Riley,W03P02,State Senate,22,Dem,Tom Hawk,344
-Riley,W03P03,State Senate,22,Dem,Tom Hawk,672
-Riley,W04P02,State Senate,22,Dem,Tom Hawk,207
-Riley,W04P03,State Senate,22,Dem,Tom Hawk,526
-Riley,W04P04,State Senate,22,Dem,Tom Hawk,962
-Riley,W04P05,State Senate,22,Dem,Tom Hawk,524
-Riley,W04P06,State Senate,22,Dem,Tom Hawk,305
-Riley,W04P07,State Senate,22,Dem,Tom Hawk,19
-Riley,W05P02,State Senate,22,Dem,Tom Hawk,505
-Riley,W05P03,State Senate,22,Dem,Tom Hawk,647
-Riley,W05P05,State Senate,22,Dem,Tom Hawk,266
-Riley,W05P06,State Senate,22,Dem,Tom Hawk,604
-Riley,W05P07,State Senate,22,Dem,Tom Hawk,273
-Riley,W05P08,State Senate,22,Dem,Tom Hawk,378
-Riley,W05P09,State Senate,22,Dem,Tom Hawk,995
-Riley,W05P10,State Senate,22,Dem,Tom Hawk,1096
-Riley,W05P11,State Senate,22,Dem,Tom Hawk,1054
-Riley,W06P01,State Senate,22,Dem,Tom Hawk,1
-Riley,W08P01,State Senate,22,Dem,Tom Hawk,176
-Riley,W08P02,State Senate,22,Dem,Tom Hawk,2
-Riley,W08P03,State Senate,22,Dem,Tom Hawk,310
-Riley,W09P01,State Senate,22,Dem,Tom Hawk,96
-Riley,W09P02,State Senate,22,Dem,Tom Hawk,96
-Riley,W09P03,State Senate,22,Dem,Tom Hawk,46
-Riley,W10P01,State Senate,22,Dem,Tom Hawk,103
-Riley,W11P01,State Senate,22,Dem,Tom Hawk,264
-Riley,W11P03,State Senate,22,Dem,Tom Hawk,45
-Riley,W11P12,State Senate,22,Dem,Tom Hawk,157
-Riley,W01P01,State Senate,22,,Write-ins,24
-Riley,W02P01,State Senate,22,,Write-ins,17
-Riley,W02P02,State Senate,22,,Write-ins,6
-Riley,W02P03,State Senate,22,,Write-ins,34
-Riley,W02P04,State Senate,22,,Write-ins,12
-Riley,W03P02,State Senate,22,,Write-ins,13
-Riley,W03P03,State Senate,22,,Write-ins,17
-Riley,W04P02,State Senate,22,,Write-ins,14
-Riley,W04P03,State Senate,22,,Write-ins,14
-Riley,W04P04,State Senate,22,,Write-ins,27
-Riley,W04P05,State Senate,22,,Write-ins,13
-Riley,W04P06,State Senate,22,,Write-ins,10
-Riley,W04P07,State Senate,22,,Write-ins,0
-Riley,W05P02,State Senate,22,,Write-ins,20
-Riley,W05P03,State Senate,22,,Write-ins,19
-Riley,W05P05,State Senate,22,,Write-ins,9
-Riley,W05P06,State Senate,22,,Write-ins,10
-Riley,W05P07,State Senate,22,,Write-ins,2
-Riley,W05P08,State Senate,22,,Write-ins,14
-Riley,W05P09,State Senate,22,,Write-ins,30
-Riley,W05P10,State Senate,22,,Write-ins,36
-Riley,W05P11,State Senate,22,,Write-ins,33
-Riley,W06P01,State Senate,22,,Write-ins,0
-Riley,W08P01,State Senate,22,,Write-ins,3
-Riley,W08P02,State Senate,22,,Write-ins,1
-Riley,W08P03,State Senate,22,,Write-ins,11
-Riley,W09P01,State Senate,22,,Write-ins,1
-Riley,W09P02,State Senate,22,,Write-ins,5
-Riley,W09P03,State Senate,22,,Write-ins,1
-Riley,W10P01,State Senate,22,,Write-ins,5
-Riley,W11P01,State Senate,22,,Write-ins,3
-Riley,W11P03,State Senate,22,,Write-ins,3
-Riley,W11P12,State Senate,22,,Write-ins,8
-Riley,W06P01,State House,64,Rep,Susie Swanson,1
-Riley,W06P01,State House,64,,Write-ins,0
-Riley,W01P01,State House,66,Dem,Sydney Carlin,505
-Riley,W02P01,State House,66,Dem,Sydney Carlin,508
-Riley,W02P02,State House,66,Dem,Sydney Carlin,195
-Riley,W02P03,State House,66,Dem,Sydney Carlin,748
-Riley,W02P04,State House,66,Dem,Sydney Carlin,398
-Riley,W03P02,State House,66,Dem,Sydney Carlin,272
-Riley,W03P03,State House,66,Dem,Sydney Carlin,512
-Riley,W04P02,State House,66,Dem,Sydney Carlin,170
-Riley,W05P02,State House,66,Dem,Sydney Carlin,419
-Riley,W05P03,State House,66,Dem,Sydney Carlin,490
-Riley,W08P01,State House,66,Dem,Sydney Carlin,123
-Riley,W08P02,State House,66,Dem,Sydney Carlin,1
-Riley,W08P03,State House,66,Dem,Sydney Carlin,229
-Riley,W09P01,State House,66,Dem,Sydney Carlin,80
-Riley,W09P02,State House,66,Dem,Sydney Carlin,81
-Riley,W01P01,State House,66,Rep,Stanley Hoerman,172
-Riley,W02P01,State House,66,Rep,Stanley Hoerman,171
-Riley,W02P02,State House,66,Rep,Stanley Hoerman,75
-Riley,W02P03,State House,66,Rep,Stanley Hoerman,413
-Riley,W02P04,State House,66,Rep,Stanley Hoerman,246
-Riley,W03P02,State House,66,Rep,Stanley Hoerman,148
-Riley,W03P03,State House,66,Rep,Stanley Hoerman,288
-Riley,W04P02,State House,66,Rep,Stanley Hoerman,79
-Riley,W05P02,State House,66,Rep,Stanley Hoerman,186
-Riley,W05P03,State House,66,Rep,Stanley Hoerman,281
-Riley,W08P01,State House,66,Rep,Stanley Hoerman,90
-Riley,W08P02,State House,66,Rep,Stanley Hoerman,2
-Riley,W08P03,State House,66,Rep,Stanley Hoerman,131
-Riley,W09P01,State House,66,Rep,Stanley Hoerman,34
-Riley,W09P02,State House,66,Rep,Stanley Hoerman,40
-Riley,W01P01,State House,66,,Write-ins,3
-Riley,W02P01,State House,66,,Write-ins,2
-Riley,W02P02,State House,66,,Write-ins,0
-Riley,W02P03,State House,66,,Write-ins,3
-Riley,W02P04,State House,66,,Write-ins,6
-Riley,W03P02,State House,66,,Write-ins,1
-Riley,W03P03,State House,66,,Write-ins,3
-Riley,W04P02,State House,66,,Write-ins,1
-Riley,W05P02,State House,66,,Write-ins,0
-Riley,W05P03,State House,66,,Write-ins,1
-Riley,W08P01,State House,66,,Write-ins,0
-Riley,W08P02,State House,66,,Write-ins,0
-Riley,W08P03,State House,66,,Write-ins,0
-Riley,W09P01,State House,66,,Write-ins,0
-Riley,W09P02,State House,66,,Write-ins,0
-Riley,W04P03,State House,67,Rep,Tom Phillips,490
-Riley,W04P04,State House,67,Rep,Tom Phillips,999
-Riley,W04P05,State House,67,Rep,Tom Phillips,554
-Riley,W04P06,State House,67,Rep,Tom Phillips,351
-Riley,W04P07,State House,67,Rep,Tom Phillips,27
-Riley,W05P05,State House,67,Rep,Tom Phillips,272
-Riley,W05P06,State House,67,Rep,Tom Phillips,636
-Riley,W05P07,State House,67,Rep,Tom Phillips,280
-Riley,W05P08,State House,67,Rep,Tom Phillips,389
-Riley,W05P09,State House,67,Rep,Tom Phillips,1027
-Riley,W05P10,State House,67,Rep,Tom Phillips,1151
-Riley,W05P11,State House,67,Rep,Tom Phillips,1095
-Riley,W09P03,State House,67,Rep,Tom Phillips,49
-Riley,W10P01,State House,67,Rep,Tom Phillips,108
-Riley,W11P01,State House,67,Rep,Tom Phillips,256
-Riley,W11P03,State House,67,Rep,Tom Phillips,42
-Riley,W11P12,State House,67,Rep,Tom Phillips,166
-Riley,W04P03,State House,67,,Write-ins,13
-Riley,W04P04,State House,67,,Write-ins,31
-Riley,W04P05,State House,67,,Write-ins,8
-Riley,W04P06,State House,67,,Write-ins,7
-Riley,W04P07,State House,67,,Write-ins,0
-Riley,W05P05,State House,67,,Write-ins,6
-Riley,W05P06,State House,67,,Write-ins,5
-Riley,W05P07,State House,67,,Write-ins,4
-Riley,W05P08,State House,67,,Write-ins,11
-Riley,W05P09,State House,67,,Write-ins,19
-Riley,W05P10,State House,67,,Write-ins,20
-Riley,W05P11,State House,67,,Write-ins,28
-Riley,W09P03,State House,67,,Write-ins,0
-Riley,W10P01,State House,67,,Write-ins,1
-Riley,W11P01,State House,67,,Write-ins,4
-Riley,W11P03,State House,67,,Write-ins,3
-Riley,W11P12,State House,67,,Write-ins,6
-Riley,Ashland twp,Voters,,,Registered,119
-Riley,Bala twp,Voters,,,Registered,450
-Riley,Center twp,Voters,,,Registered,55
-Riley,Fancy Creek twp,Voters,,,Registered,84
-Riley,Grant twp,Voters,,,Registered,734
-Riley,Jackson twp,Voters,,,Registered,220
-Riley,Mad/Ft Riley A,Voters,,,Registered,407
-Riley,Mad/Ft Riley B,Voters,,,Registered,208
-Riley,Madison twp H64,Voters,,,Registered,740
-Riley,Madison twp H67,Voters,,,Registered,23
-Riley,Manhattan twp 1,Voters,,,Registered,393
-Riley,Manhattan twp 2,Voters,,,Registered,407
-Riley,Manhattan twp 3,Voters,,,Registered,155
-Riley,Manhattan twp 4,Voters,,,Registered,513
-Riley,May Day twp,Voters,,,Registered,47
-Riley,Ogden twp,Voters,,,Registered,292
-Riley,Ogden twp/Ft Riley A,Voters,,,Registered,771
-Riley,Sherman twp,Voters,,,Registered,423
-Riley,Swede Creek twp,Voters,,,Registered,93
-Riley,Wildcat twp,Voters,,,Registered,626
-Riley,Zeandale twp,Voters,,,Registered,259
-Riley,Ashland twp,Voters,,,Ballots Cast,99
-Riley,Bala twp,Voters,,,Ballots Cast,337
-Riley,Center twp,Voters,,,Ballots Cast,44
-Riley,Fancy Creek twp,Voters,,,Ballots Cast,71
-Riley,Grant twp,Voters,,,Ballots Cast,586
-Riley,Jackson twp,Voters,,,Ballots Cast,163
-Riley,Mad/Ft Riley A,Voters,,,Ballots Cast,34
-Riley,Mad/Ft Riley B,Voters,,,Ballots Cast,39
-Riley,Madison twp H64,Voters,,,Ballots Cast,539
-Riley,Madison twp H67,Voters,,,Ballots Cast,15
-Riley,Manhattan twp 1,Voters,,,Ballots Cast,297
-Riley,Manhattan twp 2,Voters,,,Ballots Cast,318
-Riley,Manhattan twp 3,Voters,,,Ballots Cast,112
-Riley,Manhattan twp 4,Voters,,,Ballots Cast,331
-Riley,May Day twp,Voters,,,Ballots Cast,40
-Riley,Ogden twp,Voters,,,Ballots Cast,204
-Riley,Ogden twp/Ft Riley A,Voters,,,Ballots Cast,378
-Riley,Sherman twp,Voters,,,Ballots Cast,318
-Riley,Swede Creek twp,Voters,,,Ballots Cast,76
-Riley,Wildcat twp,Voters,,,Ballots Cast,513
-Riley,Zeandale twp,Voters,,,Ballots Cast,203
-Riley,Ashland twp,President,,Dem,Hillary Clinton,42
-Riley,Bala twp,President,,Dem,Hillary Clinton,56
-Riley,Center twp,President,,Dem,Hillary Clinton,3
-Riley,Fancy Creek twp,President,,Dem,Hillary Clinton,15
-Riley,Grant twp,President,,Dem,Hillary Clinton,182
-Riley,Jackson twp,President,,Dem,Hillary Clinton,37
-Riley,Mad/Ft Riley A,President,,Dem,Hillary Clinton,6
-Riley,Mad/Ft Riley B,President,,Dem,Hillary Clinton,17
-Riley,Madison twp H64,President,,Dem,Hillary Clinton,124
-Riley,Madison twp H67,President,,Dem,Hillary Clinton,2
-Riley,Manhattan twp 1,President,,Dem,Hillary Clinton,88
-Riley,Manhattan twp 2,President,,Dem,Hillary Clinton,93
-Riley,Manhattan twp 3,President,,Dem,Hillary Clinton,30
-Riley,Manhattan twp 4,President,,Dem,Hillary Clinton,111
-Riley,May Day twp,President,,Dem,Hillary Clinton,3
-Riley,Ogden twp,President,,Dem,Hillary Clinton,51
-Riley,Ogden twp/Ft Riley A,President,,Dem,Hillary Clinton,123
-Riley,Sherman twp,President,,Dem,Hillary Clinton,86
-Riley,Swede Creek twp,President,,Dem,Hillary Clinton,17
-Riley,Wildcat twp,President,,Dem,Hillary Clinton,103
-Riley,Zeandale twp,President,,Dem,Hillary Clinton,54
-Riley,Ashland twp,President,,Rep,Donald Trump,49
-Riley,Bala twp,President,,Rep,Donald Trump,254
-Riley,Center twp,President,,Rep,Donald Trump,34
-Riley,Fancy Creek twp,President,,Rep,Donald Trump,53
-Riley,Grant twp,President,,Rep,Donald Trump,341
-Riley,Jackson twp,President,,Rep,Donald Trump,113
-Riley,Mad/Ft Riley A,President,,Rep,Donald Trump,20
-Riley,Mad/Ft Riley B,President,,Rep,Donald Trump,17
-Riley,Madison twp H64,President,,Rep,Donald Trump,353
-Riley,Madison twp H67,President,,Rep,Donald Trump,12
-Riley,Manhattan twp 1,President,,Rep,Donald Trump,180
-Riley,Manhattan twp 2,President,,Rep,Donald Trump,181
-Riley,Manhattan twp 3,President,,Rep,Donald Trump,71
-Riley,Manhattan twp 4,President,,Rep,Donald Trump,179
-Riley,May Day twp,President,,Rep,Donald Trump,33
-Riley,Ogden twp,President,,Rep,Donald Trump,137
-Riley,Ogden twp/Ft Riley A,President,,Rep,Donald Trump,221
-Riley,Sherman twp,President,,Rep,Donald Trump,208
-Riley,Swede Creek twp,President,,Rep,Donald Trump,52
-Riley,Wildcat twp,President,,Rep,Donald Trump,349
-Riley,Zeandale twp,President,,Rep,Donald Trump,121
-Riley,Ashland twp,President,,LBT,Gary Johnson,5
-Riley,Bala twp,President,,LBT,Gary Johnson,18
-Riley,Center twp,President,,LBT,Gary Johnson,4
-Riley,Fancy Creek twp,President,,LBT,Gary Johnson,0
-Riley,Grant twp,President,,LBT,Gary Johnson,29
-Riley,Jackson twp,President,,LBT,Gary Johnson,6
-Riley,Mad/Ft Riley A,President,,LBT,Gary Johnson,7
-Riley,Mad/Ft Riley B,President,,LBT,Gary Johnson,3
-Riley,Madison twp H64,President,,LBT,Gary Johnson,36
-Riley,Madison twp H67,President,,LBT,Gary Johnson,1
-Riley,Manhattan twp 1,President,,LBT,Gary Johnson,15
-Riley,Manhattan twp 2,President,,LBT,Gary Johnson,21
-Riley,Manhattan twp 3,President,,LBT,Gary Johnson,1
-Riley,Manhattan twp 4,President,,LBT,Gary Johnson,22
-Riley,May Day twp,President,,LBT,Gary Johnson,2
-Riley,Ogden twp,President,,LBT,Gary Johnson,5
-Riley,Ogden twp/Ft Riley A,President,,LBT,Gary Johnson,19
-Riley,Sherman twp,President,,LBT,Gary Johnson,13
-Riley,Swede Creek twp,President,,LBT,Gary Johnson,2
-Riley,Wildcat twp,President,,LBT,Gary Johnson,27
-Riley,Zeandale twp,President,,LBT,Gary Johnson,13
-Riley,Ashland twp,President,,IND,Jill Stein,1
-Riley,Bala twp,President,,IND,Jill Stein,4
-Riley,Center twp,President,,IND,Jill Stein,1
-Riley,Fancy Creek twp,President,,IND,Jill Stein,0
-Riley,Grant twp,President,,IND,Jill Stein,10
-Riley,Jackson twp,President,,IND,Jill Stein,1
-Riley,Mad/Ft Riley A,President,,IND,Jill Stein,0
-Riley,Mad/Ft Riley B,President,,IND,Jill Stein,1
-Riley,Madison twp H64,President,,IND,Jill Stein,10
-Riley,Madison twp H67,President,,IND,Jill Stein,0
-Riley,Manhattan twp 1,President,,IND,Jill Stein,3
-Riley,Manhattan twp 2,President,,IND,Jill Stein,12
-Riley,Manhattan twp 3,President,,IND,Jill Stein,4
-Riley,Manhattan twp 4,President,,IND,Jill Stein,6
-Riley,May Day twp,President,,IND,Jill Stein,0
-Riley,Ogden twp,President,,IND,Jill Stein,0
-Riley,Ogden twp/Ft Riley A,President,,IND,Jill Stein,7
-Riley,Sherman twp,President,,IND,Jill Stein,3
-Riley,Swede Creek twp,President,,IND,Jill Stein,2
-Riley,Wildcat twp,President,,IND,Jill Stein,7
-Riley,Zeandale twp,President,,IND,Jill Stein,5
-Riley,Ashland twp,President,,,Write-ins,1
-Riley,Bala twp,President,,,Write-ins,5
-Riley,Center twp,President,,,Write-ins,1
-Riley,Fancy Creek twp,President,,,Write-ins,0
-Riley,Grant twp,President,,,Write-ins,21
-Riley,Jackson twp,President,,,Write-ins,4
-Riley,Mad/Ft Riley A,President,,,Write-ins,1
-Riley,Mad/Ft Riley B,President,,,Write-ins,1
-Riley,Madison twp H64,President,,,Write-ins,11
-Riley,Madison twp H67,President,,,Write-ins,0
-Riley,Manhattan twp 1,President,,,Write-ins,8
-Riley,Manhattan twp 2,President,,,Write-ins,5
-Riley,Manhattan twp 3,President,,,Write-ins,3
-Riley,Manhattan twp 4,President,,,Write-ins,13
-Riley,May Day twp,President,,,Write-ins,0
-Riley,Ogden twp,President,,,Write-ins,9
-Riley,Ogden twp/Ft Riley A,President,,,Write-ins,6
-Riley,Sherman twp,President,,,Write-ins,7
-Riley,Swede Creek twp,President,,,Write-ins,1
-Riley,Wildcat twp,President,,,Write-ins,18
-Riley,Zeandale twp,President,,,Write-ins,7
-Riley,Ashland twp,U.S. Senate,,Dem,Patrick Wiesner,22
-Riley,Bala twp,U.S. Senate,,Dem,Patrick Wiesner,45
-Riley,Center twp,U.S. Senate,,Dem,Patrick Wiesner,2
-Riley,Fancy Creek twp,U.S. Senate,,Dem,Patrick Wiesner,10
-Riley,Grant twp,U.S. Senate,,Dem,Patrick Wiesner,128
-Riley,Jackson twp,U.S. Senate,,Dem,Patrick Wiesner,21
-Riley,Mad/Ft Riley A,U.S. Senate,,Dem,Patrick Wiesner,6
-Riley,Mad/Ft Riley B,U.S. Senate,,Dem,Patrick Wiesner,16
-Riley,Madison twp H64,U.S. Senate,,Dem,Patrick Wiesner,101
-Riley,Madison twp H67,U.S. Senate,,Dem,Patrick Wiesner,1
-Riley,Manhattan twp 1,U.S. Senate,,Dem,Patrick Wiesner,58
-Riley,Manhattan twp 2,U.S. Senate,,Dem,Patrick Wiesner,66
-Riley,Manhattan twp 3,U.S. Senate,,Dem,Patrick Wiesner,25
-Riley,Manhattan twp 4,U.S. Senate,,Dem,Patrick Wiesner,93
-Riley,May Day twp,U.S. Senate,,Dem,Patrick Wiesner,0
-Riley,Ogden twp,U.S. Senate,,Dem,Patrick Wiesner,31
-Riley,Ogden twp/Ft Riley A,U.S. Senate,,Dem,Patrick Wiesner,92
-Riley,Sherman twp,U.S. Senate,,Dem,Patrick Wiesner,61
-Riley,Swede Creek twp,U.S. Senate,,Dem,Patrick Wiesner,13
-Riley,Wildcat twp,U.S. Senate,,Dem,Patrick Wiesner,70
-Riley,Zeandale twp,U.S. Senate,,Dem,Patrick Wiesner,40
-Riley,Ashland twp,U.S. Senate,,Rep,Jerry Moran,71
-Riley,Bala twp,U.S. Senate,,Rep,Jerry Moran,271
-Riley,Center twp,U.S. Senate,,Rep,Jerry Moran,40
-Riley,Fancy Creek twp,U.S. Senate,,Rep,Jerry Moran,61
-Riley,Grant twp,U.S. Senate,,Rep,Jerry Moran,427
-Riley,Jackson twp,U.S. Senate,,Rep,Jerry Moran,134
-Riley,Mad/Ft Riley A,U.S. Senate,,Rep,Jerry Moran,21
-Riley,Mad/Ft Riley B,U.S. Senate,,Rep,Jerry Moran,17
-Riley,Madison twp H64,U.S. Senate,,Rep,Jerry Moran,392
-Riley,Madison twp H67,U.S. Senate,,Rep,Jerry Moran,14
-Riley,Manhattan twp 1,U.S. Senate,,Rep,Jerry Moran,226
-Riley,Manhattan twp 2,U.S. Senate,,Rep,Jerry Moran,224
-Riley,Manhattan twp 3,U.S. Senate,,Rep,Jerry Moran,81
-Riley,Manhattan twp 4,U.S. Senate,,Rep,Jerry Moran,222
-Riley,May Day twp,U.S. Senate,,Rep,Jerry Moran,40
-Riley,Ogden twp,U.S. Senate,,Rep,Jerry Moran,156
-Riley,Ogden twp/Ft Riley A,U.S. Senate,,Rep,Jerry Moran,248
-Riley,Sherman twp,U.S. Senate,,Rep,Jerry Moran,232
-Riley,Swede Creek twp,U.S. Senate,,Rep,Jerry Moran,57
-Riley,Wildcat twp,U.S. Senate,,Rep,Jerry Moran,414
-Riley,Zeandale twp,U.S. Senate,,Rep,Jerry Moran,155
-Riley,Ashland twp,U.S. Senate,,LBT,Robert Garrard,6
-Riley,Bala twp,U.S. Senate,,LBT,Robert Garrard,16
-Riley,Center twp,U.S. Senate,,LBT,Robert Garrard,2
-Riley,Fancy Creek twp,U.S. Senate,,LBT,Robert Garrard,0
-Riley,Grant twp,U.S. Senate,,LBT,Robert Garrard,18
-Riley,Jackson twp,U.S. Senate,,LBT,Robert Garrard,6
-Riley,Mad/Ft Riley A,U.S. Senate,,LBT,Robert Garrard,6
-Riley,Mad/Ft Riley B,U.S. Senate,,LBT,Robert Garrard,4
-Riley,Madison twp H64,U.S. Senate,,LBT,Robert Garrard,32
-Riley,Madison twp H67,U.S. Senate,,LBT,Robert Garrard,0
-Riley,Manhattan twp 1,U.S. Senate,,LBT,Robert Garrard,5
-Riley,Manhattan twp 2,U.S. Senate,,LBT,Robert Garrard,23
-Riley,Manhattan twp 3,U.S. Senate,,LBT,Robert Garrard,3
-Riley,Manhattan twp 4,U.S. Senate,,LBT,Robert Garrard,10
-Riley,May Day twp,U.S. Senate,,LBT,Robert Garrard,0
-Riley,Ogden twp,U.S. Senate,,LBT,Robert Garrard,10
-Riley,Ogden twp/Ft Riley A,U.S. Senate,,LBT,Robert Garrard,28
-Riley,Sherman twp,U.S. Senate,,LBT,Robert Garrard,19
-Riley,Swede Creek twp,U.S. Senate,,LBT,Robert Garrard,2
-Riley,Wildcat twp,U.S. Senate,,LBT,Robert Garrard,20
-Riley,Zeandale twp,U.S. Senate,,LBT,Robert Garrard,4
-Riley,Ashland twp,U.S. Senate,,,Write-ins,0
-Riley,Bala twp,U.S. Senate,,,Write-ins,0
-Riley,Center twp,U.S. Senate,,,Write-ins,0
-Riley,Fancy Creek twp,U.S. Senate,,,Write-ins,0
-Riley,Grant twp,U.S. Senate,,,Write-ins,1
-Riley,Jackson twp,U.S. Senate,,,Write-ins,1
-Riley,Mad/Ft Riley A,U.S. Senate,,,Write-ins,0
-Riley,Mad/Ft Riley B,U.S. Senate,,,Write-ins,0
-Riley,Madison twp H64,U.S. Senate,,,Write-ins,0
-Riley,Madison twp H67,U.S. Senate,,,Write-ins,0
-Riley,Manhattan twp 1,U.S. Senate,,,Write-ins,1
-Riley,Manhattan twp 2,U.S. Senate,,,Write-ins,2
-Riley,Manhattan twp 3,U.S. Senate,,,Write-ins,0
-Riley,Manhattan twp 4,U.S. Senate,,,Write-ins,1
-Riley,May Day twp,U.S. Senate,,,Write-ins,0
-Riley,Ogden twp,U.S. Senate,,,Write-ins,0
-Riley,Ogden twp/Ft Riley A,U.S. Senate,,,Write-ins,0
-Riley,Sherman twp,U.S. Senate,,,Write-ins,0
-Riley,Swede Creek twp,U.S. Senate,,,Write-ins,0
-Riley,Wildcat twp,U.S. Senate,,,Write-ins,0
-Riley,Zeandale twp,U.S. Senate,,,Write-ins,2
-Riley,Ashland twp,U.S. House,1,Rep,Roger Marshall,64
-Riley,Bala twp,U.S. House,1,Rep,Roger Marshall,217
-Riley,Center twp,U.S. House,1,Rep,Roger Marshall,34
-Riley,Fancy Creek twp,U.S. House,1,Rep,Roger Marshall,54
-Riley,Grant twp,U.S. House,1,Rep,Roger Marshall,366
-Riley,Jackson twp,U.S. House,1,Rep,Roger Marshall,102
-Riley,Mad/Ft Riley A,U.S. House,1,Rep,Roger Marshall,19
-Riley,Mad/Ft Riley B,U.S. House,1,Rep,Roger Marshall,17
-Riley,Madison twp H64,U.S. House,1,Rep,Roger Marshall,320
-Riley,Madison twp H67,U.S. House,1,Rep,Roger Marshall,12
-Riley,Manhattan twp 1,U.S. House,1,Rep,Roger Marshall,200
-Riley,Manhattan twp 2,U.S. House,1,Rep,Roger Marshall,178
-Riley,Manhattan twp 3,U.S. House,1,Rep,Roger Marshall,74
-Riley,Manhattan twp 4,U.S. House,1,Rep,Roger Marshall,170
-Riley,May Day twp,U.S. House,1,Rep,Roger Marshall,33
-Riley,Ogden twp,U.S. House,1,Rep,Roger Marshall,132
-Riley,Ogden twp/Ft Riley A,U.S. House,1,Rep,Roger Marshall,228
-Riley,Sherman twp,U.S. House,1,Rep,Roger Marshall,191
-Riley,Swede Creek twp,U.S. House,1,Rep,Roger Marshall,48
-Riley,Wildcat twp,U.S. House,1,Rep,Roger Marshall,334
-Riley,Zeandale twp,U.S. House,1,Rep,Roger Marshall,135
-Riley,Ashland twp,U.S. House,1,LBT,Kerry Burt,5
-Riley,Bala twp,U.S. House,1,LBT,Kerry Burt,16
-Riley,Center twp,U.S. House,1,LBT,Kerry Burt,1
-Riley,Fancy Creek twp,U.S. House,1,LBT,Kerry Burt,3
-Riley,Grant twp,U.S. House,1,LBT,Kerry Burt,33
-Riley,Jackson twp,U.S. House,1,LBT,Kerry Burt,10
-Riley,Mad/Ft Riley A,U.S. House,1,LBT,Kerry Burt,9
-Riley,Mad/Ft Riley B,U.S. House,1,LBT,Kerry Burt,12
-Riley,Madison twp H64,U.S. House,1,LBT,Kerry Burt,26
-Riley,Madison twp H67,U.S. House,1,LBT,Kerry Burt,1
-Riley,Manhattan twp 1,U.S. House,1,LBT,Kerry Burt,17
-Riley,Manhattan twp 2,U.S. House,1,LBT,Kerry Burt,29
-Riley,Manhattan twp 3,U.S. House,1,LBT,Kerry Burt,5
-Riley,Manhattan twp 4,U.S. House,1,LBT,Kerry Burt,49
-Riley,May Day twp,U.S. House,1,LBT,Kerry Burt,1
-Riley,Ogden twp,U.S. House,1,LBT,Kerry Burt,7
-Riley,Ogden twp/Ft Riley A,U.S. House,1,LBT,Kerry Burt,41
-Riley,Sherman twp,U.S. House,1,LBT,Kerry Burt,22
-Riley,Swede Creek twp,U.S. House,1,LBT,Kerry Burt,1
-Riley,Wildcat twp,U.S. House,1,LBT,Kerry Burt,13
-Riley,Zeandale twp,U.S. House,1,LBT,Kerry Burt,12
-Riley,Ashland twp,U.S. House,1,IND,Alan LaPolice,24
-Riley,Bala twp,U.S. House,1,IND,Alan LaPolice,99
-Riley,Center twp,U.S. House,1,IND,Alan LaPolice,8
-Riley,Fancy Creek twp,U.S. House,1,IND,Alan LaPolice,12
-Riley,Grant twp,U.S. House,1,IND,Alan LaPolice,155
-Riley,Jackson twp,U.S. House,1,IND,Alan LaPolice,47
-Riley,Mad/Ft Riley A,U.S. House,1,IND,Alan LaPolice,4
-Riley,Mad/Ft Riley B,U.S. House,1,IND,Alan LaPolice,7
-Riley,Madison twp H64,U.S. House,1,IND,Alan LaPolice,162
-Riley,Madison twp H67,U.S. House,1,IND,Alan LaPolice,1
-Riley,Manhattan twp 1,U.S. House,1,IND,Alan LaPolice,64
-Riley,Manhattan twp 2,U.S. House,1,IND,Alan LaPolice,95
-Riley,Manhattan twp 3,U.S. House,1,IND,Alan LaPolice,26
-Riley,Manhattan twp 4,U.S. House,1,IND,Alan LaPolice,93
-Riley,May Day twp,U.S. House,1,IND,Alan LaPolice,6
-Riley,Ogden twp,U.S. House,1,IND,Alan LaPolice,50
-Riley,Ogden twp/Ft Riley A,U.S. House,1,IND,Alan LaPolice,79
-Riley,Sherman twp,U.S. House,1,IND,Alan LaPolice,96
-Riley,Swede Creek twp,U.S. House,1,IND,Alan LaPolice,23
-Riley,Wildcat twp,U.S. House,1,IND,Alan LaPolice,142
-Riley,Zeandale twp,U.S. House,1,IND,Alan LaPolice,43
-Riley,Ashland twp,U.S. House,1,,Write-ins,1
-Riley,Bala twp,U.S. House,1,,Write-ins,0
-Riley,Center twp,U.S. House,1,,Write-ins,0
-Riley,Fancy Creek twp,U.S. House,1,,Write-ins,1
-Riley,Grant twp,U.S. House,1,,Write-ins,4
-Riley,Jackson twp,U.S. House,1,,Write-ins,0
-Riley,Mad/Ft Riley A,U.S. House,1,,Write-ins,1
-Riley,Mad/Ft Riley B,U.S. House,1,,Write-ins,0
-Riley,Madison twp H64,U.S. House,1,,Write-ins,2
-Riley,Madison twp H67,U.S. House,1,,Write-ins,0
-Riley,Manhattan twp 1,U.S. House,1,,Write-ins,2
-Riley,Manhattan twp 2,U.S. House,1,,Write-ins,1
-Riley,Manhattan twp 3,U.S. House,1,,Write-ins,0
-Riley,Manhattan twp 4,U.S. House,1,,Write-ins,2
-Riley,May Day twp,U.S. House,1,,Write-ins,0
-Riley,Ogden twp,U.S. House,1,,Write-ins,3
-Riley,Ogden twp/Ft Riley A,U.S. House,1,,Write-ins,7
-Riley,Sherman twp,U.S. House,1,,Write-ins,0
-Riley,Swede Creek twp,U.S. House,1,,Write-ins,0
-Riley,Wildcat twp,U.S. House,1,,Write-ins,1
-Riley,Zeandale twp,U.S. House,1,,Write-ins,3
-Riley,Ashland twp,State Senate,22,Dem,Tom Hawk,74
-Riley,Bala twp,State Senate,22,Dem,Tom Hawk,248
-Riley,Center twp,State Senate,22,Dem,Tom Hawk,34
-Riley,Fancy Creek twp,State Senate,22,Dem,Tom Hawk,45
-Riley,Grant twp,State Senate,22,Dem,Tom Hawk,413
-Riley,Jackson twp,State Senate,22,Dem,Tom Hawk,122
-Riley,Mad/Ft Riley A,State Senate,22,Dem,Tom Hawk,24
-Riley,Mad/Ft Riley B,State Senate,22,Dem,Tom Hawk,23
-Riley,Madison twp H64,State Senate,22,Dem,Tom Hawk,392
-Riley,Madison twp H67,State Senate,22,Dem,Tom Hawk,11
-Riley,Manhattan twp 1,State Senate,22,Dem,Tom Hawk,197
-Riley,Manhattan twp 2,State Senate,22,Dem,Tom Hawk,257
-Riley,Manhattan twp 3,State Senate,22,Dem,Tom Hawk,83
-Riley,Manhattan twp 4,State Senate,22,Dem,Tom Hawk,253
-Riley,May Day twp,State Senate,22,Dem,Tom Hawk,26
-Riley,Ogden twp,State Senate,22,Dem,Tom Hawk,125
-Riley,Ogden twp/Ft Riley A,State Senate,22,Dem,Tom Hawk,286
-Riley,Sherman twp,State Senate,22,Dem,Tom Hawk,232
-Riley,Swede Creek twp,State Senate,22,Dem,Tom Hawk,56
-Riley,Wildcat twp,State Senate,22,Dem,Tom Hawk,360
-Riley,Zeandale twp,State Senate,22,Dem,Tom Hawk,152
-Riley,Ashland twp,State Senate,22,,Write-ins,3
-Riley,Bala twp,State Senate,22,,Write-ins,12
-Riley,Center twp,State Senate,22,,Write-ins,2
-Riley,Fancy Creek twp,State Senate,22,,Write-ins,1
-Riley,Grant twp,State Senate,22,,Write-ins,22
-Riley,Jackson twp,State Senate,22,,Write-ins,4
-Riley,Mad/Ft Riley A,State Senate,22,,Write-ins,1
-Riley,Mad/Ft Riley B,State Senate,22,,Write-ins,2
-Riley,Madison twp H64,State Senate,22,,Write-ins,27
-Riley,Madison twp H67,State Senate,22,,Write-ins,0
-Riley,Manhattan twp 1,State Senate,22,,Write-ins,8
-Riley,Manhattan twp 2,State Senate,22,,Write-ins,3
-Riley,Manhattan twp 3,State Senate,22,,Write-ins,2
-Riley,Manhattan twp 4,State Senate,22,,Write-ins,10
-Riley,May Day twp,State Senate,22,,Write-ins,0
-Riley,Ogden twp,State Senate,22,,Write-ins,11
-Riley,Ogden twp/Ft Riley A,State Senate,22,,Write-ins,5
-Riley,Sherman twp,State Senate,22,,Write-ins,10
-Riley,Swede Creek twp,State Senate,22,,Write-ins,0
-Riley,Wildcat twp,State Senate,22,,Write-ins,16
-Riley,Zeandale twp,State Senate,22,,Write-ins,6
-Riley,Zeandale twp,State House,51,Dem,Adrienne Olejnik,80
-Riley,Zeandale twp,State House,51,Rep,Ron Highland,121
-Riley,Zeandale twp,State House,51,,Write-ins,0
-Riley,Bala twp,State House,64,Rep,Susie Swanson,305
-Riley,Center twp,State House,64,Rep,Susie Swanson,38
-Riley,Fancy Creek twp,State House,64,Rep,Susie Swanson,63
-Riley,Jackson twp,State House,64,Rep,Susie Swanson,146
-Riley,Mad/Ft Riley A,State House,64,Rep,Susie Swanson,27
-Riley,Mad/Ft Riley B,State House,64,Rep,Susie Swanson,25
-Riley,Madison twp H64,State House,64,Rep,Susie Swanson,468
-Riley,May Day twp,State House,64,Rep,Susie Swanson,34
-Riley,Ogden twp,State House,64,Rep,Susie Swanson,175
-Riley,Ogden twp/Ft Riley A,State House,64,Rep,Susie Swanson,306
-Riley,Sherman twp,State House,64,Rep,Susie Swanson,279
-Riley,Swede Creek twp,State House,64,Rep,Susie Swanson,61
-Riley,Bala twp,State House,64,,Write-ins,3
-Riley,Center twp,State House,64,,Write-ins,2
-Riley,Fancy Creek twp,State House,64,,Write-ins,0
-Riley,Jackson twp,State House,64,,Write-ins,0
-Riley,Mad/Ft Riley A,State House,64,,Write-ins,2
-Riley,Mad/Ft Riley B,State House,64,,Write-ins,1
-Riley,Madison twp H64,State House,64,,Write-ins,7
-Riley,May Day twp,State House,64,,Write-ins,0
-Riley,Ogden twp,State House,64,,Write-ins,7
-Riley,Ogden twp/Ft Riley A,State House,64,,Write-ins,12
-Riley,Sherman twp,State House,64,,Write-ins,2
-Riley,Swede Creek twp,State House,64,,Write-ins,0
-Riley,Manhattan twp 1,State House,66,Dem,Sydney Carlin,133
-Riley,Manhattan twp 4,State House,66,Dem,Sydney Carlin,184
-Riley,Manhattan twp 1,State House,66,Rep,Stanley Hoerman,151
-Riley,Manhattan twp 4,State House,66,Rep,Stanley Hoerman,136
-Riley,Manhattan twp 1,State House,66,,Write-ins,0
-Riley,Manhattan twp 4,State House,66,,Write-ins,2
-Riley,Ashland twp,State House,67,Rep,Tom Phillips,89
-Riley,Grant twp,State House,67,Rep,Tom Phillips,503
-Riley,Madison twp H67,State House,67,Rep,Tom Phillips,14
-Riley,Manhattan twp 2,State House,67,Rep,Tom Phillips,270
-Riley,Manhattan twp 3,State House,67,Rep,Tom Phillips,88
-Riley,Wildcat twp,State House,67,Rep,Tom Phillips,455
-Riley,Ashland twp,State House,67,,Write-ins,0
-Riley,Grant twp,State House,67,,Write-ins,8
-Riley,Madison twp H67,State House,67,,Write-ins,0
-Riley,Manhattan twp 2,State House,67,,Write-ins,4
-Riley,Manhattan twp 3,State House,67,,Write-ins,2
-Riley,Wildcat twp,State House,67,,Write-ins,2
-Riley,W01P01,President,,Write-ins,Darrell Castle (included),1
-Riley,W01P01,President,,Write-ins,Evan McMullin (included),12
-Riley,W02P01,President,,Write-ins,Evan McMullin (included),5
-Riley,W02P02,President,,Write-ins,Evan McMullin (included),2
-Riley,W02P03,President,,Write-ins,Evan McMullin (included),14
-Riley,W02P04,President,,Write-ins,Evan McMullin (included),3
-Riley,W03P02,President,,Write-ins,Evan McMullin (included),8
-Riley,W03P03,President,,Write-ins,Darrell Castle (included),1
-Riley,W03P03,President,,Write-ins,Evan McMullin (included),5
-Riley,W04P02,President,,Write-ins,Darrell Castle (included),1
-Riley,W04P02,President,,Write-ins,Evan McMullin (included),7
-Riley,W04P03,President,,Write-ins,Evan McMullin (included),7
-Riley,W04P04,President,,Write-ins,Darrell Castle (included),2
-Riley,W04P05,President,,Write-ins,Darrell Castle (included),1
-Riley,W04P06,President,,Write-ins,Evan McMullin (included),3
-Riley,W05P02,President,,Write-ins,Evan McMullin (included),7
-Riley,W05P03,President,,Write-ins,Evan McMullin (included),8
-Riley,W05P05,President,,Write-ins,Evan McMullin (included),4
-Riley,W05P06,President,,Write-ins,Evan McMullin (included),14
-Riley,W05P07,President,,Write-ins,Evan McMullin (included),5
-Riley,W05P08,President,,Write-ins,Evan McMullin (included),6
-Riley,W05P09,President,,Write-ins,Evan McMullin (included),14
-Riley,W05P10,President,,Write-ins,Evan McMullin (included),18
-Riley,W05P11,President,,Write-ins,Evan McMullin (included),8
-Riley,W08P03,President,,Write-ins,Evan McMullin (included),4
-Riley,W11P01,President,,Write-ins,Evan McMullin (included),5
-Riley,W11P03,President,,Write-ins,Evan McMullin (included),1
-Riley,W11P12,President,,Write-ins,Evan McMullin (included),2
-Riley,Bala twp,President,,Write-ins,Evan McMullin (included),1
-Riley,Grant twp,President,,Write-ins,Evan McMullin (included),6
-Riley,Mad/Ft Riley A,President,,Write-ins,Evan McMullin (included),1
-Riley,Madison twp H64,President,,Write-ins,Darrell Castle (included),2
-Riley,Madison twp H64,President,,Write-ins,Evan McMullin (included),2
-Riley,Manhattan twp 1,President,,Write-ins,Evan McMullin (included),1
-Riley,Manhattan twp 2,President,,Write-ins,Evan McMullin (included),2
-Riley,Manhattan twp 4,President,,Write-ins,Evan McMullin (included),7
-Riley,Ogden twp/Ft Riley A,President,,Write-ins,Evan McMullin (included),2
-Riley,Sherman twp,President,,Write-ins,Evan McMullin (included),2
-Riley,Wildcat twp,President,,Write-ins,Evan McMullin (included),6
-Riley,Zeandale twp,President,,Write-ins,Evan McMullin (included),2
+county,precinct,office,district,party,candidate,votes,vtd
+RILEY,Ashland Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",89,000010
+RILEY,Bala Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",306,000020
+RILEY,Center Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",38,000030
+RILEY,Fancy Creek Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",63,000040
+RILEY,Fort Riley B Madison Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",27,00005B
+RILEY,Grant Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",508,000060
+RILEY,Jackson Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",148,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",200,000120
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",79,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",402,000140
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",248,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",282,000170
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",148,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",173,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",79,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",496,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas House of Representatives,67,Republican,"Phillips, Tom",561,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas House of Representatives,67,Republican,"Phillips, Tom",275,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas House of Representatives,67,Republican,"Phillips, Tom",643,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas House of Representatives,67,Republican,"Phillips, Tom",285,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas House of Representatives,67,Republican,"Phillips, Tom",393,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas House of Representatives,67,Republican,"Phillips, Tom",1031,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas House of Representatives,67,Republican,"Phillips, Tom",1161,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas House of Representatives,67,Republican,"Phillips, Tom",1099,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas House of Representatives,64,Republican,"Swanson, Susie",1,000380
+RILEY,Manhattan Township Precinct 1,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",135,00039A
+RILEY,Manhattan Township Precinct 1,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",153,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00039H
+RILEY,Manhattan Township Precinct 2,Kansas House of Representatives,67,Republican,"Phillips, Tom",270,000400
+RILEY,Manhattan Township Precinct 3,Kansas House of Representatives,67,Republican,"Phillips, Tom",89,000410
+RILEY,Manhattan Township Precinct 4,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",184,000420
+RILEY,Manhattan Township Precinct 4,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",136,000420
+RILEY,May Day Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",34,000430
+RILEY,Ogden Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",176,00044A
+RILEY,Sherman Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",281,000450
+RILEY,Swede Creek Township,Kansas House of Representatives,64,Republican,"Swanson, Susie",61,000460
+RILEY,Wildcat Township,Kansas House of Representatives,67,Republican,"Phillips, Tom",460,00047A
+RILEY,Wildcat Township Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00047B
+RILEY,Wildcat Township Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",108,00047D
+RILEY,Zeandale Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",122,000480
+RILEY,Zeandale Township,Kansas House of Representatives,51,Republican,"Highland, Ron",80,000480
+RILEY,Fort Riley A Madison Township H64,Kansas House of Representatives,64,Republican,"Swanson, Susie",41,120020
+RILEY,Fort Riley A Madison Township H67,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,120030
+RILEY,Madison Township H64,Kansas House of Representatives,64,Republican,"Swanson, Susie",469,120040
+RILEY,Madison Township H67,Kansas House of Representatives,67,Republican,"Phillips, Tom",14,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",123,300020
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",90,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",1,300030
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",2,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",80,300040
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",35,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",81,300050
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",40,300050
+RILEY,Ogden Township Fort Riley A,Kansas House of Representatives,64,Republican,"Swanson, Susie",313,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300090
+RILEY,Ogden Township Ward 5,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",507,400010
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",174,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",515,400020
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",172,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",752,400030
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",417,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",521,400040
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",294,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas House of Representatives,67,Republican,"Phillips, Tom",1007,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",432,400060
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",188,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",495,400070
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",283,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas House of Representatives,67,Republican,"Phillips, Tom",27,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas House of Representatives,67,Republican,"Phillips, Tom",353,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas House of Representatives,67,Republican,"Phillips, Tom",262,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas House of Representatives,66,Democratic,"Carlin, Sydney",232,500030
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas House of Representatives,66,Republican,"Hoerman, Stanley",131,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",42,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas House of Representatives,67,Republican,"Phillips, Tom",50,800001
+RILEY,Ogden Township Enclave 1,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,900010
+RILEY,Ogden Township Enclave 2,Kansas House of Representatives,64,Republican,"Swanson, Susie",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas House of Representatives,67,Republican,"Phillips, Tom",171,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas House of Representatives,67,Republican,"Phillips, Tom",0,900060
+RILEY,Ashland Township,Kansas Senate,22,Democratic,"Hawk, Tom",74,000010
+RILEY,Bala Township,Kansas Senate,22,Democratic,"Hawk, Tom",249,000020
+RILEY,Center Township,Kansas Senate,22,Democratic,"Hawk, Tom",34,000030
+RILEY,Fancy Creek Township,Kansas Senate,22,Democratic,"Hawk, Tom",45,000040
+RILEY,Fort Riley B Madison Township,Kansas Senate,22,Democratic,"Hawk, Tom",25,00005B
+RILEY,Grant Township,Kansas Senate,22,Democratic,"Hawk, Tom",420,000060
+RILEY,Jackson Township,Kansas Senate,22,Democratic,"Hawk, Tom",123,000070
+RILEY,Manhattan City Ward 02 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",239,000120
+RILEY,Manhattan City Ward 02 Precinct 04,Kansas Senate,22,Democratic,"Hawk, Tom",547,000140
+RILEY,Manhattan City Ward 03 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",361,000170
+RILEY,Manhattan City Ward 04 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",210,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",540,000230
+RILEY,Manhattan City Ward 04 Precinct 05,Kansas Senate,22,Democratic,"Hawk, Tom",538,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,Kansas Senate,22,Democratic,"Hawk, Tom",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,Kansas Senate,22,Democratic,"Hawk, Tom",271,000310
+RILEY,Manhattan City Ward 05 Precinct 06,Kansas Senate,22,Democratic,"Hawk, Tom",614,000320
+RILEY,Manhattan City Ward 05 Precinct 07,Kansas Senate,22,Democratic,"Hawk, Tom",279,000330
+RILEY,Manhattan City Ward 05 Precinct 08,Kansas Senate,22,Democratic,"Hawk, Tom",383,000340
+RILEY,Manhattan City Ward 05 Precinct 09,Kansas Senate,22,Democratic,"Hawk, Tom",1001,000350
+RILEY,Manhattan City Ward 05 Precinct 10,Kansas Senate,22,Democratic,"Hawk, Tom",1110,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,Kansas Senate,22,Democratic,"Hawk, Tom",1064,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,Kansas Senate,22,Democratic,"Hawk, Tom",1,000380
+RILEY,Manhattan Township Precinct 1,Kansas Senate,22,Democratic,"Hawk, Tom",200,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,Kansas Senate,22,Democratic,"Hawk, Tom",0,00039H
+RILEY,Manhattan Township Precinct 2,Kansas Senate,22,Democratic,"Hawk, Tom",260,000400
+RILEY,Manhattan Township Precinct 3,Kansas Senate,22,Democratic,"Hawk, Tom",85,000410
+RILEY,Manhattan Township Precinct 4,Kansas Senate,22,Democratic,"Hawk, Tom",253,000420
+RILEY,May Day Township,Kansas Senate,22,Democratic,"Hawk, Tom",26,000430
+RILEY,Ogden Township,Kansas Senate,22,Democratic,"Hawk, Tom",126,00044A
+RILEY,Sherman Township,Kansas Senate,22,Democratic,"Hawk, Tom",233,000450
+RILEY,Swede Creek Township,Kansas Senate,22,Democratic,"Hawk, Tom",56,000460
+RILEY,Wildcat Township,Kansas Senate,22,Democratic,"Hawk, Tom",366,00047A
+RILEY,Wildcat Township Enclave A,Kansas Senate,22,Democratic,"Hawk, Tom",0,00047B
+RILEY,Wildcat Township Enclave B,Kansas Senate,22,Democratic,"Hawk, Tom",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",103,00047D
+RILEY,Zeandale Township,Kansas Senate,22,Democratic,"Hawk, Tom",153,000480
+RILEY,Fort Riley A Madison Township H64,Kansas Senate,22,Democratic,"Hawk, Tom",37,120020
+RILEY,Fort Riley A Madison Township H67,Kansas Senate,22,Democratic,"Hawk, Tom",0,120030
+RILEY,Madison Township H64,Kansas Senate,22,Democratic,"Hawk, Tom",394,120040
+RILEY,Madison Township H67,Kansas Senate,22,Democratic,"Hawk, Tom",11,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,Kansas Senate,22,Democratic,"Hawk, Tom",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",176,300020
+RILEY,Manhattan City Ward 08 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",2,300030
+RILEY,Manhattan City Ward 09 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",96,300040
+RILEY,Manhattan City Ward 09 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",96,300050
+RILEY,Ogden Township Fort Riley A,Kansas Senate,22,Democratic,"Hawk, Tom",291,300060
+RILEY,Ogden Township Ward 2 Annex order 506,Kansas Senate,22,Democratic,"Hawk, Tom",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,Kansas Senate,22,Democratic,"Hawk, Tom",0,300090
+RILEY,Ogden Township Ward 5,Kansas Senate,22,Democratic,"Hawk, Tom",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",572,400010
+RILEY,Manhattan City Ward 02 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",611,400020
+RILEY,Manhattan City Ward 02 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",1004,400030
+RILEY,Manhattan City Ward 03 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",691,400040
+RILEY,Manhattan City Ward 04 Precinct 04,Kansas Senate,22,Democratic,"Hawk, Tom",971,400050
+RILEY,Manhattan City Ward 05 Precinct 02,Kansas Senate,22,Democratic,"Hawk, Tom",519,400060
+RILEY,Manhattan City Ward 05 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",657,400070
+RILEY,Manhattan City Ward 04 Precinct 07,Kansas Senate,22,Democratic,"Hawk, Tom",20,400080
+RILEY,Manhattan City Ward 04 Precinct 06,Kansas Senate,22,Democratic,"Hawk, Tom",307,400090
+RILEY,Manhattan City Ward 11 Precinct 01,Kansas Senate,22,Democratic,"Hawk, Tom",270,500010
+RILEY,Manhattan City Ward 08 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",316,500030
+RILEY,Manhattan City Ward 11 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",46,600001
+RILEY,Manhattan City Ward 09 Precinct 03,Kansas Senate,22,Democratic,"Hawk, Tom",47,800001
+RILEY,Ogden Township Enclave 1,Kansas Senate,22,Democratic,"Hawk, Tom",0,900010
+RILEY,Ogden Township Enclave 2,Kansas Senate,22,Democratic,"Hawk, Tom",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,Kansas Senate,22,Democratic,"Hawk, Tom",162,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,Kansas Senate,22,Democratic,"Hawk, Tom",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,Kansas Senate,22,Democratic,"Hawk, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,Kansas Senate,22,Democratic,"Hawk, Tom",0,900060
+RILEY,Ashland Township,President / Vice President,,independent,"Stein, Jill",1,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+RILEY,Ashland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+RILEY,Ashland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000010
+RILEY,Ashland Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+RILEY,Ashland Township,President / Vice President,,Republican,"Trump, Donald J.",49,000010
+RILEY,Bala Township,President / Vice President,,independent,"Stein, Jill",4,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"McMullin, Evan",1,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+RILEY,Bala Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+RILEY,Bala Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000020
+RILEY,Bala Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000020
+RILEY,Bala Township,President / Vice President,,Republican,"Trump, Donald J.",256,000020
+RILEY,Center Township,President / Vice President,,independent,"Stein, Jill",1,000030
+RILEY,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+RILEY,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+RILEY,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+RILEY,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000030
+RILEY,Center Township,President / Vice President,,Republican,"Trump, Donald J.",34,000030
+RILEY,Fancy Creek Township,President / Vice President,,independent,"Stein, Jill",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000040
+RILEY,Fancy Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+RILEY,Fancy Creek Township,President / Vice President,,Republican,"Trump, Donald J.",53,000040
+RILEY,Fort Riley B Madison Township,President / Vice President,,independent,"Stein, Jill",1,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Castle, Darrell L",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Giordani, Rocky",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Hedges, James A",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Hoefling, Tom",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Kahn, Lynn",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"La Riva, Gloria",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Maturen, Michael A",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"McMullin, Evan",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Perry, Darryl",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Schriner, Joe C",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Smith, Mike",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Sood, Ajay",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Sterling, Shawna",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00005B
+RILEY,Fort Riley B Madison Township,President / Vice President,,Republican,"Trump, Donald J.",18,00005B
+RILEY,Grant Township,President / Vice President,,independent,"Stein, Jill",11,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"McMullin, Evan",6,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+RILEY,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+RILEY,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",188,000060
+RILEY,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",30,000060
+RILEY,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",342,000060
+RILEY,Jackson Township,President / Vice President,,independent,"Stein, Jill",1,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+RILEY,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+RILEY,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",37,000070
+RILEY,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000070
+RILEY,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",115,000070
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,independent,"Stein, Jill",10,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",2,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",158,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",26,000120
+RILEY,Manhattan City Ward 02 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",91,000120
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,independent,"Stein, Jill",11,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"McMullin, Evan",3,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",295,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",42,000140
+RILEY,Manhattan City Ward 02 Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",311,000140
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,independent,"Stein, Jill",13,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",8,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",256,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",44,000170
+RILEY,Manhattan City Ward 03 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",148,000170
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,independent,"Stein, Jill",3,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",1,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",7,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",137,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",9,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",92,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,independent,"Stein, Jill",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,independent,"Stein, Jill",18,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",7,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",363,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",35,000230
+RILEY,Manhattan City Ward 04 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",230,000230
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,independent,"Stein, Jill",14,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",1,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"McMullin, Evan",8,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",275,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",43,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",322,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,independent,"Stein, Jill",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,independent,"Stein, Jill",12,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"McMullin, Evan",4,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",166,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",26,000310
+RILEY,Manhattan City Ward 05 Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",124,000310
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,independent,"Stein, Jill",11,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"McMullin, Evan",14,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",301,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",46,000320
+RILEY,Manhattan City Ward 05 Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",367,000320
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,independent,"Stein, Jill",4,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"McMullin, Evan",5,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",162,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",22,000330
+RILEY,Manhattan City Ward 05 Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",129,000330
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,independent,"Stein, Jill",8,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Hedges, James A",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"McMullin, Evan",6,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Perry, Darryl",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Smith, Mike",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Sood, Ajay",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",221,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",28,000340
+RILEY,Manhattan City Ward 05 Precinct 08,President / Vice President,,Republican,"Trump, Donald J.",210,000340
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,independent,"Stein, Jill",12,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"McMullin, Evan",14,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",550,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",43,000350
+RILEY,Manhattan City Ward 05 Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",564,000350
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,independent,"Stein, Jill",17,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"McMullin, Evan",18,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",620,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",89,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",621,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,independent,"Stein, Jill",20,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Hedges, James A",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"McMullin, Evan",8,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Perry, Darryl",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Smith, Mike",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Sood, Ajay",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",542,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",104,000370
+RILEY,Manhattan City Ward 05 Precinct 11,President / Vice President,,Republican,"Trump, Donald J.",638,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,independent,"Stein, Jill",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Hedges, James A",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"McMullin, Evan",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Perry, Darryl",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Smith, Mike",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Sood, Ajay",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Libertarian,"Johnson, Gary",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,President / Vice President,,Republican,"Trump, Donald J.",1,000380
+RILEY,Manhattan Township Precinct 1,President / Vice President,,independent,"Stein, Jill",3,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",89,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",15,00039A
+RILEY,Manhattan Township Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",183,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,independent,"Stein, Jill",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,independent,"Stein, Jill",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,independent,"Stein, Jill",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Castle, Darrell L",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Giordani, Rocky",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Hedges, James A",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Hoefling, Tom",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Kahn, Lynn",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"La Riva, Gloria",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Levinson, Michael S.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Maturen, Michael A",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"McMullin, Evan",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Perry, Darryl",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Schriner, Joe C",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Smith, Mike",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Sood, Ajay",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Sterling, Shawna",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Libertarian,"Johnson, Gary",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,President / Vice President,,Republican,"Trump, Donald J.",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,independent,"Stein, Jill",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Castle, Darrell L",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Giordani, Rocky",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Hedges, James A",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Hoefling, Tom",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Kahn, Lynn",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"La Riva, Gloria",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Levinson, Michael S.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Maturen, Michael A",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"McMullin, Evan",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Perry, Darryl",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Schriner, Joe C",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Smith, Mike",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Sood, Ajay",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Sterling, Shawna",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Libertarian,"Johnson, Gary",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,President / Vice President,,Republican,"Trump, Donald J.",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,independent,"Stein, Jill",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Hedges, James A",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Smith, Mike",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Libertarian,"Johnson, Gary",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,President / Vice President,,Republican,"Trump, Donald J.",0,00039H
+RILEY,Manhattan Township Precinct 2,President / Vice President,,independent,"Stein, Jill",12,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"McMullin, Evan",2,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",21,000400
+RILEY,Manhattan Township Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",181,000400
+RILEY,Manhattan Township Precinct 3,President / Vice President,,independent,"Stein, Jill",5,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",1,000410
+RILEY,Manhattan Township Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",71,000410
+RILEY,Manhattan Township Precinct 4,President / Vice President,,independent,"Stein, Jill",6,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Castle, Darrell L",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Giordani, Rocky",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Hedges, James A",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Hoefling, Tom",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Kahn, Lynn",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"La Riva, Gloria",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Maturen, Michael A",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"McMullin, Evan",7,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Perry, Darryl",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Schriner, Joe C",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Smith, Mike",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Sood, Ajay",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Sterling, Shawna",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",111,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Libertarian,"Johnson, Gary",22,000420
+RILEY,Manhattan Township Precinct 4,President / Vice President,,Republican,"Trump, Donald J.",180,000420
+RILEY,May Day Township,President / Vice President,,independent,"Stein, Jill",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Hedges, James A",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"McMullin, Evan",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Perry, Darryl",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Smith, Mike",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Sood, Ajay",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+RILEY,May Day Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+RILEY,May Day Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000430
+RILEY,May Day Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000430
+RILEY,May Day Township,President / Vice President,,Republican,"Trump, Donald J.",33,000430
+RILEY,Ogden Township,President / Vice President,,independent,"Stein, Jill",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Castle, Darrell L",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Giordani, Rocky",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Hedges, James A",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Hoefling, Tom",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Kahn, Lynn",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"La Riva, Gloria",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Maturen, Michael A",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"McMullin, Evan",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Perry, Darryl",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Schriner, Joe C",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Smith, Mike",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Sood, Ajay",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Sterling, Shawna",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00044A
+RILEY,Ogden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00044A
+RILEY,Ogden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,00044A
+RILEY,Ogden Township,President / Vice President,,Libertarian,"Johnson, Gary",6,00044A
+RILEY,Ogden Township,President / Vice President,,Republican,"Trump, Donald J.",137,00044A
+RILEY,Sherman Township,President / Vice President,,independent,"Stein, Jill",3,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",2,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+RILEY,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+RILEY,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",86,000450
+RILEY,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000450
+RILEY,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",210,000450
+RILEY,Swede Creek Township,President / Vice President,,independent,"Stein, Jill",2,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000460
+RILEY,Swede Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000460
+RILEY,Swede Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000460
+RILEY,Swede Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000460
+RILEY,Swede Creek Township,President / Vice President,,Republican,"Trump, Donald J.",52,000460
+RILEY,Wildcat Township,President / Vice President,,independent,"Stein, Jill",7,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Castle, Darrell L",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Giordani, Rocky",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Hedges, James A",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Hoefling, Tom",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Kahn, Lynn",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"La Riva, Gloria",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Maturen, Michael A",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"McMullin, Evan",6,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Perry, Darryl",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Schriner, Joe C",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Smith, Mike",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Sood, Ajay",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Sterling, Shawna",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00047A
+RILEY,Wildcat Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00047A
+RILEY,Wildcat Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,00047A
+RILEY,Wildcat Township,President / Vice President,,Libertarian,"Johnson, Gary",29,00047A
+RILEY,Wildcat Township,President / Vice President,,Republican,"Trump, Donald J.",351,00047A
+RILEY,Wildcat Township Enclave A,President / Vice President,,independent,"Stein, Jill",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Hedges, James A",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Smith, Mike",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,00047B
+RILEY,Wildcat Township Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,00047B
+RILEY,Wildcat Township Enclave B,President / Vice President,,independent,"Stein, Jill",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Hedges, James A",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Smith, Mike",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,00047C
+RILEY,Wildcat Township Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,independent,"Stein, Jill",2,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",5,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",64,00047D
+RILEY,Zeandale Township,President / Vice President,,independent,"Stein, Jill",5,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Hedges, James A",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"McMullin, Evan",2,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Perry, Darryl",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Smith, Mike",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Sood, Ajay",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000480
+RILEY,Zeandale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000480
+RILEY,Zeandale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000480
+RILEY,Zeandale Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000480
+RILEY,Zeandale Township,President / Vice President,,Republican,"Trump, Donald J.",121,000480
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,independent,"Stein, Jill",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Hedges, James A",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"McMullin, Evan",1,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Perry, Darryl",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Smith, Mike",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Sood, Ajay",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Libertarian,"Johnson, Gary",7,120020
+RILEY,Fort Riley A Madison Township H64,President / Vice President,,Republican,"Trump, Donald J.",27,120020
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,independent,"Stein, Jill",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Hedges, James A",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"McMullin, Evan",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Perry, Darryl",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Smith, Mike",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Sood, Ajay",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+RILEY,Fort Riley A Madison Township H67,President / Vice President,,Republican,"Trump, Donald J.",0,120030
+RILEY,Madison Township H64,President / Vice President,,independent,"Stein, Jill",10,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Castle, Darrell L",2,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Hedges, James A",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"McMullin, Evan",2,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Perry, Darryl",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Smith, Mike",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Sood, Ajay",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+RILEY,Madison Township H64,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+RILEY,Madison Township H64,President / Vice President,,Democratic,"Clinton, Hillary Rodham",125,120040
+RILEY,Madison Township H64,President / Vice President,,Libertarian,"Johnson, Gary",36,120040
+RILEY,Madison Township H64,President / Vice President,,Republican,"Trump, Donald J.",355,120040
+RILEY,Madison Township H67,President / Vice President,,independent,"Stein, Jill",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Hedges, James A",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"McMullin, Evan",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Perry, Darryl",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Smith, Mike",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Sood, Ajay",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+RILEY,Madison Township H67,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+RILEY,Madison Township H67,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,120050
+RILEY,Madison Township H67,President / Vice President,,Libertarian,"Johnson, Gary",1,120050
+RILEY,Madison Township H67,President / Vice President,,Republican,"Trump, Donald J.",12,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,independent,"Stein, Jill",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Basiago, Andrew D.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Castle, Darrell L",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Giordani, Rocky",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Hedges, James A",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Kahn, Lynn",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"La Riva, Gloria",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Levinson, Michael S.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Maturen, Michael A",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"McMullin, Evan",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Moorehead, Monica G.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Perry, Darryl",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Schriner, Joe C",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Smith, Mike",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Sood, Ajay",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Sterling, Shawna",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Valdivia, Anthony J",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Libertarian,"Johnson, Gary",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,President / Vice President,,Republican,"Trump, Donald J.",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,independent,"Stein, Jill",12,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",93,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",11,300020
+RILEY,Manhattan City Ward 08 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",100,300020
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,independent,"Stein, Jill",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",4,300030
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,independent,"Stein, Jill",1,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",56,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",4,300040
+RILEY,Manhattan City Ward 09 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",54,300040
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,independent,"Stein, Jill",2,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",3,300050
+RILEY,Manhattan City Ward 09 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",50,300050
+RILEY,Ogden Township Fort Riley A,President / Vice President,,independent,"Stein, Jill",7,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Basiago, Andrew D.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Castle, Darrell L",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Giordani, Rocky",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Hedges, James A",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Hoefling, Tom",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Kahn, Lynn",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"La Riva, Gloria",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Levinson, Michael S.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Maturen, Michael A",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"McMullin, Evan",2,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Moorehead, Monica G.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Perry, Darryl",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Schriner, Joe C",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Smith, Mike",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Sood, Ajay",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Sterling, Shawna",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Valdivia, Anthony J",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",126,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Libertarian,"Johnson, Gary",21,300060
+RILEY,Ogden Township Fort Riley A,President / Vice President,,Republican,"Trump, Donald J.",224,300060
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,independent,"Stein, Jill",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Basiago, Andrew D.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Castle, Darrell L",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Giordani, Rocky",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Hedges, James A",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Hoefling, Tom",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Kahn, Lynn",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"La Riva, Gloria",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Levinson, Michael S.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Maturen, Michael A",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"McMullin, Evan",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Moorehead, Monica G.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Perry, Darryl",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Schriner, Joe C",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Smith, Mike",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Sood, Ajay",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Sterling, Shawna",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Valdivia, Anthony J",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Libertarian,"Johnson, Gary",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,President / Vice President,,Republican,"Trump, Donald J.",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,independent,"Stein, Jill",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Basiago, Andrew D.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Castle, Darrell L",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Giordani, Rocky",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Hedges, James A",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Hoefling, Tom",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Kahn, Lynn",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"La Riva, Gloria",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Levinson, Michael S.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Maturen, Michael A",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"McMullin, Evan",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Moorehead, Monica G.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Perry, Darryl",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Schriner, Joe C",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Smith, Mike",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Sood, Ajay",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Sterling, Shawna",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Valdivia, Anthony J",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Libertarian,"Johnson, Gary",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,President / Vice President,,Republican,"Trump, Donald J.",0,300090
+RILEY,Ogden Township Ward 5,President / Vice President,,independent,"Stein, Jill",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Hedges, James A",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Smith, Mike",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",0,300100
+RILEY,Ogden Township Ward 5,President / Vice President,,Republican,"Trump, Donald J.",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,independent,"Stein, Jill",13,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",1,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",12,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",415,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",47,400010
+RILEY,Manhattan City Ward 01 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",202,400010
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,independent,"Stein, Jill",24,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",5,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",433,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",71,400020
+RILEY,Manhattan City Ward 02 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",196,400020
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,independent,"Stein, Jill",16,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",14,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",522,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",103,400030
+RILEY,Manhattan City Ward 02 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",526,400030
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,independent,"Stein, Jill",17,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",1,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",5,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",447,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",62,400040
+RILEY,Manhattan City Ward 03 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",340,400040
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,independent,"Stein, Jill",20,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",2,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"McMullin, Evan",7,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",491,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",90,400050
+RILEY,Manhattan City Ward 04 Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",568,400050
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,independent,"Stein, Jill",16,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",7,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",381,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",45,400060
+RILEY,Manhattan City Ward 05 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",194,400060
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,independent,"Stein, Jill",22,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",8,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",422,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",89,400070
+RILEY,Manhattan City Ward 05 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",288,400070
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,independent,"Stein, Jill",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"McMullin, Evan",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",2,400080
+RILEY,Manhattan City Ward 04 Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",17,400080
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,independent,"Stein, Jill",4,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"McMullin, Evan",3,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",161,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",20,400090
+RILEY,Manhattan City Ward 04 Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",220,400090
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,independent,"Stein, Jill",5,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Castle, Darrell L",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Giordani, Rocky",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Hedges, James A",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Hoefling, Tom",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Kahn, Lynn",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"La Riva, Gloria",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Levinson, Michael S.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Maturen, Michael A",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"McMullin, Evan",5,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Perry, Darryl",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Schriner, Joe C",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Smith, Mike",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Sood, Ajay",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Sterling, Shawna",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",150,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Libertarian,"Johnson, Gary",38,500010
+RILEY,Manhattan City Ward 11 Precinct 01,President / Vice President,,Republican,"Trump, Donald J.",127,500010
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,independent,"Stein, Jill",10,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",4,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",192,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",37,500030
+RILEY,Manhattan City Ward 08 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",136,500030
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,independent,"Stein, Jill",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",1,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",4,600001
+RILEY,Manhattan City Ward 11 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",28,600001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,independent,"Stein, Jill",1,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"McMullin, Evan",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",4,800001
+RILEY,Manhattan City Ward 09 Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",27,800001
+RILEY,Ogden Township Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+RILEY,Ogden Township Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+RILEY,Ogden Township Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+RILEY,Ogden Township Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,independent,"Stein, Jill",2,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Hedges, James A",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"McMullin, Evan",2,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Perry, Darryl",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Smith, Mike",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Sood, Ajay",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",77,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Libertarian,"Johnson, Gary",21,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,President / Vice President,,Republican,"Trump, Donald J.",114,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,independent,"Stein, Jill",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Hedges, James A",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"McMullin, Evan",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Perry, Darryl",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Smith, Mike",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Sood, Ajay",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,independent,"Stein, Jill",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Hedges, James A",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"McMullin, Evan",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Perry, Darryl",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Smith, Mike",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Sood, Ajay",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,independent,"Stein, Jill",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Hedges, James A",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Smith, Mike",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,900060
+RILEY,Ashland Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000010
+RILEY,Ashland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000010
+RILEY,Ashland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000010
+RILEY,Ashland Township,United States House of Representatives,1,Republican,"Marshall, Roger",64,000010
+RILEY,Bala Township,United States House of Representatives,1,independent,"LaPolice, Alan",99,000020
+RILEY,Bala Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+RILEY,Bala Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000020
+RILEY,Bala Township,United States House of Representatives,1,Republican,"Marshall, Roger",220,000020
+RILEY,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000030
+RILEY,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+RILEY,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+RILEY,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000030
+RILEY,Fancy Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000040
+RILEY,Fancy Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+RILEY,Fancy Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000040
+RILEY,Fancy Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000040
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,00005B
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005B
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,00005B
+RILEY,Fort Riley B Madison Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,00005B
+RILEY,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",158,000060
+RILEY,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000060
+RILEY,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,000060
+RILEY,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",371,000060
+RILEY,Jackson Township,United States House of Representatives,1,independent,"LaPolice, Alan",48,000070
+RILEY,Jackson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+RILEY,Jackson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000070
+RILEY,Jackson Township,United States House of Representatives,1,Republican,"Marshall, Roger",102,000070
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",100,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",53,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",105,000120
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,independent,"LaPolice, Alan",210,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",89,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States House of Representatives,1,Republican,"Marshall, Roger",343,000140
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",130,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",103,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",192,000170
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",100,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",111,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",243,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",74,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",290,000230
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",206,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",64,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",378,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",107,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",177,000310
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,independent,"LaPolice, Alan",237,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,Libertarian,"Burt, Kerry",56,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States House of Representatives,1,Republican,"Marshall, Roger",432,000320
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,independent,"LaPolice, Alan",126,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States House of Representatives,1,Republican,"Marshall, Roger",163,000330
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,independent,"LaPolice, Alan",159,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States House of Representatives,1,Republican,"Marshall, Roger",242,000340
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,independent,"LaPolice, Alan",386,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,Libertarian,"Burt, Kerry",78,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States House of Representatives,1,Republican,"Marshall, Roger",691,000350
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,independent,"LaPolice, Alan",387,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",104,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States House of Representatives,1,Republican,"Marshall, Roger",803,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,independent,"LaPolice, Alan",375,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,Libertarian,"Burt, Kerry",136,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States House of Representatives,1,Republican,"Marshall, Roger",741,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,independent,"LaPolice, Alan",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States House of Representatives,1,Republican,"Marshall, Roger",1,000380
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",65,00039A
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00039A
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,00039A
+RILEY,Manhattan Township Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",203,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,independent,"LaPolice, Alan",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States House of Representatives,1,Republican,"Marshall, Roger",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,independent,"LaPolice, Alan",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States House of Representatives,1,Republican,"Marshall, Roger",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00039H
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",96,000400
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000400
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000400
+RILEY,Manhattan Township Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",179,000400
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",27,000410
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000410
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000410
+RILEY,Manhattan Township Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",74,000410
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,independent,"LaPolice, Alan",94,000420
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000420
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,000420
+RILEY,Manhattan Township Precinct 4,United States House of Representatives,1,Republican,"Marshall, Roger",170,000420
+RILEY,May Day Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000430
+RILEY,May Day Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000430
+RILEY,May Day Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000430
+RILEY,May Day Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000430
+RILEY,Ogden Township,United States House of Representatives,1,independent,"LaPolice, Alan",51,00044A
+RILEY,Ogden Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00044A
+RILEY,Ogden Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,00044A
+RILEY,Ogden Township,United States House of Representatives,1,Republican,"Marshall, Roger",133,00044A
+RILEY,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",96,000450
+RILEY,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000450
+RILEY,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000450
+RILEY,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",193,000450
+RILEY,Swede Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000460
+RILEY,Swede Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000460
+RILEY,Swede Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000460
+RILEY,Swede Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",48,000460
+RILEY,Wildcat Township,United States House of Representatives,1,independent,"LaPolice, Alan",144,00047A
+RILEY,Wildcat Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00047A
+RILEY,Wildcat Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,00047A
+RILEY,Wildcat Township,United States House of Representatives,1,Republican,"Marshall, Roger",337,00047A
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,00047B
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00047B
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00047B
+RILEY,Wildcat Township Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,00047B
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,00047C
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00047C
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00047C
+RILEY,Wildcat Township Enclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",27,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",74,00047D
+RILEY,Zeandale Township,United States House of Representatives,1,independent,"LaPolice, Alan",44,000480
+RILEY,Zeandale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000480
+RILEY,Zeandale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000480
+RILEY,Zeandale Township,United States House of Representatives,1,Republican,"Marshall, Roger",135,000480
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,independent,"LaPolice, Alan",8,120020
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,120020
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,120020
+RILEY,Fort Riley A Madison Township H64,United States House of Representatives,1,Republican,"Marshall, Roger",27,120020
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,independent,"LaPolice, Alan",0,120030
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120030
+RILEY,Fort Riley A Madison Township H67,United States House of Representatives,1,Republican,"Marshall, Roger",0,120030
+RILEY,Madison Township H64,United States House of Representatives,1,independent,"LaPolice, Alan",162,120040
+RILEY,Madison Township H64,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120040
+RILEY,Madison Township H64,United States House of Representatives,1,Libertarian,"Burt, Kerry",26,120040
+RILEY,Madison Township H64,United States House of Representatives,1,Republican,"Marshall, Roger",321,120040
+RILEY,Madison Township H67,United States House of Representatives,1,independent,"LaPolice, Alan",1,120050
+RILEY,Madison Township H67,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120050
+RILEY,Madison Township H67,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,120050
+RILEY,Madison Township H67,United States House of Representatives,1,Republican,"Marshall, Roger",12,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,independent,"LaPolice, Alan",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States House of Representatives,1,Republican,"Marshall, Roger",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",56,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",120,300020
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",4,300030
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",39,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",64,300040
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",48,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",59,300050
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,independent,"LaPolice, Alan",79,300060
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,300060
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,Libertarian,"Burt, Kerry",43,300060
+RILEY,Ogden Township Fort Riley A,United States House of Representatives,1,Republican,"Marshall, Roger",234,300060
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,independent,"LaPolice, Alan",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States House of Representatives,1,Republican,"Marshall, Roger",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,independent,"LaPolice, Alan",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States House of Representatives,1,Republican,"Marshall, Roger",0,300090
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,independent,"LaPolice, Alan",0,300100
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300100
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,300100
+RILEY,Ogden Township Ward 5,United States House of Representatives,1,Republican,"Marshall, Roger",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",279,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",86,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",250,400010
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",288,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",129,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",235,400020
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",369,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",172,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",601,400030
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",238,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",111,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",429,400040
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,independent,"LaPolice, Alan",366,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",124,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States House of Representatives,1,Republican,"Marshall, Roger",654,400050
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",254,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",94,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",229,400060
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",254,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",122,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",378,400070
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,independent,"LaPolice, Alan",7,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States House of Representatives,1,Republican,"Marshall, Roger",21,400080
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,independent,"LaPolice, Alan",88,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States House of Representatives,1,Republican,"Marshall, Roger",270,400090
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,independent,"LaPolice, Alan",89,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",57,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States House of Representatives,1,Republican,"Marshall, Roger",159,500010
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",108,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",67,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",185,500030
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",10,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",34,600001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",17,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",37,800001
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+RILEY,Ogden Township Enclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+RILEY,Ogden Township Enclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,independent,"LaPolice, Alan",44,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States House of Representatives,1,Republican,"Marshall, Roger",128,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,independent,"LaPolice, Alan",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States House of Representatives,1,Republican,"Marshall, Roger",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,independent,"LaPolice, Alan",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States House of Representatives,1,Republican,"Marshall, Roger",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,900060
+RILEY,Ashland Township,United States Senate,,write - in,"Smith, DJ",0,000010
+RILEY,Ashland Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000010
+RILEY,Ashland Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000010
+RILEY,Ashland Township,United States Senate,,Republican,"Moran, Jerry",71,000010
+RILEY,Bala Township,United States Senate,,write - in,"Smith, DJ",0,000020
+RILEY,Bala Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000020
+RILEY,Bala Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000020
+RILEY,Bala Township,United States Senate,,Republican,"Moran, Jerry",274,000020
+RILEY,Center Township,United States Senate,,write - in,"Smith, DJ",0,000030
+RILEY,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+RILEY,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+RILEY,Center Township,United States Senate,,Republican,"Moran, Jerry",40,000030
+RILEY,Fancy Creek Township,United States Senate,,write - in,"Smith, DJ",0,000040
+RILEY,Fancy Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000040
+RILEY,Fancy Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+RILEY,Fancy Creek Township,United States Senate,,Republican,"Moran, Jerry",61,000040
+RILEY,Fort Riley B Madison Township,United States Senate,,write - in,"Smith, DJ",0,00005B
+RILEY,Fort Riley B Madison Township,United States Senate,,Democratic,"Wiesner, Patrick",18,00005B
+RILEY,Fort Riley B Madison Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,00005B
+RILEY,Fort Riley B Madison Township,United States Senate,,Republican,"Moran, Jerry",18,00005B
+RILEY,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000060
+RILEY,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",130,000060
+RILEY,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",18,000060
+RILEY,Grant Township,United States Senate,,Republican,"Moran, Jerry",433,000060
+RILEY,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000070
+RILEY,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000070
+RILEY,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000070
+RILEY,Jackson Township,United States Senate,,Republican,"Moran, Jerry",135,000070
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",138,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",17,000120
+RILEY,Manhattan City Ward 02 Precinct 02,United States Senate,,Republican,"Moran, Jerry",131,000120
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,write - in,"Smith, DJ",0,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",235,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",38,000140
+RILEY,Manhattan City Ward 02 Precinct 04,United States Senate,,Republican,"Moran, Jerry",395,000140
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",205,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",38,000170
+RILEY,Manhattan City Ward 03 Precinct 02,United States Senate,,Republican,"Moran, Jerry",210,000170
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",115,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",9,00022A
+RILEY,Manhattan City Ward 04 Precinct 02,United States Senate,,Republican,"Moran, Jerry",135,00022A
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",0,00022B
+RILEY,Manhattan City Ward 07 Precinct 01,United States Senate,,Republican,"Moran, Jerry",0,00022B
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",293,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",31,000230
+RILEY,Manhattan City Ward 04 Precinct 03,United States Senate,,Republican,"Moran, Jerry",334,000230
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,write - in,"Smith, DJ",0,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",221,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",26,00025A
+RILEY,Manhattan City Ward 04 Precinct 05,United States Senate,,Republican,"Moran, Jerry",427,00025A
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,write - in,"Smith, DJ",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00025B
+RILEY,Manhattan City Ward 04 Precinct 05 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00025B
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,write - in,"Smith, DJ",0,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",123,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",22,000310
+RILEY,Manhattan City Ward 05 Precinct 05,United States Senate,,Republican,"Moran, Jerry",189,000310
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,write - in,"Smith, DJ",0,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",224,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",28,000320
+RILEY,Manhattan City Ward 05 Precinct 06,United States Senate,,Republican,"Moran, Jerry",508,000320
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,write - in,"Smith, DJ",0,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",119,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",20,000330
+RILEY,Manhattan City Ward 05 Precinct 07,United States Senate,,Republican,"Moran, Jerry",195,000330
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,write - in,"Smith, DJ",0,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,Democratic,"Wiesner, Patrick",161,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,Libertarian,"Garrard, Robert D.",17,000340
+RILEY,Manhattan City Ward 05 Precinct 08,United States Senate,,Republican,"Moran, Jerry",295,000340
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,write - in,"Smith, DJ",0,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",374,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",21,000350
+RILEY,Manhattan City Ward 05 Precinct 09,United States Senate,,Republican,"Moran, Jerry",813,000350
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,write - in,"Smith, DJ",0,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",437,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",37,00036A
+RILEY,Manhattan City Ward 05 Precinct 10,United States Senate,,Republican,"Moran, Jerry",903,00036A
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,write - in,"Smith, DJ",0,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,Democratic,"Wiesner, Patrick",414,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,Libertarian,"Garrard, Robert D.",44,000370
+RILEY,Manhattan City Ward 05 Precinct 11,United States Senate,,Republican,"Moran, Jerry",861,000370
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,write - in,"Smith, DJ",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,Democratic,"Wiesner, Patrick",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,Libertarian,"Garrard, Robert D.",0,000380
+RILEY,Manhattan City Ward 06 Precinct 01 Job Corp,United States Senate,,Republican,"Moran, Jerry",1,000380
+RILEY,Manhattan Township Precinct 1,United States Senate,,write - in,"Smith, DJ",0,00039A
+RILEY,Manhattan Township Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",59,00039A
+RILEY,Manhattan Township Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",5,00039A
+RILEY,Manhattan Township Precinct 1,United States Senate,,Republican,"Moran, Jerry",229,00039A
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,write - in,"Smith, DJ",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00039B
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,write - in,"Smith, DJ",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00039C
+RILEY,Manhattan Township Precinct 1 Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00039C
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,write - in,"Smith, DJ",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,Democratic,"Wiesner, Patrick",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,Libertarian,"Garrard, Robert D.",0,00039E
+RILEY,Manahattan Township Precinct 1 Enclave D,United States Senate,,Republican,"Moran, Jerry",0,00039E
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,write - in,"Smith, DJ",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,Democratic,"Wiesner, Patrick",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,Libertarian,"Garrard, Robert D.",0,00039G
+RILEY,Manhattan Township Precinct 1 Enclave F,United States Senate,,Republican,"Moran, Jerry",0,00039G
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,write - in,"Smith, DJ",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,Democratic,"Wiesner, Patrick",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00039H
+RILEY,Manhattan Township Precinct 1 Part A,United States Senate,,Republican,"Moran, Jerry",0,00039H
+RILEY,Manhattan Township Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000400
+RILEY,Manhattan Township Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",70,000400
+RILEY,Manhattan Township Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",23,000400
+RILEY,Manhattan Township Precinct 2,United States Senate,,Republican,"Moran, Jerry",224,000400
+RILEY,Manhattan Township Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000410
+RILEY,Manhattan Township Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",26,000410
+RILEY,Manhattan Township Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",4,000410
+RILEY,Manhattan Township Precinct 3,United States Senate,,Republican,"Moran, Jerry",81,000410
+RILEY,Manhattan Township Precinct 4,United States Senate,,write - in,"Smith, DJ",0,000420
+RILEY,Manhattan Township Precinct 4,United States Senate,,Democratic,"Wiesner, Patrick",93,000420
+RILEY,Manhattan Township Precinct 4,United States Senate,,Libertarian,"Garrard, Robert D.",11,000420
+RILEY,Manhattan Township Precinct 4,United States Senate,,Republican,"Moran, Jerry",223,000420
+RILEY,May Day Township,United States Senate,,write - in,"Smith, DJ",0,000430
+RILEY,May Day Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000430
+RILEY,May Day Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000430
+RILEY,May Day Township,United States Senate,,Republican,"Moran, Jerry",40,000430
+RILEY,Ogden Township,United States Senate,,write - in,"Smith, DJ",0,00044A
+RILEY,Ogden Township,United States Senate,,Democratic,"Wiesner, Patrick",32,00044A
+RILEY,Ogden Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,00044A
+RILEY,Ogden Township,United States Senate,,Republican,"Moran, Jerry",157,00044A
+RILEY,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000450
+RILEY,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",61,000450
+RILEY,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000450
+RILEY,Sherman Township,United States Senate,,Republican,"Moran, Jerry",234,000450
+RILEY,Swede Creek Township,United States Senate,,write - in,"Smith, DJ",0,000460
+RILEY,Swede Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000460
+RILEY,Swede Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000460
+RILEY,Swede Creek Township,United States Senate,,Republican,"Moran, Jerry",57,000460
+RILEY,Wildcat Township,United States Senate,,write - in,"Smith, DJ",0,00047A
+RILEY,Wildcat Township,United States Senate,,Democratic,"Wiesner, Patrick",70,00047A
+RILEY,Wildcat Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,00047A
+RILEY,Wildcat Township,United States Senate,,Republican,"Moran, Jerry",419,00047A
+RILEY,Wildcat Township Enclave A,United States Senate,,write - in,"Smith, DJ",0,00047B
+RILEY,Wildcat Township Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,00047B
+RILEY,Wildcat Township Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,00047B
+RILEY,Wildcat Township Enclave A,United States Senate,,Republican,"Moran, Jerry",0,00047B
+RILEY,Wildcat Township Enclave B,United States Senate,,write - in,"Smith, DJ",0,00047C
+RILEY,Wildcat Township Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,00047C
+RILEY,Wildcat Township Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,00047C
+RILEY,Wildcat Township Enclave B,United States Senate,,Republican,"Moran, Jerry",0,00047C
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",43,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",3,00047D
+RILEY,Manhattan City Ward 10 Precinct 01,United States Senate,,Republican,"Moran, Jerry",82,00047D
+RILEY,Zeandale Township,United States Senate,,write - in,"Smith, DJ",0,000480
+RILEY,Zeandale Township,United States Senate,,Democratic,"Wiesner, Patrick",41,000480
+RILEY,Zeandale Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000480
+RILEY,Zeandale Township,United States Senate,,Republican,"Moran, Jerry",155,000480
+RILEY,Fort Riley A Madison Township H64,United States Senate,,write - in,"Smith, DJ",0,120020
+RILEY,Fort Riley A Madison Township H64,United States Senate,,Democratic,"Wiesner, Patrick",15,120020
+RILEY,Fort Riley A Madison Township H64,United States Senate,,Libertarian,"Garrard, Robert D.",7,120020
+RILEY,Fort Riley A Madison Township H64,United States Senate,,Republican,"Moran, Jerry",27,120020
+RILEY,Fort Riley A Madison Township H67,United States Senate,,write - in,"Smith, DJ",0,120030
+RILEY,Fort Riley A Madison Township H67,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+RILEY,Fort Riley A Madison Township H67,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+RILEY,Fort Riley A Madison Township H67,United States Senate,,Republican,"Moran, Jerry",0,120030
+RILEY,Madison Township H64,United States Senate,,write - in,"Smith, DJ",0,120040
+RILEY,Madison Township H64,United States Senate,,Democratic,"Wiesner, Patrick",102,120040
+RILEY,Madison Township H64,United States Senate,,Libertarian,"Garrard, Robert D.",32,120040
+RILEY,Madison Township H64,United States Senate,,Republican,"Moran, Jerry",394,120040
+RILEY,Madison Township H67,United States Senate,,write - in,"Smith, DJ",0,120050
+RILEY,Madison Township H67,United States Senate,,Democratic,"Wiesner, Patrick",1,120050
+RILEY,Madison Township H67,United States Senate,,Libertarian,"Garrard, Robert D.",0,120050
+RILEY,Madison Township H67,United States Senate,,Republican,"Moran, Jerry",14,120050
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,write - in,"Smith, DJ",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,Democratic,"Wiesner, Patrick",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,Libertarian,"Garrard, Robert D.",0,300010
+RILEY,Manhattan City Ward 06 Precinct 02 Tech Park,United States Senate,,Republican,"Moran, Jerry",0,300010
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",65,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",18,300020
+RILEY,Manhattan City Ward 08 Precinct 01,United States Senate,,Republican,"Moran, Jerry",129,300020
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",0,300030
+RILEY,Manhattan City Ward 08 Precinct 02,United States Senate,,Republican,"Moran, Jerry",4,300030
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",39,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",3,300040
+RILEY,Manhattan City Ward 09 Precinct 01,United States Senate,,Republican,"Moran, Jerry",75,300040
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",50,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",0,300050
+RILEY,Manhattan City Ward 09 Precinct 02,United States Senate,,Republican,"Moran, Jerry",71,300050
+RILEY,Ogden Township Fort Riley A,United States Senate,,write - in,"Smith, DJ",0,300060
+RILEY,Ogden Township Fort Riley A,United States Senate,,Democratic,"Wiesner, Patrick",95,300060
+RILEY,Ogden Township Fort Riley A,United States Senate,,Libertarian,"Garrard, Robert D.",28,300060
+RILEY,Ogden Township Fort Riley A,United States Senate,,Republican,"Moran, Jerry",254,300060
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,write - in,"Smith, DJ",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,Democratic,"Wiesner, Patrick",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,Libertarian,"Garrard, Robert D.",0,300070
+RILEY,Ogden Township Ward 2 Annex order 506,United States Senate,,Republican,"Moran, Jerry",0,300070
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,write - in,"Smith, DJ",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,Democratic,"Wiesner, Patrick",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,Libertarian,"Garrard, Robert D.",0,300090
+RILEY,Ogden Township Ward 4 Order 10-06-93,United States Senate,,Republican,"Moran, Jerry",0,300090
+RILEY,Ogden Township Ward 5,United States Senate,,write - in,"Smith, DJ",0,300100
+RILEY,Ogden Township Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",0,300100
+RILEY,Ogden Township Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",0,300100
+RILEY,Ogden Township Ward 5,United States Senate,,Republican,"Moran, Jerry",0,300100
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",347,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",40,400010
+RILEY,Manhattan City Ward 01 Precinct 01,United States Senate,,Republican,"Moran, Jerry",297,400010
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",374,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",56,400020
+RILEY,Manhattan City Ward 02 Precinct 01,United States Senate,,Republican,"Moran, Jerry",286,400020
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",421,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",74,400030
+RILEY,Manhattan City Ward 02 Precinct 03,United States Senate,,Republican,"Moran, Jerry",698,400030
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",310,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",55,400040
+RILEY,Manhattan City Ward 03 Precinct 03,United States Senate,,Republican,"Moran, Jerry",485,400040
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,write - in,"Smith, DJ",0,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",381,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",57,400050
+RILEY,Manhattan City Ward 04 Precinct 04,United States Senate,,Republican,"Moran, Jerry",764,400050
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",321,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",34,400060
+RILEY,Manhattan City Ward 05 Precinct 02,United States Senate,,Republican,"Moran, Jerry",281,400060
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",365,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",43,400070
+RILEY,Manhattan City Ward 05 Precinct 03,United States Senate,,Republican,"Moran, Jerry",406,400070
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,write - in,"Smith, DJ",0,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",4,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",1,400080
+RILEY,Manhattan City Ward 04 Precinct 07,United States Senate,,Republican,"Moran, Jerry",24,400080
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,write - in,"Smith, DJ",0,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",97,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",22,400090
+RILEY,Manhattan City Ward 04 Precinct 06,United States Senate,,Republican,"Moran, Jerry",292,400090
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,write - in,"Smith, DJ",0,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,Democratic,"Wiesner, Patrick",119,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,Libertarian,"Garrard, Robert D.",25,500010
+RILEY,Manhattan City Ward 11 Precinct 01,United States Senate,,Republican,"Moran, Jerry",178,500010
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",162,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",15,500030
+RILEY,Manhattan City Ward 08 Precinct 03,United States Senate,,Republican,"Moran, Jerry",199,500030
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",18,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",0,600001
+RILEY,Manhattan City Ward 11 Precinct 03,United States Senate,,Republican,"Moran, Jerry",38,600001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,write - in,"Smith, DJ",0,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",16,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",1,800001
+RILEY,Manhattan City Ward 09 Precinct 03,United States Senate,,Republican,"Moran, Jerry",42,800001
+RILEY,Ogden Township Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+RILEY,Ogden Township Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+RILEY,Ogden Township Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+RILEY,Ogden Township Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010
+RILEY,Ogden Township Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900020
+RILEY,Ogden Township Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+RILEY,Ogden Township Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+RILEY,Ogden Township Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900020
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,write - in,"Smith, DJ",0,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,Democratic,"Wiesner, Patrick",53,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,Libertarian,"Garrard, Robert D.",11,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part B,United States Senate,,Republican,"Moran, Jerry",150,900030
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,write - in,"Smith, DJ",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+RILEY,Manhattan City Ward 11 Precinct 01 Part C,United States Senate,,Republican,"Moran, Jerry",0,900040
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,write - in,"Smith, DJ",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave A,United States Senate,,Republican,"Moran, Jerry",0,900050
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,write - in,"Smith, DJ",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+RILEY,Manhattan Township Precinct 3 Enclave B,United States Senate,,Republican,"Moran, Jerry",0,900060

--- a/2016/20161108__ks__general__rooks__precinct.csv
+++ b/2016/20161108__ks__general__rooks__precinct.csv
@@ -1,207 +1,577 @@
-county,precinct,office,district,party,candidate,poll_votes,advance_votes,military_votes,provisional_votes,votes
-Rooks,#1,President,,REP,Trump/Pence,70,8,,1,79
-Rooks,#2,President,,REP,Trump/Pence,137,26,,1,164
-Rooks,#3-1,President,,REP,Trump/Pence,33,4,,,37
-Rooks,#3-2,President,,REP,Trump/Pence,396,62,2,5,465
-Rooks,#4,President,,REP,Trump/Pence,11,1,,,12
-Rooks,#5,President,,REP,Trump/Pence,27,14,,,41
-Rooks,#6,President,,REP,Trump/Pence,38,4,,,42
-Rooks,#7,President,,REP,Trump/Pence,71,6,,,77
-Rooks,#8,President,,REP,Trump/Pence,92,7,,,99
-Rooks,#9,President,,REP,Trump/Pence,21,2,,,23
-Rooks,#10,President,,REP,Trump/Pence,64,7,,1,72
-Rooks,#11-1,President,,REP,Trump/Pence,203,23,,6,232
-Rooks,#11-2,President,,REP,Trump/Pence,549,67,,15,631
-Rooks,#12,President,,REP,Trump/Pence,50,7,,,57
-Rooks,Grand Totals,President,,REP,Trump/Pence,1762,238,2,29,2031
-Rooks,#1,President,,DEM,Clinton/Kaine,12,0,,,12
-Rooks,#2,President,,DEM,Clinton/Kaine,15,5,,,20
-Rooks,#3-1,President,,DEM,Clinton/Kaine,4,1,,,5
-Rooks,#3-2,President,,DEM,Clinton/Kaine,42,18,,,60
-Rooks,#4,President,,DEM,Clinton/Kaine,3,2,,,5
-Rooks,#5,President,,DEM,Clinton/Kaine,1,1,,,2
-Rooks,#6,President,,DEM,Clinton/Kaine,3,3,,,6
-Rooks,#7,President,,DEM,Clinton/Kaine,8,3,,,11
-Rooks,#8,President,,DEM,Clinton/Kaine,20,2,1,,23
-Rooks,#9,President,,DEM,Clinton/Kaine,3,1,,,4
-Rooks,#10,President,,DEM,Clinton/Kaine,3,0,,,3
-Rooks,#11-1,President,,DEM,Clinton/Kaine,27,4,,,31
-Rooks,#11-2,President,,DEM,Clinton/Kaine,66,12,,1,79
-Rooks,#12,President,,DEM,Clinton/Kaine,13,1,,,14
-Rooks,Grand Totals,President,,DEM,Clinton/Kaine,220,53,1,1,275
-Rooks,#1,President,,LIB,Johnson/Weld,3,0,,,3
-Rooks,#2,President,,LIB,Johnson/Weld,6,3,1,,10
-Rooks,#3-1,President,,LIB,Johnson/Weld,1,0,,,1
-Rooks,#3-2,President,,LIB,Johnson/Weld,19,4,,2,25
-Rooks,#4,President,,LIB,Johnson/Weld,0,0,,,0
-Rooks,#5,President,,LIB,Johnson/Weld,0,0,,,0
-Rooks,#6,President,,LIB,Johnson/Weld,0,0,,,0
-Rooks,#7,President,,LIB,Johnson/Weld,2,0,,,2
-Rooks,#8,President,,LIB,Johnson/Weld,2,0,,,2
-Rooks,#9,President,,LIB,Johnson/Weld,1,0,,,1
-Rooks,#10,President,,LIB,Johnson/Weld,4,0,,,4
-Rooks,#11-1,President,,LIB,Johnson/Weld,5,1,,,6
-Rooks,#11-2,President,,LIB,Johnson/Weld,22,2,,,24
-Rooks,#12,President,,LIB,Johnson/Weld,2,0,,,2
-Rooks,Grand Totals,President,,LIB,Johnson/Weld,67,10,1,2,80
-Rooks,#1,President,,IND,Stein/Baraka,1,0,,,1
-Rooks,#2,President,,IND,Stein/Baraka,1,1,,,2
-Rooks,#3-1,President,,IND,Stein/Baraka,1,0,,,1
-Rooks,#3-2,President,,IND,Stein/Baraka,5,1,,,6
-Rooks,#4,President,,IND,Stein/Baraka,1,0,,,1
-Rooks,#5,President,,IND,Stein/Baraka,0,0,,,0
-Rooks,#6,President,,IND,Stein/Baraka,1,0,,,1
-Rooks,#7,President,,IND,Stein/Baraka,1,0,,,1
-Rooks,#8,President,,IND,Stein/Baraka,1,0,,,1
-Rooks,#9,President,,IND,Stein/Baraka,0,0,,,0
-Rooks,#10,President,,IND,Stein/Baraka,2,0,,,2
-Rooks,#11-1,President,,IND,Stein/Baraka,5,0,,,5
-Rooks,#11-2,President,,IND,Stein/Baraka,3,2,,,5
-Rooks,#12,President,,IND,Stein/Baraka,3,0,,,3
-Rooks,Grand Totals,President,,IND,Stein/Baraka,25,4,,,29
-Rooks,#2,President,,,Evan McMullin,1,,,,1
-Rooks,#11-2,President,,,Evan McMullin,1,,,,1
-Rooks,Grand Totals,President,,,Evan McMullin,2,,,,2
-Rooks,#2,President,,,Darrell Castle,1,,,,1
-Rooks,#11-2,President,,,Darrell Castle,1,,,,1
-Rooks,Grand Totals,President,,,Darrell Castle,2,,,,2
-Rooks,#1,U.S. Senate,,DEM,Patrick Wiesner,8,0,,,8
-Rooks,#2,U.S. Senate,,DEM,Patrick Wiesner,5,5,,,10
-Rooks,#3-1,U.S. Senate,,DEM,Patrick Wiesner,3,2,,,5
-Rooks,#3-2,U.S. Senate,,DEM,Patrick Wiesner,37,14,,,51
-Rooks,#4,U.S. Senate,,DEM,Patrick Wiesner,4,2,,,6
-Rooks,#5,U.S. Senate,,DEM,Patrick Wiesner,1,0,,,1
-Rooks,#6,U.S. Senate,,DEM,Patrick Wiesner,3,2,,,5
-Rooks,#7,U.S. Senate,,DEM,Patrick Wiesner,7,1,,,8
-Rooks,#8,U.S. Senate,,DEM,Patrick Wiesner,11,2,,,13
-Rooks,#9,U.S. Senate,,DEM,Patrick Wiesner,2,0,,,2
-Rooks,#10,U.S. Senate,,DEM,Patrick Wiesner,6,0,,,6
-Rooks,#11-1,U.S. Senate,,DEM,Patrick Wiesner,16,4,,,20
-Rooks,#11-2,U.S. Senate,,DEM,Patrick Wiesner,35,8,,2,45
-Rooks,#12,U.S. Senate,,DEM,Patrick Wiesner,10,2,,,12
-Rooks,Grand Totals,U.S. Senate,,DEM,Patrick Wiesner,148,42,,2,192
-Rooks,#1,U.S. Senate,,LIB,Robert D. Garrard,2,0,,,2
-Rooks,#2,U.S. Senate,,LIB,Robert D. Garrard,9,0,,,9
-Rooks,#3-1,U.S. Senate,,LIB,Robert D. Garrard,1,0,,,1
-Rooks,#3-2,U.S. Senate,,LIB,Robert D. Garrard,26,4,,1,31
-Rooks,#4,U.S. Senate,,LIB,Robert D. Garrard,2,0,,,2
-Rooks,#5,U.S. Senate,,LIB,Robert D. Garrard,2,2,,,4
-Rooks,#6,U.S. Senate,,LIB,Robert D. Garrard,2,0,,,2
-Rooks,#7,U.S. Senate,,LIB,Robert D. Garrard,0,0,,,0
-Rooks,#8,U.S. Senate,,LIB,Robert D. Garrard,2,1,,,3
-Rooks,#9,U.S. Senate,,LIB,Robert D. Garrard,0,0,,,0
-Rooks,#10,U.S. Senate,,LIB,Robert D. Garrard,2,0,,,2
-Rooks,#11-1,U.S. Senate,,LIB,Robert D. Garrard,11,2,,1,14
-Rooks,#11-2,U.S. Senate,,LIB,Robert D. Garrard,40,2,,1,43
-Rooks,#12,U.S. Senate,,LIB,Robert D. Garrard,0,1,,,1
-Rooks,Grand Totals,U.S. Senate,,LIB,Robert D. Garrard,99,12,,3,114
-Rooks,#1,U.S. Senate,,REP,Jerry Moran,75,8,,1,84
-Rooks,#2,U.S. Senate,,REP,Jerry Moran,148,30,1,1,180
-Rooks,#3-1,U.S. Senate,,REP,Jerry Moran,33,4,,,37
-Rooks,#3-2,U.S. Senate,,REP,Jerry Moran,392,68,2,8,470
-Rooks,#4,U.S. Senate,,REP,Jerry Moran,7,1,,,8
-Rooks,#5,U.S. Senate,,REP,Jerry Moran,23,12,,,35
-Rooks,#6,U.S. Senate,,REP,Jerry Moran,36,5,,,41
-Rooks,#7,U.S. Senate,,REP,Jerry Moran,72,8,,,80
-Rooks,#8,U.S. Senate,,REP,Jerry Moran,100,7,,,107
-Rooks,#9,U.S. Senate,,REP,Jerry Moran,23,3,,,26
-Rooks,#10,U.S. Senate,,REP,Jerry Moran,64,7,,1,72
-Rooks,#11-1,U.S. Senate,,REP,Jerry Moran,216,22,,5,243
-Rooks,#11-2,U.S. Senate,,REP,Jerry Moran,577,72,,12,661
-Rooks,#12,U.S. Senate,,REP,Jerry Moran,55,5,,,60
-Rooks,Grand Totals,U.S. Senate,,REP,Jerry Moran,1821,252,3,28,2104
-Rooks,#1,U.S. House,1,REP,Roger Marshall,62,7,,1,70
-Rooks,#2,U.S. House,1,REP,Roger Marshall,110,24,,,134
-Rooks,#3-1,U.S. House,1,REP,Roger Marshall,26,3,,,29
-Rooks,#3-2,U.S. House,1,REP,Roger Marshall,344,62,2,7,415
-Rooks,#4,U.S. House,1,REP,Roger Marshall,11,1,,,12
-Rooks,#5,U.S. House,1,REP,Roger Marshall,21,11,,,32
-Rooks,#6,U.S. House,1,REP,Roger Marshall,32,3,,,35
-Rooks,#7,U.S. House,1,REP,Roger Marshall,64,7,,,71
-Rooks,#8,U.S. House,1,REP,Roger Marshall,73,6,,,79
-Rooks,#9,U.S. House,1,REP,Roger Marshall,21,2,,,23
-Rooks,#10,U.S. House,1,REP,Roger Marshall,57,4,,1,62
-Rooks,#11-1,U.S. House,1,REP,Roger Marshall,171,19,,5,195
-Rooks,#11-2,U.S. House,1,REP,Roger Marshall,474,62,,13,549
-Rooks,#12,U.S. House,1,REP,Roger Marshall,40,6,,,46
-Rooks,Grand Totals,U.S. House,1,REP,Roger Marshall,1506,217,2,27,1752
-Rooks,#1,U.S. House,1,LIB,Kerry Burt,2,0,,,2
-Rooks,#2,U.S. House,1,LIB,Kerry Burt,9,1,,1,11
-Rooks,#3-1,U.S. House,1,LIB,Kerry Burt,0,0,,,0
-Rooks,#3-2,U.S. House,1,LIB,Kerry Burt,20,5,,1,26
-Rooks,#4,U.S. House,1,LIB,Kerry Burt,0,0,,,0
-Rooks,#5,U.S. House,1,LIB,Kerry Burt,2,1,,,3
-Rooks,#6,U.S. House,1,LIB,Kerry Burt,2,1,,,3
-Rooks,#7,U.S. House,1,LIB,Kerry Burt,0,1,,,1
-Rooks,#8,U.S. House,1,LIB,Kerry Burt,8,0,,,8
-Rooks,#9,U.S. House,1,LIB,Kerry Burt,0,1,,,1
-Rooks,#10,U.S. House,1,LIB,Kerry Burt,3,1,,,4
-Rooks,#11-1,U.S. House,1,LIB,Kerry Burt,9,1,,,10
-Rooks,#11-2,U.S. House,1,LIB,Kerry Burt,44,3,,,47
-Rooks,#12,U.S. House,1,LIB,Kerry Burt,4,0,,,4
-Rooks,Grand Totals,U.S. House,1,LIB,Kerry Burt,103,15,,2,120
-Rooks,#1,U.S. House,1,IND,Alan LaPolice,21,1,,,22
-Rooks,#2,U.S. House,1,IND,Alan LaPolice,38,7,,,45
-Rooks,#3-1,U.S. House,1,IND,Alan LaPolice,10,2,,,12
-Rooks,#3-2,U.S. House,1,IND,Alan LaPolice,84,14,,1,99
-Rooks,#4,U.S. House,1,IND,Alan LaPolice,4,1,,,5
-Rooks,#5,U.S. House,1,IND,Alan LaPolice,3,2,,,5
-Rooks,#6,U.S. House,1,IND,Alan LaPolice,7,3,,,10
-Rooks,#7,U.S. House,1,IND,Alan LaPolice,14,1,,,15
-Rooks,#8,U.S. House,1,IND,Alan LaPolice,29,3,,,32
-Rooks,#9,U.S. House,1,IND,Alan LaPolice,2,0,,,2
-Rooks,#10,U.S. House,1,IND,Alan LaPolice,11,2,,,13
-Rooks,#11-1,U.S. House,1,IND,Alan LaPolice,54,7,,1,62
-Rooks,#11-2,U.S. House,1,IND,Alan LaPolice,112,16,,2,130
-Rooks,#12,U.S. House,1,IND,Alan LaPolice,19,1,,,20
-Rooks,Grand Totals,U.S. House,1,IND,Alan LaPolice,408,60,,4,472
-Rooks,#2,U.S. House,1,,Tim Huelskamp,1,,,,1
-Rooks,#3-2,U.S. House,1,,Tim Huelskamp,1,,,,1
-Rooks,#6,U.S. House,1,,Tim Huelskamp,1,,,,1
-Rooks,#11-2,U.S. House,1,,Tim Huelskamp,5,,,,5
-Rooks,Grand Totals,U.S. House,1,,Tim Huelskamp,8,,,,8
-Rooks,#1,State Senate,36,REP,Elaine S. Bowers,69,8,,1,78
-Rooks,#2,State Senate,36,REP,Elaine S. Bowers,140,26,,1,167
-Rooks,#3-1,State Senate,36,REP,Elaine S. Bowers,32,4,,,36
-Rooks,#3-2,State Senate,36,REP,Elaine S. Bowers,399,67,2,7,475
-Rooks,#4,State Senate,36,REP,Elaine S. Bowers,10,1,,,11
-Rooks,#5,State Senate,36,REP,Elaine S. Bowers,25,15,,,40
-Rooks,#6,State Senate,36,REP,Elaine S. Bowers,38,5,,,43
-Rooks,#7,State Senate,36,REP,Elaine S. Bowers,66,6,,,72
-Rooks,#8,State Senate,36,REP,Elaine S. Bowers,88,7,,,95
-Rooks,#9,State Senate,36,REP,Elaine S. Bowers,21,3,,,24
-Rooks,#10,State Senate,36,REP,Elaine S. Bowers,66,7,,1,74
-Rooks,#11-1,State Senate,36,REP,Elaine S. Bowers,211,21,,5,237
-Rooks,#11-2,State Senate,36,REP,Elaine S. Bowers,569,63,,14,646
-Rooks,#12,State Senate,36,REP,Elaine S. Bowers,52,4,,,56
-Rooks,Grand Totals,State Senate,36,REP,Elaine S. Bowers,1786,237,2,29,2054
-Rooks,#1,State Senate,36,DEM,Brian G. Angevine,11,0,,,11
-Rooks,#2,State Senate,36,DEM,Brian G. Angevine,17,7,1,,25
-Rooks,#3-1,State Senate,36,DEM,Brian G. Angevine,5,1,,,6
-Rooks,#3-2,State Senate,36,DEM,Brian G. Angevine,39,15,,,54
-Rooks,#4,State Senate,36,DEM,Brian G. Angevine,4,2,,,6
-Rooks,#5,State Senate,36,DEM,Brian G. Angevine,1,0,,,1
-Rooks,#6,State Senate,36,DEM,Brian G. Angevine,4,2,,,6
-Rooks,#7,State Senate,36,DEM,Brian G. Angevine,10,2,,,12
-Rooks,#8,State Senate,36,DEM,Brian G. Angevine,21,3,1,,25
-Rooks,#9,State Senate,36,DEM,Brian G. Angevine,3,0,,,3
-Rooks,#10,State Senate,36,DEM,Brian G. Angevine,8,0,,,8
-Rooks,#11-1,State Senate,36,DEM,Brian G. Angevine,23,5,,,28
-Rooks,#11-2,State Senate,36,DEM,Brian G. Angevine,56,16,,,72
-Rooks,#12,State Senate,36,DEM,Brian G. Angevine,13,2,,,15
-Rooks,Grand Totals,State Senate,36,DEM,Brian G. Angevine,215,55,2,,272
-Rooks,#1,State House,110,REP,Ken Rahjes,78,8,,1,87
-Rooks,#2,State House,110,REP,Ken Rahjes,147,32,1,1,181
-Rooks,#3-1,State House,110,REP,Ken Rahjes,35,5,,,40
-Rooks,#3-2,State House,110,REP,Ken Rahjes,416,73,2,8,499
-Rooks,#4,State House,110,REP,Ken Rahjes,13,1,,,14
-Rooks,#5,State House,110,REP,Ken Rahjes,23,14,,,37
-Rooks,#6,State House,110,REP,Ken Rahjes,40,4,,,44
-Rooks,#7,State House,110,REP,Ken Rahjes,74,7,,,81
-Rooks,#8,State House,110,REP,Ken Rahjes,97,9,1,,107
-Rooks,#9,State House,110,REP,Ken Rahjes,21,3,,,24
-Rooks,#10,State House,110,REP,Ken Rahjes,70,7,,1,78
-Rooks,#11-1,State House,110,REP,Ken Rahjes,222,24,,4,250
-Rooks,#11-2,State House,110,REP,Ken Rahjes,590,72,,13,675
-Rooks,#12,State House,110,REP,Ken Rahjes,56,5,,,61
-Rooks,Grand Totals,State House,110,REP,Ken Rahjes,1882,264,4,28,2178
+county,precinct,office,district,party,candidate,votes,vtd
+ROOKS,Township 01,Kansas House of Representatives,110,Republican,"Rahjes, Ken",87,000010
+ROOKS,Township 02,Kansas House of Representatives,110,Republican,"Rahjes, Ken",181,000020
+ROOKS,Township 03 Precinct 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",40,000030
+ROOKS,Township 03 Precinct 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",499,000040
+ROOKS,Township 04,Kansas House of Representatives,110,Republican,"Rahjes, Ken",14,000050
+ROOKS,Township 06,Kansas House of Representatives,110,Republican,"Rahjes, Ken",44,000070
+ROOKS,Township 07,Kansas House of Representatives,110,Republican,"Rahjes, Ken",81,000080
+ROOKS,Township 08,Kansas House of Representatives,110,Republican,"Rahjes, Ken",107,000090
+ROOKS,Township 09,Kansas House of Representatives,110,Republican,"Rahjes, Ken",24,000100
+ROOKS,Township 10,Kansas House of Representatives,110,Republican,"Rahjes, Ken",78,000110
+ROOKS,Township 11 Precinct 1,Kansas House of Representatives,110,Republican,"Rahjes, Ken",250,000120
+ROOKS,Township 11 Precinct 2,Kansas House of Representatives,110,Republican,"Rahjes, Ken",675,000130
+ROOKS,Township 12,Kansas House of Representatives,110,Republican,"Rahjes, Ken",61,000140
+ROOKS,Township 05 H110,Kansas House of Representatives,110,Republican,"Rahjes, Ken",37,120020
+ROOKS,Township 05 H118 A,Kansas House of Representatives,118,Republican,"Hineman, Don",0,12003A
+ROOKS,Township 05 H118,Kansas House of Representatives,118,Republican,"Hineman, Don",0,120030
+ROOKS,Township 01,Kansas Senate,36,Democratic,"Angevine, Brian G.",11,000010
+ROOKS,Township 01,Kansas Senate,36,Republican,"Bowers, Elaine S.",78,000010
+ROOKS,Township 02,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,000020
+ROOKS,Township 02,Kansas Senate,36,Republican,"Bowers, Elaine S.",167,000020
+ROOKS,Township 03 Precinct 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000030
+ROOKS,Township 03 Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000030
+ROOKS,Township 03 Precinct 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",54,000040
+ROOKS,Township 03 Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",475,000040
+ROOKS,Township 04,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000050
+ROOKS,Township 04,Kansas Senate,36,Republican,"Bowers, Elaine S.",11,000050
+ROOKS,Township 06,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000070
+ROOKS,Township 06,Kansas Senate,36,Republican,"Bowers, Elaine S.",43,000070
+ROOKS,Township 07,Kansas Senate,36,Democratic,"Angevine, Brian G.",12,000080
+ROOKS,Township 07,Kansas Senate,36,Republican,"Bowers, Elaine S.",72,000080
+ROOKS,Township 08,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,000090
+ROOKS,Township 08,Kansas Senate,36,Republican,"Bowers, Elaine S.",95,000090
+ROOKS,Township 09,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000100
+ROOKS,Township 09,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000100
+ROOKS,Township 10,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000110
+ROOKS,Township 10,Kansas Senate,36,Republican,"Bowers, Elaine S.",74,000110
+ROOKS,Township 11 Precinct 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",28,000120
+ROOKS,Township 11 Precinct 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",237,000120
+ROOKS,Township 11 Precinct 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",72,000130
+ROOKS,Township 11 Precinct 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",646,000130
+ROOKS,Township 12,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,000140
+ROOKS,Township 12,Kansas Senate,36,Republican,"Bowers, Elaine S.",56,000140
+ROOKS,Township 05 H110,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,120020
+ROOKS,Township 05 H110,Kansas Senate,36,Republican,"Bowers, Elaine S.",40,120020
+ROOKS,Township 05 H118 A,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,12003A
+ROOKS,Township 05 H118 A,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,12003A
+ROOKS,Township 05 H118,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,120030
+ROOKS,Township 05 H118,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,120030
+ROOKS,Township 01,President / Vice President,,independent,"Stein, Jill",1,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Hedges, James A",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"McMullin, Evan",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Perry, Darryl",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Smith, Mike",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Sood, Ajay",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+ROOKS,Township 01,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+ROOKS,Township 01,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000010
+ROOKS,Township 01,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+ROOKS,Township 01,President / Vice President,,Republican,"Trump, Donald J.",79,000010
+ROOKS,Township 02,President / Vice President,,independent,"Stein, Jill",2,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Castle, Darrell L",1,000020
+ROOKS,Township 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Hedges, James A",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"McMullin, Evan",1,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Perry, Darryl",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Smith, Mike",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Sood, Ajay",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+ROOKS,Township 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+ROOKS,Township 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000020
+ROOKS,Township 02,President / Vice President,,Libertarian,"Johnson, Gary",10,000020
+ROOKS,Township 02,President / Vice President,,Republican,"Trump, Donald J.",164,000020
+ROOKS,Township 03 Precinct 1,President / Vice President,,independent,"Stein, Jill",1,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+ROOKS,Township 03 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",37,000030
+ROOKS,Township 03 Precinct 2,President / Vice President,,independent,"Stein, Jill",6,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",25,000040
+ROOKS,Township 03 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",465,000040
+ROOKS,Township 04,President / Vice President,,independent,"Stein, Jill",1,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Hedges, James A",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"McMullin, Evan",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Perry, Darryl",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Smith, Mike",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Sood, Ajay",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+ROOKS,Township 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+ROOKS,Township 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000050
+ROOKS,Township 04,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+ROOKS,Township 04,President / Vice President,,Republican,"Trump, Donald J.",12,000050
+ROOKS,Township 06,President / Vice President,,independent,"Stein, Jill",1,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Hedges, James A",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"McMullin, Evan",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Perry, Darryl",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Smith, Mike",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Sood, Ajay",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+ROOKS,Township 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+ROOKS,Township 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000070
+ROOKS,Township 06,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+ROOKS,Township 06,President / Vice President,,Republican,"Trump, Donald J.",42,000070
+ROOKS,Township 07,President / Vice President,,independent,"Stein, Jill",1,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Hedges, James A",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"McMullin, Evan",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Perry, Darryl",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Smith, Mike",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Sood, Ajay",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+ROOKS,Township 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+ROOKS,Township 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000080
+ROOKS,Township 07,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+ROOKS,Township 07,President / Vice President,,Republican,"Trump, Donald J.",77,000080
+ROOKS,Township 08,President / Vice President,,independent,"Stein, Jill",1,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Hedges, James A",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"McMullin, Evan",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Perry, Darryl",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Smith, Mike",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Sood, Ajay",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+ROOKS,Township 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+ROOKS,Township 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000090
+ROOKS,Township 08,President / Vice President,,Libertarian,"Johnson, Gary",2,000090
+ROOKS,Township 08,President / Vice President,,Republican,"Trump, Donald J.",99,000090
+ROOKS,Township 09,President / Vice President,,independent,"Stein, Jill",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Hedges, James A",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"McMullin, Evan",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Perry, Darryl",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Smith, Mike",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Sood, Ajay",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+ROOKS,Township 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+ROOKS,Township 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000100
+ROOKS,Township 09,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+ROOKS,Township 09,President / Vice President,,Republican,"Trump, Donald J.",23,000100
+ROOKS,Township 10,President / Vice President,,independent,"Stein, Jill",2,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Hedges, James A",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"McMullin, Evan",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Perry, Darryl",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Smith, Mike",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Sood, Ajay",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+ROOKS,Township 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+ROOKS,Township 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000110
+ROOKS,Township 10,President / Vice President,,Libertarian,"Johnson, Gary",4,000110
+ROOKS,Township 10,President / Vice President,,Republican,"Trump, Donald J.",72,000110
+ROOKS,Township 11 Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",6,000120
+ROOKS,Township 11 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",232,000120
+ROOKS,Township 11 Precinct 2,President / Vice President,,independent,"Stein, Jill",5,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",1,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",1,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",24,000130
+ROOKS,Township 11 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",631,000130
+ROOKS,Township 12,President / Vice President,,independent,"Stein, Jill",3,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Hedges, James A",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"McMullin, Evan",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Perry, Darryl",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Smith, Mike",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Sood, Ajay",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+ROOKS,Township 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+ROOKS,Township 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000140
+ROOKS,Township 12,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+ROOKS,Township 12,President / Vice President,,Republican,"Trump, Donald J.",57,000140
+ROOKS,Township 05 H110,President / Vice President,,independent,"Stein, Jill",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Hedges, James A",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"McMullin, Evan",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Perry, Darryl",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Smith, Mike",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Sood, Ajay",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+ROOKS,Township 05 H110,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+ROOKS,Township 05 H110,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,120020
+ROOKS,Township 05 H110,President / Vice President,,Libertarian,"Johnson, Gary",0,120020
+ROOKS,Township 05 H110,President / Vice President,,Republican,"Trump, Donald J.",41,120020
+ROOKS,Township 05 H118 A,President / Vice President,,independent,"Stein, Jill",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Castle, Darrell L",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Giordani, Rocky",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Hedges, James A",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Hoefling, Tom",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Kahn, Lynn",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"La Riva, Gloria",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Maturen, Michael A",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"McMullin, Evan",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Perry, Darryl",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Schriner, Joe C",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Smith, Mike",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Sood, Ajay",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Sterling, Shawna",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12003A
+ROOKS,Township 05 H118 A,President / Vice President,,Republican,"Trump, Donald J.",0,12003A
+ROOKS,Township 05 H118,President / Vice President,,independent,"Stein, Jill",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Hedges, James A",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"McMullin, Evan",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Perry, Darryl",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Smith, Mike",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Sood, Ajay",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+ROOKS,Township 05 H118,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+ROOKS,Township 05 H118,President / Vice President,,Republican,"Trump, Donald J.",0,120030
+ROOKS,Township 01,United States House of Representatives,1,independent,"LaPolice, Alan",22,000010
+ROOKS,Township 01,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+ROOKS,Township 01,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+ROOKS,Township 01,United States House of Representatives,1,Republican,"Marshall, Roger",70,000010
+ROOKS,Township 02,United States House of Representatives,1,independent,"LaPolice, Alan",45,000020
+ROOKS,Township 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+ROOKS,Township 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000020
+ROOKS,Township 02,United States House of Representatives,1,Republican,"Marshall, Roger",134,000020
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",12,000030
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+ROOKS,Township 03 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",29,000030
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",99,000040
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",26,000040
+ROOKS,Township 03 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",415,000040
+ROOKS,Township 04,United States House of Representatives,1,independent,"LaPolice, Alan",5,000050
+ROOKS,Township 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+ROOKS,Township 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+ROOKS,Township 04,United States House of Representatives,1,Republican,"Marshall, Roger",12,000050
+ROOKS,Township 06,United States House of Representatives,1,independent,"LaPolice, Alan",10,000070
+ROOKS,Township 06,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000070
+ROOKS,Township 06,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000070
+ROOKS,Township 06,United States House of Representatives,1,Republican,"Marshall, Roger",35,000070
+ROOKS,Township 07,United States House of Representatives,1,independent,"LaPolice, Alan",15,000080
+ROOKS,Township 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+ROOKS,Township 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000080
+ROOKS,Township 07,United States House of Representatives,1,Republican,"Marshall, Roger",71,000080
+ROOKS,Township 08,United States House of Representatives,1,independent,"LaPolice, Alan",32,000090
+ROOKS,Township 08,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+ROOKS,Township 08,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000090
+ROOKS,Township 08,United States House of Representatives,1,Republican,"Marshall, Roger",79,000090
+ROOKS,Township 09,United States House of Representatives,1,independent,"LaPolice, Alan",2,000100
+ROOKS,Township 09,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+ROOKS,Township 09,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000100
+ROOKS,Township 09,United States House of Representatives,1,Republican,"Marshall, Roger",23,000100
+ROOKS,Township 10,United States House of Representatives,1,independent,"LaPolice, Alan",13,000110
+ROOKS,Township 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+ROOKS,Township 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000110
+ROOKS,Township 10,United States House of Representatives,1,Republican,"Marshall, Roger",62,000110
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",62,000120
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000120
+ROOKS,Township 11 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",195,000120
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",130,000130
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,000130
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",47,000130
+ROOKS,Township 11 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",549,000130
+ROOKS,Township 12,United States House of Representatives,1,independent,"LaPolice, Alan",20,000140
+ROOKS,Township 12,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+ROOKS,Township 12,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000140
+ROOKS,Township 12,United States House of Representatives,1,Republican,"Marshall, Roger",46,000140
+ROOKS,Township 05 H110,United States House of Representatives,1,independent,"LaPolice, Alan",5,120020
+ROOKS,Township 05 H110,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+ROOKS,Township 05 H110,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,120020
+ROOKS,Township 05 H110,United States House of Representatives,1,Republican,"Marshall, Roger",32,120020
+ROOKS,Township 05 H118 A,United States House of Representatives,1,independent,"LaPolice, Alan",0,12003A
+ROOKS,Township 05 H118 A,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,12003A
+ROOKS,Township 05 H118 A,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,12003A
+ROOKS,Township 05 H118 A,United States House of Representatives,1,Republican,"Marshall, Roger",0,12003A
+ROOKS,Township 05 H118,United States House of Representatives,1,independent,"LaPolice, Alan",0,120030
+ROOKS,Township 05 H118,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+ROOKS,Township 05 H118,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120030
+ROOKS,Township 05 H118,United States House of Representatives,1,Republican,"Marshall, Roger",0,120030
+ROOKS,Township 01,United States Senate,,write - in,"Smith, DJ",0,000010
+ROOKS,Township 01,United States Senate,,Democratic,"Wiesner, Patrick",8,000010
+ROOKS,Township 01,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+ROOKS,Township 01,United States Senate,,Republican,"Moran, Jerry",84,000010
+ROOKS,Township 02,United States Senate,,write - in,"Smith, DJ",0,000020
+ROOKS,Township 02,United States Senate,,Democratic,"Wiesner, Patrick",10,000020
+ROOKS,Township 02,United States Senate,,Libertarian,"Garrard, Robert D.",9,000020
+ROOKS,Township 02,United States Senate,,Republican,"Moran, Jerry",180,000020
+ROOKS,Township 03 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000030
+ROOKS,Township 03 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",5,000030
+ROOKS,Township 03 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+ROOKS,Township 03 Precinct 1,United States Senate,,Republican,"Moran, Jerry",37,000030
+ROOKS,Township 03 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000040
+ROOKS,Township 03 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",51,000040
+ROOKS,Township 03 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",31,000040
+ROOKS,Township 03 Precinct 2,United States Senate,,Republican,"Moran, Jerry",470,000040
+ROOKS,Township 04,United States Senate,,write - in,"Smith, DJ",0,000050
+ROOKS,Township 04,United States Senate,,Democratic,"Wiesner, Patrick",6,000050
+ROOKS,Township 04,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+ROOKS,Township 04,United States Senate,,Republican,"Moran, Jerry",8,000050
+ROOKS,Township 06,United States Senate,,write - in,"Smith, DJ",0,000070
+ROOKS,Township 06,United States Senate,,Democratic,"Wiesner, Patrick",5,000070
+ROOKS,Township 06,United States Senate,,Libertarian,"Garrard, Robert D.",2,000070
+ROOKS,Township 06,United States Senate,,Republican,"Moran, Jerry",41,000070
+ROOKS,Township 07,United States Senate,,write - in,"Smith, DJ",0,000080
+ROOKS,Township 07,United States Senate,,Democratic,"Wiesner, Patrick",8,000080
+ROOKS,Township 07,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+ROOKS,Township 07,United States Senate,,Republican,"Moran, Jerry",80,000080
+ROOKS,Township 08,United States Senate,,write - in,"Smith, DJ",0,000090
+ROOKS,Township 08,United States Senate,,Democratic,"Wiesner, Patrick",13,000090
+ROOKS,Township 08,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+ROOKS,Township 08,United States Senate,,Republican,"Moran, Jerry",107,000090
+ROOKS,Township 09,United States Senate,,write - in,"Smith, DJ",0,000100
+ROOKS,Township 09,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+ROOKS,Township 09,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+ROOKS,Township 09,United States Senate,,Republican,"Moran, Jerry",26,000100
+ROOKS,Township 10,United States Senate,,write - in,"Smith, DJ",0,000110
+ROOKS,Township 10,United States Senate,,Democratic,"Wiesner, Patrick",6,000110
+ROOKS,Township 10,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+ROOKS,Township 10,United States Senate,,Republican,"Moran, Jerry",72,000110
+ROOKS,Township 11 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000120
+ROOKS,Township 11 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",20,000120
+ROOKS,Township 11 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000120
+ROOKS,Township 11 Precinct 1,United States Senate,,Republican,"Moran, Jerry",243,000120
+ROOKS,Township 11 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000130
+ROOKS,Township 11 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",45,000130
+ROOKS,Township 11 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",43,000130
+ROOKS,Township 11 Precinct 2,United States Senate,,Republican,"Moran, Jerry",661,000130
+ROOKS,Township 12,United States Senate,,write - in,"Smith, DJ",0,000140
+ROOKS,Township 12,United States Senate,,Democratic,"Wiesner, Patrick",12,000140
+ROOKS,Township 12,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+ROOKS,Township 12,United States Senate,,Republican,"Moran, Jerry",60,000140
+ROOKS,Township 05 H110,United States Senate,,write - in,"Smith, DJ",0,120020
+ROOKS,Township 05 H110,United States Senate,,Democratic,"Wiesner, Patrick",1,120020
+ROOKS,Township 05 H110,United States Senate,,Libertarian,"Garrard, Robert D.",4,120020
+ROOKS,Township 05 H110,United States Senate,,Republican,"Moran, Jerry",35,120020
+ROOKS,Township 05 H118 A,United States Senate,,write - in,"Smith, DJ",0,12003A
+ROOKS,Township 05 H118 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12003A
+ROOKS,Township 05 H118 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12003A
+ROOKS,Township 05 H118 A,United States Senate,,Republican,"Moran, Jerry",0,12003A
+ROOKS,Township 05 H118,United States Senate,,write - in,"Smith, DJ",0,120030
+ROOKS,Township 05 H118,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+ROOKS,Township 05 H118,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+ROOKS,Township 05 H118,United States Senate,,Republican,"Moran, Jerry",0,120030

--- a/2016/20161108__ks__general__rush__precinct.csv
+++ b/2016/20161108__ks__general__rush__precinct.csv
@@ -1,216 +1,469 @@
-county,precinct,office,district,party,candidate,votes
-Rush,Alexander-Belle Pr.,,,,Ballots Cast,56
-Rush,Banner,,,,Ballots Cast,66
-Rush,Big Timber,,,,Ballots Cast,76
-Rush,Center,,,,Ballots Cast,122
-Rush,Garfield,,,,Ballots Cast,57
-Rush,Hampton-Fairview,,,,Ballots Cast,155
-Rush,Illinois,,,,Ballots Cast,34
-Rush,La Crosse-Brkdl #1,,,,Ballots Cast,375
-Rush,La Crosse-Brkdl #2,,,,Ballots Cast,248
-Rush,Lone Star,,,,Ballots Cast,123
-Rush,Pioneer,,,,Ballots Cast,158
-Rush,Pleasantdale,,,,Ballots Cast,17
-Rush,Union,,,,Ballots Cast,30
-Rush,Provisionals,,,,Ballots Cast,45
-Rush,Alexander-Belle Pr.,President,,REP,Trump/Pence,45
-Rush,Banner,President,,REP,Trump/Pence,55
-Rush,Big Timber,President,,REP,Trump/Pence,64
-Rush,Center,President,,REP,Trump/Pence,99
-Rush,Garfield,President,,REP,Trump/Pence,43
-Rush,Hampton-Fairview,President,,REP,Trump/Pence,110
-Rush,Illinois,President,,REP,Trump/Pence,25
-Rush,La Crosse-Brkdl #1,President,,REP,Trump/Pence,294
-Rush,La Crosse-Brkdl #2,President,,REP,Trump/Pence,195
-Rush,Lone Star,President,,REP,Trump/Pence,98
-Rush,Pioneer,President,,REP,Trump/Pence,130
-Rush,Pleasantdale,President,,REP,Trump/Pence,11
-Rush,Union,President,,REP,Trump/Pence,28
-Rush,Provisionals,President,,REP,Trump/Pence,0
-Rush,Alexander-Belle Pr.,President,,DEM,Clinton/Kaine,10
-Rush,Banner,President,,DEM,Clinton/Kaine,7
-Rush,Big Timber,President,,DEM,Clinton/Kaine,7
-Rush,Center,President,,DEM,Clinton/Kaine,16
-Rush,Garfield,President,,DEM,Clinton/Kaine,12
-Rush,Hampton-Fairview,President,,DEM,Clinton/Kaine,33
-Rush,Illinois,President,,DEM,Clinton/Kaine,9
-Rush,La Crosse-Brkdl #1,President,,DEM,Clinton/Kaine,57
-Rush,La Crosse-Brkdl #2,President,,DEM,Clinton/Kaine,38
-Rush,Lone Star,President,,DEM,Clinton/Kaine,25
-Rush,Pioneer,President,,DEM,Clinton/Kaine,16
-Rush,Pleasantdale,President,,DEM,Clinton/Kaine,2
-Rush,Union,President,,DEM,Clinton/Kaine,1
-Rush,Provisionals,President,,DEM,Clinton/Kaine,0
-Rush,Alexander-Belle Pr.,President,,LBT,Johnson/Weld,0
-Rush,Banner,President,,LBT,Johnson/Weld,3
-Rush,Big Timber,President,,LBT,Johnson/Weld,2
-Rush,Center,President,,LBT,Johnson/Weld,4
-Rush,Garfield,President,,LBT,Johnson/Weld,1
-Rush,Hampton-Fairview,President,,LBT,Johnson/Weld,5
-Rush,Illinois,President,,LBT,Johnson/Weld,0
-Rush,La Crosse-Brkdl #1,President,,LBT,Johnson/Weld,14
-Rush,La Crosse-Brkdl #2,President,,LBT,Johnson/Weld,13
-Rush,Lone Star,President,,LBT,Johnson/Weld,6
-Rush,Pioneer,President,,LBT,Johnson/Weld,5
-Rush,Pleasantdale,President,,LBT,Johnson/Weld,1
-Rush,Union,President,,LBT,Johnson/Weld,1
-Rush,Provisionals,President,,LBT,Johnson/Weld,0
-Rush,Alexander-Belle Pr.,President,,GRN,Stein/Baraka,0
-Rush,Banner,President,,GRN,Stein/Baraka,1
-Rush,Big Timber,President,,GRN,Stein/Baraka,0
-Rush,Center,President,,GRN,Stein/Baraka,1
-Rush,Garfield,President,,GRN,Stein/Baraka,0
-Rush,Hampton-Fairview,President,,GRN,Stein/Baraka,4
-Rush,Illinois,President,,GRN,Stein/Baraka,0
-Rush,La Crosse-Brkdl #1,President,,GRN,Stein/Baraka,4
-Rush,La Crosse-Brkdl #2,President,,GRN,Stein/Baraka,3
-Rush,Lone Star,President,,GRN,Stein/Baraka,1
-Rush,Pioneer,President,,GRN,Stein/Baraka,4
-Rush,Pleasantdale,President,,GRN,Stein/Baraka,0
-Rush,Union,President,,GRN,Stein/Baraka,0
-Rush,Provisionals,President,,GRN,Stein/Baraka,0
-Rush,Alexander-Belle Pr.,U.S. Senate,,DEM,Patrick Wiesner,6
-Rush,Banner,U.S. Senate,,DEM,Patrick Wiesner,8
-Rush,Big Timber,U.S. Senate,,DEM,Patrick Wiesner,6
-Rush,Center,U.S. Senate,,DEM,Patrick Wiesner,8
-Rush,Garfield,U.S. Senate,,DEM,Patrick Wiesner,10
-Rush,Hampton-Fairview,U.S. Senate,,DEM,Patrick Wiesner,24
-Rush,Illinois,U.S. Senate,,DEM,Patrick Wiesner,7
-Rush,La Crosse-Brkdl #1,U.S. Senate,,DEM,Patrick Wiesner,32
-Rush,La Crosse-Brkdl #2,U.S. Senate,,DEM,Patrick Wiesner,30
-Rush,Lone Star,U.S. Senate,,DEM,Patrick Wiesner,23
-Rush,Pioneer,U.S. Senate,,DEM,Patrick Wiesner,13
-Rush,Pleasantdale,U.S. Senate,,DEM,Patrick Wiesner,0
-Rush,Union,U.S. Senate,,DEM,Patrick Wiesner,2
-Rush,Provisionals,U.S. Senate,,DEM,Patrick Wiesner,0
-Rush,Alexander-Belle Pr.,U.S. Senate,,LBT,Robert D. Garrard,2
-Rush,Banner,U.S. Senate,,LBT,Robert D. Garrard,1
-Rush,Big Timber,U.S. Senate,,LBT,Robert D. Garrard,5
-Rush,Center,U.S. Senate,,LBT,Robert D. Garrard,2
-Rush,Garfield,U.S. Senate,,LBT,Robert D. Garrard,6
-Rush,Hampton-Fairview,U.S. Senate,,LBT,Robert D. Garrard,6
-Rush,Illinois,U.S. Senate,,LBT,Robert D. Garrard,1
-Rush,La Crosse-Brkdl #1,U.S. Senate,,LBT,Robert D. Garrard,10
-Rush,La Crosse-Brkdl #2,U.S. Senate,,LBT,Robert D. Garrard,16
-Rush,Lone Star,U.S. Senate,,LBT,Robert D. Garrard,6
-Rush,Pioneer,U.S. Senate,,LBT,Robert D. Garrard,3
-Rush,Pleasantdale,U.S. Senate,,LBT,Robert D. Garrard,0
-Rush,Union,U.S. Senate,,LBT,Robert D. Garrard,1
-Rush,Provisionals,U.S. Senate,,LBT,Robert D. Garrard,0
-Rush,Alexander-Belle Pr.,U.S. Senate,,REP,Jerry Moran,44
-Rush,Banner,U.S. Senate,,REP,Jerry Moran,54
-Rush,Big Timber,U.S. Senate,,REP,Jerry Moran,64
-Rush,Center,U.S. Senate,,REP,Jerry Moran,114
-Rush,Garfield,U.S. Senate,,REP,Jerry Moran,42
-Rush,Hampton-Fairview,U.S. Senate,,REP,Jerry Moran,121
-Rush,Illinois,U.S. Senate,,REP,Jerry Moran,23
-Rush,La Crosse-Brkdl #1,U.S. Senate,,REP,Jerry Moran,332
-Rush,La Crosse-Brkdl #2,U.S. Senate,,REP,Jerry Moran,202
-Rush,Lone Star,U.S. Senate,,REP,Jerry Moran,102
-Rush,Pioneer,U.S. Senate,,REP,Jerry Moran,139
-Rush,Pleasantdale,U.S. Senate,,REP,Jerry Moran,17
-Rush,Union,U.S. Senate,,REP,Jerry Moran,27
-Rush,Provisionals,U.S. Senate,,REP,Jerry Moran,0
-Rush,Alexander-Belle Pr.,U.S. House,1,REP,Roger Marshall,38
-Rush,Banner,U.S. House,1,REP,Roger Marshall,45
-Rush,Big Timber,U.S. House,1,REP,Roger Marshall,50
-Rush,Center,U.S. House,1,REP,Roger Marshall,94
-Rush,Garfield,U.S. House,1,REP,Roger Marshall,35
-Rush,Hampton-Fairview,U.S. House,1,REP,Roger Marshall,114
-Rush,Illinois,U.S. House,1,REP,Roger Marshall,23
-Rush,La Crosse-Brkdl #1,U.S. House,1,REP,Roger Marshall,311
-Rush,La Crosse-Brkdl #2,U.S. House,1,REP,Roger Marshall,190
-Rush,Lone Star,U.S. House,1,REP,Roger Marshall,87
-Rush,Pioneer,U.S. House,1,REP,Roger Marshall,97
-Rush,Pleasantdale,U.S. House,1,REP,Roger Marshall,12
-Rush,Union,U.S. House,1,REP,Roger Marshall,23
-Rush,Provisionals,U.S. House,1,REP,Roger Marshall,0
-Rush,Alexander-Belle Pr.,U.S. House,1,LBT,Kerry Burt,2
-Rush,Banner,U.S. House,1,LBT,Kerry Burt,8
-Rush,Big Timber,U.S. House,1,LBT,Kerry Burt,2
-Rush,Center,U.S. House,1,LBT,Kerry Burt,6
-Rush,Garfield,U.S. House,1,LBT,Kerry Burt,6
-Rush,Hampton-Fairview,U.S. House,1,LBT,Kerry Burt,11
-Rush,Illinois,U.S. House,1,LBT,Kerry Burt,2
-Rush,La Crosse-Brkdl #1,U.S. House,1,LBT,Kerry Burt,11
-Rush,La Crosse-Brkdl #2,U.S. House,1,LBT,Kerry Burt,16
-Rush,Lone Star,U.S. House,1,LBT,Kerry Burt,8
-Rush,Pioneer,U.S. House,1,LBT,Kerry Burt,9
-Rush,Pleasantdale,U.S. House,1,LBT,Kerry Burt,0
-Rush,Union,U.S. House,1,LBT,Kerry Burt,1
-Rush,Provisionals,U.S. House,1,LBT,Kerry Burt,0
-Rush,Alexander-Belle Pr.,U.S. House,1,IND,Alan LaPolice,11
-Rush,Banner,U.S. House,1,IND,Alan LaPolice,10
-Rush,Big Timber,U.S. House,1,IND,Alan LaPolice,22
-Rush,Center,U.S. House,1,IND,Alan LaPolice,21
-Rush,Garfield,U.S. House,1,IND,Alan LaPolice,16
-Rush,Hampton-Fairview,U.S. House,1,IND,Alan LaPolice,24
-Rush,Illinois,U.S. House,1,IND,Alan LaPolice,6
-Rush,La Crosse-Brkdl #1,U.S. House,1,IND,Alan LaPolice,46
-Rush,La Crosse-Brkdl #2,U.S. House,1,IND,Alan LaPolice,40
-Rush,Lone Star,U.S. House,1,IND,Alan LaPolice,31
-Rush,Pioneer,U.S. House,1,IND,Alan LaPolice,41
-Rush,Pleasantdale,U.S. House,1,IND,Alan LaPolice,2
-Rush,Union,U.S. House,1,IND,Alan LaPolice,3
-Rush,Provisionals,U.S. House,1,IND,Alan LaPolice,0
-Rush,Alexander-Belle Pr.,U.S. House,1,,Tim Huelskamp,2
-Rush,Banner,U.S. House,1,,Tim Huelskamp,0
-Rush,Big Timber,U.S. House,1,,Tim Huelskamp,0
-Rush,Center,U.S. House,1,,Tim Huelskamp,0
-Rush,Garfield,U.S. House,1,,Tim Huelskamp,0
-Rush,Hampton-Fairview,U.S. House,1,,Tim Huelskamp,0
-Rush,Illinois,U.S. House,1,,Tim Huelskamp,0
-Rush,La Crosse-Brkdl #1,U.S. House,1,,Tim Huelskamp,0
-Rush,La Crosse-Brkdl #2,U.S. House,1,,Tim Huelskamp,0
-Rush,Lone Star,U.S. House,1,,Tim Huelskamp,0
-Rush,Pioneer,U.S. House,1,,Tim Huelskamp,6
-Rush,Pleasantdale,U.S. House,1,,Tim Huelskamp,0
-Rush,Union,U.S. House,1,,Tim Huelskamp,1
-Rush,Provisionals,U.S. House,1,,Tim Huelskamp,0
-Rush,Alexander-Belle Pr.,State Senate,33,REP,Mary Jo Taylor,42
-Rush,Banner,State Senate,33,REP,Mary Jo Taylor,40
-Rush,Big Timber,State Senate,33,REP,Mary Jo Taylor,58
-Rush,Center,State Senate,33,REP,Mary Jo Taylor,100
-Rush,Garfield,State Senate,33,REP,Mary Jo Taylor,37
-Rush,Hampton-Fairview,State Senate,33,REP,Mary Jo Taylor,102
-Rush,Illinois,State Senate,33,REP,Mary Jo Taylor,23
-Rush,La Crosse-Brkdl #1,State Senate,33,REP,Mary Jo Taylor,276
-Rush,La Crosse-Brkdl #2,State Senate,33,REP,Mary Jo Taylor,185
-Rush,Lone Star,State Senate,33,REP,Mary Jo Taylor,92
-Rush,Pioneer,State Senate,33,REP,Mary Jo Taylor,120
-Rush,Pleasantdale,State Senate,33,REP,Mary Jo Taylor,14
-Rush,Union,State Senate,33,REP,Mary Jo Taylor,25
-Rush,Provisionals,State Senate,33,REP,Mary Jo Taylor,0
-Rush,Alexander-Belle Pr.,State Senate,33,DEM,Matt Bristow,9
-Rush,Banner,State Senate,33,DEM,Matt Bristow,21
-Rush,Big Timber,State Senate,33,DEM,Matt Bristow,15
-Rush,Center,State Senate,33,DEM,Matt Bristow,20
-Rush,Garfield,State Senate,33,DEM,Matt Bristow,20
-Rush,Hampton-Fairview,State Senate,33,DEM,Matt Bristow,42
-Rush,Illinois,State Senate,33,DEM,Matt Bristow,10
-Rush,La Crosse-Brkdl #1,State Senate,33,DEM,Matt Bristow,77
-Rush,La Crosse-Brkdl #2,State Senate,33,DEM,Matt Bristow,56
-Rush,Lone Star,State Senate,33,DEM,Matt Bristow,34
-Rush,Pioneer,State Senate,33,DEM,Matt Bristow,27
-Rush,Pleasantdale,State Senate,33,DEM,Matt Bristow,1
-Rush,Union,State Senate,33,DEM,Matt Bristow,2
-Rush,Provisionals,State Senate,33,DEM,Matt Bristow,0
-Rush,Alexander-Belle Pr.,State House,109,REP,Troy L. Waymaster,0
-Rush,Banner,State House,109,REP,Troy L. Waymaster,53
-Rush,Center,State House,109,REP,Troy L. Waymaster,104
-Rush,Garfield,State House,109,REP,Troy L. Waymaster,52
-Rush,Illinois,State House,109,REP,Troy L. Waymaster,28
-Rush,La Crosse-Brkdl #1,State House,109,REP,Troy L. Waymaster,0
-Rush,Lone Star,State House,109,REP,Troy L. Waymaster,113
-Rush,Pioneer,State House,109,REP,Troy L. Waymaster,139
-Rush,Pleasantdale,State House,109,REP,Troy L. Waymaster,15
-Rush,Union,State House,109,REP,Troy L. Waymaster,0
-Rush,Provisionals,State House,109,REP,Troy L. Waymaster,0
-Rush,Alexander-Belle Pr.,State House,117,REP,Leonard A. Mastroni,46
-Rush,Banner,State House,117,REP,Leonard A. Mastroni,0
-Rush,Big Timber,State House,117,REP,Leonard A. Mastroni,66
-Rush,Hampton-Fairview,State House,117,REP,Leonard A. Mastroni,132
-Rush,La Crosse-Brkdl #1,State House,117,REP,Leonard A. Mastroni,326
-Rush,La Crosse-Brkdl #2,State House,117,REP,Leonard A. Mastroni,218
-Rush,Union,State House,117,REP,Leonard A. Mastroni,26
-Rush,Provisionals,State House,117,REP,Leonard A. Mastroni,0
+county,precinct,office,district,party,candidate,votes,vtd
+RUSH,Alexander - Belle Prairie Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",46,000010
+RUSH,Banner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",53,000020
+RUSH,Big Timber Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",66,000030
+RUSH,Brookdale,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",218,000040
+RUSH,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",104,000050
+RUSH,Garfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000060
+RUSH,Hampton - Fairview Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",132,000070
+RUSH,Illinois Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",28,000080
+RUSH,LaCrosse,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",326,000090
+RUSH,Lone Star Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",113,000100
+RUSH,Pioneer Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",139,000110
+RUSH,Pleasantdale Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",15,000120
+RUSH,Union Township,Kansas House of Representatives,117,Republican,"Mastroni, Leonard A.",26,000130
+RUSH,Alexander - Belle Prairie Township,Kansas Senate,33,Democratic,"Bristow, Matt",9,000010
+RUSH,Alexander - Belle Prairie Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",42,000010
+RUSH,Banner Township,Kansas Senate,33,Democratic,"Bristow, Matt",21,000020
+RUSH,Banner Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",40,000020
+RUSH,Big Timber Township,Kansas Senate,33,Democratic,"Bristow, Matt",15,000030
+RUSH,Big Timber Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",58,000030
+RUSH,Brookdale,Kansas Senate,33,Democratic,"Bristow, Matt",56,000040
+RUSH,Brookdale,Kansas Senate,33,Republican,"Taylor, Mary Jo",185,000040
+RUSH,Center Township,Kansas Senate,33,Democratic,"Bristow, Matt",20,000050
+RUSH,Center Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",100,000050
+RUSH,Garfield Township,Kansas Senate,33,Democratic,"Bristow, Matt",20,000060
+RUSH,Garfield Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",37,000060
+RUSH,Hampton - Fairview Township,Kansas Senate,33,Democratic,"Bristow, Matt",42,000070
+RUSH,Hampton - Fairview Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",102,000070
+RUSH,Illinois Township,Kansas Senate,33,Democratic,"Bristow, Matt",10,000080
+RUSH,Illinois Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",23,000080
+RUSH,LaCrosse,Kansas Senate,33,Democratic,"Bristow, Matt",77,000090
+RUSH,LaCrosse,Kansas Senate,33,Republican,"Taylor, Mary Jo",276,000090
+RUSH,Lone Star Township,Kansas Senate,33,Democratic,"Bristow, Matt",34,000100
+RUSH,Lone Star Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",92,000100
+RUSH,Pioneer Township,Kansas Senate,33,Democratic,"Bristow, Matt",27,000110
+RUSH,Pioneer Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",120,000110
+RUSH,Pleasantdale Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000120
+RUSH,Pleasantdale Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",14,000120
+RUSH,Union Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000130
+RUSH,Union Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",25,000130
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,independent,"Stein, Jill",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+RUSH,Alexander - Belle Prairie Township,President / Vice President,,Republican,"Trump, Donald J.",45,000010
+RUSH,Banner Township,President / Vice President,,independent,"Stein, Jill",1,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+RUSH,Banner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+RUSH,Banner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000020
+RUSH,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+RUSH,Banner Township,President / Vice President,,Republican,"Trump, Donald J.",55,000020
+RUSH,Big Timber Township,President / Vice President,,independent,"Stein, Jill",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+RUSH,Big Timber Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+RUSH,Big Timber Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000030
+RUSH,Big Timber Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+RUSH,Big Timber Township,President / Vice President,,Republican,"Trump, Donald J.",64,000030
+RUSH,Brookdale,President / Vice President,,independent,"Stein, Jill",3,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Hedges, James A",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"McMullin, Evan",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Perry, Darryl",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Smith, Mike",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Sood, Ajay",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+RUSH,Brookdale,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+RUSH,Brookdale,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000040
+RUSH,Brookdale,President / Vice President,,Libertarian,"Johnson, Gary",13,000040
+RUSH,Brookdale,President / Vice President,,Republican,"Trump, Donald J.",195,000040
+RUSH,Center Township,President / Vice President,,independent,"Stein, Jill",1,000050
+RUSH,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+RUSH,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+RUSH,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000050
+RUSH,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+RUSH,Center Township,President / Vice President,,Republican,"Trump, Donald J.",99,000050
+RUSH,Garfield Township,President / Vice President,,independent,"Stein, Jill",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+RUSH,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+RUSH,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000060
+RUSH,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000060
+RUSH,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",43,000060
+RUSH,Hampton - Fairview Township,President / Vice President,,independent,"Stein, Jill",4,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+RUSH,Hampton - Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",110,000070
+RUSH,Illinois Township,President / Vice President,,independent,"Stein, Jill",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+RUSH,Illinois Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+RUSH,Illinois Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000080
+RUSH,Illinois Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+RUSH,Illinois Township,President / Vice President,,Republican,"Trump, Donald J.",25,000080
+RUSH,LaCrosse,President / Vice President,,independent,"Stein, Jill",4,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Hedges, James A",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"McMullin, Evan",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Perry, Darryl",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Smith, Mike",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Sood, Ajay",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+RUSH,LaCrosse,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+RUSH,LaCrosse,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000090
+RUSH,LaCrosse,President / Vice President,,Libertarian,"Johnson, Gary",14,000090
+RUSH,LaCrosse,President / Vice President,,Republican,"Trump, Donald J.",294,000090
+RUSH,Lone Star Township,President / Vice President,,independent,"Stein, Jill",1,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+RUSH,Lone Star Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+RUSH,Lone Star Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000100
+RUSH,Lone Star Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000100
+RUSH,Lone Star Township,President / Vice President,,Republican,"Trump, Donald J.",98,000100
+RUSH,Pioneer Township,President / Vice President,,independent,"Stein, Jill",4,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+RUSH,Pioneer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+RUSH,Pioneer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000110
+RUSH,Pioneer Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000110
+RUSH,Pioneer Township,President / Vice President,,Republican,"Trump, Donald J.",130,000110
+RUSH,Pleasantdale Township,President / Vice President,,independent,"Stein, Jill",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+RUSH,Pleasantdale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000120
+RUSH,Pleasantdale Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000120
+RUSH,Pleasantdale Township,President / Vice President,,Republican,"Trump, Donald J.",11,000120
+RUSH,Union Township,President / Vice President,,independent,"Stein, Jill",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+RUSH,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+RUSH,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000130
+RUSH,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+RUSH,Union Township,President / Vice President,,Republican,"Trump, Donald J.",28,000130
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000010
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000010
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+RUSH,Alexander - Belle Prairie Township,United States House of Representatives,1,Republican,"Marshall, Roger",38,000010
+RUSH,Banner Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000020
+RUSH,Banner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+RUSH,Banner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000020
+RUSH,Banner Township,United States House of Representatives,1,Republican,"Marshall, Roger",45,000020
+RUSH,Big Timber Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000030
+RUSH,Big Timber Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+RUSH,Big Timber Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000030
+RUSH,Big Timber Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000030
+RUSH,Brookdale,United States House of Representatives,1,independent,"LaPolice, Alan",40,000040
+RUSH,Brookdale,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+RUSH,Brookdale,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000040
+RUSH,Brookdale,United States House of Representatives,1,Republican,"Marshall, Roger",190,000040
+RUSH,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000050
+RUSH,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+RUSH,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000050
+RUSH,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",94,000050
+RUSH,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000060
+RUSH,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+RUSH,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000060
+RUSH,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000060
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000070
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000070
+RUSH,Hampton - Fairview Township,United States House of Representatives,1,Republican,"Marshall, Roger",114,000070
+RUSH,Illinois Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000080
+RUSH,Illinois Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+RUSH,Illinois Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000080
+RUSH,Illinois Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000080
+RUSH,LaCrosse,United States House of Representatives,1,independent,"LaPolice, Alan",46,000090
+RUSH,LaCrosse,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+RUSH,LaCrosse,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000090
+RUSH,LaCrosse,United States House of Representatives,1,Republican,"Marshall, Roger",311,000090
+RUSH,Lone Star Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000100
+RUSH,Lone Star Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+RUSH,Lone Star Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,000100
+RUSH,Lone Star Township,United States House of Representatives,1,Republican,"Marshall, Roger",87,000100
+RUSH,Pioneer Township,United States House of Representatives,1,independent,"LaPolice, Alan",41,000110
+RUSH,Pioneer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,000110
+RUSH,Pioneer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000110
+RUSH,Pioneer Township,United States House of Representatives,1,Republican,"Marshall, Roger",97,000110
+RUSH,Pleasantdale Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000120
+RUSH,Pleasantdale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+RUSH,Pleasantdale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+RUSH,Pleasantdale Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000120
+RUSH,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000130
+RUSH,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000130
+RUSH,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000130
+RUSH,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000130
+RUSH,Alexander - Belle Prairie Township,United States Senate,,write - in,"Smith, DJ",0,000010
+RUSH,Alexander - Belle Prairie Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000010
+RUSH,Alexander - Belle Prairie Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+RUSH,Alexander - Belle Prairie Township,United States Senate,,Republican,"Moran, Jerry",44,000010
+RUSH,Banner Township,United States Senate,,write - in,"Smith, DJ",0,000020
+RUSH,Banner Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000020
+RUSH,Banner Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+RUSH,Banner Township,United States Senate,,Republican,"Moran, Jerry",54,000020
+RUSH,Big Timber Township,United States Senate,,write - in,"Smith, DJ",0,000030
+RUSH,Big Timber Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000030
+RUSH,Big Timber Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000030
+RUSH,Big Timber Township,United States Senate,,Republican,"Moran, Jerry",64,000030
+RUSH,Brookdale,United States Senate,,write - in,"Smith, DJ",0,000040
+RUSH,Brookdale,United States Senate,,Democratic,"Wiesner, Patrick",30,000040
+RUSH,Brookdale,United States Senate,,Libertarian,"Garrard, Robert D.",16,000040
+RUSH,Brookdale,United States Senate,,Republican,"Moran, Jerry",202,000040
+RUSH,Center Township,United States Senate,,write - in,"Smith, DJ",0,000050
+RUSH,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000050
+RUSH,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+RUSH,Center Township,United States Senate,,Republican,"Moran, Jerry",114,000050
+RUSH,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000060
+RUSH,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000060
+RUSH,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000060
+RUSH,Garfield Township,United States Senate,,Republican,"Moran, Jerry",42,000060
+RUSH,Hampton - Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000070
+RUSH,Hampton - Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000070
+RUSH,Hampton - Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000070
+RUSH,Hampton - Fairview Township,United States Senate,,Republican,"Moran, Jerry",121,000070
+RUSH,Illinois Township,United States Senate,,write - in,"Smith, DJ",0,000080
+RUSH,Illinois Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000080
+RUSH,Illinois Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+RUSH,Illinois Township,United States Senate,,Republican,"Moran, Jerry",23,000080
+RUSH,LaCrosse,United States Senate,,write - in,"Smith, DJ",0,000090
+RUSH,LaCrosse,United States Senate,,Democratic,"Wiesner, Patrick",32,000090
+RUSH,LaCrosse,United States Senate,,Libertarian,"Garrard, Robert D.",10,000090
+RUSH,LaCrosse,United States Senate,,Republican,"Moran, Jerry",332,000090
+RUSH,Lone Star Township,United States Senate,,write - in,"Smith, DJ",0,000100
+RUSH,Lone Star Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000100
+RUSH,Lone Star Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000100
+RUSH,Lone Star Township,United States Senate,,Republican,"Moran, Jerry",102,000100
+RUSH,Pioneer Township,United States Senate,,write - in,"Smith, DJ",0,000110
+RUSH,Pioneer Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000110
+RUSH,Pioneer Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000110
+RUSH,Pioneer Township,United States Senate,,Republican,"Moran, Jerry",139,000110
+RUSH,Pleasantdale Township,United States Senate,,write - in,"Smith, DJ",0,000120
+RUSH,Pleasantdale Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000120
+RUSH,Pleasantdale Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+RUSH,Pleasantdale Township,United States Senate,,Republican,"Moran, Jerry",17,000120
+RUSH,Union Township,United States Senate,,write - in,"Smith, DJ",0,000130
+RUSH,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000130
+RUSH,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000130
+RUSH,Union Township,United States Senate,,Republican,"Moran, Jerry",27,000130

--- a/2016/20161108__ks__general__russell__precinct.csv
+++ b/2016/20161108__ks__general__russell__precinct.csv
@@ -1,326 +1,685 @@
-county,precinct,office,district,candidate,party,votes
-Russell,1st,U.S. House,1,Alan LaPolice,IND,74
-Russell,2nd,U.S. House,1,Alan LaPolice,IND,121
-Russell,3rd,U.S. House,1,Alan LaPolice,IND,111
-Russell,4th,U.S. House,1,Alan LaPolice,IND,89
-Russell,4th,U.S. House,1,Alan LaPolice,IND,89
-Russell,Lulu,U.S. House,1,Alan LaPolice,IND,7
-Russell,Ash,U.S. House,1,Alan LaPolice,IND,22
-Russell,Log,U.S. House,1,Alan LaPolice,IND,14
-Russell,Eur,U.S. House,1,Alan LaPolice,IND,6
-Russell,Plum,U.S. House,1,Alan LaPolice,IND,12
-Russell,Beloit,U.S. House,1,Alan LaPolice,IND,22
-Russell,Bloom,U.S. House,1,Alan LaPolice,IND,6
-Russell,Salt,U.S. House,1,Alan LaPolice,IND,3
-Russell,Sol Rap,U.S. House,1,Alan LaPolice,IND,8
-Russell,Tky Crk,U.S. House,1,Alan LaPolice,IND,17
-Russell,Ctr,U.S. House,1,Alan LaPolice,IND,2
-Russell,Rnd Spg,U.S. House,1,Alan LaPolice,IND,1
-Russell,Glen,U.S. House,1,Alan LaPolice,IND,52
-Russell,Wnt Crk,U.S. House,1,Alan LaPolice,IND,8
-Russell,Hayes,U.S. House,1,Alan LaPolice,IND,3
-Russell,Blue,U.S. House,1,Alan LaPolice,IND,6
-Russell,Cwkr,U.S. House,1,Alan LaPolice,IND,57
-Russell,Carr,U.S. House,1,Alan LaPolice,IND,4
-Russell,Pitts,U.S. House,1,Alan LaPolice,IND,18
-Russell,Cust,U.S. House,1,Alan LaPolice,IND,8
-Russell,1st,State Senate,36,Brian Angevine,DEM,26
-Russell,2nd,State Senate,36,Brian Angevine,DEM,51
-Russell,3rd,State Senate,36,Brian Angevine,DEM,48
-Russell,4th,State Senate,36,Brian Angevine,DEM,38
-Russell,4th,State Senate,36,Brian Angevine,DEM,38
-Russell,Lulu,State Senate,36,Brian Angevine,DEM,0
-Russell,Ash,State Senate,36,Brian Angevine,DEM,6
-Russell,Log,State Senate,36,Brian Angevine,DEM,3
-Russell,Eur,State Senate,36,Brian Angevine,DEM,2
-Russell,Plum,State Senate,36,Brian Angevine,DEM,0
-Russell,Beloit,State Senate,36,Brian Angevine,DEM,6
-Russell,Bloom,State Senate,36,Brian Angevine,DEM,6
-Russell,Salt,State Senate,36,Brian Angevine,DEM,2
-Russell,Sol Rap,State Senate,36,Brian Angevine,DEM,5
-Russell,Tky Crk,State Senate,36,Brian Angevine,DEM,7
-Russell,Ctr,State Senate,36,Brian Angevine,DEM,0
-Russell,Rnd Spg,State Senate,36,Brian Angevine,DEM,0
-Russell,Glen,State Senate,36,Brian Angevine,DEM,25
-Russell,Wnt Crk,State Senate,36,Brian Angevine,DEM,4
-Russell,Hayes,State Senate,36,Brian Angevine,DEM,1
-Russell,Blue,State Senate,36,Brian Angevine,DEM,2
-Russell,Cwkr,State Senate,36,Brian Angevine,DEM,26
-Russell,Carr,State Senate,36,Brian Angevine,DEM,0
-Russell,Pitts,State Senate,36,Brian Angevine,DEM,13
-Russell,Cust,State Senate,36,Brian Angevine,DEM,10
-Russell,1st,President,,Hillary Clinton,DEM,51
-Russell,2nd,President,,Hillary Clinton,DEM,106
-Russell,3rd,President,,Hillary Clinton,DEM,72
-Russell,4th,President,,Hillary Clinton,DEM,86
-Russell,4th,President,,Hillary Clinton,DEM,86
-Russell,Lulu,President,,Hillary Clinton,DEM,2
-Russell,Ash,President,,Hillary Clinton,DEM,10
-Russell,Log,President,,Hillary Clinton,DEM,7
-Russell,Eur,President,,Hillary Clinton,DEM,7
-Russell,Plum,President,,Hillary Clinton,DEM,5
-Russell,Beloit,President,,Hillary Clinton,DEM,23
-Russell,Bloom,President,,Hillary Clinton,DEM,6
-Russell,Salt,President,,Hillary Clinton,DEM,2
-Russell,Sol Rap,President,,Hillary Clinton,DEM,8
-Russell,Tky Crk,President,,Hillary Clinton,DEM,8
-Russell,Ctr,President,,Hillary Clinton,DEM,0
-Russell,Rnd Spg,President,,Hillary Clinton,DEM,0
-Russell,Glen,President,,Hillary Clinton,DEM,34
-Russell,Wnt Crk,President,,Hillary Clinton,DEM,3
-Russell,Hayes,President,,Hillary Clinton,DEM,1
-Russell,Blue,President,,Hillary Clinton,DEM,0
-Russell,Cwkr,President,,Hillary Clinton,DEM,24
-Russell,Carr,President,,Hillary Clinton,DEM,0
-Russell,Pitts,President,,Hillary Clinton,DEM,13
-Russell,Cust,President,,Hillary Clinton,DEM,9
-Russell,1st,State Senate,36,Elaine Bowers,REP,238
-Russell,2nd,State Senate,36,Elaine Bowers,REP,413
-Russell,3rd,State Senate,36,Elaine Bowers,REP,406
-Russell,4th,State Senate,36,Elaine Bowers,REP,346
-Russell,4th,State Senate,36,Elaine Bowers,REP,346
-Russell,Lulu,State Senate,36,Elaine Bowers,REP,39
-Russell,Ash,State Senate,36,Elaine Bowers,REP,44
-Russell,Log,State Senate,36,Elaine Bowers,REP,41
-Russell,Eur,State Senate,36,Elaine Bowers,REP,13
-Russell,Plum,State Senate,36,Elaine Bowers,REP,62
-Russell,Beloit,State Senate,36,Elaine Bowers,REP,111
-Russell,Bloom,State Senate,36,Elaine Bowers,REP,36
-Russell,Salt,State Senate,36,Elaine Bowers,REP,16
-Russell,Sol Rap,State Senate,36,Elaine Bowers,REP,33
-Russell,Tky Crk,State Senate,36,Elaine Bowers,REP,64
-Russell,Ctr,State Senate,36,Elaine Bowers,REP,16
-Russell,Rnd Spg,State Senate,36,Elaine Bowers,REP,14
-Russell,Glen,State Senate,36,Elaine Bowers,REP,222
-Russell,Wnt Crk,State Senate,36,Elaine Bowers,REP,21
-Russell,Hayes,State Senate,36,Elaine Bowers,REP,16
-Russell,Blue,State Senate,36,Elaine Bowers,REP,19
-Russell,Cwkr,State Senate,36,Elaine Bowers,REP,214
-Russell,Carr,State Senate,36,Elaine Bowers,REP,13
-Russell,Pitts,State Senate,36,Elaine Bowers,REP,136
-Russell,Cust,State Senate,36,Elaine Bowers,REP,56
-Russell,1st,U.S. Senate,,Jerry Moran,REP,226
-Russell,2nd,U.S. Senate,,Jerry Moran,REP,383
-Russell,3rd,U.S. Senate,,Jerry Moran,REP,369
-Russell,4th,U.S. Senate,,Jerry Moran,REP,326
-Russell,4th,U.S. Senate,,Jerry Moran,REP,326
-Russell,Lulu,U.S. Senate,,Jerry Moran,REP,38
-Russell,Ash,U.S. Senate,,Jerry Moran,REP,37
-Russell,Log,U.S. Senate,,Jerry Moran,REP,40
-Russell,Eur,U.S. Senate,,Jerry Moran,REP,13
-Russell,Plum,U.S. Senate,,Jerry Moran,REP,62
-Russell,Beloit,U.S. Senate,,Jerry Moran,REP,101
-Russell,Bloom,U.S. Senate,,Jerry Moran,REP,36
-Russell,Salt,U.S. Senate,,Jerry Moran,REP,17
-Russell,Sol Rap,U.S. Senate,,Jerry Moran,REP,27
-Russell,Tky Crk,U.S. Senate,,Jerry Moran,REP,68
-Russell,Ctr,U.S. Senate,,Jerry Moran,REP,16
-Russell,Rnd Spg,U.S. Senate,,Jerry Moran,REP,14
-Russell,Glen,U.S. Senate,,Jerry Moran,REP,221
-Russell,Wnt Crk,U.S. Senate,,Jerry Moran,REP,20
-Russell,Hayes,U.S. Senate,,Jerry Moran,REP,15
-Russell,Blue,U.S. Senate,,Jerry Moran,REP,20
-Russell,Cwkr,U.S. Senate,,Jerry Moran,REP,204
-Russell,Carr,U.S. Senate,,Jerry Moran,REP,13
-Russell,Pitts,U.S. Senate,,Jerry Moran,REP,141
-Russell,Cust,U.S. Senate,,Jerry Moran,REP,56
-Russell,1st,President,,Gary Johnson,LBT,13
-Russell,2nd,President,,Gary Johnson,LBT,15
-Russell,3rd,President,,Gary Johnson,LBT,16
-Russell,4th,President,,Gary Johnson,LBT,11
-Russell,4th,President,,Gary Johnson,LBT,11
-Russell,Lulu,President,,Gary Johnson,LBT,1
-Russell,Ash,President,,Gary Johnson,LBT,0
-Russell,Log,President,,Gary Johnson,LBT,2
-Russell,Eur,President,,Gary Johnson,LBT,0
-Russell,Plum,President,,Gary Johnson,LBT,0
-Russell,Beloit,President,,Gary Johnson,LBT,5
-Russell,Bloom,President,,Gary Johnson,LBT,0
-Russell,Salt,President,,Gary Johnson,LBT,0
-Russell,Sol Rap,President,,Gary Johnson,LBT,1
-Russell,Tky Crk,President,,Gary Johnson,LBT,1
-Russell,Ctr,President,,Gary Johnson,LBT,2
-Russell,Rnd Spg,President,,Gary Johnson,LBT,1
-Russell,Glen,President,,Gary Johnson,LBT,8
-Russell,Wnt Crk,President,,Gary Johnson,LBT,1
-Russell,Hayes,President,,Gary Johnson,LBT,0
-Russell,Blue,President,,Gary Johnson,LBT,2
-Russell,Cwkr,President,,Gary Johnson,LBT,7
-Russell,Carr,President,,Gary Johnson,LBT,0
-Russell,Pitts,President,,Gary Johnson,LBT,2
-Russell,Cust,President,,Gary Johnson,LBT,1
-Russell,1st,U.S. House,1,Kerry Burt,LBT,10
-Russell,2nd,U.S. House,1,Kerry Burt,LBT,12
-Russell,3rd,U.S. House,1,Kerry Burt,LBT,17
-Russell,4th,U.S. House,1,Kerry Burt,LBT,9
-Russell,4th,U.S. House,1,Kerry Burt,LBT,9
-Russell,Lulu,U.S. House,1,Kerry Burt,LBT,1
-Russell,Ash,U.S. House,1,Kerry Burt,LBT,2
-Russell,Log,U.S. House,1,Kerry Burt,LBT,0
-Russell,Eur,U.S. House,1,Kerry Burt,LBT,0
-Russell,Plum,U.S. House,1,Kerry Burt,LBT,2
-Russell,Beloit,U.S. House,1,Kerry Burt,LBT,8
-Russell,Bloom,U.S. House,1,Kerry Burt,LBT,2
-Russell,Salt,U.S. House,1,Kerry Burt,LBT,0
-Russell,Sol Rap,U.S. House,1,Kerry Burt,LBT,2
-Russell,Tky Crk,U.S. House,1,Kerry Burt,LBT,2
-Russell,Ctr,U.S. House,1,Kerry Burt,LBT,0
-Russell,Rnd Spg,U.S. House,1,Kerry Burt,LBT,0
-Russell,Glen,U.S. House,1,Kerry Burt,LBT,7
-Russell,Wnt Crk,U.S. House,1,Kerry Burt,LBT,0
-Russell,Hayes,U.S. House,1,Kerry Burt,LBT,0
-Russell,Blue,U.S. House,1,Kerry Burt,LBT,2
-Russell,Cwkr,U.S. House,1,Kerry Burt,LBT,16
-Russell,Carr,U.S. House,1,Kerry Burt,LBT,0
-Russell,Pitts,U.S. House,1,Kerry Burt,LBT,7
-Russell,Cust,U.S. House,1,Kerry Burt,LBT,0
-Russell,1st,U.S. Senate,,Patrick Wiesner,DEM,31
-Russell,2nd,U.S. Senate,,Patrick Wiesner,DEM,74
-Russell,3rd,U.S. Senate,,Patrick Wiesner,DEM,65
-Russell,4th,U.S. Senate,,Patrick Wiesner,DEM,49
-Russell,4th,U.S. Senate,,Patrick Wiesner,DEM,49
-Russell,Lulu,U.S. Senate,,Patrick Wiesner,DEM,1
-Russell,Ash,U.S. Senate,,Patrick Wiesner,DEM,7
-Russell,Log,U.S. Senate,,Patrick Wiesner,DEM,5
-Russell,Eur,U.S. Senate,,Patrick Wiesner,DEM,2
-Russell,Plum,U.S. Senate,,Patrick Wiesner,DEM,3
-Russell,Beloit,U.S. Senate,,Patrick Wiesner,DEM,13
-Russell,Bloom,U.S. Senate,,Patrick Wiesner,DEM,3
-Russell,Salt,U.S. Senate,,Patrick Wiesner,DEM,0
-Russell,Sol Rap,U.S. Senate,,Patrick Wiesner,DEM,9
-Russell,Tky Crk,U.S. Senate,,Patrick Wiesner,DEM,3
-Russell,Ctr,U.S. Senate,,Patrick Wiesner,DEM,0
-Russell,Rnd Spg,U.S. Senate,,Patrick Wiesner,DEM,1
-Russell,Glen,U.S. Senate,,Patrick Wiesner,DEM,22
-Russell,Wnt Crk,U.S. Senate,,Patrick Wiesner,DEM,4
-Russell,Hayes,U.S. Senate,,Patrick Wiesner,DEM,1
-Russell,Blue,U.S. Senate,,Patrick Wiesner,DEM,0
-Russell,Cwkr,U.S. Senate,,Patrick Wiesner,DEM,27
-Russell,Carr,U.S. Senate,,Patrick Wiesner,DEM,0
-Russell,Pitts,U.S. Senate,,Patrick Wiesner,DEM,8
-Russell,Cust,U.S. Senate,,Patrick Wiesner,DEM,8
-Russell,1st,U.S. Senate,,Robert Garrard,LBT,14
-Russell,2nd,U.S. Senate,,Robert Garrard,LBT,13
-Russell,3rd,U.S. Senate,,Robert Garrard,LBT,21
-Russell,4th,U.S. Senate,,Robert Garrard,LBT,14
-Russell,4th,U.S. Senate,,Robert Garrard,LBT,14
-Russell,Lulu,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Ash,U.S. Senate,,Robert Garrard,LBT,6
-Russell,Log,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Eur,U.S. Senate,,Robert Garrard,LBT,0
-Russell,Plum,U.S. Senate,,Robert Garrard,LBT,3
-Russell,Beloit,U.S. Senate,,Robert Garrard,LBT,3
-Russell,Bloom,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Salt,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Sol Rap,U.S. Senate,,Robert Garrard,LBT,2
-Russell,Tky Crk,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Ctr,U.S. Senate,,Robert Garrard,LBT,0
-Russell,Rnd Spg,U.S. Senate,,Robert Garrard,LBT,0
-Russell,Glen,U.S. Senate,,Robert Garrard,LBT,11
-Russell,Wnt Crk,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Hayes,U.S. Senate,,Robert Garrard,LBT,1
-Russell,Blue,U.S. Senate,,Robert Garrard,LBT,2
-Russell,Cwkr,U.S. Senate,,Robert Garrard,LBT,10
-Russell,Carr,U.S. Senate,,Robert Garrard,LBT,0
-Russell,Pitts,U.S. Senate,,Robert Garrard,LBT,5
-Russell,Cust,U.S. Senate,,Robert Garrard,LBT,3
-Russell,1st,U.S. House,1,Roger Marshall,REP,182
-Russell,2nd,U.S. House,1,Roger Marshall,REP,331
-Russell,3rd,U.S. House,1,Roger Marshall,REP,321
-Russell,4th,U.S. House,1,Roger Marshall,REP,278
-Russell,4th,U.S. House,1,Roger Marshall,REP,278
-Russell,Lulu,U.S. House,1,Roger Marshall,REP,32
-Russell,Ash,U.S. House,1,Roger Marshall,REP,26
-Russell,Log,U.S. House,1,Roger Marshall,REP,30
-Russell,Eur,U.S. House,1,Roger Marshall,REP,9
-Russell,Plum,U.S. House,1,Roger Marshall,REP,51
-Russell,Beloit,U.S. House,1,Roger Marshall,REP,85
-Russell,Bloom,U.S. House,1,Roger Marshall,REP,34
-Russell,Salt,U.S. House,1,Roger Marshall,REP,15
-Russell,Sol Rap,U.S. House,1,Roger Marshall,REP,27
-Russell,Tky Crk,U.S. House,1,Roger Marshall,REP,54
-Russell,Ctr,U.S. House,1,Roger Marshall,REP,13
-Russell,Rnd Spg,U.S. House,1,Roger Marshall,REP,14
-Russell,Glen,U.S. House,1,Roger Marshall,REP,188
-Russell,Wnt Crk,U.S. House,1,Roger Marshall,REP,17
-Russell,Hayes,U.S. House,1,Roger Marshall,REP,14
-Russell,Blue,U.S. House,1,Roger Marshall,REP,14
-Russell,Cwkr,U.S. House,1,Roger Marshall,REP,168
-Russell,Carr,U.S. House,1,Roger Marshall,REP,9
-Russell,Pitts,U.S. House,1,Roger Marshall,REP,125
-Russell,Cust,U.S. House,1,Roger Marshall,REP,55
-Russell,1st,President,,Jill Stein,IND,4
-Russell,2nd,President,,Jill Stein,IND,4
-Russell,3rd,President,,Jill Stein,IND,7
-Russell,4th,President,,Jill Stein,IND,9
-Russell,4th,President,,Jill Stein,IND,9
-Russell,Lulu,President,,Jill Stein,IND,1
-Russell,Ash,President,,Jill Stein,IND,2
-Russell,Log,President,,Jill Stein,IND,0
-Russell,Eur,President,,Jill Stein,IND,0
-Russell,Plum,President,,Jill Stein,IND,0
-Russell,Beloit,President,,Jill Stein,IND,1
-Russell,Bloom,President,,Jill Stein,IND,0
-Russell,Salt,President,,Jill Stein,IND,1
-Russell,Sol Rap,President,,Jill Stein,IND,3
-Russell,Tky Crk,President,,Jill Stein,IND,2
-Russell,Ctr,President,,Jill Stein,IND,0
-Russell,Rnd Spg,President,,Jill Stein,IND,0
-Russell,Glen,President,,Jill Stein,IND,7
-Russell,Wnt Crk,President,,Jill Stein,IND,2
-Russell,Hayes,President,,Jill Stein,IND,1
-Russell,Blue,President,,Jill Stein,IND,0
-Russell,Cwkr,President,,Jill Stein,IND,6
-Russell,Carr,President,,Jill Stein,IND,0
-Russell,Pitts,President,,Jill Stein,IND,3
-Russell,Cust,President,,Jill Stein,IND,2
-Russell,1st,State House,107,Susan Concannon,REP,255
-Russell,2nd,State House,107,Susan Concannon,REP,442
-Russell,3rd,State House,107,Susan Concannon,REP,437
-Russell,4th,State House,107,Susan Concannon,REP,361
-Russell,4th,State House,107,Susan Concannon,REP,361
-Russell,Lulu,State House,107,Susan Concannon,REP,37
-Russell,Ash,State House,107,Susan Concannon,REP,46
-Russell,Log,State House,107,Susan Concannon,REP,44
-Russell,Eur,State House,107,Susan Concannon,REP,15
-Russell,Plum,State House,107,Susan Concannon,REP,59
-Russell,Beloit,State House,107,Susan Concannon,REP,114
-Russell,Bloom,State House,107,Susan Concannon,REP,38
-Russell,Salt,State House,107,Susan Concannon,REP,16
-Russell,Sol Rap,State House,107,Susan Concannon,REP,37
-Russell,Tky Crk,State House,107,Susan Concannon,REP,67
-Russell,Ctr,State House,107,Susan Concannon,REP,13
-Russell,Rnd Spg,State House,107,Susan Concannon,REP,13
-Russell,Glen,State House,107,Susan Concannon,REP,238
-Russell,Wnt Crk,State House,107,Susan Concannon,REP,23
-Russell,Hayes,State House,107,Susan Concannon,REP,17
-Russell,Blue,State House,107,Susan Concannon,REP,20
-Russell,Cwkr,State House,107,Susan Concannon,REP,222
-Russell,Carr,State House,107,Susan Concannon,REP,13
-Russell,Pitts,State House,107,Susan Concannon,REP,146
-Russell,Cust,State House,107,Susan Concannon,REP,64
-Russell,1st,President,,Donald Trump,REP,203
-Russell,2nd,President,,Donald Trump,REP,342
-Russell,3rd,President,,Donald Trump,REP,351
-Russell,4th,President,,Donald Trump,REP,286
-Russell,4th,President,,Donald Trump,REP,286
-Russell,Lulu,President,,Donald Trump,REP,36
-Russell,Ash,President,,Donald Trump,REP,36
-Russell,Log,President,,Donald Trump,REP,38
-Russell,Eur,President,,Donald Trump,REP,7
-Russell,Plum,President,,Donald Trump,REP,61
-Russell,Beloit,President,,Donald Trump,REP,91
-Russell,Bloom,President,,Donald Trump,REP,34
-Russell,Salt,President,,Donald Trump,REP,14
-Russell,Sol Rap,President,,Donald Trump,REP,28
-Russell,Tky Crk,President,,Donald Trump,REP,59
-Russell,Ctr,President,,Donald Trump,REP,13
-Russell,Rnd Spg,President,,Donald Trump,REP,15
-Russell,Glen,President,,Donald Trump,REP,200
-Russell,Wnt Crk,President,,Donald Trump,REP,19
-Russell,Hayes,President,,Donald Trump,REP,15
-Russell,Blue,President,,Donald Trump,REP,18
-Russell,Cwkr,President,,Donald Trump,REP,206
-Russell,Carr,President,,Donald Trump,REP,12
-Russell,Pitts,President,,Donald Trump,REP,134
-Russell,Cust,President,,Donald Trump,REP,90
+county,precinct,office,district,party,candidate,votes,vtd
+RUSSELL,Big Creek Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",218,000010
+RUSSELL,Center Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",127,000020
+RUSSELL,Fairfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000030
+RUSSELL,Fairview Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",190,000040
+RUSSELL,Grant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",99,000050
+RUSSELL,Lincoln Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",70,000060
+RUSSELL,Luray Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",99,000070
+RUSSELL,Paradise Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",82,000080
+RUSSELL,Plymouth Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",121,000090
+RUSSELL,Russell Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",62,000100
+RUSSELL,Russell Ward 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",420,000110
+RUSSELL,Russell Ward 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",483,000120
+RUSSELL,Russell Ward 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",424,000130
+RUSSELL,Russell Ward 4,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",455,00014A
+RUSSELL,Russell Ward 4 Exclave,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,00014C
+RUSSELL,Waldo Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",53,000150
+RUSSELL,Winterset Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",34,000160
+RUSSELL,Russell Township Exclave,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",0,900010
+RUSSELL,Big Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000010
+RUSSELL,Big Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",200,000010
+RUSSELL,Center Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",14,000020
+RUSSELL,Center Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",123,000020
+RUSSELL,Fairfield Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000030
+RUSSELL,Fairfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",20,000030
+RUSSELL,Fairview Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",56,000040
+RUSSELL,Fairview Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",159,000040
+RUSSELL,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000050
+RUSSELL,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",97,000050
+RUSSELL,Lincoln Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000060
+RUSSELL,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",58,000060
+RUSSELL,Luray Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",20,000070
+RUSSELL,Luray Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",86,000070
+RUSSELL,Paradise Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",13,000080
+RUSSELL,Paradise Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",74,000080
+RUSSELL,Plymouth Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",19,000090
+RUSSELL,Plymouth Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",103,000090
+RUSSELL,Russell Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000100
+RUSSELL,Russell Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000100
+RUSSELL,Russell Ward 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",49,000110
+RUSSELL,Russell Ward 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",388,000110
+RUSSELL,Russell Ward 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",75,000120
+RUSSELL,Russell Ward 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",431,000120
+RUSSELL,Russell Ward 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",58,000130
+RUSSELL,Russell Ward 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",388,000130
+RUSSELL,Russell Ward 4,Kansas Senate,36,Democratic,"Angevine, Brian G.",56,00014A
+RUSSELL,Russell Ward 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",412,00014A
+RUSSELL,Russell Ward 4 Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00014C
+RUSSELL,Waldo Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000150
+RUSSELL,Waldo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",43,000150
+RUSSELL,Winterset Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000160
+RUSSELL,Winterset Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",34,000160
+RUSSELL,Russell Township Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,900010
+RUSSELL,Russell Township Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,900010
+RUSSELL,Big Creek Township,President / Vice President,,independent,"Stein, Jill",1,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+RUSSELL,Big Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000010
+RUSSELL,Big Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+RUSSELL,Big Creek Township,President / Vice President,,Republican,"Trump, Donald J.",212,000010
+RUSSELL,Center Township,President / Vice President,,independent,"Stein, Jill",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+RUSSELL,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+RUSSELL,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000020
+RUSSELL,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000020
+RUSSELL,Center Township,President / Vice President,,Republican,"Trump, Donald J.",115,000020
+RUSSELL,Fairfield Township,President / Vice President,,independent,"Stein, Jill",1,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+RUSSELL,Fairfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+RUSSELL,Fairfield Township,President / Vice President,,Republican,"Trump, Donald J.",18,000030
+RUSSELL,Fairview Township,President / Vice President,,independent,"Stein, Jill",3,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+RUSSELL,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+RUSSELL,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000040
+RUSSELL,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000040
+RUSSELL,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",160,000040
+RUSSELL,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+RUSSELL,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+RUSSELL,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000050
+RUSSELL,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+RUSSELL,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",96,000050
+RUSSELL,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+RUSSELL,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000060
+RUSSELL,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000060
+RUSSELL,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",57,000060
+RUSSELL,Luray Township,President / Vice President,,independent,"Stein, Jill",3,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+RUSSELL,Luray Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+RUSSELL,Luray Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000070
+RUSSELL,Luray Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+RUSSELL,Luray Township,President / Vice President,,Republican,"Trump, Donald J.",86,000070
+RUSSELL,Paradise Township,President / Vice President,,independent,"Stein, Jill",1,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+RUSSELL,Paradise Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+RUSSELL,Paradise Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000080
+RUSSELL,Paradise Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+RUSSELL,Paradise Township,President / Vice President,,Republican,"Trump, Donald J.",78,000080
+RUSSELL,Plymouth Township,President / Vice President,,independent,"Stein, Jill",2,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+RUSSELL,Plymouth Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000090
+RUSSELL,Plymouth Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000090
+RUSSELL,Plymouth Township,President / Vice President,,Republican,"Trump, Donald J.",104,000090
+RUSSELL,Russell Township,President / Vice President,,independent,"Stein, Jill",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+RUSSELL,Russell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+RUSSELL,Russell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000100
+RUSSELL,Russell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+RUSSELL,Russell Township,President / Vice President,,Republican,"Trump, Donald J.",58,000100
+RUSSELL,Russell Ward 1,President / Vice President,,independent,"Stein, Jill",9,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",20,000110
+RUSSELL,Russell Ward 1,President / Vice President,,Republican,"Trump, Donald J.",359,000110
+RUSSELL,Russell Ward 2,President / Vice President,,independent,"Stein, Jill",10,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000120
+RUSSELL,Russell Ward 2,President / Vice President,,Republican,"Trump, Donald J.",402,000120
+RUSSELL,Russell Ward 3,President / Vice President,,independent,"Stein, Jill",8,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",79,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",12,000130
+RUSSELL,Russell Ward 3,President / Vice President,,Republican,"Trump, Donald J.",365,000130
+RUSSELL,Russell Ward 4,President / Vice President,,independent,"Stein, Jill",4,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Hedges, James A",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Smith, Mike",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",16,00014A
+RUSSELL,Russell Ward 4,President / Vice President,,Republican,"Trump, Donald J.",386,00014A
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+RUSSELL,Russell Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,independent,"Stein, Jill",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Castle, Darrell L",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Giordani, Rocky",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Hedges, James A",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Hoefling, Tom",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Kahn, Lynn",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"La Riva, Gloria",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Maturen, Michael A",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"McMullin, Evan",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Perry, Darryl",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Schriner, Joe C",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Smith, Mike",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Sood, Ajay",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Sterling, Shawna",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,President / Vice President,,Republican,"Trump, Donald J.",0,00014C
+RUSSELL,Waldo Township,President / Vice President,,independent,"Stein, Jill",1,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+RUSSELL,Waldo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+RUSSELL,Waldo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000150
+RUSSELL,Waldo Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+RUSSELL,Waldo Township,President / Vice President,,Republican,"Trump, Donald J.",46,000150
+RUSSELL,Winterset Township,President / Vice President,,independent,"Stein, Jill",1,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+RUSSELL,Winterset Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+RUSSELL,Winterset Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000160
+RUSSELL,Winterset Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+RUSSELL,Winterset Township,President / Vice President,,Republican,"Trump, Donald J.",32,000160
+RUSSELL,Russell Township Exclave,President / Vice President,,independent,"Stein, Jill",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+RUSSELL,Russell Township Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+RUSSELL,Big Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",50,000010
+RUSSELL,Big Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+RUSSELL,Big Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000010
+RUSSELL,Big Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",163,000010
+RUSSELL,Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",42,000020
+RUSSELL,Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+RUSSELL,Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000020
+RUSSELL,Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",90,000020
+RUSSELL,Fairfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000030
+RUSSELL,Fairfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+RUSSELL,Fairfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+RUSSELL,Fairfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000030
+RUSSELL,Fairview Township,United States House of Representatives,1,independent,"LaPolice, Alan",62,000040
+RUSSELL,Fairview Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+RUSSELL,Fairview Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000040
+RUSSELL,Fairview Township,United States House of Representatives,1,Republican,"Marshall, Roger",143,000040
+RUSSELL,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000050
+RUSSELL,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+RUSSELL,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000050
+RUSSELL,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",72,000050
+RUSSELL,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",17,000060
+RUSSELL,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+RUSSELL,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000060
+RUSSELL,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",53,000060
+RUSSELL,Luray Township,United States House of Representatives,1,independent,"LaPolice, Alan",33,000070
+RUSSELL,Luray Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+RUSSELL,Luray Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000070
+RUSSELL,Luray Township,United States House of Representatives,1,Republican,"Marshall, Roger",65,000070
+RUSSELL,Paradise Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000080
+RUSSELL,Paradise Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+RUSSELL,Paradise Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000080
+RUSSELL,Paradise Township,United States House of Representatives,1,Republican,"Marshall, Roger",54,000080
+RUSSELL,Plymouth Township,United States House of Representatives,1,independent,"LaPolice, Alan",36,000090
+RUSSELL,Plymouth Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+RUSSELL,Plymouth Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+RUSSELL,Plymouth Township,United States House of Representatives,1,Republican,"Marshall, Roger",93,000090
+RUSSELL,Russell Township,United States House of Representatives,1,independent,"LaPolice, Alan",28,000100
+RUSSELL,Russell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+RUSSELL,Russell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000100
+RUSSELL,Russell Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000100
+RUSSELL,Russell Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",128,000110
+RUSSELL,Russell Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000110
+RUSSELL,Russell Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000110
+RUSSELL,Russell Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",290,000110
+RUSSELL,Russell Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",166,000120
+RUSSELL,Russell Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000120
+RUSSELL,Russell Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000120
+RUSSELL,Russell Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",333,000120
+RUSSELL,Russell Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",132,000130
+RUSSELL,Russell Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000130
+RUSSELL,Russell Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000130
+RUSSELL,Russell Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",312,000130
+RUSSELL,Russell Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",145,00014A
+RUSSELL,Russell Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,00014A
+RUSSELL,Russell Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",17,00014A
+RUSSELL,Russell Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",306,00014A
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,independent,"LaPolice, Alan",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States House of Representatives,1,Republican,"Marshall, Roger",0,00014C
+RUSSELL,Waldo Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000150
+RUSSELL,Waldo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+RUSSELL,Waldo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000150
+RUSSELL,Waldo Township,United States House of Representatives,1,Republican,"Marshall, Roger",39,000150
+RUSSELL,Winterset Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000160
+RUSSELL,Winterset Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+RUSSELL,Winterset Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000160
+RUSSELL,Winterset Township,United States House of Representatives,1,Republican,"Marshall, Roger",24,000160
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+RUSSELL,Russell Township Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+RUSSELL,Big Creek Township,United States Senate,,write - in,"Smith, DJ",0,000010
+RUSSELL,Big Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000010
+RUSSELL,Big Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000010
+RUSSELL,Big Creek Township,United States Senate,,Republican,"Moran, Jerry",202,000010
+RUSSELL,Center Township,United States Senate,,write - in,"Smith, DJ",0,000020
+RUSSELL,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000020
+RUSSELL,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+RUSSELL,Center Township,United States Senate,,Republican,"Moran, Jerry",115,000020
+RUSSELL,Fairfield Township,United States Senate,,write - in,"Smith, DJ",0,000030
+RUSSELL,Fairfield Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000030
+RUSSELL,Fairfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+RUSSELL,Fairfield Township,United States Senate,,Republican,"Moran, Jerry",19,000030
+RUSSELL,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000040
+RUSSELL,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",41,000040
+RUSSELL,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000040
+RUSSELL,Fairview Township,United States Senate,,Republican,"Moran, Jerry",175,000040
+RUSSELL,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000050
+RUSSELL,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000050
+RUSSELL,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000050
+RUSSELL,Grant Township,United States Senate,,Republican,"Moran, Jerry",99,000050
+RUSSELL,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000060
+RUSSELL,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000060
+RUSSELL,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+RUSSELL,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",62,000060
+RUSSELL,Luray Township,United States Senate,,write - in,"Smith, DJ",0,000070
+RUSSELL,Luray Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000070
+RUSSELL,Luray Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000070
+RUSSELL,Luray Township,United States Senate,,Republican,"Moran, Jerry",84,000070
+RUSSELL,Paradise Township,United States Senate,,write - in,"Smith, DJ",0,000080
+RUSSELL,Paradise Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000080
+RUSSELL,Paradise Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000080
+RUSSELL,Paradise Township,United States Senate,,Republican,"Moran, Jerry",73,000080
+RUSSELL,Plymouth Township,United States Senate,,write - in,"Smith, DJ",0,000090
+RUSSELL,Plymouth Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000090
+RUSSELL,Plymouth Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000090
+RUSSELL,Plymouth Township,United States Senate,,Republican,"Moran, Jerry",118,000090
+RUSSELL,Russell Township,United States Senate,,write - in,"Smith, DJ",0,000100
+RUSSELL,Russell Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000100
+RUSSELL,Russell Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000100
+RUSSELL,Russell Township,United States Senate,,Republican,"Moran, Jerry",56,000100
+RUSSELL,Russell Ward 1,United States Senate,,write - in,"Smith, DJ",0,000110
+RUSSELL,Russell Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",45,000110
+RUSSELL,Russell Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",32,000110
+RUSSELL,Russell Ward 1,United States Senate,,Republican,"Moran, Jerry",366,000110
+RUSSELL,Russell Ward 2,United States Senate,,write - in,"Smith, DJ",0,000120
+RUSSELL,Russell Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",62,000120
+RUSSELL,Russell Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",27,000120
+RUSSELL,Russell Ward 2,United States Senate,,Republican,"Moran, Jerry",423,000120
+RUSSELL,Russell Ward 3,United States Senate,,write - in,"Smith, DJ",0,000130
+RUSSELL,Russell Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",61,000130
+RUSSELL,Russell Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",22,000130
+RUSSELL,Russell Ward 3,United States Senate,,Republican,"Moran, Jerry",375,000130
+RUSSELL,Russell Ward 4,United States Senate,,write - in,"Smith, DJ",0,00014A
+RUSSELL,Russell Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",65,00014A
+RUSSELL,Russell Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",23,00014A
+RUSSELL,Russell Ward 4,United States Senate,,Republican,"Moran, Jerry",387,00014A
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00014B
+RUSSELL,Russell Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00014B
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,write - in,"Smith, DJ",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,00014C
+RUSSELL,Russell Ward 4 Exclave Airport,United States Senate,,Republican,"Moran, Jerry",0,00014C
+RUSSELL,Waldo Township,United States Senate,,write - in,"Smith, DJ",0,000150
+RUSSELL,Waldo Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000150
+RUSSELL,Waldo Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000150
+RUSSELL,Waldo Township,United States Senate,,Republican,"Moran, Jerry",48,000150
+RUSSELL,Winterset Township,United States Senate,,write - in,"Smith, DJ",0,000160
+RUSSELL,Winterset Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000160
+RUSSELL,Winterset Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+RUSSELL,Winterset Township,United States Senate,,Republican,"Moran, Jerry",33,000160
+RUSSELL,Russell Township Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+RUSSELL,Russell Township Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+RUSSELL,Russell Township Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+RUSSELL,Russell Township Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__saline__precinct.csv
+++ b/2016/20161108__ks__general__saline__precinct.csv
@@ -1,858 +1,2434 @@
-county,precinct,office,district,party,candidate,votes
-Saline,1,President,,DEM,Hillary Clinton,133
-Saline,2,President,,DEM,Hillary Clinton,103
-Saline,3,President,,DEM,Hillary Clinton,97
-Saline,4,President,,DEM,Hillary Clinton,147
-Saline,5,President,,DEM,Hillary Clinton,132
-Saline,6,President,,DEM,Hillary Clinton,106
-Saline,7,President,,DEM,Hillary Clinton,137
-Saline,8,President,,DEM,Hillary Clinton,133
-Saline,9,President,,DEM,Hillary Clinton,120
-Saline,10,President,,DEM,Hillary Clinton,136
-Saline,11,President,,DEM,Hillary Clinton,111
-Saline,12,President,,DEM,Hillary Clinton,206
-Saline,13,President,,DEM,Hillary Clinton,103
-Saline,14,President,,DEM,Hillary Clinton,169
-Saline,15,President,,DEM,Hillary Clinton,151
-Saline,16,President,,DEM,Hillary Clinton,76
-Saline,17,President,,DEM,Hillary Clinton,125
-Saline,18,President,,DEM,Hillary Clinton,109
-Saline,19,President,,DEM,Hillary Clinton,134
-Saline,20,President,,DEM,Hillary Clinton,315
-Saline,21,President,,DEM,Hillary Clinton,311
-Saline,22,President,,DEM,Hillary Clinton,259
-Saline,23,President,,DEM,Hillary Clinton,315
-Saline,24,President,,DEM,Hillary Clinton,127
-Saline,25,President,,DEM,Hillary Clinton,106
-Saline,26,President,,DEM,Hillary Clinton,106
-Saline,27,President,,DEM,Hillary Clinton,159
-Saline,28,President,,DEM,Hillary Clinton,92
-Saline,29,President,,DEM,Hillary Clinton,164
-Saline,30,President,,DEM,Hillary Clinton,122
-Saline,31,President,,DEM,Hillary Clinton,321
-Saline,32,President,,DEM,Hillary Clinton,97
-Saline,33,President,,DEM,Hillary Clinton,197
-Saline,34,President,,DEM,Hillary Clinton,299
-Saline,35,President,,DEM,Hillary Clinton,215
-Saline,CA ,President,,DEM,Hillary Clinton,30
-Saline,DA ,President,,DEM,Hillary Clinton,13
-Saline,EC ,President,,DEM,Hillary Clinton,81
-Saline,EU ,President,,DEM,Hillary Clinton,49
-Saline,FA ,President,,DEM,Hillary Clinton,18
-Saline,GL ,President,,DEM,Hillary Clinton,8
-Saline,GR ,President,,DEM,Hillary Clinton,81
-Saline,GY ,President,,DEM,Hillary Clinton,4
-Saline,LI ,President,,DEM,Hillary Clinton,15
-Saline,OH ,President,,DEM,Hillary Clinton,33
-Saline,PV ,President,,DEM,Hillary Clinton,31
-Saline,SH ,President,,DEM,Hillary Clinton,35
-Saline,SV ,President,,DEM,Hillary Clinton,91
-Saline,SM ,President,,DEM,Hillary Clinton,65
-Saline,SO ,President,,DEM,Hillary Clinton,31
-Saline,SC ,President,,DEM,Hillary Clinton,29
-Saline,WL ,President,,DEM,Hillary Clinton,58
-Saline,WS ,President,,DEM,Hillary Clinton,12
-Saline,1,President,,REP,Donald J Trump,196
-Saline,2,President,,REP,Donald J Trump,169
-Saline,3,President,,REP,Donald J Trump,151
-Saline,4,President,,REP,Donald J Trump,197
-Saline,5,President,,REP,Donald J Trump,197
-Saline,6,President,,REP,Donald J Trump,149
-Saline,7,President,,REP,Donald J Trump,222
-Saline,8,President,,REP,Donald J Trump,187
-Saline,9,President,,REP,Donald J Trump,230
-Saline,10,President,,REP,Donald J Trump,175
-Saline,11,President,,REP,Donald J Trump,207
-Saline,12,President,,REP,Donald J Trump,279
-Saline,13,President,,REP,Donald J Trump,220
-Saline,14,President,,REP,Donald J Trump,258
-Saline,15,President,,REP,Donald J Trump,178
-Saline,16,President,,REP,Donald J Trump,172
-Saline,17,President,,REP,Donald J Trump,208
-Saline,18,President,,REP,Donald J Trump,207
-Saline,19,President,,REP,Donald J Trump,318
-Saline,20,President,,REP,Donald J Trump,620
-Saline,21,President,,REP,Donald J Trump,612
-Saline,22,President,,REP,Donald J Trump,557
-Saline,23,President,,REP,Donald J Trump,661
-Saline,24,President,,REP,Donald J Trump,208
-Saline,25,President,,REP,Donald J Trump,160
-Saline,26,President,,REP,Donald J Trump,203
-Saline,27,President,,REP,Donald J Trump,298
-Saline,28,President,,REP,Donald J Trump,258
-Saline,29,President,,REP,Donald J Trump,345
-Saline,30,President,,REP,Donald J Trump,303
-Saline,31,President,,REP,Donald J Trump,831
-Saline,32,President,,REP,Donald J Trump,213
-Saline,33,President,,REP,Donald J Trump,391
-Saline,34,President,,REP,Donald J Trump,725
-Saline,35,President,,REP,Donald J Trump,436
-Saline,CA ,President,,REP,Donald J Trump,173
-Saline,DA ,President,,REP,Donald J Trump,43
-Saline,EC ,President,,REP,Donald J Trump,372
-Saline,EU ,President,,REP,Donald J Trump,212
-Saline,FA ,President,,REP,Donald J Trump,114
-Saline,GL ,President,,REP,Donald J Trump,43
-Saline,GR ,President,,REP,Donald J Trump,357
-Saline,GY ,President,,REP,Donald J Trump,77
-Saline,LI ,President,,REP,Donald J Trump,84
-Saline,OH ,President,,REP,Donald J Trump,151
-Saline,PV ,President,,REP,Donald J Trump,148
-Saline,SH ,President,,REP,Donald J Trump,85
-Saline,SV ,President,,REP,Donald J Trump,296
-Saline,SM ,President,,REP,Donald J Trump,305
-Saline,SO ,President,,REP,Donald J Trump,156
-Saline,SC ,President,,REP,Donald J Trump,163
-Saline,WL ,President,,REP,Donald J Trump,251
-Saline,WS ,President,,REP,Donald J Trump,57
-Saline,1,President,,LBT,Gary Johnson,23
-Saline,2,President,,LBT,Gary Johnson,35
-Saline,3,President,,LBT,Gary Johnson,30
-Saline,4,President,,LBT,Gary Johnson,21
-Saline,5,President,,LBT,Gary Johnson,30
-Saline,6,President,,LBT,Gary Johnson,24
-Saline,7,President,,LBT,Gary Johnson,38
-Saline,8,President,,LBT,Gary Johnson,37
-Saline,9,President,,LBT,Gary Johnson,38
-Saline,10,President,,LBT,Gary Johnson,41
-Saline,11,President,,LBT,Gary Johnson,26
-Saline,12,President,,LBT,Gary Johnson,42
-Saline,13,President,,LBT,Gary Johnson,17
-Saline,14,President,,LBT,Gary Johnson,37
-Saline,15,President,,LBT,Gary Johnson,17
-Saline,16,President,,LBT,Gary Johnson,27
-Saline,17,President,,LBT,Gary Johnson,25
-Saline,18,President,,LBT,Gary Johnson,29
-Saline,19,President,,LBT,Gary Johnson,28
-Saline,20,President,,LBT,Gary Johnson,46
-Saline,21,President,,LBT,Gary Johnson,44
-Saline,22,President,,LBT,Gary Johnson,45
-Saline,23,President,,LBT,Gary Johnson,47
-Saline,24,President,,LBT,Gary Johnson,23
-Saline,25,President,,LBT,Gary Johnson,22
-Saline,26,President,,LBT,Gary Johnson,28
-Saline,27,President,,LBT,Gary Johnson,24
-Saline,28,President,,LBT,Gary Johnson,27
-Saline,29,President,,LBT,Gary Johnson,36
-Saline,30,President,,LBT,Gary Johnson,30
-Saline,31,President,,LBT,Gary Johnson,65
-Saline,32,President,,LBT,Gary Johnson,18
-Saline,33,President,,LBT,Gary Johnson,40
-Saline,34,President,,LBT,Gary Johnson,70
-Saline,35,President,,LBT,Gary Johnson,56
-Saline,CA ,President,,LBT,Gary Johnson,17
-Saline,DA ,President,,LBT,Gary Johnson,2
-Saline,EC ,President,,LBT,Gary Johnson,24
-Saline,EU ,President,,LBT,Gary Johnson,12
-Saline,FA ,President,,LBT,Gary Johnson,6
-Saline,GL ,President,,LBT,Gary Johnson,0
-Saline,GR ,President,,LBT,Gary Johnson,17
-Saline,GY ,President,,LBT,Gary Johnson,1
-Saline,LI ,President,,LBT,Gary Johnson,1
-Saline,OH ,President,,LBT,Gary Johnson,9
-Saline,PV ,President,,LBT,Gary Johnson,12
-Saline,SH ,President,,LBT,Gary Johnson,10
-Saline,SV ,President,,LBT,Gary Johnson,24
-Saline,SM ,President,,LBT,Gary Johnson,20
-Saline,SO ,President,,LBT,Gary Johnson,7
-Saline,SC ,President,,LBT,Gary Johnson,11
-Saline,WL ,President,,LBT,Gary Johnson,15
-Saline,WS ,President,,LBT,Gary Johnson,4
-Saline,1,President,,IND,Jill Stein,9
-Saline,2,President,,IND,Jill Stein,14
-Saline,3,President,,IND,Jill Stein,8
-Saline,4,President,,IND,Jill Stein,12
-Saline,5,President,,IND,Jill Stein,16
-Saline,6,President,,IND,Jill Stein,13
-Saline,7,President,,IND,Jill Stein,17
-Saline,8,President,,IND,Jill Stein,8
-Saline,9,President,,IND,Jill Stein,13
-Saline,10,President,,IND,Jill Stein,11
-Saline,11,President,,IND,Jill Stein,10
-Saline,12,President,,IND,Jill Stein,6
-Saline,13,President,,IND,Jill Stein,13
-Saline,14,President,,IND,Jill Stein,12
-Saline,15,President,,IND,Jill Stein,13
-Saline,16,President,,IND,Jill Stein,9
-Saline,17,President,,IND,Jill Stein,10
-Saline,18,President,,IND,Jill Stein,6
-Saline,19,President,,IND,Jill Stein,3
-Saline,20,President,,IND,Jill Stein,8
-Saline,21,President,,IND,Jill Stein,10
-Saline,22,President,,IND,Jill Stein,16
-Saline,23,President,,IND,Jill Stein,16
-Saline,24,President,,IND,Jill Stein,5
-Saline,25,President,,IND,Jill Stein,8
-Saline,26,President,,IND,Jill Stein,9
-Saline,27,President,,IND,Jill Stein,15
-Saline,28,President,,IND,Jill Stein,14
-Saline,29,President,,IND,Jill Stein,15
-Saline,30,President,,IND,Jill Stein,11
-Saline,31,President,,IND,Jill Stein,18
-Saline,32,President,,IND,Jill Stein,4
-Saline,33,President,,IND,Jill Stein,7
-Saline,34,President,,IND,Jill Stein,23
-Saline,35,President,,IND,Jill Stein,14
-Saline,CA ,President,,IND,Jill Stein,1
-Saline,DA ,President,,IND,Jill Stein,1
-Saline,EC ,President,,IND,Jill Stein,16
-Saline,EU ,President,,IND,Jill Stein,6
-Saline,FA ,President,,IND,Jill Stein,1
-Saline,GL ,President,,IND,Jill Stein,0
-Saline,GR ,President,,IND,Jill Stein,3
-Saline,GY ,President,,IND,Jill Stein,1
-Saline,LI ,President,,IND,Jill Stein,1
-Saline,OH ,President,,IND,Jill Stein,3
-Saline,PV ,President,,IND,Jill Stein,2
-Saline,SH ,President,,IND,Jill Stein,2
-Saline,SV ,President,,IND,Jill Stein,10
-Saline,SM ,President,,IND,Jill Stein,7
-Saline,SO ,President,,IND,Jill Stein,5
-Saline,SC ,President,,IND,Jill Stein,2
-Saline,WL ,President,,IND,Jill Stein,3
-Saline,WS ,President,,IND,Jill Stein,1
-Saline,4,President,,,Darrell Castle,1
-Saline,9,President,,,Darrell Castle,1
-Saline,11,President,,,Darrell Castle,1
-Saline,14,President,,,Darrell Castle,1
-Saline,19,President,,,Darrell Castle,1
-Saline,1,President,,,Hoefling/Schulin,1
-Saline,5,President,,,Hoefling/Schulin,1
-Saline,8,President,,,Riva/Puryer,1
-Saline,6,President,,,Maturen/Munoz,1
-Saline,1,President,,,Evan McMullin,3
-Saline,2,President,,,Evan McMullin,1
-Saline,4,President,,,Evan McMullin,3
-Saline,5,President,,,Evan McMullin,1
-Saline,7,President,,,Evan McMullin,3
-Saline,8,President,,,Evan McMullin,2
-Saline,9,President,,,Evan McMullin,1
-Saline,10,President,,,Evan McMullin,3
-Saline,11,President,,,Evan McMullin,4
-Saline,12,President,,,Evan McMullin,2
-Saline,16,President,,,Evan McMullin,3
-Saline,18,President,,,Evan McMullin,5
-Saline,19,President,,,Evan McMullin,2
-Saline,20,President,,,Evan McMullin,11
-Saline,21,President,,,Evan McMullin,3
-Saline,22,President,,,Evan McMullin,2
-Saline,23,President,,,Evan McMullin,7
-Saline,25,President,,,Evan McMullin,1
-Saline,26,President,,,Evan McMullin,1
-Saline,27,President,,,Evan McMullin,3
-Saline,28,President,,,Evan McMullin,2
-Saline,29,President,,,Evan McMullin,1
-Saline,31,President,,,Evan McMullin,3
-Saline,SV ,President,,,Evan McMullin,2
-Saline,SM ,President,,,Evan McMullin,1
-Saline,11,President,,,Sood/Mende,1
-Saline,1,U.S. Senate,,DEM,Patrick Wiesner,112
-Saline,2,U.S. Senate,,DEM,Patrick Wiesner,95
-Saline,3,U.S. Senate,,DEM,Patrick Wiesner,101
-Saline,4,U.S. Senate,,DEM,Patrick Wiesner,141
-Saline,5,U.S. Senate,,DEM,Patrick Wiesner,121
-Saline,6,U.S. Senate,,DEM,Patrick Wiesner,103
-Saline,7,U.S. Senate,,DEM,Patrick Wiesner,117
-Saline,8,U.S. Senate,,DEM,Patrick Wiesner,106
-Saline,9,U.S. Senate,,DEM,Patrick Wiesner,110
-Saline,10,U.S. Senate,,DEM,Patrick Wiesner,124
-Saline,11,U.S. Senate,,DEM,Patrick Wiesner,97
-Saline,12,U.S. Senate,,DEM,Patrick Wiesner,171
-Saline,13,U.S. Senate,,DEM,Patrick Wiesner,99
-Saline,14,U.S. Senate,,DEM,Patrick Wiesner,142
-Saline,15,U.S. Senate,,DEM,Patrick Wiesner,128
-Saline,16,U.S. Senate,,DEM,Patrick Wiesner,76
-Saline,17,U.S. Senate,,DEM,Patrick Wiesner,102
-Saline,18,U.S. Senate,,DEM,Patrick Wiesner,94
-Saline,19,U.S. Senate,,DEM,Patrick Wiesner,97
-Saline,20,U.S. Senate,,DEM,Patrick Wiesner,190
-Saline,21,U.S. Senate,,DEM,Patrick Wiesner,204
-Saline,22,U.S. Senate,,DEM,Patrick Wiesner,165
-Saline,23,U.S. Senate,,DEM,Patrick Wiesner,238
-Saline,24,U.S. Senate,,DEM,Patrick Wiesner,105
-Saline,25,U.S. Senate,,DEM,Patrick Wiesner,97
-Saline,26,U.S. Senate,,DEM,Patrick Wiesner,89
-Saline,27,U.S. Senate,,DEM,Patrick Wiesner,108
-Saline,28,U.S. Senate,,DEM,Patrick Wiesner,89
-Saline,29,U.S. Senate,,DEM,Patrick Wiesner,117
-Saline,30,U.S. Senate,,DEM,Patrick Wiesner,104
-Saline,31,U.S. Senate,,DEM,Patrick Wiesner,257
-Saline,32,U.S. Senate,,DEM,Patrick Wiesner,71
-Saline,33,U.S. Senate,,DEM,Patrick Wiesner,151
-Saline,34,U.S. Senate,,DEM,Patrick Wiesner,243
-Saline,35,U.S. Senate,,DEM,Patrick Wiesner,197
-Saline,CA ,U.S. Senate,,DEM,Patrick Wiesner,29
-Saline,DA ,U.S. Senate,,DEM,Patrick Wiesner,12
-Saline,EC ,U.S. Senate,,DEM,Patrick Wiesner,56
-Saline,EU ,U.S. Senate,,DEM,Patrick Wiesner,45
-Saline,FA ,U.S. Senate,,DEM,Patrick Wiesner,17
-Saline,GL ,U.S. Senate,,DEM,Patrick Wiesner,6
-Saline,GR ,U.S. Senate,,DEM,Patrick Wiesner,71
-Saline,GY ,U.S. Senate,,DEM,Patrick Wiesner,5
-Saline,LI ,U.S. Senate,,DEM,Patrick Wiesner,11
-Saline,OH ,U.S. Senate,,DEM,Patrick Wiesner,27
-Saline,PV ,U.S. Senate,,DEM,Patrick Wiesner,21
-Saline,SH ,U.S. Senate,,DEM,Patrick Wiesner,29
-Saline,SV ,U.S. Senate,,DEM,Patrick Wiesner,70
-Saline,SM ,U.S. Senate,,DEM,Patrick Wiesner,56
-Saline,SO ,U.S. Senate,,DEM,Patrick Wiesner,22
-Saline,SC ,U.S. Senate,,DEM,Patrick Wiesner,25
-Saline,WL ,U.S. Senate,,DEM,Patrick Wiesner,49
-Saline,WS ,U.S. Senate,,DEM,Patrick Wiesner,5
-Saline,1,U.S. Senate,,LBT,Robert D Garrard,36
-Saline,2,U.S. Senate,,LBT,Robert D Garrard,47
-Saline,3,U.S. Senate,,LBT,Robert D Garrard,40
-Saline,4,U.S. Senate,,LBT,Robert D Garrard,46
-Saline,5,U.S. Senate,,LBT,Robert D Garrard,39
-Saline,6,U.S. Senate,,LBT,Robert D Garrard,28
-Saline,7,U.S. Senate,,LBT,Robert D Garrard,42
-Saline,8,U.S. Senate,,LBT,Robert D Garrard,38
-Saline,9,U.S. Senate,,LBT,Robert D Garrard,51
-Saline,10,U.S. Senate,,LBT,Robert D Garrard,33
-Saline,11,U.S. Senate,,LBT,Robert D Garrard,30
-Saline,12,U.S. Senate,,LBT,Robert D Garrard,48
-Saline,13,U.S. Senate,,LBT,Robert D Garrard,37
-Saline,14,U.S. Senate,,LBT,Robert D Garrard,38
-Saline,15,U.S. Senate,,LBT,Robert D Garrard,29
-Saline,16,U.S. Senate,,LBT,Robert D Garrard,25
-Saline,17,U.S. Senate,,LBT,Robert D Garrard,35
-Saline,18,U.S. Senate,,LBT,Robert D Garrard,36
-Saline,19,U.S. Senate,,LBT,Robert D Garrard,33
-Saline,20,U.S. Senate,,LBT,Robert D Garrard,54
-Saline,21,U.S. Senate,,LBT,Robert D Garrard,30
-Saline,22,U.S. Senate,,LBT,Robert D Garrard,47
-Saline,23,U.S. Senate,,LBT,Robert D Garrard,58
-Saline,24,U.S. Senate,,LBT,Robert D Garrard,29
-Saline,25,U.S. Senate,,LBT,Robert D Garrard,34
-Saline,26,U.S. Senate,,LBT,Robert D Garrard,26
-Saline,27,U.S. Senate,,LBT,Robert D Garrard,43
-Saline,28,U.S. Senate,,LBT,Robert D Garrard,37
-Saline,29,U.S. Senate,,LBT,Robert D Garrard,36
-Saline,30,U.S. Senate,,LBT,Robert D Garrard,32
-Saline,31,U.S. Senate,,LBT,Robert D Garrard,67
-Saline,32,U.S. Senate,,LBT,Robert D Garrard,20
-Saline,33,U.S. Senate,,LBT,Robert D Garrard,36
-Saline,34,U.S. Senate,,LBT,Robert D Garrard,69
-Saline,35,U.S. Senate,,LBT,Robert D Garrard,78
-Saline,CA ,U.S. Senate,,LBT,Robert D Garrard,24
-Saline,DA ,U.S. Senate,,LBT,Robert D Garrard,1
-Saline,EC ,U.S. Senate,,LBT,Robert D Garrard,33
-Saline,EU ,U.S. Senate,,LBT,Robert D Garrard,20
-Saline,FA ,U.S. Senate,,LBT,Robert D Garrard,14
-Saline,GL ,U.S. Senate,,LBT,Robert D Garrard,3
-Saline,GR ,U.S. Senate,,LBT,Robert D Garrard,27
-Saline,GY ,U.S. Senate,,LBT,Robert D Garrard,4
-Saline,LI ,U.S. Senate,,LBT,Robert D Garrard,4
-Saline,OH ,U.S. Senate,,LBT,Robert D Garrard,7
-Saline,PV ,U.S. Senate,,LBT,Robert D Garrard,15
-Saline,SH ,U.S. Senate,,LBT,Robert D Garrard,8
-Saline,SV ,U.S. Senate,,LBT,Robert D Garrard,32
-Saline,SM ,U.S. Senate,,LBT,Robert D Garrard,31
-Saline,SO ,U.S. Senate,,LBT,Robert D Garrard,10
-Saline,SC ,U.S. Senate,,LBT,Robert D Garrard,19
-Saline,WL ,U.S. Senate,,LBT,Robert D Garrard,16
-Saline,WS ,U.S. Senate,,LBT,Robert D Garrard,0
-Saline,1,U.S. Senate,,REP,Jerry Moran,196
-Saline,2,U.S. Senate,,REP,Jerry Moran,181
-Saline,3,U.S. Senate,,REP,Jerry Moran,141
-Saline,4,U.S. Senate,,REP,Jerry Moran,186
-Saline,5,U.S. Senate,,REP,Jerry Moran,220
-Saline,6,U.S. Senate,,REP,Jerry Moran,161
-Saline,7,U.S. Senate,,REP,Jerry Moran,249
-Saline,8,U.S. Senate,,REP,Jerry Moran,222
-Saline,9,U.S. Senate,,REP,Jerry Moran,238
-Saline,10,U.S. Senate,,REP,Jerry Moran,202
-Saline,11,U.S. Senate,,REP,Jerry Moran,226
-Saline,12,U.S. Senate,,REP,Jerry Moran,304
-Saline,13,U.S. Senate,,REP,Jerry Moran,218
-Saline,14,U.S. Senate,,REP,Jerry Moran,289
-Saline,15,U.S. Senate,,REP,Jerry Moran,185
-Saline,16,U.S. Senate,,REP,Jerry Moran,178
-Saline,17,U.S. Senate,,REP,Jerry Moran,226
-Saline,18,U.S. Senate,,REP,Jerry Moran,218
-Saline,19,U.S. Senate,,REP,Jerry Moran,359
-Saline,20,U.S. Senate,,REP,Jerry Moran,754
-Saline,21,U.S. Senate,,REP,Jerry Moran,748
-Saline,22,U.S. Senate,,REP,Jerry Moran,675
-Saline,23,U.S. Senate,,REP,Jerry Moran,745
-Saline,24,U.S. Senate,,REP,Jerry Moran,232
-Saline,25,U.S. Senate,,REP,Jerry Moran,167
-Saline,26,U.S. Senate,,REP,Jerry Moran,226
-Saline,27,U.S. Senate,,REP,Jerry Moran,335
-Saline,28,U.S. Senate,,REP,Jerry Moran,263
-Saline,29,U.S. Senate,,REP,Jerry Moran,402
-Saline,30,U.S. Senate,,REP,Jerry Moran,323
-Saline,31,U.S. Senate,,REP,Jerry Moran,909
-Saline,32,U.S. Senate,,REP,Jerry Moran,238
-Saline,33,U.S. Senate,,REP,Jerry Moran,453
-Saline,34,U.S. Senate,,REP,Jerry Moran,811
-Saline,35,U.S. Senate,,REP,Jerry Moran,438
-Saline,CA ,U.S. Senate,,REP,Jerry Moran,166
-Saline,DA ,U.S. Senate,,REP,Jerry Moran,47
-Saline,EC ,U.S. Senate,,REP,Jerry Moran,407
-Saline,EU ,U.S. Senate,,REP,Jerry Moran,214
-Saline,FA ,U.S. Senate,,REP,Jerry Moran,110
-Saline,GL ,U.S. Senate,,REP,Jerry Moran,40
-Saline,GR ,U.S. Senate,,REP,Jerry Moran,359
-Saline,GY ,U.S. Senate,,REP,Jerry Moran,73
-Saline,LI ,U.S. Senate,,REP,Jerry Moran,83
-Saline,OH ,U.S. Senate,,REP,Jerry Moran,162
-Saline,PV ,U.S. Senate,,REP,Jerry Moran,156
-Saline,SH ,U.S. Senate,,REP,Jerry Moran,98
-Saline,SV ,U.S. Senate,,REP,Jerry Moran,328
-Saline,SM ,U.S. Senate,,REP,Jerry Moran,310
-Saline,SO ,U.S. Senate,,REP,Jerry Moran,174
-Saline,SC ,U.S. Senate,,REP,Jerry Moran,154
-Saline,WL ,U.S. Senate,,REP,Jerry Moran,255
-Saline,WS ,U.S. Senate,,REP,Jerry Moran,69
-Saline,1,U.S. House,1,REP,Roger Marshall,161
-Saline,2,U.S. House,1,REP,Roger Marshall,143
-Saline,3,U.S. House,1,REP,Roger Marshall,137
-Saline,4,U.S. House,1,REP,Roger Marshall,161
-Saline,5,U.S. House,1,REP,Roger Marshall,156
-Saline,6,U.S. House,1,REP,Roger Marshall,128
-Saline,7,U.S. House,1,REP,Roger Marshall,192
-Saline,8,U.S. House,1,REP,Roger Marshall,177
-Saline,9,U.S. House,1,REP,Roger Marshall,207
-Saline,10,U.S. House,1,REP,Roger Marshall,164
-Saline,11,U.S. House,1,REP,Roger Marshall,183
-Saline,12,U.S. House,1,REP,Roger Marshall,246
-Saline,13,U.S. House,1,REP,Roger Marshall,188
-Saline,14,U.S. House,1,REP,Roger Marshall,242
-Saline,15,U.S. House,1,REP,Roger Marshall,157
-Saline,16,U.S. House,1,REP,Roger Marshall,142
-Saline,17,U.S. House,1,REP,Roger Marshall,197
-Saline,18,U.S. House,1,REP,Roger Marshall,164
-Saline,19,U.S. House,1,REP,Roger Marshall,307
-Saline,20,U.S. House,1,REP,Roger Marshall,588
-Saline,21,U.S. House,1,REP,Roger Marshall,547
-Saline,22,U.S. House,1,REP,Roger Marshall,537
-Saline,23,U.S. House,1,REP,Roger Marshall,567
-Saline,24,U.S. House,1,REP,Roger Marshall,192
-Saline,25,U.S. House,1,REP,Roger Marshall,127
-Saline,26,U.S. House,1,REP,Roger Marshall,167
-Saline,27,U.S. House,1,REP,Roger Marshall,276
-Saline,28,U.S. House,1,REP,Roger Marshall,208
-Saline,29,U.S. House,1,REP,Roger Marshall,315
-Saline,30,U.S. House,1,REP,Roger Marshall,237
-Saline,31,U.S. House,1,REP,Roger Marshall,728
-Saline,32,U.S. House,1,REP,Roger Marshall,192
-Saline,33,U.S. House,1,REP,Roger Marshall,353
-Saline,34,U.S. House,1,REP,Roger Marshall,619
-Saline,35,U.S. House,1,REP,Roger Marshall,357
-Saline,CA ,U.S. House,1,REP,Roger Marshall,126
-Saline,DA ,U.S. House,1,REP,Roger Marshall,43
-Saline,EC ,U.S. House,1,REP,Roger Marshall,313
-Saline,EU ,U.S. House,1,REP,Roger Marshall,165
-Saline,FA ,U.S. House,1,REP,Roger Marshall,80
-Saline,GL ,U.S. House,1,REP,Roger Marshall,35
-Saline,GR ,U.S. House,1,REP,Roger Marshall,293
-Saline,GY ,U.S. House,1,REP,Roger Marshall,57
-Saline,LI ,U.S. House,1,REP,Roger Marshall,67
-Saline,OH ,U.S. House,1,REP,Roger Marshall,120
-Saline,PV ,U.S. House,1,REP,Roger Marshall,131
-Saline,SH ,U.S. House,1,REP,Roger Marshall,75
-Saline,SV ,U.S. House,1,REP,Roger Marshall,239
-Saline,SM ,U.S. House,1,REP,Roger Marshall,229
-Saline,SO ,U.S. House,1,REP,Roger Marshall,130
-Saline,SC ,U.S. House,1,REP,Roger Marshall,131
-Saline,WL ,U.S. House,1,REP,Roger Marshall,191
-Saline,WS ,U.S. House,1,REP,Roger Marshall,51
-Saline,1,U.S. House,1,LBT,Kerry Burt,48
-Saline,2,U.S. House,1,LBT,Kerry Burt,52
-Saline,3,U.S. House,1,LBT,Kerry Burt,30
-Saline,4,U.S. House,1,LBT,Kerry Burt,38
-Saline,5,U.S. House,1,LBT,Kerry Burt,57
-Saline,6,U.S. House,1,LBT,Kerry Burt,34
-Saline,7,U.S. House,1,LBT,Kerry Burt,58
-Saline,8,U.S. House,1,LBT,Kerry Burt,39
-Saline,9,U.S. House,1,LBT,Kerry Burt,46
-Saline,10,U.S. House,1,LBT,Kerry Burt,28
-Saline,11,U.S. House,1,LBT,Kerry Burt,30
-Saline,12,U.S. House,1,LBT,Kerry Burt,51
-Saline,13,U.S. House,1,LBT,Kerry Burt,31
-Saline,14,U.S. House,1,LBT,Kerry Burt,50
-Saline,15,U.S. House,1,LBT,Kerry Burt,51
-Saline,16,U.S. House,1,LBT,Kerry Burt,27
-Saline,17,U.S. House,1,LBT,Kerry Burt,28
-Saline,18,U.S. House,1,LBT,Kerry Burt,32
-Saline,19,U.S. House,1,LBT,Kerry Burt,24
-Saline,20,U.S. House,1,LBT,Kerry Burt,49
-Saline,21,U.S. House,1,LBT,Kerry Burt,40
-Saline,22,U.S. House,1,LBT,Kerry Burt,51
-Saline,23,U.S. House,1,LBT,Kerry Burt,43
-Saline,24,U.S. House,1,LBT,Kerry Burt,31
-Saline,25,U.S. House,1,LBT,Kerry Burt,33
-Saline,26,U.S. House,1,LBT,Kerry Burt,24
-Saline,27,U.S. House,1,LBT,Kerry Burt,38
-Saline,28,U.S. House,1,LBT,Kerry Burt,34
-Saline,29,U.S. House,1,LBT,Kerry Burt,40
-Saline,30,U.S. House,1,LBT,Kerry Burt,27
-Saline,31,U.S. House,1,LBT,Kerry Burt,61
-Saline,32,U.S. House,1,LBT,Kerry Burt,10
-Saline,33,U.S. House,1,LBT,Kerry Burt,46
-Saline,34,U.S. House,1,LBT,Kerry Burt,71
-Saline,35,U.S. House,1,LBT,Kerry Burt,82
-Saline,CA ,U.S. House,1,LBT,Kerry Burt,16
-Saline,DA ,U.S. House,1,LBT,Kerry Burt,5
-Saline,EC ,U.S. House,1,LBT,Kerry Burt,20
-Saline,EU ,U.S. House,1,LBT,Kerry Burt,9
-Saline,FA ,U.S. House,1,LBT,Kerry Burt,9
-Saline,GL ,U.S. House,1,LBT,Kerry Burt,2
-Saline,GR ,U.S. House,1,LBT,Kerry Burt,16
-Saline,GY ,U.S. House,1,LBT,Kerry Burt,3
-Saline,LI ,U.S. House,1,LBT,Kerry Burt,3
-Saline,OH ,U.S. House,1,LBT,Kerry Burt,9
-Saline,PV ,U.S. House,1,LBT,Kerry Burt,11
-Saline,SH ,U.S. House,1,LBT,Kerry Burt,8
-Saline,SV ,U.S. House,1,LBT,Kerry Burt,28
-Saline,SM ,U.S. House,1,LBT,Kerry Burt,24
-Saline,SO ,U.S. House,1,LBT,Kerry Burt,9
-Saline,SC ,U.S. House,1,LBT,Kerry Burt,9
-Saline,WL ,U.S. House,1,LBT,Kerry Burt,15
-Saline,WS ,U.S. House,1,LBT,Kerry Burt,3
-Saline,1,U.S. House,1,IND,Alan LaPolice,113
-Saline,2,U.S. House,1,IND,Alan LaPolice,122
-Saline,3,U.S. House,1,IND,Alan LaPolice,113
-Saline,4,U.S. House,1,IND,Alan LaPolice,153
-Saline,5,U.S. House,1,IND,Alan LaPolice,151
-Saline,6,U.S. House,1,IND,Alan LaPolice,114
-Saline,7,U.S. House,1,IND,Alan LaPolice,158
-Saline,8,U.S. House,1,IND,Alan LaPolice,136
-Saline,9,U.S. House,1,IND,Alan LaPolice,134
-Saline,10,U.S. House,1,IND,Alan LaPolice,157
-Saline,11,U.S. House,1,IND,Alan LaPolice,136
-Saline,12,U.S. House,1,IND,Alan LaPolice,223
-Saline,13,U.S. House,1,IND,Alan LaPolice,127
-Saline,14,U.S. House,1,IND,Alan LaPolice,165
-Saline,15,U.S. House,1,IND,Alan LaPolice,122
-Saline,16,U.S. House,1,IND,Alan LaPolice,103
-Saline,17,U.S. House,1,IND,Alan LaPolice,134
-Saline,18,U.S. House,1,IND,Alan LaPolice,147
-Saline,19,U.S. House,1,IND,Alan LaPolice,153
-Saline,20,U.S. House,1,IND,Alan LaPolice,354
-Saline,21,U.S. House,1,IND,Alan LaPolice,367
-Saline,22,U.S. House,1,IND,Alan LaPolice,284
-Saline,23,U.S. House,1,IND,Alan LaPolice,415
-Saline,24,U.S. House,1,IND,Alan LaPolice,137
-Saline,25,U.S. House,1,IND,Alan LaPolice,131
-Saline,26,U.S. House,1,IND,Alan LaPolice,143
-Saline,27,U.S. House,1,IND,Alan LaPolice,168
-Saline,28,U.S. House,1,IND,Alan LaPolice,141
-Saline,29,U.S. House,1,IND,Alan LaPolice,186
-Saline,30,U.S. House,1,IND,Alan LaPolice,197
-Saline,31,U.S. House,1,IND,Alan LaPolice,432
-Saline,32,U.S. House,1,IND,Alan LaPolice,120
-Saline,33,U.S. House,1,IND,Alan LaPolice,224
-Saline,34,U.S. House,1,IND,Alan LaPolice,396
-Saline,35,U.S. House,1,IND,Alan LaPolice,266
-Saline,CA ,U.S. House,1,IND,Alan LaPolice,75
-Saline,DA ,U.S. House,1,IND,Alan LaPolice,10
-Saline,EC ,U.S. House,1,IND,Alan LaPolice,158
-Saline,EU ,U.S. House,1,IND,Alan LaPolice,102
-Saline,FA ,U.S. House,1,IND,Alan LaPolice,49
-Saline,GL ,U.S. House,1,IND,Alan LaPolice,14
-Saline,GR ,U.S. House,1,IND,Alan LaPolice,144
-Saline,GY ,U.S. House,1,IND,Alan LaPolice,22
-Saline,LI ,U.S. House,1,IND,Alan LaPolice,27
-Saline,OH ,U.S. House,1,IND,Alan LaPolice,66
-Saline,PV ,U.S. House,1,IND,Alan LaPolice,50
-Saline,SH ,U.S. House,1,IND,Alan LaPolice,51
-Saline,SV ,U.S. House,1,IND,Alan LaPolice,159
-Saline,SM ,U.S. House,1,IND,Alan LaPolice,147
-Saline,SO ,U.S. House,1,IND,Alan LaPolice,61
-Saline,SC ,U.S. House,1,IND,Alan LaPolice,60
-Saline,WL ,U.S. House,1,IND,Alan LaPolice,114
-Saline,WS ,U.S. House,1,IND,Alan LaPolice,35
-Saline,1,U.S. House,1,,Tim Huelskamp,1
-Saline,2,U.S. House,1,,Tim Huelskamp,1
-Saline,3,U.S. House,1,,Tim Huelskamp,0
-Saline,4,U.S. House,1,,Tim Huelskamp,0
-Saline,5,U.S. House,1,,Tim Huelskamp,2
-Saline,6,U.S. House,1,,Tim Huelskamp,1
-Saline,7,U.S. House,1,,Tim Huelskamp,0
-Saline,8,U.S. House,1,,Tim Huelskamp,0
-Saline,9,U.S. House,1,,Tim Huelskamp,0
-Saline,10,U.S. House,1,,Tim Huelskamp,0
-Saline,11,U.S. House,1,,Tim Huelskamp,0
-Saline,12,U.S. House,1,,Tim Huelskamp,0
-Saline,13,U.S. House,1,,Tim Huelskamp,1
-Saline,14,U.S. House,1,,Tim Huelskamp,2
-Saline,15,U.S. House,1,,Tim Huelskamp,1
-Saline,16,U.S. House,1,,Tim Huelskamp,0
-Saline,17,U.S. House,1,,Tim Huelskamp,0
-Saline,18,U.S. House,1,,Tim Huelskamp,0
-Saline,19,U.S. House,1,,Tim Huelskamp,3
-Saline,20,U.S. House,1,,Tim Huelskamp,4
-Saline,21,U.S. House,1,,Tim Huelskamp,2
-Saline,22,U.S. House,1,,Tim Huelskamp,1
-Saline,23,U.S. House,1,,Tim Huelskamp,4
-Saline,24,U.S. House,1,,Tim Huelskamp,0
-Saline,25,U.S. House,1,,Tim Huelskamp,0
-Saline,26,U.S. House,1,,Tim Huelskamp,0
-Saline,27,U.S. House,1,,Tim Huelskamp,0
-Saline,28,U.S. House,1,,Tim Huelskamp,0
-Saline,29,U.S. House,1,,Tim Huelskamp,0
-Saline,30,U.S. House,1,,Tim Huelskamp,0
-Saline,31,U.S. House,1,,Tim Huelskamp,3
-Saline,32,U.S. House,1,,Tim Huelskamp,0
-Saline,33,U.S. House,1,,Tim Huelskamp,0
-Saline,34,U.S. House,1,,Tim Huelskamp,4
-Saline,35,U.S. House,1,,Tim Huelskamp,5
-Saline,CA ,U.S. House,1,,Tim Huelskamp,1
-Saline,DA ,U.S. House,1,,Tim Huelskamp,0
-Saline,EC ,U.S. House,1,,Tim Huelskamp,1
-Saline,EU ,U.S. House,1,,Tim Huelskamp,2
-Saline,FA ,U.S. House,1,,Tim Huelskamp,1
-Saline,GL ,U.S. House,1,,Tim Huelskamp,0
-Saline,GR ,U.S. House,1,,Tim Huelskamp,0
-Saline,GY ,U.S. House,1,,Tim Huelskamp,1
-Saline,LI ,U.S. House,1,,Tim Huelskamp,0
-Saline,OH ,U.S. House,1,,Tim Huelskamp,0
-Saline,PV ,U.S. House,1,,Tim Huelskamp,0
-Saline,SH ,U.S. House,1,,Tim Huelskamp,0
-Saline,SV ,U.S. House,1,,Tim Huelskamp,0
-Saline,SM ,U.S. House,1,,Tim Huelskamp,0
-Saline,SO ,U.S. House,1,,Tim Huelskamp,0
-Saline,SC ,U.S. House,1,,Tim Huelskamp,0
-Saline,WL ,U.S. House,1,,Tim Huelskamp,0
-Saline,WS ,U.S. House,1,,Tim Huelskamp,0
-Saline,1,State Senate,24,DEM,Donald R Merriman,173
-Saline,2,State Senate,24,DEM,Donald R Merriman,161
-Saline,3,State Senate,24,DEM,Donald R Merriman,141
-Saline,4,State Senate,24,DEM,Donald R Merriman,205
-Saline,5,State Senate,24,DEM,Donald R Merriman,175
-Saline,6,State Senate,24,DEM,Donald R Merriman,155
-Saline,7,State Senate,24,DEM,Donald R Merriman,192
-Saline,8,State Senate,24,DEM,Donald R Merriman,178
-Saline,9,State Senate,24,DEM,Donald R Merriman,191
-Saline,10,State Senate,24,DEM,Donald R Merriman,179
-Saline,11,State Senate,24,DEM,Donald R Merriman,164
-Saline,12,State Senate,24,DEM,Donald R Merriman,273
-Saline,13,State Senate,24,DEM,Donald R Merriman,157
-Saline,14,State Senate,24,DEM,Donald R Merriman,234
-Saline,15,State Senate,24,DEM,Donald R Merriman,197
-Saline,16,State Senate,24,DEM,Donald R Merriman,117
-Saline,17,State Senate,24,DEM,Donald R Merriman,147
-Saline,18,State Senate,24,DEM,Donald R Merriman,168
-Saline,19,State Senate,24,DEM,Donald R Merriman,196
-Saline,20,State Senate,24,DEM,Donald R Merriman,445
-Saline,21,State Senate,24,DEM,Donald R Merriman,432
-Saline,22,State Senate,24,DEM,Donald R Merriman,397
-Saline,23,State Senate,24,DEM,Donald R Merriman,442
-Saline,24,State Senate,24,DEM,Donald R Merriman,175
-Saline,25,State Senate,24,DEM,Donald R Merriman,146
-Saline,26,State Senate,24,DEM,Donald R Merriman,161
-Saline,27,State Senate,24,DEM,Donald R Merriman,210
-Saline,28,State Senate,24,DEM,Donald R Merriman,157
-Saline,29,State Senate,24,DEM,Donald R Merriman,260
-Saline,30,State Senate,24,DEM,Donald R Merriman,215
-Saline,31,State Senate,24,DEM,Donald R Merriman,528
-Saline,32,State Senate,24,DEM,Donald R Merriman,163
-Saline,33,State Senate,24,DEM,Donald R Merriman,310
-Saline,34,State Senate,24,DEM,Donald R Merriman,480
-Saline,35,State Senate,24,DEM,Donald R Merriman,325
-Saline,CA ,State Senate,24,DEM,Donald R Merriman,93
-Saline,DA ,State Senate,24,DEM,Donald R Merriman,24
-Saline,EC ,State Senate,24,DEM,Donald R Merriman,182
-Saline,EU ,State Senate,24,DEM,Donald R Merriman,120
-Saline,FA ,State Senate,24,DEM,Donald R Merriman,49
-Saline,GL ,State Senate,24,DEM,Donald R Merriman,15
-Saline,GR ,State Senate,24,DEM,Donald R Merriman,183
-Saline,GY ,State Senate,24,DEM,Donald R Merriman,27
-Saline,LI ,State Senate,24,DEM,Donald R Merriman,40
-Saline,OH ,State Senate,24,DEM,Donald R Merriman,79
-Saline,PV ,State Senate,24,DEM,Donald R Merriman,67
-Saline,SH ,State Senate,24,DEM,Donald R Merriman,63
-Saline,SV ,State Senate,24,DEM,Donald R Merriman,176
-Saline,SM ,State Senate,24,DEM,Donald R Merriman,153
-Saline,SO ,State Senate,24,DEM,Donald R Merriman,81
-Saline,SC ,State Senate,24,DEM,Donald R Merriman,86
-Saline,WL ,State Senate,24,DEM,Donald R Merriman,117
-Saline,WS ,State Senate,24,DEM,Donald R Merriman,29
-Saline,1,State Senate,24,REP,Randall R Hardy,159
-Saline,2,State Senate,24,REP,Randall R Hardy,152
-Saline,3,State Senate,24,REP,Randall R Hardy,135
-Saline,4,State Senate,24,REP,Randall R Hardy,159
-Saline,5,State Senate,24,REP,Randall R Hardy,193
-Saline,6,State Senate,24,REP,Randall R Hardy,131
-Saline,7,State Senate,24,REP,Randall R Hardy,215
-Saline,8,State Senate,24,REP,Randall R Hardy,180
-Saline,9,State Senate,24,REP,Randall R Hardy,202
-Saline,10,State Senate,24,REP,Randall R Hardy,178
-Saline,11,State Senate,24,REP,Randall R Hardy,186
-Saline,12,State Senate,24,REP,Randall R Hardy,247
-Saline,13,State Senate,24,REP,Randall R Hardy,191
-Saline,14,State Senate,24,REP,Randall R Hardy,230
-Saline,15,State Senate,24,REP,Randall R Hardy,147
-Saline,16,State Senate,24,REP,Randall R Hardy,155
-Saline,17,State Senate,24,REP,Randall R Hardy,216
-Saline,18,State Senate,24,REP,Randall R Hardy,175
-Saline,19,State Senate,24,REP,Randall R Hardy,293
-Saline,20,State Senate,24,REP,Randall R Hardy,547
-Saline,21,State Senate,24,REP,Randall R Hardy,530
-Saline,22,State Senate,24,REP,Randall R Hardy,483
-Saline,23,State Senate,24,REP,Randall R Hardy,573
-Saline,24,State Senate,24,REP,Randall R Hardy,186
-Saline,25,State Senate,24,REP,Randall R Hardy,145
-Saline,26,State Senate,24,REP,Randall R Hardy,173
-Saline,27,State Senate,24,REP,Randall R Hardy,269
-Saline,28,State Senate,24,REP,Randall R Hardy,224
-Saline,29,State Senate,24,REP,Randall R Hardy,282
-Saline,30,State Senate,24,REP,Randall R Hardy,246
-Saline,31,State Senate,24,REP,Randall R Hardy,683
-Saline,32,State Senate,24,REP,Randall R Hardy,165
-Saline,33,State Senate,24,REP,Randall R Hardy,324
-Saline,34,State Senate,24,REP,Randall R Hardy,608
-Saline,35,State Senate,24,REP,Randall R Hardy,375
-Saline,CA ,State Senate,24,REP,Randall R Hardy,123
-Saline,DA ,State Senate,24,REP,Randall R Hardy,34
-Saline,EC ,State Senate,24,REP,Randall R Hardy,302
-Saline,EU ,State Senate,24,REP,Randall R Hardy,151
-Saline,FA ,State Senate,24,REP,Randall R Hardy,90
-Saline,GL ,State Senate,24,REP,Randall R Hardy,33
-Saline,GR ,State Senate,24,REP,Randall R Hardy,266
-Saline,GY ,State Senate,24,REP,Randall R Hardy,55
-Saline,LI ,State Senate,24,REP,Randall R Hardy,57
-Saline,OH ,State Senate,24,REP,Randall R Hardy,113
-Saline,PV ,State Senate,24,REP,Randall R Hardy,124
-Saline,SH ,State Senate,24,REP,Randall R Hardy,72
-Saline,SV ,State Senate,24,REP,Randall R Hardy,244
-Saline,SM ,State Senate,24,REP,Randall R Hardy,243
-Saline,SO ,State Senate,24,REP,Randall R Hardy,122
-Saline,SC ,State Senate,24,REP,Randall R Hardy,116
-Saline,WL ,State Senate,24,REP,Randall R Hardy,200
-Saline,WS ,State Senate,24,REP,Randall R Hardy,43
-Saline,1,State House,69,DEM,Gerrett Morris,182
-Saline,2,State House,69,DEM,Gerrett Morris,169
-Saline,3,State House,69,DEM,Gerrett Morris,154
-Saline,4,State House,69,DEM,Gerrett Morris,198
-Saline,6,State House,69,DEM,Gerrett Morris,144
-Saline,7,State House,69,DEM,Gerrett Morris,211
-Saline,9,State House,69,DEM,Gerrett Morris,193
-Saline,11,State House,69,DEM,Gerrett Morris,159
-Saline,12,State House,69,DEM,Gerrett Morris,297
-Saline,13,State House,69,DEM,Gerrett Morris,175
-Saline,14,State House,69,DEM,Gerrett Morris,262
-Saline,27,State House,69,DEM,Gerrett Morris,226
-Saline,30,State House,69,DEM,Gerrett Morris,217
-Saline,31,State House,69,DEM,Gerrett Morris,527
-Saline,32,State House,69,DEM,Gerrett Morris,153
-Saline,EC ,State House,69,DEM,Gerrett Morris,176
-Saline,GL ,State House,69,DEM,Gerrett Morris,15
-Saline,PV ,State House,69,DEM,Gerrett Morris,59
-Saline,SH ,State House,69,DEM,Gerrett Morris,58
-Saline,1,State House,69,REP,J.R. Claeys,154
-Saline,2,State House,69,REP,J.R. Claeys,148
-Saline,3,State House,69,REP,J.R. Claeys,128
-Saline,4,State House,69,REP,J.R. Claeys,170
-Saline,6,State House,69,REP,J.R. Claeys,140
-Saline,7,State House,69,REP,J.R. Claeys,197
-Saline,9,State House,69,REP,J.R. Claeys,198
-Saline,11,State House,69,REP,J.R. Claeys,192
-Saline,12,State House,69,REP,J.R. Claeys,231
-Saline,13,State House,69,REP,J.R. Claeys,172
-Saline,14,State House,69,REP,J.R. Claeys,205
-Saline,27,State House,69,REP,J.R. Claeys,254
-Saline,30,State House,69,REP,J.R. Claeys,243
-Saline,31,State House,69,REP,J.R. Claeys,691
-Saline,32,State House,69,REP,J.R. Claeys,172
-Saline,EC ,State House,69,REP,J.R. Claeys,318
-Saline,GL ,State House,69,REP,J.R. Claeys,33
-Saline,PV ,State House,69,REP,J.R. Claeys,129
-Saline,SH ,State House,69,REP,J.R. Claeys,77
-Saline,5,State House,71,DEM,Jeffrey A Zamrzla,108
-Saline,8,State House,71,DEM,Jeffrey A Zamrzla,90
-Saline,10,State House,71,DEM,Jeffrey A Zamrzla,88
-Saline,15,State House,71,DEM,Jeffrey A Zamrzla,108
-Saline,16,State House,71,DEM,Jeffrey A Zamrzla,66
-Saline,17,State House,71,DEM,Jeffrey A Zamrzla,89
-Saline,18,State House,71,DEM,Jeffrey A Zamrzla,80
-Saline,19,State House,71,DEM,Jeffrey A Zamrzla,88
-Saline,20,State House,71,DEM,Jeffrey A Zamrzla,132
-Saline,21,State House,71,DEM,Jeffrey A Zamrzla,145
-Saline,22,State House,71,DEM,Jeffrey A Zamrzla,115
-Saline,23,State House,71,DEM,Jeffrey A Zamrzla,155
-Saline,24,State House,71,DEM,Jeffrey A Zamrzla,82
-Saline,25,State House,71,DEM,Jeffrey A Zamrzla,73
-Saline,26,State House,71,DEM,Jeffrey A Zamrzla,69
-Saline,28,State House,71,DEM,Jeffrey A Zamrzla,60
-Saline,29,State House,71,DEM,Jeffrey A Zamrzla,84
-Saline,CA ,State House,71,DEM,Jeffrey A Zamrzla,20
-Saline,DA ,State House,71,DEM,Jeffrey A Zamrzla,7
-Saline,GR ,State House,71,DEM,Jeffrey A Zamrzla,59
-Saline,SO ,State House,71,DEM,Jeffrey A Zamrzla,21
-Saline,EC71 ,State House,71,DEM,Jeffrey A Zamrzla,1
-Saline,SH71 ,State House,71,DEM,Jeffrey A Zamrzla,1
-Saline,5,State House,71,REP,Diana Dierks,195
-Saline,8,State House,71,REP,Diana Dierks,215
-Saline,10,State House,71,REP,Diana Dierks,229
-Saline,15,State House,71,REP,Diana Dierks,173
-Saline,16,State House,71,REP,Diana Dierks,159
-Saline,17,State House,71,REP,Diana Dierks,218
-Saline,18,State House,71,REP,Diana Dierks,203
-Saline,19,State House,71,REP,Diana Dierks,355
-Saline,20,State House,71,REP,Diana Dierks,753
-Saline,21,State House,71,REP,Diana Dierks,733
-Saline,22,State House,71,REP,Diana Dierks,669
-Saline,23,State House,71,REP,Diana Dierks,732
-Saline,24,State House,71,REP,Diana Dierks,227
-Saline,25,State House,71,REP,Diana Dierks,172
-Saline,26,State House,71,REP,Diana Dierks,235
-Saline,28,State House,71,REP,Diana Dierks,270
-Saline,29,State House,71,REP,Diana Dierks,390
-Saline,CA ,State House,71,REP,Diana Dierks,157
-Saline,DA ,State House,71,REP,Diana Dierks,44
-Saline,GR ,State House,71,REP,Diana Dierks,334
-Saline,SO ,State House,71,REP,Diana Dierks,158
-Saline,EC71 ,State House,71,REP,Diana Dierks,3
-Saline,SH71 ,State House,71,REP,Diana Dierks,3
-Saline,5,State House,71,LBT,Joey Frazier,70
-Saline,8,State House,71,LBT,Joey Frazier,57
-Saline,10,State House,71,LBT,Joey Frazier,44
-Saline,15,State House,71,LBT,Joey Frazier,56
-Saline,16,State House,71,LBT,Joey Frazier,47
-Saline,17,State House,71,LBT,Joey Frazier,58
-Saline,18,State House,71,LBT,Joey Frazier,66
-Saline,19,State House,71,LBT,Joey Frazier,44
-Saline,20,State House,71,LBT,Joey Frazier,106
-Saline,21,State House,71,LBT,Joey Frazier,83
-Saline,22,State House,71,LBT,Joey Frazier,85
-Saline,23,State House,71,LBT,Joey Frazier,134
-Saline,24,State House,71,LBT,Joey Frazier,58
-Saline,25,State House,71,LBT,Joey Frazier,48
-Saline,26,State House,71,LBT,Joey Frazier,36
-Saline,28,State House,71,LBT,Joey Frazier,53
-Saline,29,State House,71,LBT,Joey Frazier,70
-Saline,CA ,State House,71,LBT,Joey Frazier,41
-Saline,DA ,State House,71,LBT,Joey Frazier,7
-Saline,GR ,State House,71,LBT,Joey Frazier,60
-Saline,SO ,State House,71,LBT,Joey Frazier,21
-Saline,EC71 ,State House,71,LBT,Joey Frazier,1
-Saline,SH71 ,State House,71,LBT,Joey Frazier,0
-Saline,33,State House,108,DEM,Kelley Menke,226
-Saline,34,State House,108,DEM,Kelley Menke,372
-Saline,35,State House,108,DEM,Kelley Menke,264
-Saline,EU ,State House,108,DEM,Kelley Menke,52
-Saline,FA ,State House,108,DEM,Kelley Menke,30
-Saline,GY ,State House,108,DEM,Kelley Menke,7
-Saline,LI ,State House,108,DEM,Kelley Menke,15
-Saline,OH ,State House,108,DEM,Kelley Menke,47
-Saline,SC ,State House,108,DEM,Kelley Menke,42
-Saline,SM ,State House,108,DEM,Kelley Menke,87
-Saline,SV ,State House,108,DEM,Kelley Menke,95
-Saline,WL ,State House,108,DEM,Kelley Menke,51
-Saline,WS ,State House,108,DEM,Kelley Menke,17
-Saline,33,State House,108,REP,Steven Johnson,399
-Saline,34,State House,108,REP,Steven Johnson,717
-Saline,35,State House,108,REP,Steven Johnson,435
-Saline,EU ,State House,108,REP,Steven Johnson,227
-Saline,FA ,State House,108,REP,Steven Johnson,112
-Saline,GY ,State House,108,REP,Steven Johnson,75
-Saline,LI ,State House,108,REP,Steven Johnson,85
-Saline,OH ,State House,108,REP,Steven Johnson,148
-Saline,SC ,State House,108,REP,Steven Johnson,156
-Saline,SM ,State House,108,REP,Steven Johnson,312
-Saline,SV ,State House,108,REP,Steven Johnson,330
-Saline,WL ,State House,108,REP,Steven Johnson,272
-Saline,WS ,State House,108,REP,Steven Johnson,55
+county,precinct,office,district,party,candidate,votes,vtd
+SALINE,Cambria Township,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",20,000010
+SALINE,Cambria Township,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",41,000010
+SALINE,Cambria Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",157,000010
+SALINE,Dayton Township,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",7,000020
+SALINE,Dayton Township,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",7,000020
+SALINE,Dayton Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",44,000020
+SALINE,Eureka Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",52,000040
+SALINE,Eureka Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",227,000040
+SALINE,Falun Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",30,000050
+SALINE,Falun Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",112,000050
+SALINE,Glendale Township,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",15,000060
+SALINE,Glendale Township,Kansas House of Representatives,69,Republican,"Claeys, J.R.",33,000060
+SALINE,Greeley Township,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",59,000070
+SALINE,Greeley Township,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",60,000070
+SALINE,Greeley Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",334,000070
+SALINE,Gypsum Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",7,000080
+SALINE,Gypsum Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",75,000080
+SALINE,Liberty Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",15,000090
+SALINE,Liberty Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",85,000090
+SALINE,Ohio Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",47,000100
+SALINE,Ohio Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",148,000100
+SALINE,Pleasant Valley Township,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",59,000110
+SALINE,Pleasant Valley Township,Kansas House of Representatives,69,Republican,"Claeys, J.R.",129,000110
+SALINE,Salina Precinct 01 Part A,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",182,00012A
+SALINE,Salina Precinct 01 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",154,00012A
+SALINE,Salina Precinct 02,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",169,00013A
+SALINE,Salina Precinct 02,Kansas House of Representatives,69,Republican,"Claeys, J.R.",148,00013A
+SALINE,Salina Precinct 03,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",154,000140
+SALINE,Salina Precinct 03,Kansas House of Representatives,69,Republican,"Claeys, J.R.",128,000140
+SALINE,Salina Precinct 04,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",198,000150
+SALINE,Salina Precinct 04,Kansas House of Representatives,69,Republican,"Claeys, J.R.",170,000150
+SALINE,Salina Precinct 05,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",108,000160
+SALINE,Salina Precinct 05,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",70,000160
+SALINE,Salina Precinct 05,Kansas House of Representatives,71,Republican,"Dierks, Diana",195,000160
+SALINE,Salina Precinct 06,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",144,000170
+SALINE,Salina Precinct 06,Kansas House of Representatives,69,Republican,"Claeys, J.R.",140,000170
+SALINE,Salina Precinct 07,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",211,000180
+SALINE,Salina Precinct 07,Kansas House of Representatives,69,Republican,"Claeys, J.R.",197,000180
+SALINE,Salina Precinct 08,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",90,000190
+SALINE,Salina Precinct 08,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",57,000190
+SALINE,Salina Precinct 08,Kansas House of Representatives,71,Republican,"Dierks, Diana",215,000190
+SALINE,Salina Precinct 09,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",193,000200
+SALINE,Salina Precinct 09,Kansas House of Representatives,69,Republican,"Claeys, J.R.",198,000200
+SALINE,Salina Precinct 10,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",88,000210
+SALINE,Salina Precinct 10,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",44,000210
+SALINE,Salina Precinct 10,Kansas House of Representatives,71,Republican,"Dierks, Diana",229,000210
+SALINE,Salina Precinct 11,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",159,000220
+SALINE,Salina Precinct 11,Kansas House of Representatives,69,Republican,"Claeys, J.R.",192,000220
+SALINE,Salina Precinct 12,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",297,000230
+SALINE,Salina Precinct 12,Kansas House of Representatives,69,Republican,"Claeys, J.R.",231,000230
+SALINE,Salina Precinct 13,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",175,000240
+SALINE,Salina Precinct 13,Kansas House of Representatives,69,Republican,"Claeys, J.R.",172,000240
+SALINE,Salina Precinct 14 Part A,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",262,00025A
+SALINE,Salina Precinct 14 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",205,00025A
+SALINE,Salina Precinct 15 Part A,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",108,00026A
+SALINE,Salina Precinct 15 Part A,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",56,00026A
+SALINE,Salina Precinct 15 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",173,00026A
+SALINE,Salina Precinct 16,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",66,000270
+SALINE,Salina Precinct 16,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",47,000270
+SALINE,Salina Precinct 16,Kansas House of Representatives,71,Republican,"Dierks, Diana",159,000270
+SALINE,Salina Precinct 17,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",89,000280
+SALINE,Salina Precinct 17,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",58,000280
+SALINE,Salina Precinct 17,Kansas House of Representatives,71,Republican,"Dierks, Diana",218,000280
+SALINE,Salina Precinct 18,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",80,000290
+SALINE,Salina Precinct 18,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",66,000290
+SALINE,Salina Precinct 18,Kansas House of Representatives,71,Republican,"Dierks, Diana",203,000290
+SALINE,Salina Precinct 19,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",88,000300
+SALINE,Salina Precinct 19,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",44,000300
+SALINE,Salina Precinct 19,Kansas House of Representatives,71,Republican,"Dierks, Diana",355,000300
+SALINE,Salina Precinct 20 Part A,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",132,00031A
+SALINE,Salina Precinct 20 Part A,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",106,00031A
+SALINE,Salina Precinct 20 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",753,00031A
+SALINE,Salina Precinct 21 Part A,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",145,00032A
+SALINE,Salina Precinct 21 Part A,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",83,00032A
+SALINE,Salina Precinct 21 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",733,00032A
+SALINE,Salina Precinct 22 Part A,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",115,00033A
+SALINE,Salina Precinct 22 Part A,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",85,00033A
+SALINE,Salina Precinct 22 Part A,Kansas House of Representatives,71,Republican,"Dierks, Diana",669,00033A
+SALINE,Salina Precinct 23,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",155,000340
+SALINE,Salina Precinct 23,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",134,000340
+SALINE,Salina Precinct 23,Kansas House of Representatives,71,Republican,"Dierks, Diana",732,000340
+SALINE,Salina Precinct 24,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",82,000350
+SALINE,Salina Precinct 24,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",58,000350
+SALINE,Salina Precinct 24,Kansas House of Representatives,71,Republican,"Dierks, Diana",227,000350
+SALINE,Salina Precinct 25,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",73,000360
+SALINE,Salina Precinct 25,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",48,000360
+SALINE,Salina Precinct 25,Kansas House of Representatives,71,Republican,"Dierks, Diana",172,000360
+SALINE,Salina Precinct 26,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",69,000370
+SALINE,Salina Precinct 26,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",36,000370
+SALINE,Salina Precinct 26,Kansas House of Representatives,71,Republican,"Dierks, Diana",235,000370
+SALINE,Salina Precinct 27,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",226,000380
+SALINE,Salina Precinct 27,Kansas House of Representatives,69,Republican,"Claeys, J.R.",254,000380
+SALINE,Salina Precinct 28,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",60,000390
+SALINE,Salina Precinct 28,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",53,000390
+SALINE,Salina Precinct 28,Kansas House of Representatives,71,Republican,"Dierks, Diana",270,000390
+SALINE,Salina Precinct 29,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",84,000400
+SALINE,Salina Precinct 29,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",70,000400
+SALINE,Salina Precinct 29,Kansas House of Representatives,71,Republican,"Dierks, Diana",390,000400
+SALINE,Salina Precinct 30,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",217,000410
+SALINE,Salina Precinct 30,Kansas House of Representatives,69,Republican,"Claeys, J.R.",243,000410
+SALINE,Salina Precinct 31 Part A,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",527,00042A
+SALINE,Salina Precinct 31 Part A,Kansas House of Representatives,69,Republican,"Claeys, J.R.",691,00042A
+SALINE,Salina Precinct 32,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",153,000430
+SALINE,Salina Precinct 32,Kansas House of Representatives,69,Republican,"Claeys, J.R.",172,000430
+SALINE,Salina Precinct 33,Kansas House of Representatives,108,Democratic,"Menke, Kelley",226,000440
+SALINE,Salina Precinct 33,Kansas House of Representatives,108,Republican,"Johnson, Steven",399,000440
+SALINE,Salina Precinct 34,Kansas House of Representatives,108,Democratic,"Menke, Kelley",372,000450
+SALINE,Salina Precinct 34,Kansas House of Representatives,108,Republican,"Johnson, Steven",717,000450
+SALINE,Salina Precinct 35,Kansas House of Representatives,108,Democratic,"Menke, Kelley",264,00046A
+SALINE,Salina Precinct 35,Kansas House of Representatives,108,Republican,"Johnson, Steven",435,00046A
+SALINE,Smokey Hill Township Part B,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",58,00047B
+SALINE,Smokey Hill Township Part B,Kansas House of Representatives,69,Republican,"Claeys, J.R.",77,00047B
+SALINE,Smoky View Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",95,000480
+SALINE,Smoky View Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",330,000480
+SALINE,Smolan Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",87,000490
+SALINE,Smolan Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",312,000490
+SALINE,Solomon Township,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",21,000500
+SALINE,Solomon Township,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",21,000500
+SALINE,Solomon Township,Kansas House of Representatives,71,Republican,"Dierks, Diana",158,000500
+SALINE,Spring Creek Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",42,000510
+SALINE,Spring Creek Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",156,000510
+SALINE,Walnut Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",51,000520
+SALINE,Walnut Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",272,000520
+SALINE,Elm Creek Township H69,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",176,120020
+SALINE,Elm Creek Township H69,Kansas House of Representatives,69,Republican,"Claeys, J.R.",318,120020
+SALINE,Elm Creek Township H71,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",1,120030
+SALINE,Elm Creek Township H71,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",1,120030
+SALINE,Elm Creek Township H71,Kansas House of Representatives,71,Republican,"Dierks, Diana",3,120030
+SALINE,Washington Township,Kansas House of Representatives,108,Democratic,"Menke, Kelley",17,300010
+SALINE,Washington Township,Kansas House of Representatives,108,Republican,"Johnson, Steven",55,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Kansas House of Representatives,71,Republican,"Dierks, Diana",0,900070
+SALINE,Salina Precinct 33 Exclave,Kansas House of Representatives,108,Democratic,"Menke, Kelley",0,900080
+SALINE,Salina Precinct 33 Exclave,Kansas House of Representatives,108,Republican,"Johnson, Steven",0,900080
+SALINE,Salina Precinct 35 Exclave,Kansas House of Representatives,108,Democratic,"Menke, Kelley",0,900090
+SALINE,Salina Precinct 35 Exclave,Kansas House of Representatives,108,Republican,"Johnson, Steven",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas House of Representatives,71,Democratic,"Zamrzla, Jeffrey A",1,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas House of Representatives,71,Libertarian,"Frazier, Joey",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas House of Representatives,71,Republican,"Dierks, Diana",3,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas House of Representatives,69,Democratic,"Morris, Gerrett",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas House of Representatives,69,Republican,"Claeys, J.R.",0,900110
+SALINE,Cambria Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",93,000010
+SALINE,Cambria Township,Kansas Senate,24,Republican,"Hardy, Randall R.",123,000010
+SALINE,Dayton Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",24,000020
+SALINE,Dayton Township,Kansas Senate,24,Republican,"Hardy, Randall R.",34,000020
+SALINE,Eureka Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",120,000040
+SALINE,Eureka Township,Kansas Senate,24,Republican,"Hardy, Randall R.",151,000040
+SALINE,Falun Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",49,000050
+SALINE,Falun Township,Kansas Senate,24,Republican,"Hardy, Randall R.",90,000050
+SALINE,Glendale Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",15,000060
+SALINE,Glendale Township,Kansas Senate,24,Republican,"Hardy, Randall R.",33,000060
+SALINE,Greeley Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",183,000070
+SALINE,Greeley Township,Kansas Senate,24,Republican,"Hardy, Randall R.",266,000070
+SALINE,Gypsum Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",27,000080
+SALINE,Gypsum Township,Kansas Senate,24,Republican,"Hardy, Randall R.",55,000080
+SALINE,Liberty Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",40,000090
+SALINE,Liberty Township,Kansas Senate,24,Republican,"Hardy, Randall R.",57,000090
+SALINE,Ohio Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",79,000100
+SALINE,Ohio Township,Kansas Senate,24,Republican,"Hardy, Randall R.",113,000100
+SALINE,Pleasant Valley Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",67,000110
+SALINE,Pleasant Valley Township,Kansas Senate,24,Republican,"Hardy, Randall R.",124,000110
+SALINE,Salina Precinct 01 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",173,00012A
+SALINE,Salina Precinct 01 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",159,00012A
+SALINE,Salina Precinct 02,Kansas Senate,24,Democratic,"Merriman, Donald R.",161,00013A
+SALINE,Salina Precinct 02,Kansas Senate,24,Republican,"Hardy, Randall R.",152,00013A
+SALINE,Salina Precinct 03,Kansas Senate,24,Democratic,"Merriman, Donald R.",141,000140
+SALINE,Salina Precinct 03,Kansas Senate,24,Republican,"Hardy, Randall R.",135,000140
+SALINE,Salina Precinct 04,Kansas Senate,24,Democratic,"Merriman, Donald R.",205,000150
+SALINE,Salina Precinct 04,Kansas Senate,24,Republican,"Hardy, Randall R.",159,000150
+SALINE,Salina Precinct 05,Kansas Senate,24,Democratic,"Merriman, Donald R.",175,000160
+SALINE,Salina Precinct 05,Kansas Senate,24,Republican,"Hardy, Randall R.",193,000160
+SALINE,Salina Precinct 06,Kansas Senate,24,Democratic,"Merriman, Donald R.",155,000170
+SALINE,Salina Precinct 06,Kansas Senate,24,Republican,"Hardy, Randall R.",131,000170
+SALINE,Salina Precinct 07,Kansas Senate,24,Democratic,"Merriman, Donald R.",192,000180
+SALINE,Salina Precinct 07,Kansas Senate,24,Republican,"Hardy, Randall R.",215,000180
+SALINE,Salina Precinct 08,Kansas Senate,24,Democratic,"Merriman, Donald R.",178,000190
+SALINE,Salina Precinct 08,Kansas Senate,24,Republican,"Hardy, Randall R.",180,000190
+SALINE,Salina Precinct 09,Kansas Senate,24,Democratic,"Merriman, Donald R.",191,000200
+SALINE,Salina Precinct 09,Kansas Senate,24,Republican,"Hardy, Randall R.",202,000200
+SALINE,Salina Precinct 10,Kansas Senate,24,Democratic,"Merriman, Donald R.",179,000210
+SALINE,Salina Precinct 10,Kansas Senate,24,Republican,"Hardy, Randall R.",178,000210
+SALINE,Salina Precinct 11,Kansas Senate,24,Democratic,"Merriman, Donald R.",164,000220
+SALINE,Salina Precinct 11,Kansas Senate,24,Republican,"Hardy, Randall R.",186,000220
+SALINE,Salina Precinct 12,Kansas Senate,24,Democratic,"Merriman, Donald R.",273,000230
+SALINE,Salina Precinct 12,Kansas Senate,24,Republican,"Hardy, Randall R.",247,000230
+SALINE,Salina Precinct 13,Kansas Senate,24,Democratic,"Merriman, Donald R.",157,000240
+SALINE,Salina Precinct 13,Kansas Senate,24,Republican,"Hardy, Randall R.",191,000240
+SALINE,Salina Precinct 14 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",234,00025A
+SALINE,Salina Precinct 14 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",230,00025A
+SALINE,Salina Precinct 15 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",197,00026A
+SALINE,Salina Precinct 15 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",147,00026A
+SALINE,Salina Precinct 16,Kansas Senate,24,Democratic,"Merriman, Donald R.",117,000270
+SALINE,Salina Precinct 16,Kansas Senate,24,Republican,"Hardy, Randall R.",155,000270
+SALINE,Salina Precinct 17,Kansas Senate,24,Democratic,"Merriman, Donald R.",147,000280
+SALINE,Salina Precinct 17,Kansas Senate,24,Republican,"Hardy, Randall R.",216,000280
+SALINE,Salina Precinct 18,Kansas Senate,24,Democratic,"Merriman, Donald R.",168,000290
+SALINE,Salina Precinct 18,Kansas Senate,24,Republican,"Hardy, Randall R.",175,000290
+SALINE,Salina Precinct 19,Kansas Senate,24,Democratic,"Merriman, Donald R.",196,000300
+SALINE,Salina Precinct 19,Kansas Senate,24,Republican,"Hardy, Randall R.",293,000300
+SALINE,Salina Precinct 20 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",445,00031A
+SALINE,Salina Precinct 20 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",547,00031A
+SALINE,Salina Precinct 21 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",432,00032A
+SALINE,Salina Precinct 21 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",530,00032A
+SALINE,Salina Precinct 22 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",397,00033A
+SALINE,Salina Precinct 22 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",483,00033A
+SALINE,Salina Precinct 23,Kansas Senate,24,Democratic,"Merriman, Donald R.",442,000340
+SALINE,Salina Precinct 23,Kansas Senate,24,Republican,"Hardy, Randall R.",573,000340
+SALINE,Salina Precinct 24,Kansas Senate,24,Democratic,"Merriman, Donald R.",175,000350
+SALINE,Salina Precinct 24,Kansas Senate,24,Republican,"Hardy, Randall R.",186,000350
+SALINE,Salina Precinct 25,Kansas Senate,24,Democratic,"Merriman, Donald R.",146,000360
+SALINE,Salina Precinct 25,Kansas Senate,24,Republican,"Hardy, Randall R.",145,000360
+SALINE,Salina Precinct 26,Kansas Senate,24,Democratic,"Merriman, Donald R.",161,000370
+SALINE,Salina Precinct 26,Kansas Senate,24,Republican,"Hardy, Randall R.",173,000370
+SALINE,Salina Precinct 27,Kansas Senate,24,Democratic,"Merriman, Donald R.",210,000380
+SALINE,Salina Precinct 27,Kansas Senate,24,Republican,"Hardy, Randall R.",269,000380
+SALINE,Salina Precinct 28,Kansas Senate,24,Democratic,"Merriman, Donald R.",157,000390
+SALINE,Salina Precinct 28,Kansas Senate,24,Republican,"Hardy, Randall R.",224,000390
+SALINE,Salina Precinct 29,Kansas Senate,24,Democratic,"Merriman, Donald R.",260,000400
+SALINE,Salina Precinct 29,Kansas Senate,24,Republican,"Hardy, Randall R.",282,000400
+SALINE,Salina Precinct 30,Kansas Senate,24,Democratic,"Merriman, Donald R.",215,000410
+SALINE,Salina Precinct 30,Kansas Senate,24,Republican,"Hardy, Randall R.",246,000410
+SALINE,Salina Precinct 31 Part A,Kansas Senate,24,Democratic,"Merriman, Donald R.",528,00042A
+SALINE,Salina Precinct 31 Part A,Kansas Senate,24,Republican,"Hardy, Randall R.",683,00042A
+SALINE,Salina Precinct 32,Kansas Senate,24,Democratic,"Merriman, Donald R.",163,000430
+SALINE,Salina Precinct 32,Kansas Senate,24,Republican,"Hardy, Randall R.",165,000430
+SALINE,Salina Precinct 33,Kansas Senate,24,Democratic,"Merriman, Donald R.",310,000440
+SALINE,Salina Precinct 33,Kansas Senate,24,Republican,"Hardy, Randall R.",324,000440
+SALINE,Salina Precinct 34,Kansas Senate,24,Democratic,"Merriman, Donald R.",480,000450
+SALINE,Salina Precinct 34,Kansas Senate,24,Republican,"Hardy, Randall R.",608,000450
+SALINE,Salina Precinct 35,Kansas Senate,24,Democratic,"Merriman, Donald R.",325,00046A
+SALINE,Salina Precinct 35,Kansas Senate,24,Republican,"Hardy, Randall R.",375,00046A
+SALINE,Smokey Hill Township Part B,Kansas Senate,24,Democratic,"Merriman, Donald R.",63,00047B
+SALINE,Smokey Hill Township Part B,Kansas Senate,24,Republican,"Hardy, Randall R.",72,00047B
+SALINE,Smoky View Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",176,000480
+SALINE,Smoky View Township,Kansas Senate,24,Republican,"Hardy, Randall R.",244,000480
+SALINE,Smolan Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",153,000490
+SALINE,Smolan Township,Kansas Senate,24,Republican,"Hardy, Randall R.",243,000490
+SALINE,Solomon Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",81,000500
+SALINE,Solomon Township,Kansas Senate,24,Republican,"Hardy, Randall R.",122,000500
+SALINE,Spring Creek Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",86,000510
+SALINE,Spring Creek Township,Kansas Senate,24,Republican,"Hardy, Randall R.",116,000510
+SALINE,Walnut Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",117,000520
+SALINE,Walnut Township,Kansas Senate,24,Republican,"Hardy, Randall R.",200,000520
+SALINE,Elm Creek Township H69,Kansas Senate,24,Democratic,"Merriman, Donald R.",182,120020
+SALINE,Elm Creek Township H69,Kansas Senate,24,Republican,"Hardy, Randall R.",302,120020
+SALINE,Elm Creek Township H71,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,120030
+SALINE,Elm Creek Township H71,Kansas Senate,24,Republican,"Hardy, Randall R.",0,120030
+SALINE,Washington Township,Kansas Senate,24,Democratic,"Merriman, Donald R.",29,300010
+SALINE,Washington Township,Kansas Senate,24,Republican,"Hardy, Randall R.",43,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900070
+SALINE,Salina Precinct 33 Exclave,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900080
+SALINE,Salina Precinct 33 Exclave,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900080
+SALINE,Salina Precinct 35 Exclave,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900090
+SALINE,Salina Precinct 35 Exclave,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas Senate,24,Democratic,"Merriman, Donald R.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,Kansas Senate,24,Republican,"Hardy, Randall R.",0,900110
+SALINE,Cambria Township,President / Vice President,,independent,"Stein, Jill",1,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SALINE,Cambria Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SALINE,Cambria Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000010
+SALINE,Cambria Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000010
+SALINE,Cambria Township,President / Vice President,,Republican,"Trump, Donald J.",173,000010
+SALINE,Dayton Township,President / Vice President,,independent,"Stein, Jill",1,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+SALINE,Dayton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+SALINE,Dayton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000020
+SALINE,Dayton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+SALINE,Dayton Township,President / Vice President,,Republican,"Trump, Donald J.",43,000020
+SALINE,Eureka Township,President / Vice President,,independent,"Stein, Jill",6,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SALINE,Eureka Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SALINE,Eureka Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000040
+SALINE,Eureka Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000040
+SALINE,Eureka Township,President / Vice President,,Republican,"Trump, Donald J.",212,000040
+SALINE,Falun Township,President / Vice President,,independent,"Stein, Jill",1,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+SALINE,Falun Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+SALINE,Falun Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000050
+SALINE,Falun Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000050
+SALINE,Falun Township,President / Vice President,,Republican,"Trump, Donald J.",114,000050
+SALINE,Glendale Township,President / Vice President,,independent,"Stein, Jill",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+SALINE,Glendale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+SALINE,Glendale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000060
+SALINE,Glendale Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SALINE,Glendale Township,President / Vice President,,Republican,"Trump, Donald J.",43,000060
+SALINE,Greeley Township,President / Vice President,,independent,"Stein, Jill",3,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SALINE,Greeley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SALINE,Greeley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,000070
+SALINE,Greeley Township,President / Vice President,,Libertarian,"Johnson, Gary",17,000070
+SALINE,Greeley Township,President / Vice President,,Republican,"Trump, Donald J.",357,000070
+SALINE,Gypsum Township,President / Vice President,,independent,"Stein, Jill",1,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+SALINE,Gypsum Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+SALINE,Gypsum Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000080
+SALINE,Gypsum Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000080
+SALINE,Gypsum Township,President / Vice President,,Republican,"Trump, Donald J.",77,000080
+SALINE,Liberty Township,President / Vice President,,independent,"Stein, Jill",1,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SALINE,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SALINE,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000090
+SALINE,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+SALINE,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",84,000090
+SALINE,Ohio Township,President / Vice President,,independent,"Stein, Jill",3,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+SALINE,Ohio Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+SALINE,Ohio Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000100
+SALINE,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",9,000100
+SALINE,Ohio Township,President / Vice President,,Republican,"Trump, Donald J.",151,000100
+SALINE,Pleasant Valley Township,President / Vice President,,independent,"Stein, Jill",2,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000110
+SALINE,Pleasant Valley Township,President / Vice President,,Republican,"Trump, Donald J.",148,000110
+SALINE,Salina Precinct 01 Part A,President / Vice President,,independent,"Stein, Jill",9,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Hedges, James A",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Hoefling, Tom",1,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"McMullin, Evan",3,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Smith, Mike",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",133,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Libertarian,"Johnson, Gary",23,00012A
+SALINE,Salina Precinct 01 Part A,President / Vice President,,Republican,"Trump, Donald J.",196,00012A
+SALINE,Salina Precinct 02,President / Vice President,,independent,"Stein, Jill",14,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"McMullin, Evan",1,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",35,00013A
+SALINE,Salina Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",169,00013A
+SALINE,Salina Precinct 03,President / Vice President,,independent,"Stein, Jill",8,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Hedges, James A",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"McMullin, Evan",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Perry, Darryl",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Smith, Mike",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Sood, Ajay",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+SALINE,Salina Precinct 03,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000140
+SALINE,Salina Precinct 03,President / Vice President,,Libertarian,"Johnson, Gary",30,000140
+SALINE,Salina Precinct 03,President / Vice President,,Republican,"Trump, Donald J.",151,000140
+SALINE,Salina Precinct 04,President / Vice President,,independent,"Stein, Jill",12,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Castle, Darrell L",1,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Hedges, James A",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"McMullin, Evan",3,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Perry, Darryl",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Smith, Mike",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Sood, Ajay",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+SALINE,Salina Precinct 04,President / Vice President,,Democratic,"Clinton, Hillary Rodham",147,000150
+SALINE,Salina Precinct 04,President / Vice President,,Libertarian,"Johnson, Gary",21,000150
+SALINE,Salina Precinct 04,President / Vice President,,Republican,"Trump, Donald J.",197,000150
+SALINE,Salina Precinct 05,President / Vice President,,independent,"Stein, Jill",16,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Hedges, James A",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Hoefling, Tom",1,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"McMullin, Evan",1,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Perry, Darryl",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Smith, Mike",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Sood, Ajay",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+SALINE,Salina Precinct 05,President / Vice President,,Democratic,"Clinton, Hillary Rodham",132,000160
+SALINE,Salina Precinct 05,President / Vice President,,Libertarian,"Johnson, Gary",30,000160
+SALINE,Salina Precinct 05,President / Vice President,,Republican,"Trump, Donald J.",197,000160
+SALINE,Salina Precinct 06,President / Vice President,,independent,"Stein, Jill",13,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Hedges, James A",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Maturen, Michael A",1,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"McMullin, Evan",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Perry, Darryl",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Smith, Mike",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Sood, Ajay",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+SALINE,Salina Precinct 06,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000170
+SALINE,Salina Precinct 06,President / Vice President,,Libertarian,"Johnson, Gary",24,000170
+SALINE,Salina Precinct 06,President / Vice President,,Republican,"Trump, Donald J.",149,000170
+SALINE,Salina Precinct 07,President / Vice President,,independent,"Stein, Jill",17,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Hedges, James A",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"McMullin, Evan",3,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Perry, Darryl",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Smith, Mike",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Sood, Ajay",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+SALINE,Salina Precinct 07,President / Vice President,,Democratic,"Clinton, Hillary Rodham",137,000180
+SALINE,Salina Precinct 07,President / Vice President,,Libertarian,"Johnson, Gary",38,000180
+SALINE,Salina Precinct 07,President / Vice President,,Republican,"Trump, Donald J.",222,000180
+SALINE,Salina Precinct 08,President / Vice President,,independent,"Stein, Jill",8,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Hedges, James A",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"La Riva, Gloria",1,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"McMullin, Evan",2,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Perry, Darryl",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Smith, Mike",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Sood, Ajay",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+SALINE,Salina Precinct 08,President / Vice President,,Democratic,"Clinton, Hillary Rodham",133,000190
+SALINE,Salina Precinct 08,President / Vice President,,Libertarian,"Johnson, Gary",37,000190
+SALINE,Salina Precinct 08,President / Vice President,,Republican,"Trump, Donald J.",187,000190
+SALINE,Salina Precinct 09,President / Vice President,,independent,"Stein, Jill",13,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Castle, Darrell L",1,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Hedges, James A",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"McMullin, Evan",1,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Perry, Darryl",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Smith, Mike",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Sood, Ajay",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+SALINE,Salina Precinct 09,President / Vice President,,Democratic,"Clinton, Hillary Rodham",120,000200
+SALINE,Salina Precinct 09,President / Vice President,,Libertarian,"Johnson, Gary",38,000200
+SALINE,Salina Precinct 09,President / Vice President,,Republican,"Trump, Donald J.",230,000200
+SALINE,Salina Precinct 10,President / Vice President,,independent,"Stein, Jill",11,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Hedges, James A",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"McMullin, Evan",3,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Perry, Darryl",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Smith, Mike",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Sood, Ajay",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+SALINE,Salina Precinct 10,President / Vice President,,Democratic,"Clinton, Hillary Rodham",136,000210
+SALINE,Salina Precinct 10,President / Vice President,,Libertarian,"Johnson, Gary",41,000210
+SALINE,Salina Precinct 10,President / Vice President,,Republican,"Trump, Donald J.",175,000210
+SALINE,Salina Precinct 11,President / Vice President,,independent,"Stein, Jill",10,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Castle, Darrell L",1,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Hedges, James A",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"McMullin, Evan",4,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Perry, Darryl",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Smith, Mike",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Sood, Ajay",1,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+SALINE,Salina Precinct 11,President / Vice President,,Democratic,"Clinton, Hillary Rodham",111,000220
+SALINE,Salina Precinct 11,President / Vice President,,Libertarian,"Johnson, Gary",26,000220
+SALINE,Salina Precinct 11,President / Vice President,,Republican,"Trump, Donald J.",207,000220
+SALINE,Salina Precinct 12,President / Vice President,,independent,"Stein, Jill",6,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Hedges, James A",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"McMullin, Evan",2,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Perry, Darryl",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Smith, Mike",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Sood, Ajay",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+SALINE,Salina Precinct 12,President / Vice President,,Democratic,"Clinton, Hillary Rodham",206,000230
+SALINE,Salina Precinct 12,President / Vice President,,Libertarian,"Johnson, Gary",42,000230
+SALINE,Salina Precinct 12,President / Vice President,,Republican,"Trump, Donald J.",279,000230
+SALINE,Salina Precinct 13,President / Vice President,,independent,"Stein, Jill",13,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Hedges, James A",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"McMullin, Evan",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Perry, Darryl",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Smith, Mike",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Sood, Ajay",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+SALINE,Salina Precinct 13,President / Vice President,,Democratic,"Clinton, Hillary Rodham",103,000240
+SALINE,Salina Precinct 13,President / Vice President,,Libertarian,"Johnson, Gary",17,000240
+SALINE,Salina Precinct 13,President / Vice President,,Republican,"Trump, Donald J.",220,000240
+SALINE,Salina Precinct 14 Part A,President / Vice President,,independent,"Stein, Jill",12,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Castle, Darrell L",1,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Hedges, James A",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Smith, Mike",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",169,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Libertarian,"Johnson, Gary",37,00025A
+SALINE,Salina Precinct 14 Part A,President / Vice President,,Republican,"Trump, Donald J.",258,00025A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,independent,"Stein, Jill",13,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Hedges, James A",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"McMullin, Evan",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Smith, Mike",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",151,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Libertarian,"Johnson, Gary",17,00026A
+SALINE,Salina Precinct 15 Part A,President / Vice President,,Republican,"Trump, Donald J.",178,00026A
+SALINE,Salina Precinct 16,President / Vice President,,independent,"Stein, Jill",9,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Hedges, James A",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"McMullin, Evan",3,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Perry, Darryl",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Smith, Mike",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Sood, Ajay",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+SALINE,Salina Precinct 16,President / Vice President,,Democratic,"Clinton, Hillary Rodham",76,000270
+SALINE,Salina Precinct 16,President / Vice President,,Libertarian,"Johnson, Gary",27,000270
+SALINE,Salina Precinct 16,President / Vice President,,Republican,"Trump, Donald J.",172,000270
+SALINE,Salina Precinct 17,President / Vice President,,independent,"Stein, Jill",10,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Hedges, James A",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"McMullin, Evan",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Perry, Darryl",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Smith, Mike",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Sood, Ajay",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+SALINE,Salina Precinct 17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",125,000280
+SALINE,Salina Precinct 17,President / Vice President,,Libertarian,"Johnson, Gary",25,000280
+SALINE,Salina Precinct 17,President / Vice President,,Republican,"Trump, Donald J.",208,000280
+SALINE,Salina Precinct 18,President / Vice President,,independent,"Stein, Jill",6,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Hedges, James A",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"McMullin, Evan",5,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Perry, Darryl",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Smith, Mike",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Sood, Ajay",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+SALINE,Salina Precinct 18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",109,000290
+SALINE,Salina Precinct 18,President / Vice President,,Libertarian,"Johnson, Gary",29,000290
+SALINE,Salina Precinct 18,President / Vice President,,Republican,"Trump, Donald J.",207,000290
+SALINE,Salina Precinct 19,President / Vice President,,independent,"Stein, Jill",3,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Castle, Darrell L",1,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Hedges, James A",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"McMullin, Evan",2,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Perry, Darryl",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Smith, Mike",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Sood, Ajay",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+SALINE,Salina Precinct 19,President / Vice President,,Democratic,"Clinton, Hillary Rodham",134,000300
+SALINE,Salina Precinct 19,President / Vice President,,Libertarian,"Johnson, Gary",28,000300
+SALINE,Salina Precinct 19,President / Vice President,,Republican,"Trump, Donald J.",318,000300
+SALINE,Salina Precinct 20 Part A,President / Vice President,,independent,"Stein, Jill",8,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Hedges, James A",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"McMullin, Evan",11,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Smith, Mike",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",315,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Libertarian,"Johnson, Gary",46,00031A
+SALINE,Salina Precinct 20 Part A,President / Vice President,,Republican,"Trump, Donald J.",620,00031A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,independent,"Stein, Jill",10,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Hedges, James A",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"McMullin, Evan",3,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Smith, Mike",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",311,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Libertarian,"Johnson, Gary",44,00032A
+SALINE,Salina Precinct 21 Part A,President / Vice President,,Republican,"Trump, Donald J.",612,00032A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,independent,"Stein, Jill",16,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Hedges, James A",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"McMullin, Evan",2,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Smith, Mike",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",259,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Libertarian,"Johnson, Gary",45,00033A
+SALINE,Salina Precinct 22 Part A,President / Vice President,,Republican,"Trump, Donald J.",557,00033A
+SALINE,Salina Precinct 23,President / Vice President,,independent,"Stein, Jill",16,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Basiago, Andrew D.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Castle, Darrell L",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Giordani, Rocky",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Hedges, James A",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Hoefling, Tom",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Kahn, Lynn",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"La Riva, Gloria",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Levinson, Michael S.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Maturen, Michael A",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"McMullin, Evan",7,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Moorehead, Monica G.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Perry, Darryl",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Schriner, Joe C",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Smith, Mike",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Sood, Ajay",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Sterling, Shawna",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Valdivia, Anthony J",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000340
+SALINE,Salina Precinct 23,President / Vice President,,Democratic,"Clinton, Hillary Rodham",315,000340
+SALINE,Salina Precinct 23,President / Vice President,,Libertarian,"Johnson, Gary",47,000340
+SALINE,Salina Precinct 23,President / Vice President,,Republican,"Trump, Donald J.",661,000340
+SALINE,Salina Precinct 24,President / Vice President,,independent,"Stein, Jill",5,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Basiago, Andrew D.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Castle, Darrell L",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Giordani, Rocky",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Hedges, James A",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Hoefling, Tom",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Kahn, Lynn",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"La Riva, Gloria",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Levinson, Michael S.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Maturen, Michael A",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"McMullin, Evan",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Moorehead, Monica G.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Perry, Darryl",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Schriner, Joe C",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Smith, Mike",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Sood, Ajay",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Sterling, Shawna",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Valdivia, Anthony J",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000350
+SALINE,Salina Precinct 24,President / Vice President,,Democratic,"Clinton, Hillary Rodham",127,000350
+SALINE,Salina Precinct 24,President / Vice President,,Libertarian,"Johnson, Gary",23,000350
+SALINE,Salina Precinct 24,President / Vice President,,Republican,"Trump, Donald J.",208,000350
+SALINE,Salina Precinct 25,President / Vice President,,independent,"Stein, Jill",8,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Basiago, Andrew D.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Castle, Darrell L",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Giordani, Rocky",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Hedges, James A",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Hoefling, Tom",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Kahn, Lynn",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"La Riva, Gloria",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Levinson, Michael S.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Maturen, Michael A",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"McMullin, Evan",1,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Moorehead, Monica G.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Perry, Darryl",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Schriner, Joe C",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Smith, Mike",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Sood, Ajay",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Sterling, Shawna",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Valdivia, Anthony J",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000360
+SALINE,Salina Precinct 25,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000360
+SALINE,Salina Precinct 25,President / Vice President,,Libertarian,"Johnson, Gary",22,000360
+SALINE,Salina Precinct 25,President / Vice President,,Republican,"Trump, Donald J.",160,000360
+SALINE,Salina Precinct 26,President / Vice President,,independent,"Stein, Jill",9,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Basiago, Andrew D.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Castle, Darrell L",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Giordani, Rocky",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Hedges, James A",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Hoefling, Tom",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Kahn, Lynn",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"La Riva, Gloria",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Levinson, Michael S.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Maturen, Michael A",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"McMullin, Evan",1,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Moorehead, Monica G.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Perry, Darryl",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Schriner, Joe C",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Smith, Mike",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Sood, Ajay",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Sterling, Shawna",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Valdivia, Anthony J",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000370
+SALINE,Salina Precinct 26,President / Vice President,,Democratic,"Clinton, Hillary Rodham",106,000370
+SALINE,Salina Precinct 26,President / Vice President,,Libertarian,"Johnson, Gary",28,000370
+SALINE,Salina Precinct 26,President / Vice President,,Republican,"Trump, Donald J.",203,000370
+SALINE,Salina Precinct 27,President / Vice President,,independent,"Stein, Jill",15,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Basiago, Andrew D.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Castle, Darrell L",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Giordani, Rocky",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Hedges, James A",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Hoefling, Tom",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Kahn, Lynn",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"La Riva, Gloria",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Levinson, Michael S.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Maturen, Michael A",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"McMullin, Evan",3,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Moorehead, Monica G.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Perry, Darryl",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Schriner, Joe C",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Smith, Mike",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Sood, Ajay",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Sterling, Shawna",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Valdivia, Anthony J",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000380
+SALINE,Salina Precinct 27,President / Vice President,,Democratic,"Clinton, Hillary Rodham",159,000380
+SALINE,Salina Precinct 27,President / Vice President,,Libertarian,"Johnson, Gary",24,000380
+SALINE,Salina Precinct 27,President / Vice President,,Republican,"Trump, Donald J.",298,000380
+SALINE,Salina Precinct 28,President / Vice President,,independent,"Stein, Jill",14,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Basiago, Andrew D.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Castle, Darrell L",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Giordani, Rocky",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Hedges, James A",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Hoefling, Tom",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Kahn, Lynn",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"La Riva, Gloria",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Levinson, Michael S.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Maturen, Michael A",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"McMullin, Evan",2,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Moorehead, Monica G.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Perry, Darryl",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Schriner, Joe C",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Smith, Mike",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Sood, Ajay",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Sterling, Shawna",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Valdivia, Anthony J",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000390
+SALINE,Salina Precinct 28,President / Vice President,,Democratic,"Clinton, Hillary Rodham",92,000390
+SALINE,Salina Precinct 28,President / Vice President,,Libertarian,"Johnson, Gary",27,000390
+SALINE,Salina Precinct 28,President / Vice President,,Republican,"Trump, Donald J.",258,000390
+SALINE,Salina Precinct 29,President / Vice President,,independent,"Stein, Jill",15,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Basiago, Andrew D.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Castle, Darrell L",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Giordani, Rocky",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Hedges, James A",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Hoefling, Tom",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Kahn, Lynn",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"La Riva, Gloria",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Levinson, Michael S.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Maturen, Michael A",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"McMullin, Evan",1,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Moorehead, Monica G.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Perry, Darryl",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Schriner, Joe C",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Smith, Mike",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Sood, Ajay",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Sterling, Shawna",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Valdivia, Anthony J",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000400
+SALINE,Salina Precinct 29,President / Vice President,,Democratic,"Clinton, Hillary Rodham",164,000400
+SALINE,Salina Precinct 29,President / Vice President,,Libertarian,"Johnson, Gary",36,000400
+SALINE,Salina Precinct 29,President / Vice President,,Republican,"Trump, Donald J.",345,000400
+SALINE,Salina Precinct 30,President / Vice President,,independent,"Stein, Jill",11,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Basiago, Andrew D.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Castle, Darrell L",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Giordani, Rocky",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Hedges, James A",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Hoefling, Tom",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Kahn, Lynn",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"La Riva, Gloria",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Levinson, Michael S.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Maturen, Michael A",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"McMullin, Evan",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Moorehead, Monica G.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Perry, Darryl",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Schriner, Joe C",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Smith, Mike",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Sood, Ajay",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Sterling, Shawna",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Valdivia, Anthony J",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000410
+SALINE,Salina Precinct 30,President / Vice President,,Democratic,"Clinton, Hillary Rodham",122,000410
+SALINE,Salina Precinct 30,President / Vice President,,Libertarian,"Johnson, Gary",30,000410
+SALINE,Salina Precinct 30,President / Vice President,,Republican,"Trump, Donald J.",303,000410
+SALINE,Salina Precinct 31 Part A,President / Vice President,,independent,"Stein, Jill",18,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Basiago, Andrew D.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Castle, Darrell L",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Giordani, Rocky",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Hedges, James A",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Hoefling, Tom",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Kahn, Lynn",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"La Riva, Gloria",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Levinson, Michael S.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Maturen, Michael A",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"McMullin, Evan",3,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Moorehead, Monica G.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Perry, Darryl",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Schriner, Joe C",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Smith, Mike",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Sood, Ajay",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Sterling, Shawna",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Valdivia, Anthony J",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",321,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Libertarian,"Johnson, Gary",65,00042A
+SALINE,Salina Precinct 31 Part A,President / Vice President,,Republican,"Trump, Donald J.",831,00042A
+SALINE,Salina Precinct 32,President / Vice President,,independent,"Stein, Jill",4,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Basiago, Andrew D.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Castle, Darrell L",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Giordani, Rocky",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Hedges, James A",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Hoefling, Tom",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Kahn, Lynn",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"La Riva, Gloria",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Levinson, Michael S.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Maturen, Michael A",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"McMullin, Evan",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Moorehead, Monica G.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Perry, Darryl",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Schriner, Joe C",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Smith, Mike",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Sood, Ajay",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Sterling, Shawna",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Valdivia, Anthony J",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000430
+SALINE,Salina Precinct 32,President / Vice President,,Democratic,"Clinton, Hillary Rodham",97,000430
+SALINE,Salina Precinct 32,President / Vice President,,Libertarian,"Johnson, Gary",18,000430
+SALINE,Salina Precinct 32,President / Vice President,,Republican,"Trump, Donald J.",213,000430
+SALINE,Salina Precinct 33,President / Vice President,,independent,"Stein, Jill",7,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Basiago, Andrew D.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Castle, Darrell L",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Giordani, Rocky",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Hedges, James A",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Hoefling, Tom",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Kahn, Lynn",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"La Riva, Gloria",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Levinson, Michael S.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Maturen, Michael A",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"McMullin, Evan",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Moorehead, Monica G.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Perry, Darryl",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Schriner, Joe C",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Smith, Mike",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Sood, Ajay",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Sterling, Shawna",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Valdivia, Anthony J",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000440
+SALINE,Salina Precinct 33,President / Vice President,,Democratic,"Clinton, Hillary Rodham",197,000440
+SALINE,Salina Precinct 33,President / Vice President,,Libertarian,"Johnson, Gary",40,000440
+SALINE,Salina Precinct 33,President / Vice President,,Republican,"Trump, Donald J.",391,000440
+SALINE,Salina Precinct 34,President / Vice President,,independent,"Stein, Jill",23,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Basiago, Andrew D.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Castle, Darrell L",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Giordani, Rocky",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Hedges, James A",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Hoefling, Tom",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Kahn, Lynn",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"La Riva, Gloria",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Levinson, Michael S.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Maturen, Michael A",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"McMullin, Evan",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Moorehead, Monica G.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Perry, Darryl",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Schriner, Joe C",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Smith, Mike",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Sood, Ajay",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Sterling, Shawna",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Valdivia, Anthony J",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000450
+SALINE,Salina Precinct 34,President / Vice President,,Democratic,"Clinton, Hillary Rodham",299,000450
+SALINE,Salina Precinct 34,President / Vice President,,Libertarian,"Johnson, Gary",70,000450
+SALINE,Salina Precinct 34,President / Vice President,,Republican,"Trump, Donald J.",725,000450
+SALINE,Salina Precinct 35,President / Vice President,,independent,"Stein, Jill",14,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Basiago, Andrew D.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Castle, Darrell L",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Giordani, Rocky",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Hedges, James A",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Hoefling, Tom",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Kahn, Lynn",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"La Riva, Gloria",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Levinson, Michael S.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Maturen, Michael A",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"McMullin, Evan",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Moorehead, Monica G.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Perry, Darryl",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Schriner, Joe C",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Smith, Mike",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Sood, Ajay",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Sterling, Shawna",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Valdivia, Anthony J",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Democratic,"Clinton, Hillary Rodham",215,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Libertarian,"Johnson, Gary",56,00046A
+SALINE,Salina Precinct 35,President / Vice President,,Republican,"Trump, Donald J.",436,00046A
+SALINE,Smokey Hill Township Part B,President / Vice President,,independent,"Stein, Jill",2,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Basiago, Andrew D.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Castle, Darrell L",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Giordani, Rocky",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Hedges, James A",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Hoefling, Tom",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Kahn, Lynn",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"La Riva, Gloria",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Levinson, Michael S.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Maturen, Michael A",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"McMullin, Evan",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Moorehead, Monica G.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Perry, Darryl",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Schriner, Joe C",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Smith, Mike",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Sood, Ajay",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Sterling, Shawna",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Valdivia, Anthony J",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Libertarian,"Johnson, Gary",10,00047B
+SALINE,Smokey Hill Township Part B,President / Vice President,,Republican,"Trump, Donald J.",85,00047B
+SALINE,Smoky View Township,President / Vice President,,independent,"Stein, Jill",10,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Castle, Darrell L",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Giordani, Rocky",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Hedges, James A",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Hoefling, Tom",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Kahn, Lynn",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"La Riva, Gloria",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Maturen, Michael A",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"McMullin, Evan",2,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Perry, Darryl",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Schriner, Joe C",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Smith, Mike",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Sood, Ajay",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Sterling, Shawna",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000480
+SALINE,Smoky View Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000480
+SALINE,Smoky View Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",91,000480
+SALINE,Smoky View Township,President / Vice President,,Libertarian,"Johnson, Gary",24,000480
+SALINE,Smoky View Township,President / Vice President,,Republican,"Trump, Donald J.",296,000480
+SALINE,Smolan Township,President / Vice President,,independent,"Stein, Jill",7,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Hedges, James A",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"McMullin, Evan",1,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Perry, Darryl",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Smith, Mike",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Sood, Ajay",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000490
+SALINE,Smolan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000490
+SALINE,Smolan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000490
+SALINE,Smolan Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000490
+SALINE,Smolan Township,President / Vice President,,Republican,"Trump, Donald J.",305,000490
+SALINE,Solomon Township,President / Vice President,,independent,"Stein, Jill",5,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Hedges, James A",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"McMullin, Evan",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Perry, Darryl",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Smith, Mike",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Sood, Ajay",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000500
+SALINE,Solomon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000500
+SALINE,Solomon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000500
+SALINE,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000500
+SALINE,Solomon Township,President / Vice President,,Republican,"Trump, Donald J.",156,000500
+SALINE,Spring Creek Township,President / Vice President,,independent,"Stein, Jill",2,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000510
+SALINE,Spring Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000510
+SALINE,Spring Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",29,000510
+SALINE,Spring Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000510
+SALINE,Spring Creek Township,President / Vice President,,Republican,"Trump, Donald J.",163,000510
+SALINE,Walnut Township,President / Vice President,,independent,"Stein, Jill",3,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Castle, Darrell L",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Giordani, Rocky",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Hedges, James A",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Hoefling, Tom",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Kahn, Lynn",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"La Riva, Gloria",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Maturen, Michael A",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"McMullin, Evan",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Perry, Darryl",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Schriner, Joe C",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Smith, Mike",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Sood, Ajay",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Sterling, Shawna",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000520
+SALINE,Walnut Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000520
+SALINE,Walnut Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",58,000520
+SALINE,Walnut Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000520
+SALINE,Walnut Township,President / Vice President,,Republican,"Trump, Donald J.",251,000520
+SALINE,Elm Creek Township H69,President / Vice President,,independent,"Stein, Jill",16,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Hedges, James A",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"McMullin, Evan",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Perry, Darryl",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Smith, Mike",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Sood, Ajay",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Democratic,"Clinton, Hillary Rodham",81,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Libertarian,"Johnson, Gary",24,120020
+SALINE,Elm Creek Township H69,President / Vice President,,Republican,"Trump, Donald J.",372,120020
+SALINE,Elm Creek Township H71,President / Vice President,,independent,"Stein, Jill",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Hedges, James A",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"McMullin, Evan",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Perry, Darryl",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Smith, Mike",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Sood, Ajay",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+SALINE,Elm Creek Township H71,President / Vice President,,Republican,"Trump, Donald J.",0,120030
+SALINE,Washington Township,President / Vice President,,independent,"Stein, Jill",1,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,300010
+SALINE,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,300010
+SALINE,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,300010
+SALINE,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",4,300010
+SALINE,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",57,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,independent,"Stein, Jill",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Hedges, James A",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"McMullin, Evan",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Perry, Darryl",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Smith, Mike",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Sood, Ajay",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,President / Vice President,,Republican,"Trump, Donald J.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,independent,"Stein, Jill",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Hedges, James A",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"McMullin, Evan",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Perry, Darryl",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Smith, Mike",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Sood, Ajay",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,President / Vice President,,Republican,"Trump, Donald J.",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,independent,"Stein, Jill",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Hedges, James A",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Smith, Mike",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900070
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,independent,"Stein, Jill",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900080
+SALINE,Salina Precinct 33 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900080
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,independent,"Stein, Jill",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900090
+SALINE,Salina Precinct 35 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,independent,"Stein, Jill",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Hedges, James A",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Smith, Mike",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900110
+SALINE,Cambria Township,United States House of Representatives,1,independent,"LaPolice, Alan",75,000010
+SALINE,Cambria Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+SALINE,Cambria Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000010
+SALINE,Cambria Township,United States House of Representatives,1,Republican,"Marshall, Roger",126,000010
+SALINE,Dayton Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000020
+SALINE,Dayton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+SALINE,Dayton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000020
+SALINE,Dayton Township,United States House of Representatives,1,Republican,"Marshall, Roger",43,000020
+SALINE,Eureka Township,United States House of Representatives,1,independent,"LaPolice, Alan",102,000040
+SALINE,Eureka Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000040
+SALINE,Eureka Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000040
+SALINE,Eureka Township,United States House of Representatives,1,Republican,"Marshall, Roger",165,000040
+SALINE,Falun Township,United States House of Representatives,1,independent,"LaPolice, Alan",49,000050
+SALINE,Falun Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+SALINE,Falun Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000050
+SALINE,Falun Township,United States House of Representatives,1,Republican,"Marshall, Roger",80,000050
+SALINE,Glendale Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000060
+SALINE,Glendale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+SALINE,Glendale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000060
+SALINE,Glendale Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000060
+SALINE,Greeley Township,United States House of Representatives,1,independent,"LaPolice, Alan",144,000070
+SALINE,Greeley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+SALINE,Greeley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000070
+SALINE,Greeley Township,United States House of Representatives,1,Republican,"Marshall, Roger",293,000070
+SALINE,Gypsum Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000080
+SALINE,Gypsum Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000080
+SALINE,Gypsum Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000080
+SALINE,Gypsum Township,United States House of Representatives,1,Republican,"Marshall, Roger",57,000080
+SALINE,Liberty Township,United States House of Representatives,1,independent,"LaPolice, Alan",27,000090
+SALINE,Liberty Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+SALINE,Liberty Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000090
+SALINE,Liberty Township,United States House of Representatives,1,Republican,"Marshall, Roger",67,000090
+SALINE,Ohio Township,United States House of Representatives,1,independent,"LaPolice, Alan",66,000100
+SALINE,Ohio Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+SALINE,Ohio Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000100
+SALINE,Ohio Township,United States House of Representatives,1,Republican,"Marshall, Roger",120,000100
+SALINE,Pleasant Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",50,000110
+SALINE,Pleasant Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+SALINE,Pleasant Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000110
+SALINE,Pleasant Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",131,000110
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",113,00012A
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00012A
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",48,00012A
+SALINE,Salina Precinct 01 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",161,00012A
+SALINE,Salina Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",122,00013A
+SALINE,Salina Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00013A
+SALINE,Salina Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",52,00013A
+SALINE,Salina Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",143,00013A
+SALINE,Salina Precinct 03,United States House of Representatives,1,independent,"LaPolice, Alan",113,000140
+SALINE,Salina Precinct 03,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+SALINE,Salina Precinct 03,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,000140
+SALINE,Salina Precinct 03,United States House of Representatives,1,Republican,"Marshall, Roger",137,000140
+SALINE,Salina Precinct 04,United States House of Representatives,1,independent,"LaPolice, Alan",153,000150
+SALINE,Salina Precinct 04,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+SALINE,Salina Precinct 04,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000150
+SALINE,Salina Precinct 04,United States House of Representatives,1,Republican,"Marshall, Roger",161,000150
+SALINE,Salina Precinct 05,United States House of Representatives,1,independent,"LaPolice, Alan",151,000160
+SALINE,Salina Precinct 05,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000160
+SALINE,Salina Precinct 05,United States House of Representatives,1,Libertarian,"Burt, Kerry",57,000160
+SALINE,Salina Precinct 05,United States House of Representatives,1,Republican,"Marshall, Roger",156,000160
+SALINE,Salina Precinct 06,United States House of Representatives,1,independent,"LaPolice, Alan",114,000170
+SALINE,Salina Precinct 06,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000170
+SALINE,Salina Precinct 06,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,000170
+SALINE,Salina Precinct 06,United States House of Representatives,1,Republican,"Marshall, Roger",128,000170
+SALINE,Salina Precinct 07,United States House of Representatives,1,independent,"LaPolice, Alan",158,000180
+SALINE,Salina Precinct 07,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+SALINE,Salina Precinct 07,United States House of Representatives,1,Libertarian,"Burt, Kerry",58,000180
+SALINE,Salina Precinct 07,United States House of Representatives,1,Republican,"Marshall, Roger",192,000180
+SALINE,Salina Precinct 08,United States House of Representatives,1,independent,"LaPolice, Alan",136,000190
+SALINE,Salina Precinct 08,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+SALINE,Salina Precinct 08,United States House of Representatives,1,Libertarian,"Burt, Kerry",39,000190
+SALINE,Salina Precinct 08,United States House of Representatives,1,Republican,"Marshall, Roger",177,000190
+SALINE,Salina Precinct 09,United States House of Representatives,1,independent,"LaPolice, Alan",134,000200
+SALINE,Salina Precinct 09,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+SALINE,Salina Precinct 09,United States House of Representatives,1,Libertarian,"Burt, Kerry",46,000200
+SALINE,Salina Precinct 09,United States House of Representatives,1,Republican,"Marshall, Roger",207,000200
+SALINE,Salina Precinct 10,United States House of Representatives,1,independent,"LaPolice, Alan",157,000210
+SALINE,Salina Precinct 10,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+SALINE,Salina Precinct 10,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000210
+SALINE,Salina Precinct 10,United States House of Representatives,1,Republican,"Marshall, Roger",164,000210
+SALINE,Salina Precinct 11,United States House of Representatives,1,independent,"LaPolice, Alan",136,000220
+SALINE,Salina Precinct 11,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+SALINE,Salina Precinct 11,United States House of Representatives,1,Libertarian,"Burt, Kerry",30,000220
+SALINE,Salina Precinct 11,United States House of Representatives,1,Republican,"Marshall, Roger",183,000220
+SALINE,Salina Precinct 12,United States House of Representatives,1,independent,"LaPolice, Alan",223,000230
+SALINE,Salina Precinct 12,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+SALINE,Salina Precinct 12,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,000230
+SALINE,Salina Precinct 12,United States House of Representatives,1,Republican,"Marshall, Roger",246,000230
+SALINE,Salina Precinct 13,United States House of Representatives,1,independent,"LaPolice, Alan",127,000240
+SALINE,Salina Precinct 13,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000240
+SALINE,Salina Precinct 13,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,000240
+SALINE,Salina Precinct 13,United States House of Representatives,1,Republican,"Marshall, Roger",188,000240
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",165,00025A
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00025A
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",50,00025A
+SALINE,Salina Precinct 14 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",242,00025A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",122,00026A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00026A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,00026A
+SALINE,Salina Precinct 15 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",157,00026A
+SALINE,Salina Precinct 16,United States House of Representatives,1,independent,"LaPolice, Alan",103,000270
+SALINE,Salina Precinct 16,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+SALINE,Salina Precinct 16,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000270
+SALINE,Salina Precinct 16,United States House of Representatives,1,Republican,"Marshall, Roger",142,000270
+SALINE,Salina Precinct 17,United States House of Representatives,1,independent,"LaPolice, Alan",134,000280
+SALINE,Salina Precinct 17,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000280
+SALINE,Salina Precinct 17,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000280
+SALINE,Salina Precinct 17,United States House of Representatives,1,Republican,"Marshall, Roger",197,000280
+SALINE,Salina Precinct 18,United States House of Representatives,1,independent,"LaPolice, Alan",147,000290
+SALINE,Salina Precinct 18,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000290
+SALINE,Salina Precinct 18,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,000290
+SALINE,Salina Precinct 18,United States House of Representatives,1,Republican,"Marshall, Roger",164,000290
+SALINE,Salina Precinct 19,United States House of Representatives,1,independent,"LaPolice, Alan",153,000300
+SALINE,Salina Precinct 19,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000300
+SALINE,Salina Precinct 19,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000300
+SALINE,Salina Precinct 19,United States House of Representatives,1,Republican,"Marshall, Roger",307,000300
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",354,00031A
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,00031A
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,00031A
+SALINE,Salina Precinct 20 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",588,00031A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",367,00032A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,00032A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",40,00032A
+SALINE,Salina Precinct 21 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",547,00032A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",284,00033A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00033A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",51,00033A
+SALINE,Salina Precinct 22 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",537,00033A
+SALINE,Salina Precinct 23,United States House of Representatives,1,independent,"LaPolice, Alan",415,000340
+SALINE,Salina Precinct 23,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000340
+SALINE,Salina Precinct 23,United States House of Representatives,1,Libertarian,"Burt, Kerry",43,000340
+SALINE,Salina Precinct 23,United States House of Representatives,1,Republican,"Marshall, Roger",567,000340
+SALINE,Salina Precinct 24,United States House of Representatives,1,independent,"LaPolice, Alan",137,000350
+SALINE,Salina Precinct 24,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000350
+SALINE,Salina Precinct 24,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,000350
+SALINE,Salina Precinct 24,United States House of Representatives,1,Republican,"Marshall, Roger",192,000350
+SALINE,Salina Precinct 25,United States House of Representatives,1,independent,"LaPolice, Alan",131,000360
+SALINE,Salina Precinct 25,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000360
+SALINE,Salina Precinct 25,United States House of Representatives,1,Libertarian,"Burt, Kerry",33,000360
+SALINE,Salina Precinct 25,United States House of Representatives,1,Republican,"Marshall, Roger",127,000360
+SALINE,Salina Precinct 26,United States House of Representatives,1,independent,"LaPolice, Alan",143,000370
+SALINE,Salina Precinct 26,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000370
+SALINE,Salina Precinct 26,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000370
+SALINE,Salina Precinct 26,United States House of Representatives,1,Republican,"Marshall, Roger",167,000370
+SALINE,Salina Precinct 27,United States House of Representatives,1,independent,"LaPolice, Alan",168,000380
+SALINE,Salina Precinct 27,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000380
+SALINE,Salina Precinct 27,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000380
+SALINE,Salina Precinct 27,United States House of Representatives,1,Republican,"Marshall, Roger",276,000380
+SALINE,Salina Precinct 28,United States House of Representatives,1,independent,"LaPolice, Alan",141,000390
+SALINE,Salina Precinct 28,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000390
+SALINE,Salina Precinct 28,United States House of Representatives,1,Libertarian,"Burt, Kerry",34,000390
+SALINE,Salina Precinct 28,United States House of Representatives,1,Republican,"Marshall, Roger",208,000390
+SALINE,Salina Precinct 29,United States House of Representatives,1,independent,"LaPolice, Alan",186,000400
+SALINE,Salina Precinct 29,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000400
+SALINE,Salina Precinct 29,United States House of Representatives,1,Libertarian,"Burt, Kerry",40,000400
+SALINE,Salina Precinct 29,United States House of Representatives,1,Republican,"Marshall, Roger",315,000400
+SALINE,Salina Precinct 30,United States House of Representatives,1,independent,"LaPolice, Alan",197,000410
+SALINE,Salina Precinct 30,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000410
+SALINE,Salina Precinct 30,United States House of Representatives,1,Libertarian,"Burt, Kerry",27,000410
+SALINE,Salina Precinct 30,United States House of Representatives,1,Republican,"Marshall, Roger",237,000410
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,independent,"LaPolice, Alan",432,00042A
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,00042A
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,Libertarian,"Burt, Kerry",61,00042A
+SALINE,Salina Precinct 31 Part A,United States House of Representatives,1,Republican,"Marshall, Roger",728,00042A
+SALINE,Salina Precinct 32,United States House of Representatives,1,independent,"LaPolice, Alan",120,000430
+SALINE,Salina Precinct 32,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000430
+SALINE,Salina Precinct 32,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000430
+SALINE,Salina Precinct 32,United States House of Representatives,1,Republican,"Marshall, Roger",192,000430
+SALINE,Salina Precinct 33,United States House of Representatives,1,independent,"LaPolice, Alan",224,000440
+SALINE,Salina Precinct 33,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000440
+SALINE,Salina Precinct 33,United States House of Representatives,1,Libertarian,"Burt, Kerry",46,000440
+SALINE,Salina Precinct 33,United States House of Representatives,1,Republican,"Marshall, Roger",353,000440
+SALINE,Salina Precinct 34,United States House of Representatives,1,independent,"LaPolice, Alan",396,000450
+SALINE,Salina Precinct 34,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000450
+SALINE,Salina Precinct 34,United States House of Representatives,1,Libertarian,"Burt, Kerry",71,000450
+SALINE,Salina Precinct 34,United States House of Representatives,1,Republican,"Marshall, Roger",619,000450
+SALINE,Salina Precinct 35,United States House of Representatives,1,independent,"LaPolice, Alan",266,00046A
+SALINE,Salina Precinct 35,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,00046A
+SALINE,Salina Precinct 35,United States House of Representatives,1,Libertarian,"Burt, Kerry",82,00046A
+SALINE,Salina Precinct 35,United States House of Representatives,1,Republican,"Marshall, Roger",357,00046A
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,independent,"LaPolice, Alan",51,00047B
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00047B
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,00047B
+SALINE,Smokey Hill Township Part B,United States House of Representatives,1,Republican,"Marshall, Roger",75,00047B
+SALINE,Smoky View Township,United States House of Representatives,1,independent,"LaPolice, Alan",159,000480
+SALINE,Smoky View Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000480
+SALINE,Smoky View Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000480
+SALINE,Smoky View Township,United States House of Representatives,1,Republican,"Marshall, Roger",239,000480
+SALINE,Smolan Township,United States House of Representatives,1,independent,"LaPolice, Alan",147,000490
+SALINE,Smolan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000490
+SALINE,Smolan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000490
+SALINE,Smolan Township,United States House of Representatives,1,Republican,"Marshall, Roger",229,000490
+SALINE,Solomon Township,United States House of Representatives,1,independent,"LaPolice, Alan",61,000500
+SALINE,Solomon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000500
+SALINE,Solomon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000500
+SALINE,Solomon Township,United States House of Representatives,1,Republican,"Marshall, Roger",130,000500
+SALINE,Spring Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",60,000510
+SALINE,Spring Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000510
+SALINE,Spring Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000510
+SALINE,Spring Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",131,000510
+SALINE,Walnut Township,United States House of Representatives,1,independent,"LaPolice, Alan",114,000520
+SALINE,Walnut Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000520
+SALINE,Walnut Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000520
+SALINE,Walnut Township,United States House of Representatives,1,Republican,"Marshall, Roger",191,000520
+SALINE,Elm Creek Township H69,United States House of Representatives,1,independent,"LaPolice, Alan",158,120020
+SALINE,Elm Creek Township H69,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,120020
+SALINE,Elm Creek Township H69,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,120020
+SALINE,Elm Creek Township H69,United States House of Representatives,1,Republican,"Marshall, Roger",313,120020
+SALINE,Elm Creek Township H71,United States House of Representatives,1,independent,"LaPolice, Alan",0,120030
+SALINE,Elm Creek Township H71,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+SALINE,Elm Creek Township H71,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120030
+SALINE,Elm Creek Township H71,United States House of Representatives,1,Republican,"Marshall, Roger",0,120030
+SALINE,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",35,300010
+SALINE,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,300010
+SALINE,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,300010
+SALINE,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,independent,"LaPolice, Alan",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States House of Representatives,1,Republican,"Marshall, Roger",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,independent,"LaPolice, Alan",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States House of Representatives,1,Republican,"Marshall, Roger",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900070
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900080
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900080
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900080
+SALINE,Salina Precinct 33 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900080
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900090
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900090
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900090
+SALINE,Salina Precinct 35 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,independent,"LaPolice, Alan",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States House of Representatives,1,Republican,"Marshall, Roger",0,900110
+SALINE,Cambria Township,United States Senate,,write - in,"Smith, DJ",0,000010
+SALINE,Cambria Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000010
+SALINE,Cambria Township,United States Senate,,Libertarian,"Garrard, Robert D.",24,000010
+SALINE,Cambria Township,United States Senate,,Republican,"Moran, Jerry",166,000010
+SALINE,Dayton Township,United States Senate,,write - in,"Smith, DJ",0,000020
+SALINE,Dayton Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000020
+SALINE,Dayton Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+SALINE,Dayton Township,United States Senate,,Republican,"Moran, Jerry",47,000020
+SALINE,Eureka Township,United States Senate,,write - in,"Smith, DJ",0,000040
+SALINE,Eureka Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000040
+SALINE,Eureka Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000040
+SALINE,Eureka Township,United States Senate,,Republican,"Moran, Jerry",214,000040
+SALINE,Falun Township,United States Senate,,write - in,"Smith, DJ",0,000050
+SALINE,Falun Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000050
+SALINE,Falun Township,United States Senate,,Libertarian,"Garrard, Robert D.",14,000050
+SALINE,Falun Township,United States Senate,,Republican,"Moran, Jerry",110,000050
+SALINE,Glendale Township,United States Senate,,write - in,"Smith, DJ",0,000060
+SALINE,Glendale Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000060
+SALINE,Glendale Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000060
+SALINE,Glendale Township,United States Senate,,Republican,"Moran, Jerry",40,000060
+SALINE,Greeley Township,United States Senate,,write - in,"Smith, DJ",0,000070
+SALINE,Greeley Township,United States Senate,,Democratic,"Wiesner, Patrick",71,000070
+SALINE,Greeley Township,United States Senate,,Libertarian,"Garrard, Robert D.",27,000070
+SALINE,Greeley Township,United States Senate,,Republican,"Moran, Jerry",359,000070
+SALINE,Gypsum Township,United States Senate,,write - in,"Smith, DJ",0,000080
+SALINE,Gypsum Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000080
+SALINE,Gypsum Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000080
+SALINE,Gypsum Township,United States Senate,,Republican,"Moran, Jerry",73,000080
+SALINE,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000090
+SALINE,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000090
+SALINE,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+SALINE,Liberty Township,United States Senate,,Republican,"Moran, Jerry",83,000090
+SALINE,Ohio Township,United States Senate,,write - in,"Smith, DJ",0,000100
+SALINE,Ohio Township,United States Senate,,Democratic,"Wiesner, Patrick",27,000100
+SALINE,Ohio Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000100
+SALINE,Ohio Township,United States Senate,,Republican,"Moran, Jerry",162,000100
+SALINE,Pleasant Valley Township,United States Senate,,write - in,"Smith, DJ",0,000110
+SALINE,Pleasant Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000110
+SALINE,Pleasant Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",15,000110
+SALINE,Pleasant Valley Township,United States Senate,,Republican,"Moran, Jerry",156,000110
+SALINE,Salina Precinct 01 Part A,United States Senate,,write - in,"Smith, DJ",0,00012A
+SALINE,Salina Precinct 01 Part A,United States Senate,,Democratic,"Wiesner, Patrick",112,00012A
+SALINE,Salina Precinct 01 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",36,00012A
+SALINE,Salina Precinct 01 Part A,United States Senate,,Republican,"Moran, Jerry",196,00012A
+SALINE,Salina Precinct 02,United States Senate,,write - in,"Smith, DJ",0,00013A
+SALINE,Salina Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",95,00013A
+SALINE,Salina Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",47,00013A
+SALINE,Salina Precinct 02,United States Senate,,Republican,"Moran, Jerry",181,00013A
+SALINE,Salina Precinct 03,United States Senate,,write - in,"Smith, DJ",0,000140
+SALINE,Salina Precinct 03,United States Senate,,Democratic,"Wiesner, Patrick",101,000140
+SALINE,Salina Precinct 03,United States Senate,,Libertarian,"Garrard, Robert D.",40,000140
+SALINE,Salina Precinct 03,United States Senate,,Republican,"Moran, Jerry",141,000140
+SALINE,Salina Precinct 04,United States Senate,,write - in,"Smith, DJ",0,000150
+SALINE,Salina Precinct 04,United States Senate,,Democratic,"Wiesner, Patrick",141,000150
+SALINE,Salina Precinct 04,United States Senate,,Libertarian,"Garrard, Robert D.",46,000150
+SALINE,Salina Precinct 04,United States Senate,,Republican,"Moran, Jerry",186,000150
+SALINE,Salina Precinct 05,United States Senate,,write - in,"Smith, DJ",0,000160
+SALINE,Salina Precinct 05,United States Senate,,Democratic,"Wiesner, Patrick",121,000160
+SALINE,Salina Precinct 05,United States Senate,,Libertarian,"Garrard, Robert D.",39,000160
+SALINE,Salina Precinct 05,United States Senate,,Republican,"Moran, Jerry",220,000160
+SALINE,Salina Precinct 06,United States Senate,,write - in,"Smith, DJ",0,000170
+SALINE,Salina Precinct 06,United States Senate,,Democratic,"Wiesner, Patrick",103,000170
+SALINE,Salina Precinct 06,United States Senate,,Libertarian,"Garrard, Robert D.",28,000170
+SALINE,Salina Precinct 06,United States Senate,,Republican,"Moran, Jerry",161,000170
+SALINE,Salina Precinct 07,United States Senate,,write - in,"Smith, DJ",0,000180
+SALINE,Salina Precinct 07,United States Senate,,Democratic,"Wiesner, Patrick",117,000180
+SALINE,Salina Precinct 07,United States Senate,,Libertarian,"Garrard, Robert D.",42,000180
+SALINE,Salina Precinct 07,United States Senate,,Republican,"Moran, Jerry",249,000180
+SALINE,Salina Precinct 08,United States Senate,,write - in,"Smith, DJ",0,000190
+SALINE,Salina Precinct 08,United States Senate,,Democratic,"Wiesner, Patrick",106,000190
+SALINE,Salina Precinct 08,United States Senate,,Libertarian,"Garrard, Robert D.",38,000190
+SALINE,Salina Precinct 08,United States Senate,,Republican,"Moran, Jerry",222,000190
+SALINE,Salina Precinct 09,United States Senate,,write - in,"Smith, DJ",0,000200
+SALINE,Salina Precinct 09,United States Senate,,Democratic,"Wiesner, Patrick",110,000200
+SALINE,Salina Precinct 09,United States Senate,,Libertarian,"Garrard, Robert D.",51,000200
+SALINE,Salina Precinct 09,United States Senate,,Republican,"Moran, Jerry",238,000200
+SALINE,Salina Precinct 10,United States Senate,,write - in,"Smith, DJ",0,000210
+SALINE,Salina Precinct 10,United States Senate,,Democratic,"Wiesner, Patrick",124,000210
+SALINE,Salina Precinct 10,United States Senate,,Libertarian,"Garrard, Robert D.",33,000210
+SALINE,Salina Precinct 10,United States Senate,,Republican,"Moran, Jerry",202,000210
+SALINE,Salina Precinct 11,United States Senate,,write - in,"Smith, DJ",0,000220
+SALINE,Salina Precinct 11,United States Senate,,Democratic,"Wiesner, Patrick",97,000220
+SALINE,Salina Precinct 11,United States Senate,,Libertarian,"Garrard, Robert D.",30,000220
+SALINE,Salina Precinct 11,United States Senate,,Republican,"Moran, Jerry",226,000220
+SALINE,Salina Precinct 12,United States Senate,,write - in,"Smith, DJ",0,000230
+SALINE,Salina Precinct 12,United States Senate,,Democratic,"Wiesner, Patrick",171,000230
+SALINE,Salina Precinct 12,United States Senate,,Libertarian,"Garrard, Robert D.",48,000230
+SALINE,Salina Precinct 12,United States Senate,,Republican,"Moran, Jerry",304,000230
+SALINE,Salina Precinct 13,United States Senate,,write - in,"Smith, DJ",0,000240
+SALINE,Salina Precinct 13,United States Senate,,Democratic,"Wiesner, Patrick",99,000240
+SALINE,Salina Precinct 13,United States Senate,,Libertarian,"Garrard, Robert D.",37,000240
+SALINE,Salina Precinct 13,United States Senate,,Republican,"Moran, Jerry",218,000240
+SALINE,Salina Precinct 14 Part A,United States Senate,,write - in,"Smith, DJ",0,00025A
+SALINE,Salina Precinct 14 Part A,United States Senate,,Democratic,"Wiesner, Patrick",142,00025A
+SALINE,Salina Precinct 14 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",38,00025A
+SALINE,Salina Precinct 14 Part A,United States Senate,,Republican,"Moran, Jerry",289,00025A
+SALINE,Salina Precinct 15 Part A,United States Senate,,write - in,"Smith, DJ",0,00026A
+SALINE,Salina Precinct 15 Part A,United States Senate,,Democratic,"Wiesner, Patrick",128,00026A
+SALINE,Salina Precinct 15 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",29,00026A
+SALINE,Salina Precinct 15 Part A,United States Senate,,Republican,"Moran, Jerry",185,00026A
+SALINE,Salina Precinct 16,United States Senate,,write - in,"Smith, DJ",0,000270
+SALINE,Salina Precinct 16,United States Senate,,Democratic,"Wiesner, Patrick",76,000270
+SALINE,Salina Precinct 16,United States Senate,,Libertarian,"Garrard, Robert D.",25,000270
+SALINE,Salina Precinct 16,United States Senate,,Republican,"Moran, Jerry",178,000270
+SALINE,Salina Precinct 17,United States Senate,,write - in,"Smith, DJ",0,000280
+SALINE,Salina Precinct 17,United States Senate,,Democratic,"Wiesner, Patrick",102,000280
+SALINE,Salina Precinct 17,United States Senate,,Libertarian,"Garrard, Robert D.",35,000280
+SALINE,Salina Precinct 17,United States Senate,,Republican,"Moran, Jerry",226,000280
+SALINE,Salina Precinct 18,United States Senate,,write - in,"Smith, DJ",0,000290
+SALINE,Salina Precinct 18,United States Senate,,Democratic,"Wiesner, Patrick",94,000290
+SALINE,Salina Precinct 18,United States Senate,,Libertarian,"Garrard, Robert D.",36,000290
+SALINE,Salina Precinct 18,United States Senate,,Republican,"Moran, Jerry",218,000290
+SALINE,Salina Precinct 19,United States Senate,,write - in,"Smith, DJ",0,000300
+SALINE,Salina Precinct 19,United States Senate,,Democratic,"Wiesner, Patrick",97,000300
+SALINE,Salina Precinct 19,United States Senate,,Libertarian,"Garrard, Robert D.",33,000300
+SALINE,Salina Precinct 19,United States Senate,,Republican,"Moran, Jerry",359,000300
+SALINE,Salina Precinct 20 Part A,United States Senate,,write - in,"Smith, DJ",0,00031A
+SALINE,Salina Precinct 20 Part A,United States Senate,,Democratic,"Wiesner, Patrick",190,00031A
+SALINE,Salina Precinct 20 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",54,00031A
+SALINE,Salina Precinct 20 Part A,United States Senate,,Republican,"Moran, Jerry",754,00031A
+SALINE,Salina Precinct 21 Part A,United States Senate,,write - in,"Smith, DJ",0,00032A
+SALINE,Salina Precinct 21 Part A,United States Senate,,Democratic,"Wiesner, Patrick",204,00032A
+SALINE,Salina Precinct 21 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",30,00032A
+SALINE,Salina Precinct 21 Part A,United States Senate,,Republican,"Moran, Jerry",748,00032A
+SALINE,Salina Precinct 22 Part A,United States Senate,,write - in,"Smith, DJ",0,00033A
+SALINE,Salina Precinct 22 Part A,United States Senate,,Democratic,"Wiesner, Patrick",165,00033A
+SALINE,Salina Precinct 22 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",47,00033A
+SALINE,Salina Precinct 22 Part A,United States Senate,,Republican,"Moran, Jerry",675,00033A
+SALINE,Salina Precinct 23,United States Senate,,write - in,"Smith, DJ",0,000340
+SALINE,Salina Precinct 23,United States Senate,,Democratic,"Wiesner, Patrick",238,000340
+SALINE,Salina Precinct 23,United States Senate,,Libertarian,"Garrard, Robert D.",58,000340
+SALINE,Salina Precinct 23,United States Senate,,Republican,"Moran, Jerry",745,000340
+SALINE,Salina Precinct 24,United States Senate,,write - in,"Smith, DJ",0,000350
+SALINE,Salina Precinct 24,United States Senate,,Democratic,"Wiesner, Patrick",105,000350
+SALINE,Salina Precinct 24,United States Senate,,Libertarian,"Garrard, Robert D.",29,000350
+SALINE,Salina Precinct 24,United States Senate,,Republican,"Moran, Jerry",232,000350
+SALINE,Salina Precinct 25,United States Senate,,write - in,"Smith, DJ",0,000360
+SALINE,Salina Precinct 25,United States Senate,,Democratic,"Wiesner, Patrick",97,000360
+SALINE,Salina Precinct 25,United States Senate,,Libertarian,"Garrard, Robert D.",34,000360
+SALINE,Salina Precinct 25,United States Senate,,Republican,"Moran, Jerry",167,000360
+SALINE,Salina Precinct 26,United States Senate,,write - in,"Smith, DJ",0,000370
+SALINE,Salina Precinct 26,United States Senate,,Democratic,"Wiesner, Patrick",89,000370
+SALINE,Salina Precinct 26,United States Senate,,Libertarian,"Garrard, Robert D.",26,000370
+SALINE,Salina Precinct 26,United States Senate,,Republican,"Moran, Jerry",226,000370
+SALINE,Salina Precinct 27,United States Senate,,write - in,"Smith, DJ",0,000380
+SALINE,Salina Precinct 27,United States Senate,,Democratic,"Wiesner, Patrick",108,000380
+SALINE,Salina Precinct 27,United States Senate,,Libertarian,"Garrard, Robert D.",43,000380
+SALINE,Salina Precinct 27,United States Senate,,Republican,"Moran, Jerry",335,000380
+SALINE,Salina Precinct 28,United States Senate,,write - in,"Smith, DJ",0,000390
+SALINE,Salina Precinct 28,United States Senate,,Democratic,"Wiesner, Patrick",89,000390
+SALINE,Salina Precinct 28,United States Senate,,Libertarian,"Garrard, Robert D.",37,000390
+SALINE,Salina Precinct 28,United States Senate,,Republican,"Moran, Jerry",263,000390
+SALINE,Salina Precinct 29,United States Senate,,write - in,"Smith, DJ",0,000400
+SALINE,Salina Precinct 29,United States Senate,,Democratic,"Wiesner, Patrick",117,000400
+SALINE,Salina Precinct 29,United States Senate,,Libertarian,"Garrard, Robert D.",36,000400
+SALINE,Salina Precinct 29,United States Senate,,Republican,"Moran, Jerry",402,000400
+SALINE,Salina Precinct 30,United States Senate,,write - in,"Smith, DJ",0,000410
+SALINE,Salina Precinct 30,United States Senate,,Democratic,"Wiesner, Patrick",104,000410
+SALINE,Salina Precinct 30,United States Senate,,Libertarian,"Garrard, Robert D.",32,000410
+SALINE,Salina Precinct 30,United States Senate,,Republican,"Moran, Jerry",323,000410
+SALINE,Salina Precinct 31 Part A,United States Senate,,write - in,"Smith, DJ",0,00042A
+SALINE,Salina Precinct 31 Part A,United States Senate,,Democratic,"Wiesner, Patrick",257,00042A
+SALINE,Salina Precinct 31 Part A,United States Senate,,Libertarian,"Garrard, Robert D.",67,00042A
+SALINE,Salina Precinct 31 Part A,United States Senate,,Republican,"Moran, Jerry",909,00042A
+SALINE,Salina Precinct 32,United States Senate,,write - in,"Smith, DJ",0,000430
+SALINE,Salina Precinct 32,United States Senate,,Democratic,"Wiesner, Patrick",71,000430
+SALINE,Salina Precinct 32,United States Senate,,Libertarian,"Garrard, Robert D.",20,000430
+SALINE,Salina Precinct 32,United States Senate,,Republican,"Moran, Jerry",238,000430
+SALINE,Salina Precinct 33,United States Senate,,write - in,"Smith, DJ",0,000440
+SALINE,Salina Precinct 33,United States Senate,,Democratic,"Wiesner, Patrick",151,000440
+SALINE,Salina Precinct 33,United States Senate,,Libertarian,"Garrard, Robert D.",36,000440
+SALINE,Salina Precinct 33,United States Senate,,Republican,"Moran, Jerry",453,000440
+SALINE,Salina Precinct 34,United States Senate,,write - in,"Smith, DJ",0,000450
+SALINE,Salina Precinct 34,United States Senate,,Democratic,"Wiesner, Patrick",243,000450
+SALINE,Salina Precinct 34,United States Senate,,Libertarian,"Garrard, Robert D.",69,000450
+SALINE,Salina Precinct 34,United States Senate,,Republican,"Moran, Jerry",811,000450
+SALINE,Salina Precinct 35,United States Senate,,write - in,"Smith, DJ",0,00046A
+SALINE,Salina Precinct 35,United States Senate,,Democratic,"Wiesner, Patrick",197,00046A
+SALINE,Salina Precinct 35,United States Senate,,Libertarian,"Garrard, Robert D.",78,00046A
+SALINE,Salina Precinct 35,United States Senate,,Republican,"Moran, Jerry",438,00046A
+SALINE,Smokey Hill Township Part B,United States Senate,,write - in,"Smith, DJ",0,00047B
+SALINE,Smokey Hill Township Part B,United States Senate,,Democratic,"Wiesner, Patrick",29,00047B
+SALINE,Smokey Hill Township Part B,United States Senate,,Libertarian,"Garrard, Robert D.",8,00047B
+SALINE,Smokey Hill Township Part B,United States Senate,,Republican,"Moran, Jerry",98,00047B
+SALINE,Smoky View Township,United States Senate,,write - in,"Smith, DJ",0,000480
+SALINE,Smoky View Township,United States Senate,,Democratic,"Wiesner, Patrick",70,000480
+SALINE,Smoky View Township,United States Senate,,Libertarian,"Garrard, Robert D.",32,000480
+SALINE,Smoky View Township,United States Senate,,Republican,"Moran, Jerry",328,000480
+SALINE,Smolan Township,United States Senate,,write - in,"Smith, DJ",0,000490
+SALINE,Smolan Township,United States Senate,,Democratic,"Wiesner, Patrick",56,000490
+SALINE,Smolan Township,United States Senate,,Libertarian,"Garrard, Robert D.",31,000490
+SALINE,Smolan Township,United States Senate,,Republican,"Moran, Jerry",310,000490
+SALINE,Solomon Township,United States Senate,,write - in,"Smith, DJ",0,000500
+SALINE,Solomon Township,United States Senate,,Democratic,"Wiesner, Patrick",22,000500
+SALINE,Solomon Township,United States Senate,,Libertarian,"Garrard, Robert D.",10,000500
+SALINE,Solomon Township,United States Senate,,Republican,"Moran, Jerry",174,000500
+SALINE,Spring Creek Township,United States Senate,,write - in,"Smith, DJ",0,000510
+SALINE,Spring Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000510
+SALINE,Spring Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",19,000510
+SALINE,Spring Creek Township,United States Senate,,Republican,"Moran, Jerry",154,000510
+SALINE,Walnut Township,United States Senate,,write - in,"Smith, DJ",0,000520
+SALINE,Walnut Township,United States Senate,,Democratic,"Wiesner, Patrick",49,000520
+SALINE,Walnut Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000520
+SALINE,Walnut Township,United States Senate,,Republican,"Moran, Jerry",255,000520
+SALINE,Elm Creek Township H69,United States Senate,,write - in,"Smith, DJ",0,120020
+SALINE,Elm Creek Township H69,United States Senate,,Democratic,"Wiesner, Patrick",56,120020
+SALINE,Elm Creek Township H69,United States Senate,,Libertarian,"Garrard, Robert D.",33,120020
+SALINE,Elm Creek Township H69,United States Senate,,Republican,"Moran, Jerry",407,120020
+SALINE,Elm Creek Township H71,United States Senate,,write - in,"Smith, DJ",0,120030
+SALINE,Elm Creek Township H71,United States Senate,,Democratic,"Wiesner, Patrick",0,120030
+SALINE,Elm Creek Township H71,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+SALINE,Elm Creek Township H71,United States Senate,,Republican,"Moran, Jerry",0,120030
+SALINE,Washington Township,United States Senate,,write - in,"Smith, DJ",0,300010
+SALINE,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",5,300010
+SALINE,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,300010
+SALINE,Washington Township,United States Senate,,Republican,"Moran, Jerry",69,300010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900010
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+SALINE,Salina Precinct 01 Part A Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900020
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900030
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900040
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,write - in,"Smith, DJ",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 3,United States Senate,,Republican,"Moran, Jerry",0,900050
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,write - in,"Smith, DJ",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+SALINE,Salina Precinct 15 Part A Exclave 4,United States Senate,,Republican,"Moran, Jerry",0,900060
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,write - in,"Smith, DJ",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900070
+SALINE,Salina Precinct 22 Part A Exclave,United States Senate,,Republican,"Moran, Jerry",0,900070
+SALINE,Salina Precinct 33 Exclave,United States Senate,,write - in,"Smith, DJ",0,900080
+SALINE,Salina Precinct 33 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900080
+SALINE,Salina Precinct 33 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900080
+SALINE,Salina Precinct 33 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900080
+SALINE,Salina Precinct 35 Exclave,United States Senate,,write - in,"Smith, DJ",0,900090
+SALINE,Salina Precinct 35 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900090
+SALINE,Salina Precinct 35 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900090
+SALINE,Salina Precinct 35 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900090
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900100
+SALINE,Smokey Hill Township Part B Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900100
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,write - in,"Smith, DJ",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900110
+SALINE,Smokey Hill Township Part B Enclave 1,United States Senate,,Republican,"Moran, Jerry",0,900110

--- a/2016/20161108__ks__general__scott__precinct.csv
+++ b/2016/20161108__ks__general__scott__precinct.csv
@@ -1,397 +1,397 @@
-county,precinct,office,district,candidate,party,votes,
-Scott,Beaver Township,President,,"Stein, Jill  ",independent,3,
-Scott,Beaver Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Beaver Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Beaver Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Beaver Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Beaver Township,President,,"Hedges, James A ",write - in,0,
-Scott,Beaver Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Beaver Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Beaver Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Beaver Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Beaver Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Beaver Township,President,,"McMullin, Evan  ",write - in,1,
-Scott,Beaver Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Beaver Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Beaver Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Beaver Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Beaver Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Beaver Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Beaver Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Beaver Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Beaver Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Beaver Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Beaver Township,President,,"Clinton, Hillary Rodham ",Democratic,11,
-Scott,Beaver Township,President,,"Johnson, Gary  ",Libertarian,2,
-Scott,Beaver Township,President,,"Trump, Donald J. ",Republican,79,
-Scott,Isbel Township,President,,"Stein, Jill  ",independent,1,
-Scott,Isbel Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Isbel Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Isbel Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Isbel Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Isbel Township,President,,"Hedges, James A ",write - in,0,
-Scott,Isbel Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Isbel Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Isbel Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Isbel Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Isbel Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Isbel Township,President,,"McMullin, Evan  ",write - in,0,
-Scott,Isbel Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Isbel Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Isbel Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Isbel Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Isbel Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Isbel Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Isbel Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Isbel Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Isbel Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Isbel Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Isbel Township,President,,"Clinton, Hillary Rodham ",Democratic,1,
-Scott,Isbel Township,President,,"Johnson, Gary  ",Libertarian,1,
-Scott,Isbel Township,President,,"Trump, Donald J. ",Republican,45,
-Scott,Keystone Township,President,,"Stein, Jill  ",independent,1,
-Scott,Keystone Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Keystone Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Keystone Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Keystone Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Keystone Township,President,,"Hedges, James A ",write - in,0,
-Scott,Keystone Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Keystone Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Keystone Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Keystone Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Keystone Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Keystone Township,President,,"McMullin, Evan  ",write - in,0,
-Scott,Keystone Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Keystone Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Keystone Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Keystone Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Keystone Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Keystone Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Keystone Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Keystone Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Keystone Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Keystone Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Keystone Township,President,,"Clinton, Hillary Rodham ",Democratic,0,
-Scott,Keystone Township,President,,"Johnson, Gary  ",Libertarian,1,
-Scott,Keystone Township,President,,"Trump, Donald J. ",Republican,47,
-Scott,Lake Township,President,,"Stein, Jill  ",independent,0,
-Scott,Lake Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Lake Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Lake Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Lake Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Lake Township,President,,"Hedges, James A ",write - in,0,
-Scott,Lake Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Lake Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Lake Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Lake Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Lake Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Lake Township,President,,"McMullin, Evan  ",write - in,0,
-Scott,Lake Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Lake Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Lake Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Lake Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Lake Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Lake Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Lake Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Lake Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Lake Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Lake Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Lake Township,President,,"Clinton, Hillary Rodham ",Democratic,3,
-Scott,Lake Township,President,,"Johnson, Gary  ",Libertarian,2,
-Scott,Lake Township,President,,"Trump, Donald J. ",Republican,36,
-Scott,Michigan Township,President,,"Stein, Jill  ",independent,1,
-Scott,Michigan Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Michigan Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Michigan Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Michigan Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Michigan Township,President,,"Hedges, James A ",write - in,0,
-Scott,Michigan Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Michigan Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Michigan Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Michigan Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Michigan Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Michigan Township,President,,"McMullin, Evan  ",write - in,0,
-Scott,Michigan Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Michigan Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Michigan Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Michigan Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Michigan Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Michigan Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Michigan Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Michigan Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Michigan Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Michigan Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Michigan Township,President,,"Clinton, Hillary Rodham ",Democratic,1,
-Scott,Michigan Township,President,,"Johnson, Gary  ",Libertarian,0,
-Scott,Michigan Township,President,,"Trump, Donald J. ",Republican,42,
-Scott,Scott City Ward 1,President,,"Stein, Jill  ",independent,6,
-Scott,Scott City Ward 1,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Scott City Ward 1,President,,"Castle, Darrell L ",write - in,0,
-Scott,Scott City Ward 1,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Hedges, James A ",write - in,0,
-Scott,Scott City Ward 1,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Scott City Ward 1,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Scott City Ward 1,President,,"Maturen, Michael A ",write - in,0,
-Scott,Scott City Ward 1,President,,"McMullin, Evan  ",write - in,2,
-Scott,Scott City Ward 1,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Scott City Ward 1,President,,"Perry, Darryl  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Scott City Ward 1,President,,"Schriner, Joe C ",write - in,0,
-Scott,Scott City Ward 1,President,,"Smith, Mike  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Sood, Ajay  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Scott City Ward 1,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Scott City Ward 1,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Scott City Ward 1,President,,"Clinton, Hillary Rodham ",Democratic,39,
-Scott,Scott City Ward 1,President,,"Johnson, Gary  ",Libertarian,8,
-Scott,Scott City Ward 1,President,,"Trump, Donald J. ",Republican,219,
-Scott,Scott City Ward 2,President,,"Stein, Jill  ",independent,2,
-Scott,Scott City Ward 2,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Scott City Ward 2,President,,"Castle, Darrell L ",write - in,0,
-Scott,Scott City Ward 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Hedges, James A ",write - in,0,
-Scott,Scott City Ward 2,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Scott City Ward 2,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Scott City Ward 2,President,,"Maturen, Michael A ",write - in,0,
-Scott,Scott City Ward 2,President,,"McMullin, Evan  ",write - in,2,
-Scott,Scott City Ward 2,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Scott City Ward 2,President,,"Perry, Darryl  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Scott City Ward 2,President,,"Schriner, Joe C ",write - in,0,
-Scott,Scott City Ward 2,President,,"Smith, Mike  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Sood, Ajay  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Scott City Ward 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Scott City Ward 2,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Scott City Ward 2,President,,"Clinton, Hillary Rodham ",Democratic,38,
-Scott,Scott City Ward 2,President,,"Johnson, Gary  ",Libertarian,20,
-Scott,Scott City Ward 2,President,,"Trump, Donald J. ",Republican,459,
-Scott,Scott City Ward 3,President,,"Stein, Jill  ",independent,5,
-Scott,Scott City Ward 3,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Scott City Ward 3,President,,"Castle, Darrell L ",write - in,0,
-Scott,Scott City Ward 3,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Hedges, James A ",write - in,0,
-Scott,Scott City Ward 3,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Scott City Ward 3,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Scott City Ward 3,President,,"Maturen, Michael A ",write - in,0,
-Scott,Scott City Ward 3,President,,"McMullin, Evan  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Scott City Ward 3,President,,"Perry, Darryl  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Scott City Ward 3,President,,"Schriner, Joe C ",write - in,0,
-Scott,Scott City Ward 3,President,,"Smith, Mike  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Sood, Ajay  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Scott City Ward 3,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Scott City Ward 3,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Scott City Ward 3,President,,"Clinton, Hillary Rodham ",Democratic,49,
-Scott,Scott City Ward 3,President,,"Johnson, Gary  ",Libertarian,14,
-Scott,Scott City Ward 3,President,,"Trump, Donald J. ",Republican,346,
-Scott,Scott City Ward 4,President,,"Stein, Jill  ",independent,7,
-Scott,Scott City Ward 4,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Scott City Ward 4,President,,"Castle, Darrell L ",write - in,0,
-Scott,Scott City Ward 4,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Hedges, James A ",write - in,0,
-Scott,Scott City Ward 4,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Scott City Ward 4,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Scott City Ward 4,President,,"Maturen, Michael A ",write - in,0,
-Scott,Scott City Ward 4,President,,"McMullin, Evan  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Scott City Ward 4,President,,"Perry, Darryl  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Scott City Ward 4,President,,"Schriner, Joe C ",write - in,0,
-Scott,Scott City Ward 4,President,,"Smith, Mike  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Sood, Ajay  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Scott City Ward 4,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Scott City Ward 4,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Scott City Ward 4,President,,"Clinton, Hillary Rodham ",Democratic,71,
-Scott,Scott City Ward 4,President,,"Johnson, Gary  ",Libertarian,15,
-Scott,Scott City Ward 4,President,,"Trump, Donald J. ",Republican,388,
-Scott,Scott Township,President,,"Stein, Jill  ",independent,0,
-Scott,Scott Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Scott Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Scott Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Scott Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Scott Township,President,,"Hedges, James A ",write - in,0,
-Scott,Scott Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Scott Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Scott Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Scott Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Scott Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Scott Township,President,,"McMullin, Evan  ",write - in,0,
-Scott,Scott Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Scott Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Scott Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Scott Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Scott Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Scott Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Scott Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Scott Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Scott Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Scott Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Scott Township,President,,"Clinton, Hillary Rodham ",Democratic,11,
-Scott,Scott Township,President,,"Johnson, Gary  ",Libertarian,3,
-Scott,Scott Township,President,,"Trump, Donald J. ",Republican,123,
-Scott,Valley Township,President,,"Stein, Jill  ",independent,1,
-Scott,Valley Township,President,,"Basiago, Andrew D. ",write - in,0,
-Scott,Valley Township,President,,"Castle, Darrell L ",write - in,0,
-Scott,Valley Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0,
-Scott,Valley Township,President,,"Giordani, Rocky  ",write - in,0,
-Scott,Valley Township,President,,"Hedges, James A ",write - in,0,
-Scott,Valley Township,President,,"Hoefling, Tom  ",write - in,0,
-Scott,Valley Township,President,,"Kahn, Lynn  ",write - in,0,
-Scott,Valley Township,President,,"La Riva, Gloria  ",write - in,0,
-Scott,Valley Township,President,,"Levinson, Michael S. ",write - in,0,
-Scott,Valley Township,President,,"Maturen, Michael A ",write - in,0,
-Scott,Valley Township,President,,"McMullin, Evan  ",write - in,0,
-Scott,Valley Township,President,,"Moorehead, Monica G. ",write - in,0,
-Scott,Valley Township,President,,"Perry, Darryl  ",write - in,0,
-Scott,Valley Township,President,,"Schoenke, Marshall R. ",write - in,0,
-Scott,Valley Township,President,,"Schriner, Joe C ",write - in,0,
-Scott,Valley Township,President,,"Smith, Mike  ",write - in,0,
-Scott,Valley Township,President,,"Sood, Ajay  ",write - in,0,
-Scott,Valley Township,President,,"Sterling, Shawna  ",write - in,0,
-Scott,Valley Township,President,,"Valdivia, Anthony J ",write - in,0,
-Scott,Valley Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0,
-Scott,Valley Township,President,,"Wysinger, Demetra Jefferson ",write - in,0,
-Scott,Valley Township,President,,"Clinton, Hillary Rodham ",Democratic,12,
-Scott,Valley Township,President,,"Johnson, Gary  ",Libertarian,3,
-Scott,Valley Township,President,,"Trump, Donald J. ",Republican,81,
-Scott,Beaver Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Beaver Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,8,
-Scott,Beaver Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5,
-Scott,Beaver Township,U.S. Senate,,"Moran, Jerry  ",Republican,82,
-Scott,Isbel Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Isbel Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2,
-Scott,Isbel Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2,
-Scott,Isbel Township,U.S. Senate,,"Moran, Jerry  ",Republican,44,
-Scott,Keystone Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Keystone Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,2,
-Scott,Keystone Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2,
-Scott,Keystone Township,U.S. Senate,,"Moran, Jerry  ",Republican,45,
-Scott,Lake Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Lake Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3,
-Scott,Lake Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0,
-Scott,Lake Township,U.S. Senate,,"Moran, Jerry  ",Republican,37,
-Scott,Michigan Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Michigan Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3,
-Scott,Michigan Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2,
-Scott,Michigan Township,U.S. Senate,,"Moran, Jerry  ",Republican,39,
-Scott,Scott City Ward 1,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Scott City Ward 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,36,
-Scott,Scott City Ward 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,19,
-Scott,Scott City Ward 1,U.S. Senate,,"Moran, Jerry  ",Republican,214,
-Scott,Scott City Ward 2,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Scott City Ward 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,22,
-Scott,Scott City Ward 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,16,
-Scott,Scott City Ward 2,U.S. Senate,,"Moran, Jerry  ",Republican,482,
-Scott,Scott City Ward 3,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Scott City Ward 3,U.S. Senate,,"Wiesner, Patrick  ",Democratic,46,
-Scott,Scott City Ward 3,U.S. Senate,,"Garrard, Robert D. ",Libertarian,17,
-Scott,Scott City Ward 3,U.S. Senate,,"Moran, Jerry  ",Republican,347,
-Scott,Scott City Ward 4,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Scott City Ward 4,U.S. Senate,,"Wiesner, Patrick  ",Democratic,52,
-Scott,Scott City Ward 4,U.S. Senate,,"Garrard, Robert D. ",Libertarian,23,
-Scott,Scott City Ward 4,U.S. Senate,,"Moran, Jerry  ",Republican,405,
-Scott,Scott Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Scott Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4,
-Scott,Scott Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4,
-Scott,Scott Township,U.S. Senate,,"Moran, Jerry  ",Republican,126,
-Scott,Valley Township,U.S. Senate,,"Smith, DJ  ",write - in,0,
-Scott,Valley Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,9,
-Scott,Valley Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,4,
-Scott,Valley Township,U.S. Senate,,"Moran, Jerry  ",Republican,81,
-Scott,Beaver Township,U.S. House,1,"LaPolice, Alan  ",independent,15,
-Scott,Beaver Township,U.S. House,1,"Huelskamp, Tim  ",write - in,1,
-Scott,Beaver Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3,
-Scott,Beaver Township,U.S. House,1,"Marshall, Roger  ",Republican,74,
-Scott,Isbel Township,U.S. House,1,"LaPolice, Alan  ",independent,2,
-Scott,Isbel Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0,
-Scott,Isbel Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2,
-Scott,Isbel Township,U.S. House,1,"Marshall, Roger  ",Republican,43,
-Scott,Keystone Township,U.S. House,1,"LaPolice, Alan  ",independent,3,
-Scott,Keystone Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0,
-Scott,Keystone Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1,
-Scott,Keystone Township,U.S. House,1,"Marshall, Roger  ",Republican,45,
-Scott,Lake Township,U.S. House,1,"LaPolice, Alan  ",independent,4,
-Scott,Lake Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0,
-Scott,Lake Township,U.S. House,1,"Burt, Kerry  ",Libertarian,0,
-Scott,Lake Township,U.S. House,1,"Marshall, Roger  ",Republican,37,
-Scott,Michigan Township,U.S. House,1,"LaPolice, Alan  ",independent,6,
-Scott,Michigan Township,U.S. House,1,"Huelskamp, Tim  ",write - in,1,
-Scott,Michigan Township,U.S. House,1,"Burt, Kerry  ",Libertarian,2,
-Scott,Michigan Township,U.S. House,1,"Marshall, Roger  ",Republican,34,
-Scott,Scott City Ward 1,U.S. House,1,"LaPolice, Alan  ",independent,37,
-Scott,Scott City Ward 1,U.S. House,1,"Huelskamp, Tim  ",write - in,1,
-Scott,Scott City Ward 1,U.S. House,1,"Burt, Kerry  ",Libertarian,15,
-Scott,Scott City Ward 1,U.S. House,1,"Marshall, Roger  ",Republican,213,
-Scott,Scott City Ward 2,U.S. House,1,"LaPolice, Alan  ",independent,64,
-Scott,Scott City Ward 2,U.S. House,1,"Huelskamp, Tim  ",write - in,9,
-Scott,Scott City Ward 2,U.S. House,1,"Burt, Kerry  ",Libertarian,9,
-Scott,Scott City Ward 2,U.S. House,1,"Marshall, Roger  ",Republican,440,
-Scott,Scott City Ward 3,U.S. House,1,"LaPolice, Alan  ",independent,60,
-Scott,Scott City Ward 3,U.S. House,1,"Huelskamp, Tim  ",write - in,0,
-Scott,Scott City Ward 3,U.S. House,1,"Burt, Kerry  ",Libertarian,35,
-Scott,Scott City Ward 3,U.S. House,1,"Marshall, Roger  ",Republican,309,
-Scott,Scott City Ward 4,U.S. House,1,"LaPolice, Alan  ",independent,77,
-Scott,Scott City Ward 4,U.S. House,1,"Huelskamp, Tim  ",write - in,1,
-Scott,Scott City Ward 4,U.S. House,1,"Burt, Kerry  ",Libertarian,25,
-Scott,Scott City Ward 4,U.S. House,1,"Marshall, Roger  ",Republican,374,
-Scott,Scott Township,U.S. House,1,"LaPolice, Alan  ",independent,18,
-Scott,Scott Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0,
-Scott,Scott Township,U.S. House,1,"Burt, Kerry  ",Libertarian,6,
-Scott,Scott Township,U.S. House,1,"Marshall, Roger  ",Republican,109,
-Scott,Valley Township,U.S. House,1,"LaPolice, Alan  ",independent,7,
-Scott,Valley Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0,
-Scott,Valley Township,U.S. House,1,"Burt, Kerry  ",Libertarian,4,
-Scott,Valley Township,U.S. House,1,"Marshall, Roger  ",Republican,82,
-Scott,Beaver Township,State Senate,33,"Bristow, Matt  ",Democratic,12,
-Scott,Beaver Township,State Senate,33,"Taylor, Mary Jo ",Republican,76,
-Scott,Isbel Township,State Senate,33,"Bristow, Matt  ",Democratic,1,
-Scott,Isbel Township,State Senate,33,"Taylor, Mary Jo ",Republican,44,
-Scott,Keystone Township,State Senate,33,"Bristow, Matt  ",Democratic,5,
-Scott,Keystone Township,State Senate,33,"Taylor, Mary Jo ",Republican,44,
-Scott,Lake Township,State Senate,33,"Bristow, Matt  ",Democratic,4,
-Scott,Lake Township,State Senate,33,"Taylor, Mary Jo ",Republican,35,
-Scott,Michigan Township,State Senate,33,"Bristow, Matt  ",Democratic,4,
-Scott,Michigan Township,State Senate,33,"Taylor, Mary Jo ",Republican,35,
-Scott,Scott City Ward 1,State Senate,33,"Bristow, Matt  ",Democratic,57,
-Scott,Scott City Ward 1,State Senate,33,"Taylor, Mary Jo ",Republican,209,
-Scott,Scott City Ward 2,State Senate,33,"Bristow, Matt  ",Democratic,35,
-Scott,Scott City Ward 2,State Senate,33,"Taylor, Mary Jo ",Republican,473,
-Scott,Scott City Ward 3,State Senate,33,"Bristow, Matt  ",Democratic,63,
-Scott,Scott City Ward 3,State Senate,33,"Taylor, Mary Jo ",Republican,335,
-Scott,Scott City Ward 4,State Senate,33,"Bristow, Matt  ",Democratic,82,
-Scott,Scott City Ward 4,State Senate,33,"Taylor, Mary Jo ",Republican,388,
-Scott,Scott Township,State Senate,33,"Bristow, Matt  ",Democratic,10,
-Scott,Scott Township,State Senate,33,"Taylor, Mary Jo ",Republican,123,
-Scott,Valley Township,State Senate,33,"Bristow, Matt  ",Democratic,6,
-Scott,Valley Township,State Senate,33,"Taylor, Mary Jo ",Republican,87,
-Scott,Beaver Township,State House,118,"Hineman, Don  ",Republican,74,
-Scott,Isbel Township,State House,118,"Hineman, Don  ",Republican,43,
-Scott,Keystone Township,State House,118,"Hineman, Don  ",Republican,48,
-Scott,Lake Township,State House,118,"Hineman, Don  ",Republican,36,
-Scott,Michigan Township,State House,118,"Hineman, Don  ",Republican,37,
-Scott,Scott City Ward 1,State House,118,"Hineman, Don  ",Republican,234,
-Scott,Scott City Ward 2,State House,118,"Hineman, Don  ",Republican,473,
-Scott,Scott City Ward 3,State House,118,"Hineman, Don  ",Republican,367,
-Scott,Scott City Ward 4,State House,118,"Hineman, Don  ",Republican,428,
-Scott,Scott Township,State House,118,"Hineman, Don  ",Republican,126,
-Scott,Valley Township,State House,118,"Hineman, Don  ",Republican,84,
+county,precinct,office,district,party,candidate,votes,vtd
+SCOTT,Beaver Township,Kansas House of Representatives,118,Republican,"Hineman, Don",74,000010
+SCOTT,Isbel Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000020
+SCOTT,Keystone Township,Kansas House of Representatives,118,Republican,"Hineman, Don",48,000030
+SCOTT,Lake Township,Kansas House of Representatives,118,Republican,"Hineman, Don",36,000040
+SCOTT,Michigan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",37,000050
+SCOTT,Scott City Ward 1,Kansas House of Representatives,118,Republican,"Hineman, Don",234,000060
+SCOTT,Scott City Ward 2,Kansas House of Representatives,118,Republican,"Hineman, Don",473,000070
+SCOTT,Scott City Ward 3,Kansas House of Representatives,118,Republican,"Hineman, Don",367,000080
+SCOTT,Scott City Ward 4,Kansas House of Representatives,118,Republican,"Hineman, Don",428,000090
+SCOTT,Scott Township,Kansas House of Representatives,118,Republican,"Hineman, Don",126,00010A
+SCOTT,Valley Township,Kansas House of Representatives,118,Republican,"Hineman, Don",84,000110
+SCOTT,Beaver Township,Kansas Senate,33,Democratic,"Bristow, Matt",12,000010
+SCOTT,Beaver Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",76,000010
+SCOTT,Isbel Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000020
+SCOTT,Isbel Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",44,000020
+SCOTT,Keystone Township,Kansas Senate,33,Democratic,"Bristow, Matt",5,000030
+SCOTT,Keystone Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",44,000030
+SCOTT,Lake Township,Kansas Senate,33,Democratic,"Bristow, Matt",4,000040
+SCOTT,Lake Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",35,000040
+SCOTT,Michigan Township,Kansas Senate,33,Democratic,"Bristow, Matt",4,000050
+SCOTT,Michigan Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",35,000050
+SCOTT,Scott City Ward 1,Kansas Senate,33,Democratic,"Bristow, Matt",57,000060
+SCOTT,Scott City Ward 1,Kansas Senate,33,Republican,"Taylor, Mary Jo",209,000060
+SCOTT,Scott City Ward 2,Kansas Senate,33,Democratic,"Bristow, Matt",35,000070
+SCOTT,Scott City Ward 2,Kansas Senate,33,Republican,"Taylor, Mary Jo",473,000070
+SCOTT,Scott City Ward 3,Kansas Senate,33,Democratic,"Bristow, Matt",63,000080
+SCOTT,Scott City Ward 3,Kansas Senate,33,Republican,"Taylor, Mary Jo",335,000080
+SCOTT,Scott City Ward 4,Kansas Senate,33,Democratic,"Bristow, Matt",82,000090
+SCOTT,Scott City Ward 4,Kansas Senate,33,Republican,"Taylor, Mary Jo",388,000090
+SCOTT,Scott Township,Kansas Senate,33,Democratic,"Bristow, Matt",10,00010A
+SCOTT,Scott Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",123,00010A
+SCOTT,Valley Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000110
+SCOTT,Valley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",87,000110
+SCOTT,Beaver Township,President / Vice President,,independent,"Stein, Jill",3,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",1,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SCOTT,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SCOTT,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000010
+SCOTT,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+SCOTT,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",79,000010
+SCOTT,Isbel Township,President / Vice President,,independent,"Stein, Jill",1,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+SCOTT,Isbel Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+SCOTT,Isbel Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+SCOTT,Isbel Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+SCOTT,Isbel Township,President / Vice President,,Republican,"Trump, Donald J.",45,000020
+SCOTT,Keystone Township,President / Vice President,,independent,"Stein, Jill",1,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+SCOTT,Keystone Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+SCOTT,Keystone Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+SCOTT,Keystone Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+SCOTT,Keystone Township,President / Vice President,,Republican,"Trump, Donald J.",47,000030
+SCOTT,Lake Township,President / Vice President,,independent,"Stein, Jill",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SCOTT,Lake Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SCOTT,Lake Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000040
+SCOTT,Lake Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+SCOTT,Lake Township,President / Vice President,,Republican,"Trump, Donald J.",36,000040
+SCOTT,Michigan Township,President / Vice President,,independent,"Stein, Jill",1,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+SCOTT,Michigan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+SCOTT,Michigan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000050
+SCOTT,Michigan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+SCOTT,Michigan Township,President / Vice President,,Republican,"Trump, Donald J.",42,000050
+SCOTT,Scott City Ward 1,President / Vice President,,independent,"Stein, Jill",6,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"McMullin, Evan",2,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",39,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,000060
+SCOTT,Scott City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",219,000060
+SCOTT,Scott City Ward 2,President / Vice President,,independent,"Stein, Jill",2,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"McMullin, Evan",2,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",20,000070
+SCOTT,Scott City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",459,000070
+SCOTT,Scott City Ward 3,President / Vice President,,independent,"Stein, Jill",5,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",14,000080
+SCOTT,Scott City Ward 3,President / Vice President,,Republican,"Trump, Donald J.",346,000080
+SCOTT,Scott City Ward 4,President / Vice President,,independent,"Stein, Jill",7,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",15,000090
+SCOTT,Scott City Ward 4,President / Vice President,,Republican,"Trump, Donald J.",388,000090
+SCOTT,Scott Township,President / Vice President,,independent,"Stein, Jill",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Hedges, James A",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"McMullin, Evan",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Smith, Mike",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+SCOTT,Scott Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+SCOTT,Scott Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,00010A
+SCOTT,Scott Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00010A
+SCOTT,Scott Township,President / Vice President,,Republican,"Trump, Donald J.",123,00010A
+SCOTT,Valley Township,President / Vice President,,independent,"Stein, Jill",1,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+SCOTT,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+SCOTT,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000110
+SCOTT,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+SCOTT,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",81,000110
+SCOTT,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000010
+SCOTT,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+SCOTT,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000010
+SCOTT,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",74,000010
+SCOTT,Isbel Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000020
+SCOTT,Isbel Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+SCOTT,Isbel Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000020
+SCOTT,Isbel Township,United States House of Representatives,1,Republican,"Marshall, Roger",43,000020
+SCOTT,Keystone Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000030
+SCOTT,Keystone Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+SCOTT,Keystone Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+SCOTT,Keystone Township,United States House of Representatives,1,Republican,"Marshall, Roger",45,000030
+SCOTT,Lake Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000040
+SCOTT,Lake Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+SCOTT,Lake Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+SCOTT,Lake Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000040
+SCOTT,Michigan Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000050
+SCOTT,Michigan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+SCOTT,Michigan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000050
+SCOTT,Michigan Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000050
+SCOTT,Scott City Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",37,000060
+SCOTT,Scott City Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000060
+SCOTT,Scott City Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000060
+SCOTT,Scott City Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",213,000060
+SCOTT,Scott City Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",64,000070
+SCOTT,Scott City Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",9,000070
+SCOTT,Scott City Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000070
+SCOTT,Scott City Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",440,000070
+SCOTT,Scott City Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",60,000080
+SCOTT,Scott City Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+SCOTT,Scott City Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000080
+SCOTT,Scott City Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",309,000080
+SCOTT,Scott City Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",77,000090
+SCOTT,Scott City Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000090
+SCOTT,Scott City Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000090
+SCOTT,Scott City Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",374,000090
+SCOTT,Scott Township,United States House of Representatives,1,independent,"LaPolice, Alan",18,00010A
+SCOTT,Scott Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00010A
+SCOTT,Scott Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,00010A
+SCOTT,Scott Township,United States House of Representatives,1,Republican,"Marshall, Roger",109,00010A
+SCOTT,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000110
+SCOTT,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+SCOTT,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000110
+SCOTT,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",82,000110
+SCOTT,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000010
+SCOTT,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000010
+SCOTT,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000010
+SCOTT,Beaver Township,United States Senate,,Republican,"Moran, Jerry",82,000010
+SCOTT,Isbel Township,United States Senate,,write - in,"Smith, DJ",0,000020
+SCOTT,Isbel Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000020
+SCOTT,Isbel Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+SCOTT,Isbel Township,United States Senate,,Republican,"Moran, Jerry",44,000020
+SCOTT,Keystone Township,United States Senate,,write - in,"Smith, DJ",0,000030
+SCOTT,Keystone Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+SCOTT,Keystone Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+SCOTT,Keystone Township,United States Senate,,Republican,"Moran, Jerry",45,000030
+SCOTT,Lake Township,United States Senate,,write - in,"Smith, DJ",0,000040
+SCOTT,Lake Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000040
+SCOTT,Lake Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000040
+SCOTT,Lake Township,United States Senate,,Republican,"Moran, Jerry",37,000040
+SCOTT,Michigan Township,United States Senate,,write - in,"Smith, DJ",0,000050
+SCOTT,Michigan Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000050
+SCOTT,Michigan Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+SCOTT,Michigan Township,United States Senate,,Republican,"Moran, Jerry",39,000050
+SCOTT,Scott City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000060
+SCOTT,Scott City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",36,000060
+SCOTT,Scott City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",19,000060
+SCOTT,Scott City Ward 1,United States Senate,,Republican,"Moran, Jerry",214,000060
+SCOTT,Scott City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000070
+SCOTT,Scott City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",22,000070
+SCOTT,Scott City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000070
+SCOTT,Scott City Ward 2,United States Senate,,Republican,"Moran, Jerry",482,000070
+SCOTT,Scott City Ward 3,United States Senate,,write - in,"Smith, DJ",0,000080
+SCOTT,Scott City Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",46,000080
+SCOTT,Scott City Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",17,000080
+SCOTT,Scott City Ward 3,United States Senate,,Republican,"Moran, Jerry",347,000080
+SCOTT,Scott City Ward 4,United States Senate,,write - in,"Smith, DJ",0,000090
+SCOTT,Scott City Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",52,000090
+SCOTT,Scott City Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",23,000090
+SCOTT,Scott City Ward 4,United States Senate,,Republican,"Moran, Jerry",405,000090
+SCOTT,Scott Township,United States Senate,,write - in,"Smith, DJ",0,00010A
+SCOTT,Scott Township,United States Senate,,Democratic,"Wiesner, Patrick",4,00010A
+SCOTT,Scott Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,00010A
+SCOTT,Scott Township,United States Senate,,Republican,"Moran, Jerry",126,00010A
+SCOTT,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000110
+SCOTT,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000110
+SCOTT,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000110
+SCOTT,Valley Township,United States Senate,,Republican,"Moran, Jerry",81,000110

--- a/2016/20161108__ks__general__seward__precinct.csv
+++ b/2016/20161108__ks__general__seward__precinct.csv
@@ -1,400 +1,779 @@
-county,precinct,office,district,party,candidate,votes
-Seward,Liberal W1D1,President,,D,Hillary Clinton,177
-Seward,Liberal W1D1,President,,R,Donald Trump,183
-Seward,Liberal W1D1,President,,LBT,Gary Johnson,18
-Seward,Liberal W1D1,President,,IND,Jill Stein,7
-Seward,Liberal W1D1,President,,,Write-ins,2
-Seward,Liberal W1D2,President,,D,Hillary Clinton,262
-Seward,Liberal W1D2,President,,R,Donald Trump,256
-Seward,Liberal W1D2,President,,LBT,Gary Johnson,28
-Seward,Liberal W1D2,President,,IND,Jill Stein,6
-Seward,Liberal W1D2,President,,,Write-ins,3
-Seward,Liberal W1D3,President,,D,Hillary Clinton,196
-Seward,Liberal W1D3,President,,R,Donald Trump,231
-Seward,Liberal W1D3,President,,LBT,Gary Johnson,26
-Seward,Liberal W1D3,President,,IND,Jill Stein,5
-Seward,Liberal W1D3,President,,,Write-ins,2
-Seward,Liberal W2,President,,D,Hillary Clinton,138
-Seward,Liberal W2,President,,R,Donald Trump,270
-Seward,Liberal W2,President,,LBT,Gary Johnson,14
-Seward,Liberal W2,President,,IND,Jill Stein,9
-Seward,Liberal W2,President,,wri,Evan McMullin,2
-Seward,Liberal W2,President,,,Write-ins,4
-Seward,Liberal W3,President,,D,Hillary Clinton,155
-Seward,Liberal W3,President,,R,Donald Trump,118
-Seward,Liberal W3,President,,LBT,Gary Johnson,19
-Seward,Liberal W3,President,,IND,Jill Stein,5
-Seward,Liberal W3,President,,,Evan McMullin,1
-Seward,Liberal W3,President,,,Write-ins,5
-Seward,Liberal W4,President,,D,Hillary Clinton,100
-Seward,Liberal W4,President,,R,Donald Trump,192
-Seward,Liberal W4,President,,LBT,Gary Johnson,17
-Seward,Liberal W4,President,,IND,Jill Stein,5
-Seward,Liberal W4,President,,,Write-ins,6
-Seward,Liberal W5,President,,D,Hillary Clinton,101
-Seward,Liberal W5,President,,R,Donald Trump,177
-Seward,Liberal W5,President,,LBT,Gary Johnson,6
-Seward,Liberal W5,President,,IND,Jill Stein,2
-Seward,Liberal W5,President,,,Write-ins,3
-Seward,Liberal W6P1,President,,D,Hillary Clinton,212
-Seward,Liberal W6P1,President,,R,Donald Trump,701
-Seward,Liberal W6P1,President,,LBT,Gary Johnson,24
-Seward,Liberal W6P1,President,,IND,Jill Stein,4
-Seward,Liberal W6P1,President,,,Write-ins,6
-Seward,Liberal W6P2,President,,D,Hillary Clinton,164
-Seward,Liberal W6P2,President,,R,Donald Trump,442
-Seward,Liberal W6P2,President,,LBT,Gary Johnson,15
-Seward,Liberal W6P2,President,,IND,Jill Stein,5
-Seward,Liberal W6P2,President,,,Write-ins,4
-Seward,Fargo twp 1,President,,D,Hillary Clinton,8
-Seward,Fargo twp 1,President,,R,Donald Trump,46
-Seward,Fargo twp 1,President,,LBT,Gary Johnson,0
-Seward,Fargo twp 1,President,,IND,Jill Stein,0
-Seward,Fargo twp 1,President,,,Write-ins,0
-Seward,Fargo twp 2,President,,D,Hillary Clinton,0
-Seward,Fargo twp 2,President,,R,Donald Trump,42
-Seward,Fargo twp 2,President,,LBT,Gary Johnson,0
-Seward,Fargo twp 2,President,,IND,Jill Stein,0
-Seward,Fargo twp 2,President,,,Write-ins,0
-Seward,Fargo twp 3,President,,D,Hillary Clinton,0
-Seward,Fargo twp 3,President,,R,Donald Trump,18
-Seward,Fargo twp 3,President,,LBT,Gary Johnson,0
-Seward,Fargo twp 3,President,,IND,Jill Stein,0
-Seward,Fargo twp 3,President,,,Write-ins,0
-Seward,Fargo twp 4,President,,D,Hillary Clinton,53
-Seward,Fargo twp 4,President,,R,Donald Trump,73
-Seward,Fargo twp 4,President,,LBT,Gary Johnson,4
-Seward,Fargo twp 4,President,,IND,Jill Stein,5
-Seward,Fargo twp 4,President,,,Write-ins,0
-Seward,Liberal twp 1,President,,D,Hillary Clinton,2
-Seward,Liberal twp 1,President,,R,Donald Trump,5
-Seward,Liberal twp 1,President,,LBT,Gary Johnson,0
-Seward,Liberal twp 1,President,,IND,Jill Stein,0
-Seward,Liberal twp 1,President,,,Write-ins,0
-Seward,Liberal twp 2,President,,D,Hillary Clinton,13
-Seward,Liberal twp 2,President,,R,Donald Trump,96
-Seward,Liberal twp 2,President,,LBT,Gary Johnson,2
-Seward,Liberal twp 2,President,,IND,Jill Stein,1
-Seward,Liberal twp 2,President,,wri,Darrell Castle,1
-Seward,Liberal twp 2,President,,,Write-ins,1
-Seward,Liberal twp 3,President,,D,Hillary Clinton,5
-Seward,Liberal twp 3,President,,R,Donald Trump,53
-Seward,Liberal twp 3,President,,LBT,Gary Johnson,4
-Seward,Liberal twp 3,President,,IND,Jill Stein,2
-Seward,Liberal twp 3,President,,,Write-ins,1
-Seward,Liberal twp 4,President,,D,Hillary Clinton,5
-Seward,Liberal twp 4,President,,R,Donald Trump,32
-Seward,Liberal twp 4,President,,LBT,Gary Johnson,2
-Seward,Liberal twp 4,President,,IND,Jill Stein,0
-Seward,Liberal twp 4,President,,,Write-ins,0
-Seward,Liberal twp 5,President,,D,Hillary Clinton,4
-Seward,Liberal twp 5,President,,R,Donald Trump,28
-Seward,Liberal twp 5,President,,LBT,Gary Johnson,0
-Seward,Liberal twp 5,President,,IND,Jill Stein,0
-Seward,Liberal twp 5,President,,,Write-ins,0
-Seward,Seward twp 1,President,,D,Hillary Clinton,0
-Seward,Seward twp 1,President,,R,Donald Trump,30
-Seward,Seward twp 1,President,,LBT,Gary Johnson,0
-Seward,Seward twp 1,President,,IND,Jill Stein,1
-Seward,Seward twp 1,President,,wri,Evan McMullin,1
-Seward,Seward twp 2,President,,D,Hillary Clinton,7
-Seward,Seward twp 2,President,,R,Donald Trump,37
-Seward,Seward twp 2,President,,LBT,Gary Johnson,0
-Seward,Seward twp 2,President,,IND,Jill Stein,0
-Seward,Seward twp 2,President,,,Write-ins,0
-Seward,Seward twp 3,President,,D,Hillary Clinton,2
-Seward,Seward twp 3,President,,R,Donald Trump,20
-Seward,Seward twp 3,President,,LBT,Gary Johnson,0
-Seward,Seward twp 3,President,,IND,Jill Stein,0
-Seward,Seward twp 3,President,,,Write-ins,0
-Seward,Kismet City,President,,D,Hillary Clinton,24
-Seward,Kismet City,President,,R,Donald Trump,109
-Seward,Kismet City,President,,LBT,Gary Johnson,7
-Seward,Kismet City,President,,IND,Jill Stein,1
-Seward,Kismet City,President,,,Write-ins,1
-Seward,Liberal W1D1,U.S. Senate,,D,Patrick Wiesner,131
-Seward,Liberal W1D1,U.S. Senate,,LBT,Robert Garrard,36
-Seward,Liberal W1D1,U.S. Senate,,R,Jerry Moran,168
-Seward,Liberal W1D1,U.S. Senate,,,Write-ins,1
-Seward,Liberal W1D2,U.S. Senate,,D,Patrick Wiesner,191
-Seward,Liberal W1D2,U.S. Senate,,LBT,Robert Garrard,47
-Seward,Liberal W1D2,U.S. Senate,,R,Jerry Moran,254
-Seward,Liberal W1D2,U.S. Senate,,,Write-ins,2
-Seward,Liberal W1D3,U.S. Senate,,D,Patrick Wiesner,159
-Seward,Liberal W1D3,U.S. Senate,,LBT,Robert Garrard,27
-Seward,Liberal W1D3,U.S. Senate,,R,Jerry Moran,241
-Seward,Liberal W1D3,U.S. Senate,,,Write-ins,0
-Seward,Liberal W2,U.S. Senate,,D,Patrick Wiesner,94
-Seward,Liberal W2,U.S. Senate,,LBT,Robert Garrard,32
-Seward,Liberal W2,U.S. Senate,,R,Jerry Moran,279
-Seward,Liberal W2,U.S. Senate,,,Write-ins,0
-Seward,Liberal W3,U.S. Senate,,D,Patrick Wiesner,111
-Seward,Liberal W3,U.S. Senate,,LBT,Robert Garrard,24
-Seward,Liberal W3,U.S. Senate,,R,Jerry Moran,130
-Seward,Liberal W3,U.S. Senate,,,Write-ins,1
-Seward,Liberal W4,U.S. Senate,,D,Patrick Wiesner,84
-Seward,Liberal W4,U.S. Senate,,LBT,Robert Garrard,11
-Seward,Liberal W4,U.S. Senate,,R,Jerry Moran,207
-Seward,Liberal W4,U.S. Senate,,,Write-ins,0
-Seward,Liberal W5,U.S. Senate,,D,Patrick Wiesner,70
-Seward,Liberal W5,U.S. Senate,,LBT,Robert Garrard,21
-Seward,Liberal W5,U.S. Senate,,R,Jerry Moran,167
-Seward,Liberal W5,U.S. Senate,,,Write-ins,0
-Seward,Liberal W6P1,U.S. Senate,,D,Patrick Wiesner,152
-Seward,Liberal W6P1,U.S. Senate,,LBT,Robert Garrard,55
-Seward,Liberal W6P1,U.S. Senate,,R,Jerry Moran,699
-Seward,Liberal W6P1,U.S. Senate,,,Write-ins,0
-Seward,Liberal W6P2,U.S. Senate,,D,Patrick Wiesner,119
-Seward,Liberal W6P2,U.S. Senate,,LBT,Robert Garrard,30
-Seward,Liberal W6P2,U.S. Senate,,R,Jerry Moran,463
-Seward,Liberal W6P2,U.S. Senate,,,Write-ins,0
-Seward,Fargo twp 1,U.S. Senate,,D,Patrick Wiesner,8
-Seward,Fargo twp 1,U.S. Senate,,LBT,Robert Garrard,4
-Seward,Fargo twp 1,U.S. Senate,,R,Jerry Moran,41
-Seward,Fargo twp 1,U.S. Senate,,,Write-ins,0
-Seward,Fargo twp 2,U.S. Senate,,D,Patrick Wiesner,1
-Seward,Fargo twp 2,U.S. Senate,,LBT,Robert Garrard,3
-Seward,Fargo twp 2,U.S. Senate,,R,Jerry Moran,37
-Seward,Fargo twp 2,U.S. Senate,,,Write-ins,0
-Seward,Fargo twp 3,U.S. Senate,,D,Patrick Wiesner,0
-Seward,Fargo twp 3,U.S. Senate,,LBT,Robert Garrard,0
-Seward,Fargo twp 3,U.S. Senate,,R,Jerry Moran,18
-Seward,Fargo twp 3,U.S. Senate,,,Write-ins,0
-Seward,Fargo twp 4,U.S. Senate,,D,Patrick Wiesner,44
-Seward,Fargo twp 4,U.S. Senate,,LBT,Robert Garrard,13
-Seward,Fargo twp 4,U.S. Senate,,R,Jerry Moran,65
-Seward,Fargo twp 4,U.S. Senate,,,Write-ins,1
-Seward,Liberal twp 1,U.S. Senate,,D,Patrick Wiesner,2
-Seward,Liberal twp 1,U.S. Senate,,LBT,Robert Garrard,1
-Seward,Liberal twp 1,U.S. Senate,,R,Jerry Moran,3
-Seward,Liberal twp 1,U.S. Senate,,,Write-ins,0
-Seward,Liberal twp 2,U.S. Senate,,D,Patrick Wiesner,11
-Seward,Liberal twp 2,U.S. Senate,,LBT,Robert Garrard,7
-Seward,Liberal twp 2,U.S. Senate,,R,Jerry Moran,94
-Seward,Liberal twp 2,U.S. Senate,,,Write-ins,1
-Seward,Liberal twp 3,U.S. Senate,,D,Patrick Wiesner,4
-Seward,Liberal twp 3,U.S. Senate,,LBT,Robert Garrard,4
-Seward,Liberal twp 3,U.S. Senate,,R,Jerry Moran,55
-Seward,Liberal twp 3,U.S. Senate,,,Write-ins,0
-Seward,Liberal twp 4,U.S. Senate,,D,Patrick Wiesner,3
-Seward,Liberal twp 4,U.S. Senate,,LBT,Robert Garrard,3
-Seward,Liberal twp 4,U.S. Senate,,R,Jerry Moran,31
-Seward,Liberal twp 4,U.S. Senate,,,Write-ins,0
-Seward,Liberal twp 5,U.S. Senate,,D,Patrick Wiesner,2
-Seward,Liberal twp 5,U.S. Senate,,LBT,Robert Garrard,1
-Seward,Liberal twp 5,U.S. Senate,,R,Jerry Moran,28
-Seward,Liberal twp 5,U.S. Senate,,,Write-ins,0
-Seward,Seward twp 1,U.S. Senate,,D,Patrick Wiesner,4
-Seward,Seward twp 1,U.S. Senate,,LBT,Robert Garrard,0
-Seward,Seward twp 1,U.S. Senate,,R,Jerry Moran,28
-Seward,Seward twp 1,U.S. Senate,,,Write-ins,0
-Seward,Seward twp 2,U.S. Senate,,D,Patrick Wiesner,3
-Seward,Seward twp 2,U.S. Senate,,LBT,Robert Garrard,2
-Seward,Seward twp 2,U.S. Senate,,R,Jerry Moran,35
-Seward,Seward twp 2,U.S. Senate,,,Write-ins,0
-Seward,Seward twp 3,U.S. Senate,,D,Patrick Wiesner,2
-Seward,Seward twp 3,U.S. Senate,,LBT,Robert Garrard,0
-Seward,Seward twp 3,U.S. Senate,,R,Jerry Moran,20
-Seward,Seward twp 3,U.S. Senate,,,Write-ins,0
-Seward,Kismet City,U.S. Senate,,D,Patrick Wiesner,18
-Seward,Kismet City,U.S. Senate,,LBT,Robert Garrard,14
-Seward,Kismet City,U.S. Senate,,R,Jerry Moran,105
-Seward,Kismet City,U.S. Senate,,,Write-ins,0
-Seward,Liberal W1D1,U.S. House,1,R,Roger Marshall,188
-Seward,Liberal W1D1,U.S. House,1,LBT,Kerry Burt,64
-Seward,Liberal W1D1,U.S. House,1,IND,Alan LaPolice,45
-Seward,Liberal W1D1,U.S. House,1,,Write-ins,4
-Seward,Liberal W1D2,U.S. House,1,R,Roger Marshall,278
-Seward,Liberal W1D2,U.S. House,1,LBT,Kerry Burt,88
-Seward,Liberal W1D2,U.S. House,1,IND,Alan LaPolice,86
-Seward,Liberal W1D2,U.S. House,1,,Write-ins,1
-Seward,Liberal W1D3,U.S. House,1,R,Roger Marshall,249
-Seward,Liberal W1D3,U.S. House,1,LBT,Kerry Burt,69
-Seward,Liberal W1D3,U.S. House,1,IND,Alan LaPolice,76
-Seward,Liberal W1D3,U.S. House,1,,Write-ins,0
-Seward,Liberal W2,U.S. House,1,R,Roger Marshall,265
-Seward,Liberal W2,U.S. House,1,LBT,Kerry Burt,57
-Seward,Liberal W2,U.S. House,1,IND,Alan LaPolice,67
-Seward,Liberal W2,U.S. House,1,,Write-ins,1
-Seward,Liberal W3,U.S. House,1,R,Roger Marshall,129
-Seward,Liberal W3,U.S. House,1,LBT,Kerry Burt,47
-Seward,Liberal W3,U.S. House,1,IND,Alan LaPolice,50
-Seward,Liberal W3,U.S. House,1,,Write-ins,3
-Seward,Liberal W4,U.S. House,1,R,Roger Marshall,193
-Seward,Liberal W4,U.S. House,1,LBT,Kerry Burt,35
-Seward,Liberal W4,U.S. House,1,IND,Alan LaPolice,58
-Seward,Liberal W4,U.S. House,1,,Write-ins,0
-Seward,Liberal W5,U.S. House,1,R,Roger Marshall,154
-Seward,Liberal W5,U.S. House,1,LBT,Kerry Burt,39
-Seward,Liberal W5,U.S. House,1,IND,Alan LaPolice,56
-Seward,Liberal W5,U.S. House,1,,Write-ins,1
-Seward,Liberal W6P1,U.S. House,1,R,Roger Marshall,703
-Seward,Liberal W6P1,U.S. House,1,LBT,Kerry Burt,61
-Seward,Liberal W6P1,U.S. House,1,IND,Alan LaPolice,123
-Seward,Liberal W6P1,U.S. House,1,,Write-ins,2
-Seward,Liberal W6P2,U.S. House,1,R,Roger Marshall,444
-Seward,Liberal W6P2,U.S. House,1,LBT,Kerry Burt,55
-Seward,Liberal W6P2,U.S. House,1,IND,Alan LaPolice,82
-Seward,Liberal W6P2,U.S. House,1,,Write-ins,1
-Seward,Fargo twp 1,U.S. House,1,R,Roger Marshall,38
-Seward,Fargo twp 1,U.S. House,1,LBT,Kerry Burt,6
-Seward,Fargo twp 1,U.S. House,1,IND,Alan LaPolice,8
-Seward,Fargo twp 1,U.S. House,1,,Write-ins,0
-Seward,Fargo twp 2,U.S. House,1,R,Roger Marshall,34
-Seward,Fargo twp 2,U.S. House,1,LBT,Kerry Burt,1
-Seward,Fargo twp 2,U.S. House,1,IND,Alan LaPolice,6
-Seward,Fargo twp 2,U.S. House,1,,Write-ins,0
-Seward,Fargo twp 3,U.S. House,1,R,Roger Marshall,14
-Seward,Fargo twp 3,U.S. House,1,LBT,Kerry Burt,0
-Seward,Fargo twp 3,U.S. House,1,IND,Alan LaPolice,4
-Seward,Fargo twp 3,U.S. House,1,,Write-ins,0
-Seward,Fargo twp 4,U.S. House,1,R,Roger Marshall,73
-Seward,Fargo twp 4,U.S. House,1,LBT,Kerry Burt,19
-Seward,Fargo twp 4,U.S. House,1,IND,Alan LaPolice,22
-Seward,Fargo twp 4,U.S. House,1,,Write-ins,1
-Seward,Liberal twp 1,U.S. House,1,R,Roger Marshall,2
-Seward,Liberal twp 1,U.S. House,1,LBT,Kerry Burt,0
-Seward,Liberal twp 1,U.S. House,1,IND,Alan LaPolice,4
-Seward,Liberal twp 1,U.S. House,1,,Write-ins,0
-Seward,Liberal twp 2,U.S. House,1,R,Roger Marshall,90
-Seward,Liberal twp 2,U.S. House,1,LBT,Kerry Burt,5
-Seward,Liberal twp 2,U.S. House,1,IND,Alan LaPolice,11
-Seward,Liberal twp 2,U.S. House,1,,Write-ins,1
-Seward,Liberal twp 3,U.S. House,1,R,Roger Marshall,45
-Seward,Liberal twp 3,U.S. House,1,LBT,Kerry Burt,6
-Seward,Liberal twp 3,U.S. House,1,IND,Alan LaPolice,9
-Seward,Liberal twp 3,U.S. House,1,,Write-ins,2
-Seward,Liberal twp 4,U.S. House,1,R,Roger Marshall,28
-Seward,Liberal twp 4,U.S. House,1,LBT,Kerry Burt,3
-Seward,Liberal twp 4,U.S. House,1,IND,Alan LaPolice,6
-Seward,Liberal twp 4,U.S. House,1,,Write-ins,0
-Seward,Liberal twp 5,U.S. House,1,R,Roger Marshall,22
-Seward,Liberal twp 5,U.S. House,1,LBT,Kerry Burt,2
-Seward,Liberal twp 5,U.S. House,1,IND,Alan LaPolice,5
-Seward,Liberal twp 5,U.S. House,1,,Write-ins,0
-Seward,Seward twp 1,U.S. House,1,R,Roger Marshall,26
-Seward,Seward twp 1,U.S. House,1,LBT,Kerry Burt,0
-Seward,Seward twp 1,U.S. House,1,IND,Alan LaPolice,6
-Seward,Seward twp 1,U.S. House,1,,Write-ins,0
-Seward,Seward twp 2,U.S. House,1,R,Roger Marshall,34
-Seward,Seward twp 2,U.S. House,1,LBT,Kerry Burt,2
-Seward,Seward twp 2,U.S. House,1,IND,Alan LaPolice,6
-Seward,Seward twp 2,U.S. House,1,,Write-ins,0
-Seward,Seward twp 3,U.S. House,1,R,Roger Marshall,16
-Seward,Seward twp 3,U.S. House,1,LBT,Kerry Burt,5
-Seward,Seward twp 3,U.S. House,1,IND,Alan LaPolice,0
-Seward,Seward twp 3,U.S. House,1,,Write-ins,0
-Seward,Kismet City,U.S. House,1,R,Roger Marshall,99
-Seward,Kismet City,U.S. House,1,LBT,Kerry Burt,13
-Seward,Kismet City,U.S. House,1,IND,Alan LaPolice,22
-Seward,Kismet City,U.S. House,1,,Write-ins,0
-Seward,Liberal W1D1,State Senate,38,D,Miguel Rodriguez,155
-Seward,Liberal W1D1,State Senate,38,R,Bud Estes,178
-Seward,Liberal W1D1,State Senate,38,,Write-ins,2
-Seward,Liberal W1D2,State Senate,38,D,Miguel Rodriguez,234
-Seward,Liberal W1D2,State Senate,38,R,Bud Estes,254
-Seward,Liberal W1D2,State Senate,38,,Write-ins,1
-Seward,Liberal W1D3,State Senate,38,D,Miguel Rodriguez,183
-Seward,Liberal W1D3,State Senate,38,R,Bud Estes,238
-Seward,Liberal W1D3,State Senate,38,,Write-ins,1
-Seward,Liberal W2,State Senate,38,D,Miguel Rodriguez,130
-Seward,Liberal W2,State Senate,38,R,Bud Estes,270
-Seward,Liberal W2,State Senate,38,,Write-ins,0
-Seward,Liberal W3,State Senate,38,D,Miguel Rodriguez,135
-Seward,Liberal W3,State Senate,38,R,Bud Estes,120
-Seward,Liberal W3,State Senate,38,,Write-ins,1
-Seward,Liberal W4,State Senate,38,D,Miguel Rodriguez,106
-Seward,Liberal W4,State Senate,38,R,Bud Estes,192
-Seward,Liberal W4,State Senate,38,,Write-ins,0
-Seward,Liberal W5,State Senate,38,D,Miguel Rodriguez,92
-Seward,Liberal W5,State Senate,38,R,Bud Estes,162
-Seward,Liberal W5,State Senate,38,,Write-ins,0
-Seward,Liberal W6P1,State Senate,38,D,Miguel Rodriguez,173
-Seward,Liberal W6P1,State Senate,38,R,Bud Estes,715
-Seward,Liberal W6P1,State Senate,38,,Write-ins,1
-Seward,Liberal W6P2,State Senate,38,D,Miguel Rodriguez,136
-Seward,Liberal W6P2,State Senate,38,R,Bud Estes,454
-Seward,Liberal W6P2,State Senate,38,,Write-ins,5
-Seward,Fargo twp 1,State Senate,38,D,Miguel Rodriguez,5
-Seward,Fargo twp 1,State Senate,38,R,Bud Estes,47
-Seward,Fargo twp 1,State Senate,38,,Write-ins,0
-Seward,Fargo twp 2,State Senate,38,D,Miguel Rodriguez,1
-Seward,Fargo twp 2,State Senate,38,R,Bud Estes,40
-Seward,Fargo twp 2,State Senate,38,,Write-ins,0
-Seward,Fargo twp 3,State Senate,38,D,Miguel Rodriguez,0
-Seward,Fargo twp 3,State Senate,38,R,Bud Estes,18
-Seward,Fargo twp 3,State Senate,38,,Write-ins,0
-Seward,Fargo twp 4,State Senate,38,D,Miguel Rodriguez,45
-Seward,Fargo twp 4,State Senate,38,R,Bud Estes,74
-Seward,Fargo twp 4,State Senate,38,,Write-ins,1
-Seward,Liberal twp 1,State Senate,38,D,Miguel Rodriguez,1
-Seward,Liberal twp 1,State Senate,38,R,Bud Estes,5
-Seward,Liberal twp 1,State Senate,38,,Write-ins,0
-Seward,Liberal twp 2,State Senate,38,D,Miguel Rodriguez,13
-Seward,Liberal twp 2,State Senate,38,R,Bud Estes,96
-Seward,Liberal twp 2,State Senate,38,,Write-ins,1
-Seward,Liberal twp 3,State Senate,38,D,Miguel Rodriguez,6
-Seward,Liberal twp 3,State Senate,38,R,Bud Estes,56
-Seward,Liberal twp 3,State Senate,38,,Write-ins,0
-Seward,Liberal twp 4,State Senate,38,D,Miguel Rodriguez,5
-Seward,Liberal twp 4,State Senate,38,R,Bud Estes,31
-Seward,Liberal twp 4,State Senate,38,,Write-ins,0
-Seward,Liberal twp 5,State Senate,38,D,Miguel Rodriguez,7
-Seward,Liberal twp 5,State Senate,38,R,Bud Estes,23
-Seward,Liberal twp 5,State Senate,38,,Write-ins,0
-Seward,Seward twp 1,State Senate,38,D,Miguel Rodriguez,2
-Seward,Seward twp 1,State Senate,38,R,Bud Estes,29
-Seward,Seward twp 1,State Senate,38,,Write-ins,0
-Seward,Seward twp 2,State Senate,38,D,Miguel Rodriguez,4
-Seward,Seward twp 2,State Senate,38,R,Bud Estes,36
-Seward,Seward twp 2,State Senate,38,,Write-ins,0
-Seward,Seward twp 3,State Senate,38,D,Miguel Rodriguez,2
-Seward,Seward twp 3,State Senate,38,R,Bud Estes,20
-Seward,Seward twp 3,State Senate,38,,Write-ins,0
-Seward,Kismet City,State Senate,38,D,Miguel Rodriguez,21
-Seward,Kismet City,State Senate,38,R,Bud Estes,113
-Seward,Kismet City,State Senate,38,,Write-ins,0
-Seward,Liberal W1D1,State House,125,R,Shannon Francis,284
-Seward,Liberal W1D1,State House,125,,Write-ins,7
-Seward,Liberal W1D2,State House,125,R,Shannon Francis,413
-Seward,Liberal W1D2,State House,125,,Write-ins,5
-Seward,Liberal W1D3,State House,125,R,Shannon Francis,355
-Seward,Liberal W1D3,State House,125,,Write-ins,4
-Seward,Liberal W2,State House,125,R,Shannon Francis,361
-Seward,Liberal W2,State House,125,,Write-ins,1
-Seward,Liberal W3,State House,125,R,Shannon Francis,220
-Seward,Liberal W3,State House,125,,Write-ins,9
-Seward,Liberal W4,State House,125,R,Shannon Francis,267
-Seward,Liberal W4,State House,125,,Write-ins,7
-Seward,Liberal W5,State House,125,R,Shannon Francis,220
-Seward,Liberal W5,State House,125,,Write-ins,2
-Seward,Liberal W6P1,State House,125,R,Shannon Francis,850
-Seward,Liberal W6P1,State House,125,,Write-ins,1
-Seward,Liberal W6P2,State House,125,R,Shannon Francis,563
-Seward,Liberal W6P2,State House,125,,Write-ins,4
-Seward,Fargo twp 1,State House,125,R,Shannon Francis,50
-Seward,Fargo twp 1,State House,125,,Write-ins,0
-Seward,Fargo twp 2,State House,125,R,Shannon Francis,40
-Seward,Fargo twp 2,State House,125,,Write-ins,0
-Seward,Fargo twp 3,State House,125,R,Shannon Francis,17
-Seward,Fargo twp 3,State House,125,,Write-ins,0
-Seward,Fargo twp 4,State House,125,R,Shannon Francis,105
-Seward,Fargo twp 4,State House,125,,Write-ins,2
-Seward,Liberal twp 1,State House,125,R,Shannon Francis,5
-Seward,Liberal twp 1,State House,125,,Write-ins,0
-Seward,Liberal twp 2,State House,125,R,Shannon Francis,104
-Seward,Liberal twp 2,State House,125,,Write-ins,0
-Seward,Liberal twp 3,State House,125,R,Shannon Francis,56
-Seward,Liberal twp 3,State House,125,,Write-ins,1
-Seward,Liberal twp 4,State House,125,R,Shannon Francis,36
-Seward,Liberal twp 4,State House,125,,Write-ins,0
-Seward,Liberal twp 5,State House,125,R,Shannon Francis,28
-Seward,Liberal twp 5,State House,125,,Write-ins,0
-Seward,Seward twp 1,State House,124,R,Stephen Alford,31
-Seward,Seward twp 1,State House,124,,Write-ins,0
-Seward,Seward twp 2,State House,124,R,Stephen Alford,35
-Seward,Seward twp 2,State House,124,,Write-ins,0
-Seward,Seward twp 3,State House,124,R,Stephen Alford,20
-Seward,Seward twp 3,State House,124,,Write-ins,0
-Seward,Kismet City,State House,125,R,Shannon Francis,128
-Seward,Kismet City,State House,125,,Write-ins,1
+county,precinct,office,district,party,candidate,votes,vtd
+SEWARD,Fargo Township 1,Kansas House of Representatives,125,Republican,"Francis, Shannon",50,000010
+SEWARD,Fargo Township 2,Kansas House of Representatives,125,Republican,"Francis, Shannon",168,000020
+SEWARD,Fargo Township 3,Kansas House of Representatives,125,Republican,"Francis, Shannon",17,000030
+SEWARD,Fargo Township 4,Kansas House of Representatives,125,Republican,"Francis, Shannon",105,000040
+SEWARD,Liberal Township 1,Kansas House of Representatives,125,Republican,"Francis, Shannon",5,00005A
+SEWARD,Liberal Township 1 Exclave,Kansas House of Representatives,125,Republican,"Francis, Shannon",0,00005B
+SEWARD,Liberal Township 2,Kansas House of Representatives,125,Republican,"Francis, Shannon",104,000060
+SEWARD,Liberal Township 3,Kansas House of Representatives,125,Republican,"Francis, Shannon",56,000070
+SEWARD,Liberal Township 4,Kansas House of Representatives,125,Republican,"Francis, Shannon",36,00008A
+SEWARD,Liberal Township 4 Exclave,Kansas House of Representatives,125,Republican,"Francis, Shannon",0,00008B
+SEWARD,Liberal Township 5,Kansas House of Representatives,125,Republican,"Francis, Shannon",28,000090
+SEWARD,Liberal Ward 1 Precinct 1,Kansas House of Representatives,125,Republican,"Francis, Shannon",284,000100
+SEWARD,Liberal Ward 1 Precinct 2,Kansas House of Representatives,125,Republican,"Francis, Shannon",413,000110
+SEWARD,Liberal Ward 1 Precinct 3,Kansas House of Representatives,125,Republican,"Francis, Shannon",355,000120
+SEWARD,Liberal Ward 2,Kansas House of Representatives,125,Republican,"Francis, Shannon",361,000130
+SEWARD,Liberal Ward 3,Kansas House of Representatives,125,Republican,"Francis, Shannon",220,000140
+SEWARD,Liberal Ward 4,Kansas House of Representatives,125,Republican,"Francis, Shannon",267,000150
+SEWARD,Liberal Ward 5,Kansas House of Representatives,125,Republican,"Francis, Shannon",220,000160
+SEWARD,Liberal Ward 6 Precinct 1,Kansas House of Representatives,125,Republican,"Francis, Shannon",850,000170
+SEWARD,Liberal Ward 6 Precinct 2,Kansas House of Representatives,125,Republican,"Francis, Shannon",563,000180
+SEWARD,Seward Township 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",31,000190
+SEWARD,Seward Township 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",35,000200
+SEWARD,Seward Township 3,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",20,000210
+SEWARD,Fargo Township 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",5,000010
+SEWARD,Fargo Township 1,Kansas Senate,38,Republican,"Estes, Bud",47,000010
+SEWARD,Fargo Township 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",22,000020
+SEWARD,Fargo Township 2,Kansas Senate,38,Republican,"Estes, Bud",153,000020
+SEWARD,Fargo Township 3,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,000030
+SEWARD,Fargo Township 3,Kansas Senate,38,Republican,"Estes, Bud",18,000030
+SEWARD,Fargo Township 4,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",45,000040
+SEWARD,Fargo Township 4,Kansas Senate,38,Republican,"Estes, Bud",74,000040
+SEWARD,Liberal Township 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",1,00005A
+SEWARD,Liberal Township 1,Kansas Senate,38,Republican,"Estes, Bud",5,00005A
+SEWARD,Liberal Township 1 Exclave,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00005B
+SEWARD,Liberal Township 1 Exclave,Kansas Senate,38,Republican,"Estes, Bud",0,00005B
+SEWARD,Liberal Township 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",13,000060
+SEWARD,Liberal Township 2,Kansas Senate,38,Republican,"Estes, Bud",96,000060
+SEWARD,Liberal Township 3,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",6,000070
+SEWARD,Liberal Township 3,Kansas Senate,38,Republican,"Estes, Bud",56,000070
+SEWARD,Liberal Township 4,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",5,00008A
+SEWARD,Liberal Township 4,Kansas Senate,38,Republican,"Estes, Bud",31,00008A
+SEWARD,Liberal Township 4 Exclave,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",0,00008B
+SEWARD,Liberal Township 4 Exclave,Kansas Senate,38,Republican,"Estes, Bud",0,00008B
+SEWARD,Liberal Township 5,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",7,000090
+SEWARD,Liberal Township 5,Kansas Senate,38,Republican,"Estes, Bud",23,000090
+SEWARD,Liberal Ward 1 Precinct 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",155,000100
+SEWARD,Liberal Ward 1 Precinct 1,Kansas Senate,38,Republican,"Estes, Bud",178,000100
+SEWARD,Liberal Ward 1 Precinct 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",234,000110
+SEWARD,Liberal Ward 1 Precinct 2,Kansas Senate,38,Republican,"Estes, Bud",254,000110
+SEWARD,Liberal Ward 1 Precinct 3,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",183,000120
+SEWARD,Liberal Ward 1 Precinct 3,Kansas Senate,38,Republican,"Estes, Bud",238,000120
+SEWARD,Liberal Ward 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",130,000130
+SEWARD,Liberal Ward 2,Kansas Senate,38,Republican,"Estes, Bud",270,000130
+SEWARD,Liberal Ward 3,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",135,000140
+SEWARD,Liberal Ward 3,Kansas Senate,38,Republican,"Estes, Bud",120,000140
+SEWARD,Liberal Ward 4,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",106,000150
+SEWARD,Liberal Ward 4,Kansas Senate,38,Republican,"Estes, Bud",192,000150
+SEWARD,Liberal Ward 5,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",92,000160
+SEWARD,Liberal Ward 5,Kansas Senate,38,Republican,"Estes, Bud",162,000160
+SEWARD,Liberal Ward 6 Precinct 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",173,000170
+SEWARD,Liberal Ward 6 Precinct 1,Kansas Senate,38,Republican,"Estes, Bud",715,000170
+SEWARD,Liberal Ward 6 Precinct 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",136,000180
+SEWARD,Liberal Ward 6 Precinct 2,Kansas Senate,38,Republican,"Estes, Bud",454,000180
+SEWARD,Seward Township 1,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",2,000190
+SEWARD,Seward Township 1,Kansas Senate,38,Republican,"Estes, Bud",29,000190
+SEWARD,Seward Township 2,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",4,000200
+SEWARD,Seward Township 2,Kansas Senate,38,Republican,"Estes, Bud",36,000200
+SEWARD,Seward Township 3,Kansas Senate,38,Democratic,"Rodriguez, Miguel Angel",2,000210
+SEWARD,Seward Township 3,Kansas Senate,38,Republican,"Estes, Bud",20,000210
+SEWARD,Fargo Township 1,President / Vice President,,independent,"Stein, Jill",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"McMullin, Evan",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000010
+SEWARD,Fargo Township 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+SEWARD,Fargo Township 1,President / Vice President,,Republican,"Trump, Donald J.",46,000010
+SEWARD,Fargo Township 2,President / Vice President,,independent,"Stein, Jill",1,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"McMullin, Evan",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+SEWARD,Fargo Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000020
+SEWARD,Fargo Township 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000020
+SEWARD,Fargo Township 2,President / Vice President,,Republican,"Trump, Donald J.",151,000020
+SEWARD,Fargo Township 3,President / Vice President,,independent,"Stein, Jill",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"McMullin, Evan",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SEWARD,Fargo Township 3,President / Vice President,,Republican,"Trump, Donald J.",18,000030
+SEWARD,Fargo Township 4,President / Vice President,,independent,"Stein, Jill",5,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Hedges, James A",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"McMullin, Evan",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Smith, Mike",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SEWARD,Fargo Township 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000040
+SEWARD,Fargo Township 4,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+SEWARD,Fargo Township 4,President / Vice President,,Republican,"Trump, Donald J.",73,000040
+SEWARD,Liberal Township 1,President / Vice President,,independent,"Stein, Jill",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Castle, Darrell L",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Giordani, Rocky",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Hedges, James A",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Kahn, Lynn",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"La Riva, Gloria",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Maturen, Michael A",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"McMullin, Evan",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Perry, Darryl",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Schriner, Joe C",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Smith, Mike",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Sood, Ajay",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Sterling, Shawna",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Libertarian,"Johnson, Gary",0,00005A
+SEWARD,Liberal Township 1,President / Vice President,,Republican,"Trump, Donald J.",5,00005A
+SEWARD,Liberal Township 2,President / Vice President,,independent,"Stein, Jill",1,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Castle, Darrell L",1,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"McMullin, Evan",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+SEWARD,Liberal Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000060
+SEWARD,Liberal Township 2,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+SEWARD,Liberal Township 2,President / Vice President,,Republican,"Trump, Donald J.",96,000060
+SEWARD,Liberal Township 3,President / Vice President,,independent,"Stein, Jill",2,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Hedges, James A",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"McMullin, Evan",1,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Smith, Mike",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SEWARD,Liberal Township 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000070
+SEWARD,Liberal Township 3,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+SEWARD,Liberal Township 3,President / Vice President,,Republican,"Trump, Donald J.",53,000070
+SEWARD,Liberal Township 4,President / Vice President,,independent,"Stein, Jill",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Castle, Darrell L",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Giordani, Rocky",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Hedges, James A",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Kahn, Lynn",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"La Riva, Gloria",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Levinson, Michael S.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Maturen, Michael A",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"McMullin, Evan",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Perry, Darryl",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Schriner, Joe C",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Smith, Mike",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Sood, Ajay",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Sterling, Shawna",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Libertarian,"Johnson, Gary",2,00008A
+SEWARD,Liberal Township 4,President / Vice President,,Republican,"Trump, Donald J.",32,00008A
+SEWARD,Liberal Township 5,President / Vice President,,independent,"Stein, Jill",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Hedges, James A",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Smith, Mike",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000090
+SEWARD,Liberal Township 5,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SEWARD,Liberal Township 5,President / Vice President,,Republican,"Trump, Donald J.",28,000090
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",7,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",177,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",18,000100
+SEWARD,Liberal Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",183,000100
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",6,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",262,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",28,000110
+SEWARD,Liberal Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",256,000110
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,independent,"Stein, Jill",5,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"McMullin, Evan",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",196,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",26,000120
+SEWARD,Liberal Ward 1 Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",231,000120
+SEWARD,Liberal Ward 2,President / Vice President,,independent,"Stein, Jill",9,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",138,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",14,000130
+SEWARD,Liberal Ward 2,President / Vice President,,Republican,"Trump, Donald J.",270,000130
+SEWARD,Liberal Ward 3,President / Vice President,,independent,"Stein, Jill",5,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"McMullin, Evan",1,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",155,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",19,000140
+SEWARD,Liberal Ward 3,President / Vice President,,Republican,"Trump, Donald J.",118,000140
+SEWARD,Liberal Ward 4,President / Vice President,,independent,"Stein, Jill",5,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",100,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",17,000150
+SEWARD,Liberal Ward 4,President / Vice President,,Republican,"Trump, Donald J.",192,000150
+SEWARD,Liberal Ward 5,President / Vice President,,independent,"Stein, Jill",2,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Hedges, James A",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"McMullin, Evan",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Perry, Darryl",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Smith, Mike",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Sood, Ajay",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Democratic,"Clinton, Hillary Rodham",101,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Libertarian,"Johnson, Gary",6,000160
+SEWARD,Liberal Ward 5,President / Vice President,,Republican,"Trump, Donald J.",177,000160
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,independent,"Stein, Jill",4,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",212,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",24,000170
+SEWARD,Liberal Ward 6 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",701,000170
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,independent,"Stein, Jill",5,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",164,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",15,000180
+SEWARD,Liberal Ward 6 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",442,000180
+SEWARD,Seward Township 1,President / Vice President,,independent,"Stein, Jill",1,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Hedges, James A",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"McMullin, Evan",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Perry, Darryl",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Smith, Mike",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Sood, Ajay",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+SEWARD,Seward Township 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+SEWARD,Seward Township 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000190
+SEWARD,Seward Township 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000190
+SEWARD,Seward Township 1,President / Vice President,,Republican,"Trump, Donald J.",30,000190
+SEWARD,Seward Township 2,President / Vice President,,independent,"Stein, Jill",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Hedges, James A",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"McMullin, Evan",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Perry, Darryl",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Smith, Mike",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Sood, Ajay",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+SEWARD,Seward Township 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+SEWARD,Seward Township 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000200
+SEWARD,Seward Township 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000200
+SEWARD,Seward Township 2,President / Vice President,,Republican,"Trump, Donald J.",37,000200
+SEWARD,Seward Township 3,President / Vice President,,independent,"Stein, Jill",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Hedges, James A",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"McMullin, Evan",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Perry, Darryl",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Smith, Mike",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Sood, Ajay",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+SEWARD,Seward Township 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+SEWARD,Seward Township 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000210
+SEWARD,Seward Township 3,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+SEWARD,Seward Township 3,President / Vice President,,Republican,"Trump, Donald J.",20,000210
+SEWARD,Fargo Township 1,United States House of Representatives,1,independent,"LaPolice, Alan",8,000010
+SEWARD,Fargo Township 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+SEWARD,Fargo Township 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000010
+SEWARD,Fargo Township 1,United States House of Representatives,1,Republican,"Marshall, Roger",38,000010
+SEWARD,Fargo Township 2,United States House of Representatives,1,independent,"LaPolice, Alan",28,000020
+SEWARD,Fargo Township 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+SEWARD,Fargo Township 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000020
+SEWARD,Fargo Township 2,United States House of Representatives,1,Republican,"Marshall, Roger",133,000020
+SEWARD,Fargo Township 3,United States House of Representatives,1,independent,"LaPolice, Alan",4,000030
+SEWARD,Fargo Township 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+SEWARD,Fargo Township 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+SEWARD,Fargo Township 3,United States House of Representatives,1,Republican,"Marshall, Roger",14,000030
+SEWARD,Fargo Township 4,United States House of Representatives,1,independent,"LaPolice, Alan",22,000040
+SEWARD,Fargo Township 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000040
+SEWARD,Fargo Township 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",19,000040
+SEWARD,Fargo Township 4,United States House of Representatives,1,Republican,"Marshall, Roger",73,000040
+SEWARD,Liberal Township 1,United States House of Representatives,1,independent,"LaPolice, Alan",4,00005A
+SEWARD,Liberal Township 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005A
+SEWARD,Liberal Township 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005A
+SEWARD,Liberal Township 1,United States House of Representatives,1,Republican,"Marshall, Roger",2,00005A
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00005B
+SEWARD,Liberal Township 2,United States House of Representatives,1,independent,"LaPolice, Alan",11,000060
+SEWARD,Liberal Township 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000060
+SEWARD,Liberal Township 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000060
+SEWARD,Liberal Township 2,United States House of Representatives,1,Republican,"Marshall, Roger",90,000060
+SEWARD,Liberal Township 3,United States House of Representatives,1,independent,"LaPolice, Alan",9,000070
+SEWARD,Liberal Township 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000070
+SEWARD,Liberal Township 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000070
+SEWARD,Liberal Township 3,United States House of Representatives,1,Republican,"Marshall, Roger",45,000070
+SEWARD,Liberal Township 4,United States House of Representatives,1,independent,"LaPolice, Alan",6,00008A
+SEWARD,Liberal Township 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00008A
+SEWARD,Liberal Township 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,00008A
+SEWARD,Liberal Township 4,United States House of Representatives,1,Republican,"Marshall, Roger",28,00008A
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00008B
+SEWARD,Liberal Township 5,United States House of Representatives,1,independent,"LaPolice, Alan",5,000090
+SEWARD,Liberal Township 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+SEWARD,Liberal Township 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+SEWARD,Liberal Township 5,United States House of Representatives,1,Republican,"Marshall, Roger",22,000090
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",45,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",64,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",188,000100
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",86,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",88,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",278,000110
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",76,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",69,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",249,000120
+SEWARD,Liberal Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",67,000130
+SEWARD,Liberal Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+SEWARD,Liberal Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",57,000130
+SEWARD,Liberal Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",265,000130
+SEWARD,Liberal Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",50,000140
+SEWARD,Liberal Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000140
+SEWARD,Liberal Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",47,000140
+SEWARD,Liberal Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",129,000140
+SEWARD,Liberal Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",58,000150
+SEWARD,Liberal Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+SEWARD,Liberal Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000150
+SEWARD,Liberal Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",193,000150
+SEWARD,Liberal Ward 5,United States House of Representatives,1,independent,"LaPolice, Alan",56,000160
+SEWARD,Liberal Ward 5,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+SEWARD,Liberal Ward 5,United States House of Representatives,1,Libertarian,"Burt, Kerry",39,000160
+SEWARD,Liberal Ward 5,United States House of Representatives,1,Republican,"Marshall, Roger",154,000160
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",123,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",61,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",703,000170
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",82,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",55,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",444,000180
+SEWARD,Seward Township 1,United States House of Representatives,1,independent,"LaPolice, Alan",6,000190
+SEWARD,Seward Township 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+SEWARD,Seward Township 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000190
+SEWARD,Seward Township 1,United States House of Representatives,1,Republican,"Marshall, Roger",26,000190
+SEWARD,Seward Township 2,United States House of Representatives,1,independent,"LaPolice, Alan",6,000200
+SEWARD,Seward Township 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+SEWARD,Seward Township 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000200
+SEWARD,Seward Township 2,United States House of Representatives,1,Republican,"Marshall, Roger",34,000200
+SEWARD,Seward Township 3,United States House of Representatives,1,independent,"LaPolice, Alan",0,000210
+SEWARD,Seward Township 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+SEWARD,Seward Township 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000210
+SEWARD,Seward Township 3,United States House of Representatives,1,Republican,"Marshall, Roger",16,000210
+SEWARD,Fargo Township 1,United States Senate,,write - in,"Smith, DJ",0,000010
+SEWARD,Fargo Township 1,United States Senate,,Democratic,"Wiesner, Patrick",8,000010
+SEWARD,Fargo Township 1,United States Senate,,Libertarian,"Garrard, Robert D.",4,000010
+SEWARD,Fargo Township 1,United States Senate,,Republican,"Moran, Jerry",41,000010
+SEWARD,Fargo Township 2,United States Senate,,write - in,"Smith, DJ",0,000020
+SEWARD,Fargo Township 2,United States Senate,,Democratic,"Wiesner, Patrick",19,000020
+SEWARD,Fargo Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",17,000020
+SEWARD,Fargo Township 2,United States Senate,,Republican,"Moran, Jerry",142,000020
+SEWARD,Fargo Township 3,United States Senate,,write - in,"Smith, DJ",0,000030
+SEWARD,Fargo Township 3,United States Senate,,Democratic,"Wiesner, Patrick",0,000030
+SEWARD,Fargo Township 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+SEWARD,Fargo Township 3,United States Senate,,Republican,"Moran, Jerry",18,000030
+SEWARD,Fargo Township 4,United States Senate,,write - in,"Smith, DJ",0,000040
+SEWARD,Fargo Township 4,United States Senate,,Democratic,"Wiesner, Patrick",44,000040
+SEWARD,Fargo Township 4,United States Senate,,Libertarian,"Garrard, Robert D.",13,000040
+SEWARD,Fargo Township 4,United States Senate,,Republican,"Moran, Jerry",65,000040
+SEWARD,Liberal Township 1,United States Senate,,write - in,"Smith, DJ",0,00005A
+SEWARD,Liberal Township 1,United States Senate,,Democratic,"Wiesner, Patrick",2,00005A
+SEWARD,Liberal Township 1,United States Senate,,Libertarian,"Garrard, Robert D.",1,00005A
+SEWARD,Liberal Township 1,United States Senate,,Republican,"Moran, Jerry",3,00005A
+SEWARD,Liberal Township 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00005B
+SEWARD,Liberal Township 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00005B
+SEWARD,Liberal Township 2,United States Senate,,write - in,"Smith, DJ",0,000060
+SEWARD,Liberal Township 2,United States Senate,,Democratic,"Wiesner, Patrick",11,000060
+SEWARD,Liberal Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",7,000060
+SEWARD,Liberal Township 2,United States Senate,,Republican,"Moran, Jerry",94,000060
+SEWARD,Liberal Township 3,United States Senate,,write - in,"Smith, DJ",0,000070
+SEWARD,Liberal Township 3,United States Senate,,Democratic,"Wiesner, Patrick",4,000070
+SEWARD,Liberal Township 3,United States Senate,,Libertarian,"Garrard, Robert D.",4,000070
+SEWARD,Liberal Township 3,United States Senate,,Republican,"Moran, Jerry",55,000070
+SEWARD,Liberal Township 4,United States Senate,,write - in,"Smith, DJ",0,00008A
+SEWARD,Liberal Township 4,United States Senate,,Democratic,"Wiesner, Patrick",3,00008A
+SEWARD,Liberal Township 4,United States Senate,,Libertarian,"Garrard, Robert D.",3,00008A
+SEWARD,Liberal Township 4,United States Senate,,Republican,"Moran, Jerry",31,00008A
+SEWARD,Liberal Township 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008B
+SEWARD,Liberal Township 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00008B
+SEWARD,Liberal Township 5,United States Senate,,write - in,"Smith, DJ",0,000090
+SEWARD,Liberal Township 5,United States Senate,,Democratic,"Wiesner, Patrick",2,000090
+SEWARD,Liberal Township 5,United States Senate,,Libertarian,"Garrard, Robert D.",1,000090
+SEWARD,Liberal Township 5,United States Senate,,Republican,"Moran, Jerry",28,000090
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",131,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",36,000100
+SEWARD,Liberal Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",168,000100
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",191,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",47,000110
+SEWARD,Liberal Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",254,000110
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",159,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",27,000120
+SEWARD,Liberal Ward 1 Precinct 3,United States Senate,,Republican,"Moran, Jerry",241,000120
+SEWARD,Liberal Ward 2,United States Senate,,write - in,"Smith, DJ",0,000130
+SEWARD,Liberal Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",94,000130
+SEWARD,Liberal Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",32,000130
+SEWARD,Liberal Ward 2,United States Senate,,Republican,"Moran, Jerry",279,000130
+SEWARD,Liberal Ward 3,United States Senate,,write - in,"Smith, DJ",0,000140
+SEWARD,Liberal Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",111,000140
+SEWARD,Liberal Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",24,000140
+SEWARD,Liberal Ward 3,United States Senate,,Republican,"Moran, Jerry",130,000140
+SEWARD,Liberal Ward 4,United States Senate,,write - in,"Smith, DJ",0,000150
+SEWARD,Liberal Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",84,000150
+SEWARD,Liberal Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",11,000150
+SEWARD,Liberal Ward 4,United States Senate,,Republican,"Moran, Jerry",207,000150
+SEWARD,Liberal Ward 5,United States Senate,,write - in,"Smith, DJ",0,000160
+SEWARD,Liberal Ward 5,United States Senate,,Democratic,"Wiesner, Patrick",70,000160
+SEWARD,Liberal Ward 5,United States Senate,,Libertarian,"Garrard, Robert D.",21,000160
+SEWARD,Liberal Ward 5,United States Senate,,Republican,"Moran, Jerry",167,000160
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",152,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",55,000170
+SEWARD,Liberal Ward 6 Precinct 1,United States Senate,,Republican,"Moran, Jerry",699,000170
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",119,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",30,000180
+SEWARD,Liberal Ward 6 Precinct 2,United States Senate,,Republican,"Moran, Jerry",463,000180
+SEWARD,Seward Township 1,United States Senate,,write - in,"Smith, DJ",0,000190
+SEWARD,Seward Township 1,United States Senate,,Democratic,"Wiesner, Patrick",4,000190
+SEWARD,Seward Township 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,000190
+SEWARD,Seward Township 1,United States Senate,,Republican,"Moran, Jerry",28,000190
+SEWARD,Seward Township 2,United States Senate,,write - in,"Smith, DJ",0,000200
+SEWARD,Seward Township 2,United States Senate,,Democratic,"Wiesner, Patrick",3,000200
+SEWARD,Seward Township 2,United States Senate,,Libertarian,"Garrard, Robert D.",2,000200
+SEWARD,Seward Township 2,United States Senate,,Republican,"Moran, Jerry",35,000200
+SEWARD,Seward Township 3,United States Senate,,write - in,"Smith, DJ",0,000210
+SEWARD,Seward Township 3,United States Senate,,Democratic,"Wiesner, Patrick",2,000210
+SEWARD,Seward Township 3,United States Senate,,Libertarian,"Garrard, Robert D.",0,000210
+SEWARD,Seward Township 3,United States Senate,,Republican,"Moran, Jerry",20,000210

--- a/2016/20161108__ks__general__sheridan__precinct.csv
+++ b/2016/20161108__ks__general__sheridan__precinct.csv
@@ -1,222 +1,541 @@
-county,precinct,office,district,party,candidate,votes
-Sheridan,Hoxie - East,President,,REP,Trump/Pence,307
-Sheridan,Hoxie - West,President,,REP,Trump/Pence,238
-Sheridan,Adell,President,,REP,Trump/Pence,9
-Sheridan,Bloomfield,President,,REP,Trump/Pence,22
-Sheridan,Bowcreek,President,,REP,Trump/Pence,22
-Sheridan,Kenneth - East,President,,REP,Trump/Pence,46
-Sheridan,Kenneth - West,President,,REP,Trump/Pence,50
-Sheridan,Logan,President,,REP,Trump/Pence,47
-Sheridan,Parnell,President,,REP,Trump/Pence,56
-Sheridan,Prairie Dog,President,,REP,Trump/Pence,21
-Sheridan,"Saline, East",President,,REP,Trump/Pence,31
-Sheridan,"Saline, West",President,,REP,Trump/Pence,36
-Sheridan,Sheridan,President,,REP,Trump/Pence,124
-Sheridan,Solomon,President,,REP,Trump/Pence,86
-Sheridan,Springbrook,President,,REP,Trump/Pence,42
-Sheridan,Union,President,,REP,Trump/Pence,13
-Sheridan,Valley,President,,REP,Trump/Pence,47
-Sheridan,Hoxie - East,President,,DEM,Clinton/Kaine,32
-Sheridan,Hoxie - West,President,,DEM,Clinton/Kaine,33
-Sheridan,Adell,President,,DEM,Clinton/Kaine,1
-Sheridan,Bloomfield,President,,DEM,Clinton/Kaine,1
-Sheridan,Bowcreek,President,,DEM,Clinton/Kaine,3
-Sheridan,Kenneth - East,President,,DEM,Clinton/Kaine,6
-Sheridan,Kenneth - West,President,,DEM,Clinton/Kaine,0
-Sheridan,Logan,President,,DEM,Clinton/Kaine,3
-Sheridan,Parnell,President,,DEM,Clinton/Kaine,2
-Sheridan,Prairie Dog,President,,DEM,Clinton/Kaine,2
-Sheridan,"Saline, East",President,,DEM,Clinton/Kaine,0
-Sheridan,"Saline, West",President,,DEM,Clinton/Kaine,1
-Sheridan,Sheridan,President,,DEM,Clinton/Kaine,25
-Sheridan,Solomon,President,,DEM,Clinton/Kaine,8
-Sheridan,Springbrook,President,,DEM,Clinton/Kaine,3
-Sheridan,Union,President,,DEM,Clinton/Kaine,2
-Sheridan,Valley,President,,DEM,Clinton/Kaine,5
-Sheridan,Hoxie - East,President,,LIB,Johnson/Weld,4
-Sheridan,Hoxie - West,President,,LIB,Johnson/Weld,16
-Sheridan,Adell,President,,LIB,Johnson/Weld,0
-Sheridan,Bloomfield,President,,LIB,Johnson/Weld,0
-Sheridan,Bowcreek,President,,LIB,Johnson/Weld,0
-Sheridan,Kenneth - East,President,,LIB,Johnson/Weld,2
-Sheridan,Kenneth - West,President,,LIB,Johnson/Weld,1
-Sheridan,Logan,President,,LIB,Johnson/Weld,0
-Sheridan,Parnell,President,,LIB,Johnson/Weld,1
-Sheridan,Prairie Dog,President,,LIB,Johnson/Weld,4
-Sheridan,"Saline, East",President,,LIB,Johnson/Weld,1
-Sheridan,"Saline, West",President,,LIB,Johnson/Weld,0
-Sheridan,Sheridan,President,,LIB,Johnson/Weld,5
-Sheridan,Solomon,President,,LIB,Johnson/Weld,1
-Sheridan,Springbrook,President,,LIB,Johnson/Weld,1
-Sheridan,Union,President,,LIB,Johnson/Weld,0
-Sheridan,Valley,President,,LIB,Johnson/Weld,2
-Sheridan,Hoxie - East,President,,IND,Stein/Baraka,2
-Sheridan,Hoxie - West,President,,IND,Stein/Baraka,4
-Sheridan,Adell,President,,IND,Stein/Baraka,0
-Sheridan,Bloomfield,President,,IND,Stein/Baraka,0
-Sheridan,Bowcreek,President,,IND,Stein/Baraka,1
-Sheridan,Kenneth - East,President,,IND,Stein/Baraka,0
-Sheridan,Kenneth - West,President,,IND,Stein/Baraka,0
-Sheridan,Logan,President,,IND,Stein/Baraka,0
-Sheridan,Parnell,President,,IND,Stein/Baraka,1
-Sheridan,Prairie Dog,President,,IND,Stein/Baraka,0
-Sheridan,"Saline, East",President,,IND,Stein/Baraka,1
-Sheridan,"Saline, West",President,,IND,Stein/Baraka,0
-Sheridan,Sheridan,President,,IND,Stein/Baraka,1
-Sheridan,Solomon,President,,IND,Stein/Baraka,2
-Sheridan,Springbrook,President,,IND,Stein/Baraka,0
-Sheridan,Union,President,,IND,Stein/Baraka,0
-Sheridan,Valley,President,,IND,Stein/Baraka,0
-Sheridan,Hoxie - East,U.S. Senate,,DEM,Patrick Wiesner,28
-Sheridan,Hoxie - West,U.S. Senate,,DEM,Patrick Wiesner,33
-Sheridan,Adell,U.S. Senate,,DEM,Patrick Wiesner,2
-Sheridan,Bloomfield,U.S. Senate,,DEM,Patrick Wiesner,1
-Sheridan,Bowcreek,U.S. Senate,,DEM,Patrick Wiesner,3
-Sheridan,Kenneth - East,U.S. Senate,,DEM,Patrick Wiesner,5
-Sheridan,Kenneth - West,U.S. Senate,,DEM,Patrick Wiesner,2
-Sheridan,Logan,U.S. Senate,,DEM,Patrick Wiesner,2
-Sheridan,Parnell,U.S. Senate,,DEM,Patrick Wiesner,3
-Sheridan,Prairie Dog,U.S. Senate,,DEM,Patrick Wiesner,0
-Sheridan,"Saline, East",U.S. Senate,,DEM,Patrick Wiesner,1
-Sheridan,"Saline, West",U.S. Senate,,DEM,Patrick Wiesner,2
-Sheridan,Sheridan,U.S. Senate,,DEM,Patrick Wiesner,24
-Sheridan,Solomon,U.S. Senate,,DEM,Patrick Wiesner,6
-Sheridan,Springbrook,U.S. Senate,,DEM,Patrick Wiesner,1
-Sheridan,Union,U.S. Senate,,DEM,Patrick Wiesner,1
-Sheridan,Valley,U.S. Senate,,DEM,Patrick Wiesner,5
-Sheridan,Hoxie - East,U.S. Senate,,LIB,Robert D. Garrard,7
-Sheridan,Hoxie - West,U.S. Senate,,LIB,Robert D. Garrard,15
-Sheridan,Adell,U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,Bloomfield,U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,Bowcreek,U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,Kenneth - East,U.S. Senate,,LIB,Robert D. Garrard,3
-Sheridan,Kenneth - West,U.S. Senate,,LIB,Robert D. Garrard,1
-Sheridan,Logan,U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,Parnell,U.S. Senate,,LIB,Robert D. Garrard,3
-Sheridan,Prairie Dog,U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,"Saline, East",U.S. Senate,,LIB,Robert D. Garrard,1
-Sheridan,"Saline, West",U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,Sheridan,U.S. Senate,,LIB,Robert D. Garrard,3
-Sheridan,Solomon,U.S. Senate,,LIB,Robert D. Garrard,3
-Sheridan,Springbrook,U.S. Senate,,LIB,Robert D. Garrard,1
-Sheridan,Union,U.S. Senate,,LIB,Robert D. Garrard,0
-Sheridan,Valley,U.S. Senate,,LIB,Robert D. Garrard,1
-Sheridan,Hoxie - East,U.S. Senate,,REP,Jerry Moran,304
-Sheridan,Hoxie - West,U.S. Senate,,REP,Jerry Moran,238
-Sheridan,Adell,U.S. Senate,,REP,Jerry Moran,9
-Sheridan,Bloomfield,U.S. Senate,,REP,Jerry Moran,22
-Sheridan,Bowcreek,U.S. Senate,,REP,Jerry Moran,24
-Sheridan,Kenneth - East,U.S. Senate,,REP,Jerry Moran,43
-Sheridan,Kenneth - West,U.S. Senate,,REP,Jerry Moran,48
-Sheridan,Logan,U.S. Senate,,REP,Jerry Moran,48
-Sheridan,Parnell,U.S. Senate,,REP,Jerry Moran,54
-Sheridan,Prairie Dog,U.S. Senate,,REP,Jerry Moran,27
-Sheridan,"Saline, East",U.S. Senate,,REP,Jerry Moran,29
-Sheridan,"Saline, West",U.S. Senate,,REP,Jerry Moran,37
-Sheridan,Sheridan,U.S. Senate,,REP,Jerry Moran,127
-Sheridan,Solomon,U.S. Senate,,REP,Jerry Moran,87
-Sheridan,Springbrook,U.S. Senate,,REP,Jerry Moran,44
-Sheridan,Union,U.S. Senate,,REP,Jerry Moran,15
-Sheridan,Valley,U.S. Senate,,REP,Jerry Moran,45
-Sheridan,Hoxie - East,U.S. House,1,REP,Roger Marshall,267
-Sheridan,Hoxie - West,U.S. House,1,REP,Roger Marshall,215
-Sheridan,Adell,U.S. House,1,REP,Roger Marshall,6
-Sheridan,Bloomfield,U.S. House,1,REP,Roger Marshall,20
-Sheridan,Bowcreek,U.S. House,1,REP,Roger Marshall,23
-Sheridan,Kenneth - East,U.S. House,1,REP,Roger Marshall,43
-Sheridan,Kenneth - West,U.S. House,1,REP,Roger Marshall,45
-Sheridan,Logan,U.S. House,1,REP,Roger Marshall,43
-Sheridan,Parnell,U.S. House,1,REP,Roger Marshall,47
-Sheridan,Prairie Dog,U.S. House,1,REP,Roger Marshall,25
-Sheridan,"Saline, East",U.S. House,1,REP,Roger Marshall,26
-Sheridan,"Saline, West",U.S. House,1,REP,Roger Marshall,28
-Sheridan,Sheridan,U.S. House,1,REP,Roger Marshall,123
-Sheridan,Solomon,U.S. House,1,REP,Roger Marshall,77
-Sheridan,Springbrook,U.S. House,1,REP,Roger Marshall,37
-Sheridan,Union,U.S. House,1,REP,Roger Marshall,10
-Sheridan,Valley,U.S. House,1,REP,Roger Marshall,37
-Sheridan,Hoxie - East,U.S. House,1,LIB,Kerry Burt,11
-Sheridan,Hoxie - West,U.S. House,1,LIB,Kerry Burt,15
-Sheridan,Adell,U.S. House,1,LIB,Kerry Burt,0
-Sheridan,Bloomfield,U.S. House,1,LIB,Kerry Burt,0
-Sheridan,Bowcreek,U.S. House,1,LIB,Kerry Burt,0
-Sheridan,Kenneth - East,U.S. House,1,LIB,Kerry Burt,2
-Sheridan,Kenneth - West,U.S. House,1,LIB,Kerry Burt,0
-Sheridan,Logan,U.S. House,1,LIB,Kerry Burt,1
-Sheridan,Parnell,U.S. House,1,LIB,Kerry Burt,3
-Sheridan,Prairie Dog,U.S. House,1,LIB,Kerry Burt,0
-Sheridan,"Saline, East",U.S. House,1,LIB,Kerry Burt,0
-Sheridan,"Saline, West",U.S. House,1,LIB,Kerry Burt,1
-Sheridan,Sheridan,U.S. House,1,LIB,Kerry Burt,9
-Sheridan,Solomon,U.S. House,1,LIB,Kerry Burt,3
-Sheridan,Springbrook,U.S. House,1,LIB,Kerry Burt,1
-Sheridan,Union,U.S. House,1,LIB,Kerry Burt,0
-Sheridan,Valley,U.S. House,1,LIB,Kerry Burt,1
-Sheridan,Hoxie - East,U.S. House,1,IND,Alan LaPolice,40
-Sheridan,Hoxie - West,U.S. House,1,IND,Alan LaPolice,38
-Sheridan,Adell,U.S. House,1,IND,Alan LaPolice,4
-Sheridan,Bloomfield,U.S. House,1,IND,Alan LaPolice,3
-Sheridan,Bowcreek,U.S. House,1,IND,Alan LaPolice,3
-Sheridan,Kenneth - East,U.S. House,1,IND,Alan LaPolice,7
-Sheridan,Kenneth - West,U.S. House,1,IND,Alan LaPolice,6
-Sheridan,Logan,U.S. House,1,IND,Alan LaPolice,6
-Sheridan,Parnell,U.S. House,1,IND,Alan LaPolice,7
-Sheridan,Prairie Dog,U.S. House,1,IND,Alan LaPolice,2
-Sheridan,"Saline, East",U.S. House,1,IND,Alan LaPolice,3
-Sheridan,"Saline, West",U.S. House,1,IND,Alan LaPolice,9
-Sheridan,Sheridan,U.S. House,1,IND,Alan LaPolice,19
-Sheridan,Solomon,U.S. House,1,IND,Alan LaPolice,17
-Sheridan,Springbrook,U.S. House,1,IND,Alan LaPolice,6
-Sheridan,Union,U.S. House,1,IND,Alan LaPolice,4
-Sheridan,Valley,U.S. House,1,IND,Alan LaPolice,13
-Sheridan,Hoxie - East,State Senate,40,DEM,Alex Herman,47
-Sheridan,Hoxie - West,State Senate,40,DEM,Alex Herman,57
-Sheridan,Adell,State Senate,40,DEM,Alex Herman,3
-Sheridan,Bloomfield,State Senate,40,DEM,Alex Herman,2
-Sheridan,Bowcreek,State Senate,40,DEM,Alex Herman,3
-Sheridan,Kenneth - East,State Senate,40,DEM,Alex Herman,3
-Sheridan,Kenneth - West,State Senate,40,DEM,Alex Herman,0
-Sheridan,Logan,State Senate,40,DEM,Alex Herman,6
-Sheridan,Parnell,State Senate,40,DEM,Alex Herman,5
-Sheridan,Prairie Dog,State Senate,40,DEM,Alex Herman,2
-Sheridan,"Saline, East",State Senate,40,DEM,Alex Herman,2
-Sheridan,"Saline, West",State Senate,40,DEM,Alex Herman,4
-Sheridan,Sheridan,State Senate,40,DEM,Alex Herman,28
-Sheridan,Solomon,State Senate,40,DEM,Alex Herman,11
-Sheridan,Springbrook,State Senate,40,DEM,Alex Herman,2
-Sheridan,Union,State Senate,40,DEM,Alex Herman,3
-Sheridan,Valley,State Senate,40,DEM,Alex Herman,6
-Sheridan,Hoxie - East,State Senate,40,REP,Richard (Rick) Billinger,114
-Sheridan,Hoxie - West,State Senate,40,REP,Richard (Rick) Billinger,221
-Sheridan,Adell,State Senate,40,REP,Richard (Rick) Billinger,7
-Sheridan,Bloomfield,State Senate,40,REP,Richard (Rick) Billinger,21
-Sheridan,Bowcreek,State Senate,40,REP,Richard (Rick) Billinger,23
-Sheridan,Kenneth - East,State Senate,40,REP,Richard (Rick) Billinger,48
-Sheridan,Kenneth - West,State Senate,40,REP,Richard (Rick) Billinger,51
-Sheridan,Logan,State Senate,40,REP,Richard (Rick) Billinger,42
-Sheridan,Parnell,State Senate,40,REP,Richard (Rick) Billinger,53
-Sheridan,Prairie Dog,State Senate,40,REP,Richard (Rick) Billinger,24
-Sheridan,"Saline, East",State Senate,40,REP,Richard (Rick) Billinger,29
-Sheridan,"Saline, West",State Senate,40,REP,Richard (Rick) Billinger,35
-Sheridan,Sheridan,State Senate,40,REP,Richard (Rick) Billinger,124
-Sheridan,Solomon,State Senate,40,REP,Richard (Rick) Billinger,86
-Sheridan,Springbrook,State Senate,40,REP,Richard (Rick) Billinger,42
-Sheridan,Union,State Senate,40,REP,Richard (Rick) Billinger,13
-Sheridan,Valley,State Senate,40,REP,Richard (Rick) Billinger,47
-Sheridan,Hoxie - East,State House,118,REP,Don Hineman,296
-Sheridan,Hoxie - West,State House,118,REP,Don Hineman,233
-Sheridan,Adell,State House,118,REP,Don Hineman,7
-Sheridan,Bloomfield,State House,118,REP,Don Hineman,20
-Sheridan,Bowcreek,State House,118,REP,Don Hineman,22
-Sheridan,Kenneth - East,State House,118,REP,Don Hineman,46
-Sheridan,Kenneth - West,State House,118,REP,Don Hineman,45
-Sheridan,Logan,State House,118,REP,Don Hineman,44
-Sheridan,Parnell,State House,118,REP,Don Hineman,51
-Sheridan,Prairie Dog,State House,118,REP,Don Hineman,23
-Sheridan,"Saline, East",State House,118,REP,Don Hineman,28
-Sheridan,"Saline, West",State House,118,REP,Don Hineman,33
-Sheridan,Sheridan,State House,118,REP,Don Hineman,128
-Sheridan,Solomon,State House,118,REP,Don Hineman,89
-Sheridan,Springbrook,State House,118,REP,Don Hineman,41
-Sheridan,Union,State House,118,REP,Don Hineman,13
-Sheridan,Valley,State House,118,REP,Don Hineman,49
+county,precinct,office,district,party,candidate,votes,vtd
+SHERIDAN,Adell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",7,000010
+SHERIDAN,Bloomfield Township,Kansas House of Representatives,118,Republican,"Hineman, Don",20,000020
+SHERIDAN,Bow Creek Township,Kansas House of Representatives,118,Republican,"Hineman, Don",22,000030
+SHERIDAN,East Kenneth,Kansas House of Representatives,118,Republican,"Hineman, Don",342,000040
+SHERIDAN,East Saline,Kansas House of Representatives,118,Republican,"Hineman, Don",28,000050
+SHERIDAN,Logan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",44,000060
+SHERIDAN,Parnell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",51,000070
+SHERIDAN,Prairie Dog Township,Kansas House of Representatives,118,Republican,"Hineman, Don",23,000080
+SHERIDAN,Sheridan Township,Kansas House of Representatives,118,Republican,"Hineman, Don",128,000090
+SHERIDAN,Solomon Township,Kansas House of Representatives,118,Republican,"Hineman, Don",89,000100
+SHERIDAN,Springbrook Township,Kansas House of Representatives,118,Republican,"Hineman, Don",41,000110
+SHERIDAN,Union Township,Kansas House of Representatives,118,Republican,"Hineman, Don",13,000120
+SHERIDAN,Valley Township,Kansas House of Representatives,118,Republican,"Hineman, Don",49,000130
+SHERIDAN,West Kenneth,Kansas House of Representatives,118,Republican,"Hineman, Don",278,000140
+SHERIDAN,West Saline,Kansas House of Representatives,118,Republican,"Hineman, Don",33,000150
+SHERIDAN,Adell Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000010
+SHERIDAN,Adell Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",7,000010
+SHERIDAN,Bloomfield Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000020
+SHERIDAN,Bloomfield Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",21,000020
+SHERIDAN,Bow Creek Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000030
+SHERIDAN,Bow Creek Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",23,000030
+SHERIDAN,East Kenneth,Kansas Senate,40,Democratic,"Herman, Alex",50,000040
+SHERIDAN,East Kenneth,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",162,000040
+SHERIDAN,East Saline,Kansas Senate,40,Democratic,"Herman, Alex",2,000050
+SHERIDAN,East Saline,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",29,000050
+SHERIDAN,Logan Township,Kansas Senate,40,Democratic,"Herman, Alex",6,000060
+SHERIDAN,Logan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",42,000060
+SHERIDAN,Parnell Township,Kansas Senate,40,Democratic,"Herman, Alex",5,000070
+SHERIDAN,Parnell Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",53,000070
+SHERIDAN,Prairie Dog Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000080
+SHERIDAN,Prairie Dog Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",24,000080
+SHERIDAN,Sheridan Township,Kansas Senate,40,Democratic,"Herman, Alex",28,000090
+SHERIDAN,Sheridan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",124,000090
+SHERIDAN,Solomon Township,Kansas Senate,40,Democratic,"Herman, Alex",11,000100
+SHERIDAN,Solomon Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",86,000100
+SHERIDAN,Springbrook Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000110
+SHERIDAN,Springbrook Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",42,000110
+SHERIDAN,Union Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000120
+SHERIDAN,Union Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",13,000120
+SHERIDAN,Valley Township,Kansas Senate,40,Democratic,"Herman, Alex",6,000130
+SHERIDAN,Valley Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",47,000130
+SHERIDAN,West Kenneth,Kansas Senate,40,Democratic,"Herman, Alex",57,000140
+SHERIDAN,West Kenneth,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",272,000140
+SHERIDAN,West Saline,Kansas Senate,40,Democratic,"Herman, Alex",4,000150
+SHERIDAN,West Saline,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",35,000150
+SHERIDAN,Adell Township,President / Vice President,,independent,"Stein, Jill",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SHERIDAN,Adell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SHERIDAN,Adell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000010
+SHERIDAN,Adell Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+SHERIDAN,Adell Township,President / Vice President,,Republican,"Trump, Donald J.",9,000010
+SHERIDAN,Bloomfield Township,President / Vice President,,independent,"Stein, Jill",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+SHERIDAN,Bloomfield Township,President / Vice President,,Republican,"Trump, Donald J.",22,000020
+SHERIDAN,Bow Creek Township,President / Vice President,,independent,"Stein, Jill",1,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SHERIDAN,Bow Creek Township,President / Vice President,,Republican,"Trump, Donald J.",22,000030
+SHERIDAN,East Kenneth,President / Vice President,,independent,"Stein, Jill",2,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Hedges, James A",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"McMullin, Evan",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Smith, Mike",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SHERIDAN,East Kenneth,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000040
+SHERIDAN,East Kenneth,President / Vice President,,Libertarian,"Johnson, Gary",6,000040
+SHERIDAN,East Kenneth,President / Vice President,,Republican,"Trump, Donald J.",353,000040
+SHERIDAN,East Saline,President / Vice President,,independent,"Stein, Jill",1,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Hedges, James A",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"McMullin, Evan",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Perry, Darryl",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Smith, Mike",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Sood, Ajay",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+SHERIDAN,East Saline,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+SHERIDAN,East Saline,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000050
+SHERIDAN,East Saline,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+SHERIDAN,East Saline,President / Vice President,,Republican,"Trump, Donald J.",31,000050
+SHERIDAN,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+SHERIDAN,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+SHERIDAN,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000060
+SHERIDAN,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SHERIDAN,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",47,000060
+SHERIDAN,Parnell Township,President / Vice President,,independent,"Stein, Jill",1,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SHERIDAN,Parnell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000070
+SHERIDAN,Parnell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+SHERIDAN,Parnell Township,President / Vice President,,Republican,"Trump, Donald J.",56,000070
+SHERIDAN,Prairie Dog Township,President / Vice President,,independent,"Stein, Jill",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000080
+SHERIDAN,Prairie Dog Township,President / Vice President,,Republican,"Trump, Donald J.",21,000080
+SHERIDAN,Sheridan Township,President / Vice President,,independent,"Stein, Jill",1,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SHERIDAN,Sheridan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000090
+SHERIDAN,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+SHERIDAN,Sheridan Township,President / Vice President,,Republican,"Trump, Donald J.",124,000090
+SHERIDAN,Solomon Township,President / Vice President,,independent,"Stein, Jill",2,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+SHERIDAN,Solomon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000100
+SHERIDAN,Solomon Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+SHERIDAN,Solomon Township,President / Vice President,,Republican,"Trump, Donald J.",86,000100
+SHERIDAN,Springbrook Township,President / Vice President,,independent,"Stein, Jill",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+SHERIDAN,Springbrook Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000110
+SHERIDAN,Springbrook Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000110
+SHERIDAN,Springbrook Township,President / Vice President,,Republican,"Trump, Donald J.",42,000110
+SHERIDAN,Union Township,President / Vice President,,independent,"Stein, Jill",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+SHERIDAN,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+SHERIDAN,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000120
+SHERIDAN,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+SHERIDAN,Union Township,President / Vice President,,Republican,"Trump, Donald J.",13,000120
+SHERIDAN,Valley Township,President / Vice President,,independent,"Stein, Jill",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+SHERIDAN,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+SHERIDAN,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000130
+SHERIDAN,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+SHERIDAN,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",47,000130
+SHERIDAN,West Kenneth,President / Vice President,,independent,"Stein, Jill",4,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Hedges, James A",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"McMullin, Evan",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Perry, Darryl",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Smith, Mike",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Sood, Ajay",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+SHERIDAN,West Kenneth,President / Vice President,,Democratic,"Clinton, Hillary Rodham",33,000140
+SHERIDAN,West Kenneth,President / Vice President,,Libertarian,"Johnson, Gary",17,000140
+SHERIDAN,West Kenneth,President / Vice President,,Republican,"Trump, Donald J.",288,000140
+SHERIDAN,West Saline,President / Vice President,,independent,"Stein, Jill",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Hedges, James A",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"McMullin, Evan",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Perry, Darryl",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Smith, Mike",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Sood, Ajay",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+SHERIDAN,West Saline,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+SHERIDAN,West Saline,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000150
+SHERIDAN,West Saline,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+SHERIDAN,West Saline,President / Vice President,,Republican,"Trump, Donald J.",36,000150
+SHERIDAN,Adell Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000010
+SHERIDAN,Adell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+SHERIDAN,Adell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000010
+SHERIDAN,Adell Township,United States House of Representatives,1,Republican,"Marshall, Roger",6,000010
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000020
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+SHERIDAN,Bloomfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000020
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000030
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+SHERIDAN,Bow Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000030
+SHERIDAN,East Kenneth,United States House of Representatives,1,independent,"LaPolice, Alan",47,000040
+SHERIDAN,East Kenneth,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+SHERIDAN,East Kenneth,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000040
+SHERIDAN,East Kenneth,United States House of Representatives,1,Republican,"Marshall, Roger",310,000040
+SHERIDAN,East Saline,United States House of Representatives,1,independent,"LaPolice, Alan",3,000050
+SHERIDAN,East Saline,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+SHERIDAN,East Saline,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+SHERIDAN,East Saline,United States House of Representatives,1,Republican,"Marshall, Roger",26,000050
+SHERIDAN,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000060
+SHERIDAN,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+SHERIDAN,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+SHERIDAN,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",43,000060
+SHERIDAN,Parnell Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000070
+SHERIDAN,Parnell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+SHERIDAN,Parnell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000070
+SHERIDAN,Parnell Township,United States House of Representatives,1,Republican,"Marshall, Roger",47,000070
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000080
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+SHERIDAN,Prairie Dog Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000080
+SHERIDAN,Sheridan Township,United States House of Representatives,1,independent,"LaPolice, Alan",19,000090
+SHERIDAN,Sheridan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+SHERIDAN,Sheridan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000090
+SHERIDAN,Sheridan Township,United States House of Representatives,1,Republican,"Marshall, Roger",123,000090
+SHERIDAN,Solomon Township,United States House of Representatives,1,independent,"LaPolice, Alan",17,000100
+SHERIDAN,Solomon Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+SHERIDAN,Solomon Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000100
+SHERIDAN,Solomon Township,United States House of Representatives,1,Republican,"Marshall, Roger",77,000100
+SHERIDAN,Springbrook Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000110
+SHERIDAN,Springbrook Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+SHERIDAN,Springbrook Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000110
+SHERIDAN,Springbrook Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000110
+SHERIDAN,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000120
+SHERIDAN,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+SHERIDAN,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+SHERIDAN,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000120
+SHERIDAN,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000130
+SHERIDAN,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+SHERIDAN,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000130
+SHERIDAN,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000130
+SHERIDAN,West Kenneth,United States House of Representatives,1,independent,"LaPolice, Alan",44,000140
+SHERIDAN,West Kenneth,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+SHERIDAN,West Kenneth,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000140
+SHERIDAN,West Kenneth,United States House of Representatives,1,Republican,"Marshall, Roger",260,000140
+SHERIDAN,West Saline,United States House of Representatives,1,independent,"LaPolice, Alan",9,000150
+SHERIDAN,West Saline,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+SHERIDAN,West Saline,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000150
+SHERIDAN,West Saline,United States House of Representatives,1,Republican,"Marshall, Roger",28,000150
+SHERIDAN,Adell Township,United States Senate,,write - in,"Smith, DJ",0,000010
+SHERIDAN,Adell Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+SHERIDAN,Adell Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+SHERIDAN,Adell Township,United States Senate,,Republican,"Moran, Jerry",9,000010
+SHERIDAN,Bloomfield Township,United States Senate,,write - in,"Smith, DJ",0,000020
+SHERIDAN,Bloomfield Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+SHERIDAN,Bloomfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+SHERIDAN,Bloomfield Township,United States Senate,,Republican,"Moran, Jerry",22,000020
+SHERIDAN,Bow Creek Township,United States Senate,,write - in,"Smith, DJ",0,000030
+SHERIDAN,Bow Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000030
+SHERIDAN,Bow Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+SHERIDAN,Bow Creek Township,United States Senate,,Republican,"Moran, Jerry",24,000030
+SHERIDAN,East Kenneth,United States Senate,,write - in,"Smith, DJ",0,000040
+SHERIDAN,East Kenneth,United States Senate,,Democratic,"Wiesner, Patrick",33,000040
+SHERIDAN,East Kenneth,United States Senate,,Libertarian,"Garrard, Robert D.",10,000040
+SHERIDAN,East Kenneth,United States Senate,,Republican,"Moran, Jerry",347,000040
+SHERIDAN,East Saline,United States Senate,,write - in,"Smith, DJ",0,000050
+SHERIDAN,East Saline,United States Senate,,Democratic,"Wiesner, Patrick",1,000050
+SHERIDAN,East Saline,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+SHERIDAN,East Saline,United States Senate,,Republican,"Moran, Jerry",29,000050
+SHERIDAN,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000060
+SHERIDAN,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000060
+SHERIDAN,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+SHERIDAN,Logan Township,United States Senate,,Republican,"Moran, Jerry",48,000060
+SHERIDAN,Parnell Township,United States Senate,,write - in,"Smith, DJ",0,000070
+SHERIDAN,Parnell Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000070
+SHERIDAN,Parnell Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000070
+SHERIDAN,Parnell Township,United States Senate,,Republican,"Moran, Jerry",54,000070
+SHERIDAN,Prairie Dog Township,United States Senate,,write - in,"Smith, DJ",0,000080
+SHERIDAN,Prairie Dog Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000080
+SHERIDAN,Prairie Dog Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000080
+SHERIDAN,Prairie Dog Township,United States Senate,,Republican,"Moran, Jerry",27,000080
+SHERIDAN,Sheridan Township,United States Senate,,write - in,"Smith, DJ",0,000090
+SHERIDAN,Sheridan Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000090
+SHERIDAN,Sheridan Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+SHERIDAN,Sheridan Township,United States Senate,,Republican,"Moran, Jerry",127,000090
+SHERIDAN,Solomon Township,United States Senate,,write - in,"Smith, DJ",0,000100
+SHERIDAN,Solomon Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000100
+SHERIDAN,Solomon Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000100
+SHERIDAN,Solomon Township,United States Senate,,Republican,"Moran, Jerry",87,000100
+SHERIDAN,Springbrook Township,United States Senate,,write - in,"Smith, DJ",0,000110
+SHERIDAN,Springbrook Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+SHERIDAN,Springbrook Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+SHERIDAN,Springbrook Township,United States Senate,,Republican,"Moran, Jerry",44,000110
+SHERIDAN,Union Township,United States Senate,,write - in,"Smith, DJ",0,000120
+SHERIDAN,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000120
+SHERIDAN,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+SHERIDAN,Union Township,United States Senate,,Republican,"Moran, Jerry",15,000120
+SHERIDAN,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000130
+SHERIDAN,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000130
+SHERIDAN,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000130
+SHERIDAN,Valley Township,United States Senate,,Republican,"Moran, Jerry",45,000130
+SHERIDAN,West Kenneth,United States Senate,,write - in,"Smith, DJ",0,000140
+SHERIDAN,West Kenneth,United States Senate,,Democratic,"Wiesner, Patrick",35,000140
+SHERIDAN,West Kenneth,United States Senate,,Libertarian,"Garrard, Robert D.",16,000140
+SHERIDAN,West Kenneth,United States Senate,,Republican,"Moran, Jerry",286,000140
+SHERIDAN,West Saline,United States Senate,,write - in,"Smith, DJ",0,000150
+SHERIDAN,West Saline,United States Senate,,Democratic,"Wiesner, Patrick",2,000150
+SHERIDAN,West Saline,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+SHERIDAN,West Saline,United States Senate,,Republican,"Moran, Jerry",37,000150

--- a/2016/20161108__ks__general__sherman__precinct.csv
+++ b/2016/20161108__ks__general__sherman__precinct.csv
@@ -1,343 +1,704 @@
-county,precinct,office,district,candidate,party,votes
-Sherman,Ward 1,President,,Trump/Pence,REP,460
-Sherman,Ward 1,President,,Clinton/Kaine,DEM,83
-Sherman,Ward 1,President,,Johnson/Weld,LBT,28
-Sherman,Ward 1,President,,Stein/Baraka,IND,3
-Sherman,Ward 1,President,,Write-ins,,10
-Sherman,Ward 1,U.S. Senate,,Patrick Wiesner,DEM,73
-Sherman,Ward 1,U.S. Senate,,Robert Garrard,LBT,28
-Sherman,Ward 1,U.S. Senate,,Jerry Moran,REP,470
-Sherman,Ward 1,U.S. Senate,,Write-ins,,5
-Sherman,Ward 1,U.S. House,1,Roger Marshall,REP,429
-Sherman,Ward 1,U.S. House,1,Kerry Burt,LBT,35
-Sherman,Ward 1,U.S. House,1,Alan LaPolice,IND,89
-Sherman,Ward 1,U.S. House,1,Write-ins,,3
-Sherman,Ward 1,State Senate,40,Alex Herman,DEM,77
-Sherman,Ward 1,State Senate,40,Rick Billinger,REP,498
-Sherman,Ward 1,State Senate,40,Write-ins,,1
-Sherman,Ward 1,State House,120,Bonita Peterson,DEM,67
-Sherman,Ward 1,State House,120,Adam Smith,REP,493
-Sherman,Ward 1,State House,120,Write-ins,,3
-Sherman,Ward 2,President,,Trump/Pence,REP,244
-Sherman,Ward 2,President,,Clinton/Kaine,DEM,51
-Sherman,Ward 2,President,,Johnson/Weld,LBT,19
-Sherman,Ward 2,President,,Stein/Baraka,IND,11
-Sherman,Ward 2,President,,Write-ins,,1
-Sherman,Ward 2,U.S. Senate,,Patrick Wiesner,DEM,51
-Sherman,Ward 2,U.S. Senate,,Robert Garrard,LBT,22
-Sherman,Ward 2,U.S. Senate,,Jerry Moran,REP,248
-Sherman,Ward 2,U.S. Senate,,Write-ins,,0
-Sherman,Ward 2,U.S. House,1,Roger Marshall,REP,235
-Sherman,Ward 2,U.S. House,1,Kerry Burt,LBT,32
-Sherman,Ward 2,U.S. House,1,Alan LaPolice,IND,43
-Sherman,Ward 2,U.S. House,1,Write-ins,,0
-Sherman,Ward 2,State Senate,40,Alex Herman,DEM,60
-Sherman,Ward 2,State Senate,40,Rick Billinger,REP,261
-Sherman,Ward 2,State Senate,40,Write-ins,,0
-Sherman,Ward 2,State House,120,Bonita Peterson,DEM,61
-Sherman,Ward 2,State House,120,Adam Smith,REP,249
-Sherman,Ward 2,State House,120,Write-ins,,0
-Sherman,Ward 3,President,,Trump/Pence,REP,262
-Sherman,Ward 3,President,,Clinton/Kaine,DEM,62
-Sherman,Ward 3,President,,Johnson/Weld,LBT,20
-Sherman,Ward 3,President,,Stein/Baraka,IND,6
-Sherman,Ward 3,President,,Write-ins,,7
-Sherman,Ward 3,U.S. Senate,,Patrick Wiesner,DEM,44
-Sherman,Ward 3,U.S. Senate,,Robert Garrard,LBT,23
-Sherman,Ward 3,U.S. Senate,,Jerry Moran,REP,287
-Sherman,Ward 3,U.S. Senate,,Write-ins,,1
-Sherman,Ward 3,U.S. House,1,Roger Marshall,REP,265
-Sherman,Ward 3,U.S. House,1,Kerry Burt,LBT,24
-Sherman,Ward 3,U.S. House,1,Alan LaPolice,IND,54
-Sherman,Ward 3,U.S. House,1,Write-ins,,1
-Sherman,Ward 3,State Senate,40,Alex Herman,DEM,47
-Sherman,Ward 3,State Senate,40,Rick Billinger,REP,309
-Sherman,Ward 3,State Senate,40,Write-ins,,0
-Sherman,Ward 3,State House,120,Bonita Peterson,DEM,54
-Sherman,Ward 3,State House,120,Adam Smith,REP,286
-Sherman,Ward 3,State House,120,Write-ins,,0
-Sherman,Ward 4,President,,Trump/Pence,REP,451
-Sherman,Ward 4,President,,Clinton/Kaine,DEM,84
-Sherman,Ward 4,President,,Johnson/Weld,LBT,27
-Sherman,Ward 4,President,,Stein/Baraka,IND,10
-Sherman,Ward 4,President,,Write-ins,,9
-Sherman,Ward 4,U.S. Senate,,Patrick Wiesner,DEM,59
-Sherman,Ward 4,U.S. Senate,,Robert Garrard,LBT,26
-Sherman,Ward 4,U.S. Senate,,Jerry Moran,REP,477
-Sherman,Ward 4,U.S. Senate,,Write-ins,,2
-Sherman,Ward 4,U.S. House,1,Roger Marshall,REP,451
-Sherman,Ward 4,U.S. House,1,Kerry Burt,LBT,38
-Sherman,Ward 4,U.S. House,1,Alan LaPolice,IND,59
-Sherman,Ward 4,U.S. House,1,Write-ins,,1
-Sherman,Ward 4,State Senate,40,Alex Herman,DEM,74
-Sherman,Ward 4,State Senate,40,Rick Billinger,REP,497
-Sherman,Ward 4,State Senate,40,Write-ins,,0
-Sherman,Ward 4,State House,120,Bonita Peterson,DEM,72
-Sherman,Ward 4,State House,120,Adam Smith,REP,485
-Sherman,Ward 4,State House,120,Write-ins,,2
-Sherman,05 Kanorado City,President,,Trump/Pence,REP,51
-Sherman,05 Kanorado City,President,,Clinton/Kaine,DEM,6
-Sherman,05 Kanorado City,President,,Johnson/Weld,LBT,3
-Sherman,05 Kanorado City,President,,Stein/Baraka,IND,1
-Sherman,05 Kanorado City,President,,Write-ins,,0
-Sherman,05 Kanorado City,U.S. Senate,,Patrick Wiesner,DEM,4
-Sherman,05 Kanorado City,U.S. Senate,,Robert Garrard,LBT,5
-Sherman,05 Kanorado City,U.S. Senate,,Jerry Moran,REP,50
-Sherman,05 Kanorado City,U.S. Senate,,Write-ins,,1
-Sherman,05 Kanorado City,U.S. House,1,Roger Marshall,REP,44
-Sherman,05 Kanorado City,U.S. House,1,Kerry Burt,LBT,3
-Sherman,05 Kanorado City,U.S. House,1,Alan LaPolice,IND,7
-Sherman,05 Kanorado City,U.S. House,1,Write-ins,,0
-Sherman,05 Kanorado City,State Senate,40,Alex Herman,DEM,8
-Sherman,05 Kanorado City,State Senate,40,Rick Billinger,REP,51
-Sherman,05 Kanorado City,State Senate,40,Write-ins,,0
-Sherman,05 Kanorado City,State House,120,Bonita Peterson,DEM,2
-Sherman,05 Kanorado City,State House,120,Adam Smith,REP,51
-Sherman,05 Kanorado City,State House,120,Write-ins,,0
-Sherman,06 Grant twp,President,,Trump/Pence,REP,30
-Sherman,06 Grant twp,President,,Clinton/Kaine,DEM,5
-Sherman,06 Grant twp,President,,Johnson/Weld,LBT,0
-Sherman,06 Grant twp,President,,Stein/Baraka,IND,1
-Sherman,06 Grant twp,President,,Write-ins,,0
-Sherman,06 Grant twp,U.S. Senate,,Patrick Wiesner,DEM,9
-Sherman,06 Grant twp,U.S. Senate,,Robert Garrard,LBT,1
-Sherman,06 Grant twp,U.S. Senate,,Jerry Moran,REP,25
-Sherman,06 Grant twp,U.S. Senate,,Write-ins,,0
-Sherman,06 Grant twp,U.S. House,1,Roger Marshall,REP,27
-Sherman,06 Grant twp,U.S. House,1,Kerry Burt,LBT,0
-Sherman,06 Grant twp,U.S. House,1,Alan LaPolice,IND,6
-Sherman,06 Grant twp,U.S. House,1,Write-ins,,0
-Sherman,06 Grant twp,State Senate,40,Alex Herman,DEM,8
-Sherman,06 Grant twp,State Senate,40,Rick Billinger,REP,28
-Sherman,06 Grant twp,State Senate,40,Write-ins,,0
-Sherman,06 Grant twp,State House,120,Bonita Peterson,DEM,5
-Sherman,06 Grant twp,State House,120,Adam Smith,REP,28
-Sherman,06 Grant twp,State House,120,Write-ins,,0
-Sherman,07 Iowa twp,President,,Trump/Pence,REP,13
-Sherman,07 Iowa twp,President,,Clinton/Kaine,DEM,1
-Sherman,07 Iowa twp,President,,Johnson/Weld,LBT,0
-Sherman,07 Iowa twp,President,,Stein/Baraka,IND,0
-Sherman,07 Iowa twp,President,,Write-ins,,0
-Sherman,07 Iowa twp,U.S. Senate,,Patrick Wiesner,DEM,0
-Sherman,07 Iowa twp,U.S. Senate,,Robert Garrard,LBT,0
-Sherman,07 Iowa twp,U.S. Senate,,Jerry Moran,REP,14
-Sherman,07 Iowa twp,U.S. Senate,,Write-ins,,0
-Sherman,07 Iowa twp,U.S. House,1,Roger Marshall,REP,12
-Sherman,07 Iowa twp,U.S. House,1,Kerry Burt,LBT,1
-Sherman,07 Iowa twp,U.S. House,1,Alan LaPolice,IND,1
-Sherman,07 Iowa twp,U.S. House,1,Write-ins,,0
-Sherman,07 Iowa twp,State Senate,40,Alex Herman,DEM,1
-Sherman,07 Iowa twp,State Senate,40,Rick Billinger,REP,13
-Sherman,07 Iowa twp,State Senate,40,Write-ins,,0
-Sherman,07 Iowa twp,State House,120,Bonita Peterson,DEM,1
-Sherman,07 Iowa twp,State House,120,Adam Smith,REP,13
-Sherman,07 Iowa twp,State House,120,Write-ins,,0
-Sherman,08 Itasca twp,President,,Trump/Pence,REP,137
-Sherman,08 Itasca twp,President,,Clinton/Kaine,DEM,16
-Sherman,08 Itasca twp,President,,Johnson/Weld,LBT,4
-Sherman,08 Itasca twp,President,,Stein/Baraka,IND,2
-Sherman,08 Itasca twp,President,,Write-ins,,1
-Sherman,08 Itasca twp,U.S. Senate,,Patrick Wiesner,DEM,18
-Sherman,08 Itasca twp,U.S. Senate,,Robert Garrard,LBT,4
-Sherman,08 Itasca twp,U.S. Senate,,Jerry Moran,REP,134
-Sherman,08 Itasca twp,U.S. Senate,,Write-ins,,0
-Sherman,08 Itasca twp,U.S. House,1,Roger Marshall,REP,127
-Sherman,08 Itasca twp,U.S. House,1,Kerry Burt,LBT,4
-Sherman,08 Itasca twp,U.S. House,1,Alan LaPolice,IND,22
-Sherman,08 Itasca twp,U.S. House,1,Write-ins,,3
-Sherman,08 Itasca twp,State Senate,40,Alex Herman,DEM,19
-Sherman,08 Itasca twp,State Senate,40,Rick Billinger,REP,139
-Sherman,08 Itasca twp,State Senate,40,Write-ins,,0
-Sherman,08 Itasca twp,State House,120,Bonita Peterson,DEM,19
-Sherman,08 Itasca twp,State House,120,Adam Smith,REP,137
-Sherman,08 Itasca twp,State House,120,Write-ins,,1
-Sherman,09 Lincoln twp,President,,Trump/Pence,REP,37
-Sherman,09 Lincoln twp,President,,Clinton/Kaine,DEM,1
-Sherman,09 Lincoln twp,President,,Johnson/Weld,LBT,3
-Sherman,09 Lincoln twp,President,,Stein/Baraka,IND,2
-Sherman,09 Lincoln twp,President,,Write-ins,,0
-Sherman,09 Lincoln twp,U.S. Senate,,Patrick Wiesner,DEM,9
-Sherman,09 Lincoln twp,U.S. Senate,,Robert Garrard,LBT,2
-Sherman,09 Lincoln twp,U.S. Senate,,Jerry Moran,REP,33
-Sherman,09 Lincoln twp,U.S. Senate,,Write-ins,,0
-Sherman,09 Lincoln twp,U.S. House,1,Roger Marshall,REP,29
-Sherman,09 Lincoln twp,U.S. House,1,Kerry Burt,LBT,7
-Sherman,09 Lincoln twp,U.S. House,1,Alan LaPolice,IND,6
-Sherman,09 Lincoln twp,U.S. House,1,Write-ins,,0
-Sherman,09 Lincoln twp,State Senate,40,Alex Herman,DEM,5
-Sherman,09 Lincoln twp,State Senate,40,Rick Billinger,REP,39
-Sherman,09 Lincoln twp,State Senate,40,Write-ins,,0
-Sherman,09 Lincoln twp,State House,120,Bonita Peterson,DEM,5
-Sherman,09 Lincoln twp,State House,120,Adam Smith,REP,39
-Sherman,09 Lincoln twp,State House,120,Write-ins,,0
-Sherman,10 Llanos,President,,Trump/Pence,REP,21
-Sherman,10 Llanos,President,,Clinton/Kaine,DEM,3
-Sherman,10 Llanos,President,,Johnson/Weld,LBT,0
-Sherman,10 Llanos,President,,Stein/Baraka,IND,0
-Sherman,10 Llanos,President,,Write-ins,,1
-Sherman,10 Llanos,U.S. Senate,,Patrick Wiesner,DEM,2
-Sherman,10 Llanos,U.S. Senate,,Robert Garrard,LBT,0
-Sherman,10 Llanos,U.S. Senate,,Jerry Moran,REP,23
-Sherman,10 Llanos,U.S. Senate,,Write-ins,,1
-Sherman,10 Llanos,U.S. House,1,Roger Marshall,REP,20
-Sherman,10 Llanos,U.S. House,1,Kerry Burt,LBT,0
-Sherman,10 Llanos,U.S. House,1,Alan LaPolice,IND,2
-Sherman,10 Llanos,U.S. House,1,Write-ins,,4
-Sherman,10 Llanos,State Senate,40,Alex Herman,DEM,1
-Sherman,10 Llanos,State Senate,40,Rick Billinger,REP,25
-Sherman,10 Llanos,State Senate,40,Write-ins,,0
-Sherman,10 Llanos,State House,120,Bonita Peterson,DEM,1
-Sherman,10 Llanos,State House,120,Adam Smith,REP,25
-Sherman,10 Llanos,State House,120,Write-ins,,0
-Sherman,11 Logan twp,President,,Trump/Pence,REP,113
-Sherman,11 Logan twp,President,,Clinton/Kaine,DEM,10
-Sherman,11 Logan twp,President,,Johnson/Weld,LBT,0
-Sherman,11 Logan twp,President,,Stein/Baraka,IND,5
-Sherman,11 Logan twp,President,,Write-ins,,0
-Sherman,11 Logan twp,U.S. Senate,,Patrick Wiesner,DEM,4
-Sherman,11 Logan twp,U.S. Senate,,Robert Garrard,LBT,3
-Sherman,11 Logan twp,U.S. Senate,,Jerry Moran,REP,119
-Sherman,11 Logan twp,U.S. Senate,,Write-ins,,0
-Sherman,11 Logan twp,U.S. House,1,Roger Marshall,REP,110
-Sherman,11 Logan twp,U.S. House,1,Kerry Burt,LBT,1
-Sherman,11 Logan twp,U.S. House,1,Alan LaPolice,IND,9
-Sherman,11 Logan twp,U.S. House,1,Write-ins,,0
-Sherman,11 Logan twp,State Senate,40,Alex Herman,DEM,11
-Sherman,11 Logan twp,State Senate,40,Rick Billinger,REP,118
-Sherman,11 Logan twp,State Senate,40,Write-ins,,0
-Sherman,11 Logan twp,State House,120,Bonita Peterson,DEM,5
-Sherman,11 Logan twp,State House,120,Adam Smith,REP,118
-Sherman,11 Logan twp,State House,120,Write-ins,,0
-Sherman,12 McPherson twp,President,,Trump/Pence,REP,24
-Sherman,12 McPherson twp,President,,Clinton/Kaine,DEM,0
-Sherman,12 McPherson twp,President,,Johnson/Weld,LBT,0
-Sherman,12 McPherson twp,President,,Stein/Baraka,IND,1
-Sherman,12 McPherson twp,President,,Write-ins,,0
-Sherman,12 McPherson twp,U.S. Senate,,Patrick Wiesner,DEM,0
-Sherman,12 McPherson twp,U.S. Senate,,Robert Garrard,LBT,0
-Sherman,12 McPherson twp,U.S. Senate,,Jerry Moran,REP,25
-Sherman,12 McPherson twp,U.S. Senate,,Write-ins,,0
-Sherman,12 McPherson twp,U.S. House,1,Roger Marshall,REP,21
-Sherman,12 McPherson twp,U.S. House,1,Kerry Burt,LBT,0
-Sherman,12 McPherson twp,U.S. House,1,Alan LaPolice,IND,2
-Sherman,12 McPherson twp,U.S. House,1,Write-ins,,1
-Sherman,12 McPherson twp,State Senate,40,Alex Herman,DEM,0
-Sherman,12 McPherson twp,State Senate,40,Rick Billinger,REP,25
-Sherman,12 McPherson twp,State Senate,40,Write-ins,,0
-Sherman,12 McPherson twp,State House,120,Bonita Peterson,DEM,0
-Sherman,12 McPherson twp,State House,120,Adam Smith,REP,24
-Sherman,12 McPherson twp,State House,120,Write-ins,,0
-Sherman,13 Shermanville twp,President,,Trump/Pence,REP,18
-Sherman,13 Shermanville twp,President,,Clinton/Kaine,DEM,0
-Sherman,13 Shermanville twp,President,,Johnson/Weld,LBT,0
-Sherman,13 Shermanville twp,President,,Stein/Baraka,IND,0
-Sherman,13 Shermanville twp,President,,Write-ins,,0
-Sherman,13 Shermanville twp,U.S. Senate,,Patrick Wiesner,DEM,0
-Sherman,13 Shermanville twp,U.S. Senate,,Robert Garrard,LBT,0
-Sherman,13 Shermanville twp,U.S. Senate,,Jerry Moran,REP,18
-Sherman,13 Shermanville twp,U.S. Senate,,Write-ins,,0
-Sherman,13 Shermanville twp,U.S. House,1,Roger Marshall,REP,18
-Sherman,13 Shermanville twp,U.S. House,1,Kerry Burt,LBT,0
-Sherman,13 Shermanville twp,U.S. House,1,Alan LaPolice,IND,0
-Sherman,13 Shermanville twp,U.S. House,1,Write-ins,,0
-Sherman,13 Shermanville twp,State Senate,40,Alex Herman,DEM,0
-Sherman,13 Shermanville twp,State Senate,40,Rick Billinger,REP,18
-Sherman,13 Shermanville twp,State Senate,40,Write-ins,,0
-Sherman,13 Shermanville twp,State House,120,Bonita Peterson,DEM,0
-Sherman,13 Shermanville twp,State House,120,Adam Smith,REP,17
-Sherman,13 Shermanville twp,State House,120,Write-ins,,0
-Sherman,14 Smoky twp,President,,Trump/Pence,REP,30
-Sherman,14 Smoky twp,President,,Clinton/Kaine,DEM,2
-Sherman,14 Smoky twp,President,,Johnson/Weld,LBT,3
-Sherman,14 Smoky twp,President,,Stein/Baraka,IND,0
-Sherman,14 Smoky twp,President,,Write-ins,,2
-Sherman,14 Smoky twp,U.S. Senate,,Patrick Wiesner,DEM,1
-Sherman,14 Smoky twp,U.S. Senate,,Robert Garrard,LBT,3
-Sherman,14 Smoky twp,U.S. Senate,,Jerry Moran,REP,31
-Sherman,14 Smoky twp,U.S. Senate,,Write-ins,,0
-Sherman,14 Smoky twp,U.S. House,1,Roger Marshall,REP,33
-Sherman,14 Smoky twp,U.S. House,1,Kerry Burt,LBT,3
-Sherman,14 Smoky twp,U.S. House,1,Alan LaPolice,IND,0
-Sherman,14 Smoky twp,U.S. House,1,Write-ins,,1
-Sherman,14 Smoky twp,State Senate,40,Alex Herman,DEM,3
-Sherman,14 Smoky twp,State Senate,40,Rick Billinger,REP,34
-Sherman,14 Smoky twp,State Senate,40,Write-ins,,0
-Sherman,14 Smoky twp,State House,120,Bonita Peterson,DEM,2
-Sherman,14 Smoky twp,State House,120,Adam Smith,REP,34
-Sherman,14 Smoky twp,State House,120,Write-ins,,0
-Sherman,15 Stateline twp,President,,Trump/Pence,REP,29
-Sherman,15 Stateline twp,President,,Clinton/Kaine,DEM,9
-Sherman,15 Stateline twp,President,,Johnson/Weld,LBT,0
-Sherman,15 Stateline twp,President,,Stein/Baraka,IND,1
-Sherman,15 Stateline twp,President,,Write-ins,,0
-Sherman,15 Stateline twp,U.S. Senate,,Patrick Wiesner,DEM,4
-Sherman,15 Stateline twp,U.S. Senate,,Robert Garrard,LBT,1
-Sherman,15 Stateline twp,U.S. Senate,,Jerry Moran,REP,35
-Sherman,15 Stateline twp,U.S. Senate,,Write-ins,,0
-Sherman,15 Stateline twp,U.S. House,1,Roger Marshall,REP,34
-Sherman,15 Stateline twp,U.S. House,1,Kerry Burt,LBT,2
-Sherman,15 Stateline twp,U.S. House,1,Alan LaPolice,IND,3
-Sherman,15 Stateline twp,U.S. House,1,Write-ins,,0
-Sherman,15 Stateline twp,State Senate,40,Alex Herman,DEM,3
-Sherman,15 Stateline twp,State Senate,40,Rick Billinger,REP,37
-Sherman,15 Stateline twp,State Senate,40,Write-ins,,0
-Sherman,15 Stateline twp,State House,120,Bonita Peterson,DEM,2
-Sherman,15 Stateline twp,State House,120,Adam Smith,REP,36
-Sherman,15 Stateline twp,State House,120,Write-ins,,0
-Sherman,16 Union twp,President,,Trump/Pence,REP,28
-Sherman,16 Union twp,President,,Clinton/Kaine,DEM,0
-Sherman,16 Union twp,President,,Johnson/Weld,LBT,1
-Sherman,16 Union twp,President,,Stein/Baraka,IND,0
-Sherman,16 Union twp,President,,Write-ins,,0
-Sherman,16 Union twp,U.S. Senate,,Patrick Wiesner,DEM,1
-Sherman,16 Union twp,U.S. Senate,,Robert Garrard,LBT,1
-Sherman,16 Union twp,U.S. Senate,,Jerry Moran,REP,27
-Sherman,16 Union twp,U.S. Senate,,Write-ins,,0
-Sherman,16 Union twp,U.S. House,1,Roger Marshall,REP,21
-Sherman,16 Union twp,U.S. House,1,Kerry Burt,LBT,1
-Sherman,16 Union twp,U.S. House,1,Alan LaPolice,IND,3
-Sherman,16 Union twp,U.S. House,1,Write-ins,,4
-Sherman,16 Union twp,State Senate,40,Alex Herman,DEM,0
-Sherman,16 Union twp,State Senate,40,Rick Billinger,REP,29
-Sherman,16 Union twp,State Senate,40,Write-ins,,0
-Sherman,16 Union twp,State House,120,Bonita Peterson,DEM,1
-Sherman,16 Union twp,State House,120,Adam Smith,REP,28
-Sherman,16 Union twp,State House,120,Write-ins,,0
-Sherman,17 Voltaire twp,President,,Trump/Pence,REP,104
-Sherman,17 Voltaire twp,President,,Clinton/Kaine,DEM,12
-Sherman,17 Voltaire twp,President,,Johnson/Weld,LBT,2
-Sherman,17 Voltaire twp,President,,Stein/Baraka,IND,2
-Sherman,17 Voltaire twp,President,,Write-ins,,1
-Sherman,17 Voltaire twp,U.S. Senate,,Patrick Wiesner,DEM,12
-Sherman,17 Voltaire twp,U.S. Senate,,Robert Garrard,LBT,3
-Sherman,17 Voltaire twp,U.S. Senate,,Jerry Moran,REP,106
-Sherman,17 Voltaire twp,U.S. Senate,,Write-ins,,1
-Sherman,17 Voltaire twp,U.S. House,1,Roger Marshall,REP,98
-Sherman,17 Voltaire twp,U.S. House,1,Kerry Burt,LBT,5
-Sherman,17 Voltaire twp,U.S. House,1,Alan LaPolice,IND,10
-Sherman,17 Voltaire twp,U.S. House,1,Write-ins,,0
-Sherman,17 Voltaire twp,State Senate,40,Alex Herman,DEM,10
-Sherman,17 Voltaire twp,State Senate,40,Rick Billinger,REP,110
-Sherman,17 Voltaire twp,State Senate,40,Write-ins,,0
-Sherman,17 Voltaire twp,State House,120,Bonita Peterson,DEM,7
-Sherman,17 Voltaire twp,State House,120,Adam Smith,REP,110
-Sherman,17 Voltaire twp,State House,120,Write-ins,,0
-Sherman,18 Washington twp,President,,Trump/Pence,REP,37
-Sherman,18 Washington twp,President,,Clinton/Kaine,DEM,2
-Sherman,18 Washington twp,President,,Johnson/Weld,LBT,1
-Sherman,18 Washington twp,President,,Stein/Baraka,IND,2
-Sherman,18 Washington twp,President,,Write-ins,,0
-Sherman,18 Washington twp,U.S. Senate,,Patrick Wiesner,DEM,5
-Sherman,18 Washington twp,U.S. Senate,,Robert Garrard,LBT,1
-Sherman,18 Washington twp,U.S. Senate,,Jerry Moran,REP,36
-Sherman,18 Washington twp,U.S. Senate,,Write-ins,,0
-Sherman,18 Washington twp,U.S. House,1,Roger Marshall,REP,37
-Sherman,18 Washington twp,U.S. House,1,Kerry Burt,LBT,1
-Sherman,18 Washington twp,U.S. House,1,Alan LaPolice,IND,4
-Sherman,18 Washington twp,U.S. House,1,Write-ins,,0
-Sherman,18 Washington twp,State Senate,40,Alex Herman,DEM,3
-Sherman,18 Washington twp,State Senate,40,Rick Billinger,REP,39
-Sherman,18 Washington twp,State Senate,40,Write-ins,,0
-Sherman,18 Washington twp,State House,120,Bonita Peterson,DEM,3
-Sherman,18 Washington twp,State House,120,Adam Smith,REP,39
-Sherman,18 Washington twp,State House,120,Write-ins,,0
+county,precinct,office,district,party,candidate,votes,vtd
+SHERMAN,Goodland Ward 1,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",67,000010
+SHERMAN,Goodland Ward 1,Kansas House of Representatives,120,Republican,"Smith, Adam",493,000010
+SHERMAN,Goodland Ward 2,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",61,000020
+SHERMAN,Goodland Ward 2,Kansas House of Representatives,120,Republican,"Smith, Adam",249,000020
+SHERMAN,Goodland Ward 3,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",54,000030
+SHERMAN,Goodland Ward 3,Kansas House of Representatives,120,Republican,"Smith, Adam",286,000030
+SHERMAN,Goodland Ward 4,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",72,000040
+SHERMAN,Goodland Ward 4,Kansas House of Representatives,120,Republican,"Smith, Adam",485,000040
+SHERMAN,Grant Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",5,000050
+SHERMAN,Grant Township,Kansas House of Representatives,120,Republican,"Smith, Adam",28,000050
+SHERMAN,Iowa Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000060
+SHERMAN,Iowa Township,Kansas House of Representatives,120,Republican,"Smith, Adam",13,000060
+SHERMAN,Itasca Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",19,000070
+SHERMAN,Itasca Township,Kansas House of Representatives,120,Republican,"Smith, Adam",137,000070
+SHERMAN,Kanorado City,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000080
+SHERMAN,Kanorado City,Kansas House of Representatives,120,Republican,"Smith, Adam",51,000080
+SHERMAN,Lincoln Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",5,000090
+SHERMAN,Lincoln Township,Kansas House of Representatives,120,Republican,"Smith, Adam",39,000090
+SHERMAN,Llanos Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000100
+SHERMAN,Llanos Township,Kansas House of Representatives,120,Republican,"Smith, Adam",25,000100
+SHERMAN,Logan Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",5,00011A
+SHERMAN,Logan Township,Kansas House of Representatives,120,Republican,"Smith, Adam",118,00011A
+SHERMAN,Logan Township Enclave (B),Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,00011C
+SHERMAN,Logan Township Enclave (B),Kansas House of Representatives,120,Republican,"Smith, Adam",0,00011C
+SHERMAN,McPherson Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000120
+SHERMAN,McPherson Township,Kansas House of Representatives,120,Republican,"Smith, Adam",24,000120
+SHERMAN,Shermanville Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,000130
+SHERMAN,Shermanville Township,Kansas House of Representatives,120,Republican,"Smith, Adam",17,000130
+SHERMAN,Smoky Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000140
+SHERMAN,Smoky Township,Kansas House of Representatives,120,Republican,"Smith, Adam",34,000140
+SHERMAN,State Line Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",2,000150
+SHERMAN,State Line Township,Kansas House of Representatives,120,Republican,"Smith, Adam",36,000150
+SHERMAN,Union Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",1,000160
+SHERMAN,Union Township,Kansas House of Representatives,120,Republican,"Smith, Adam",28,000160
+SHERMAN,Voltaire Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",7,000170
+SHERMAN,Voltaire Township,Kansas House of Representatives,120,Republican,"Smith, Adam",110,000170
+SHERMAN,Washington Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",3,000180
+SHERMAN,Washington Township,Kansas House of Representatives,120,Republican,"Smith, Adam",39,000180
+SHERMAN,Goodland Ward 1,Kansas Senate,40,Democratic,"Herman, Alex",77,000010
+SHERMAN,Goodland Ward 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",498,000010
+SHERMAN,Goodland Ward 2,Kansas Senate,40,Democratic,"Herman, Alex",60,000020
+SHERMAN,Goodland Ward 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",261,000020
+SHERMAN,Goodland Ward 3,Kansas Senate,40,Democratic,"Herman, Alex",47,000030
+SHERMAN,Goodland Ward 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",309,000030
+SHERMAN,Goodland Ward 4,Kansas Senate,40,Democratic,"Herman, Alex",74,000040
+SHERMAN,Goodland Ward 4,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",497,000040
+SHERMAN,Grant Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000050
+SHERMAN,Grant Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",28,000050
+SHERMAN,Iowa Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000060
+SHERMAN,Iowa Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",13,000060
+SHERMAN,Itasca Township,Kansas Senate,40,Democratic,"Herman, Alex",19,000070
+SHERMAN,Itasca Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",139,000070
+SHERMAN,Kanorado City,Kansas Senate,40,Democratic,"Herman, Alex",8,000080
+SHERMAN,Kanorado City,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",51,000080
+SHERMAN,Lincoln Township,Kansas Senate,40,Democratic,"Herman, Alex",5,000090
+SHERMAN,Lincoln Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",39,000090
+SHERMAN,Llanos Township,Kansas Senate,40,Democratic,"Herman, Alex",1,000100
+SHERMAN,Llanos Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",25,000100
+SHERMAN,Logan Township,Kansas Senate,40,Democratic,"Herman, Alex",11,00011A
+SHERMAN,Logan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",118,00011A
+SHERMAN,Logan Township Enclave (B),Kansas Senate,40,Democratic,"Herman, Alex",0,00011C
+SHERMAN,Logan Township Enclave (B),Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,00011C
+SHERMAN,McPherson Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000120
+SHERMAN,McPherson Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",25,000120
+SHERMAN,Shermanville Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000130
+SHERMAN,Shermanville Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",18,000130
+SHERMAN,Smoky Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000140
+SHERMAN,Smoky Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",34,000140
+SHERMAN,State Line Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000150
+SHERMAN,State Line Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",37,000150
+SHERMAN,Union Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000160
+SHERMAN,Union Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",29,000160
+SHERMAN,Voltaire Township,Kansas Senate,40,Democratic,"Herman, Alex",10,000170
+SHERMAN,Voltaire Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",110,000170
+SHERMAN,Washington Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000180
+SHERMAN,Washington Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",39,000180
+SHERMAN,Goodland Ward 1,President / Vice President,,independent,"Stein, Jill",3,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Castle, Darrell L",1,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"McMullin, Evan",6,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",83,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",28,000010
+SHERMAN,Goodland Ward 1,President / Vice President,,Republican,"Trump, Donald J.",460,000010
+SHERMAN,Goodland Ward 2,President / Vice President,,independent,"Stein, Jill",11,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",19,000020
+SHERMAN,Goodland Ward 2,President / Vice President,,Republican,"Trump, Donald J.",244,000020
+SHERMAN,Goodland Ward 3,President / Vice President,,independent,"Stein, Jill",6,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"McMullin, Evan",4,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",62,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",20,000030
+SHERMAN,Goodland Ward 3,President / Vice President,,Republican,"Trump, Donald J.",262,000030
+SHERMAN,Goodland Ward 4,President / Vice President,,independent,"Stein, Jill",10,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Castle, Darrell L",1,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",84,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",27,000040
+SHERMAN,Goodland Ward 4,President / Vice President,,Republican,"Trump, Donald J.",451,000040
+SHERMAN,Grant Township,President / Vice President,,independent,"Stein, Jill",1,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+SHERMAN,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+SHERMAN,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000050
+SHERMAN,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+SHERMAN,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",30,000050
+SHERMAN,Iowa Township,President / Vice President,,independent,"Stein, Jill",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+SHERMAN,Iowa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+SHERMAN,Iowa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000060
+SHERMAN,Iowa Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+SHERMAN,Iowa Township,President / Vice President,,Republican,"Trump, Donald J.",13,000060
+SHERMAN,Itasca Township,President / Vice President,,independent,"Stein, Jill",2,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Castle, Darrell L",1,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SHERMAN,Itasca Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SHERMAN,Itasca Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000070
+SHERMAN,Itasca Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000070
+SHERMAN,Itasca Township,President / Vice President,,Republican,"Trump, Donald J.",137,000070
+SHERMAN,Kanorado City,President / Vice President,,independent,"Stein, Jill",1,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Hedges, James A",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"McMullin, Evan",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Perry, Darryl",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Smith, Mike",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Sood, Ajay",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+SHERMAN,Kanorado City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+SHERMAN,Kanorado City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000080
+SHERMAN,Kanorado City,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+SHERMAN,Kanorado City,President / Vice President,,Republican,"Trump, Donald J.",51,000080
+SHERMAN,Lincoln Township,President / Vice President,,independent,"Stein, Jill",2,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SHERMAN,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000090
+SHERMAN,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000090
+SHERMAN,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",37,000090
+SHERMAN,Llanos Township,President / Vice President,,independent,"Stein, Jill",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+SHERMAN,Llanos Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+SHERMAN,Llanos Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000100
+SHERMAN,Llanos Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+SHERMAN,Llanos Township,President / Vice President,,Republican,"Trump, Donald J.",21,000100
+SHERMAN,Logan Township,President / Vice President,,independent,"Stein, Jill",5,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011A
+SHERMAN,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011A
+SHERMAN,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,00011A
+SHERMAN,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,00011A
+SHERMAN,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",113,00011A
+SHERMAN,Logan Township Enclave (B),President / Vice President,,independent,"Stein, Jill",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Basiago, Andrew D.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Castle, Darrell L",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Giordani, Rocky",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Hedges, James A",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Hoefling, Tom",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Kahn, Lynn",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"La Riva, Gloria",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Levinson, Michael S.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Maturen, Michael A",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"McMullin, Evan",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Moorehead, Monica G.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Perry, Darryl",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Schoenke, Marshall R.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Schriner, Joe C",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Smith, Mike",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Sood, Ajay",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Sterling, Shawna",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Valdivia, Anthony J",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Libertarian,"Johnson, Gary",0,00011C
+SHERMAN,Logan Township Enclave (B),President / Vice President,,Republican,"Trump, Donald J.",0,00011C
+SHERMAN,McPherson Township,President / Vice President,,independent,"Stein, Jill",1,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+SHERMAN,McPherson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+SHERMAN,McPherson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+SHERMAN,McPherson Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+SHERMAN,McPherson Township,President / Vice President,,Republican,"Trump, Donald J.",24,000120
+SHERMAN,Shermanville Township,President / Vice President,,independent,"Stein, Jill",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+SHERMAN,Shermanville Township,President / Vice President,,Republican,"Trump, Donald J.",18,000130
+SHERMAN,Smoky Township,President / Vice President,,independent,"Stein, Jill",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"McMullin, Evan",2,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+SHERMAN,Smoky Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+SHERMAN,Smoky Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000140
+SHERMAN,Smoky Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000140
+SHERMAN,Smoky Township,President / Vice President,,Republican,"Trump, Donald J.",30,000140
+SHERMAN,State Line Township,President / Vice President,,independent,"Stein, Jill",1,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+SHERMAN,State Line Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+SHERMAN,State Line Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000150
+SHERMAN,State Line Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000150
+SHERMAN,State Line Township,President / Vice President,,Republican,"Trump, Donald J.",29,000150
+SHERMAN,Union Township,President / Vice President,,independent,"Stein, Jill",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+SHERMAN,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+SHERMAN,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000160
+SHERMAN,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+SHERMAN,Union Township,President / Vice President,,Republican,"Trump, Donald J.",28,000160
+SHERMAN,Voltaire Township,President / Vice President,,independent,"Stein, Jill",2,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"McMullin, Evan",1,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+SHERMAN,Voltaire Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000170
+SHERMAN,Voltaire Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+SHERMAN,Voltaire Township,President / Vice President,,Republican,"Trump, Donald J.",104,000170
+SHERMAN,Washington Township,President / Vice President,,independent,"Stein, Jill",2,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+SHERMAN,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+SHERMAN,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000180
+SHERMAN,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+SHERMAN,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",37,000180
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",89,000010
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000010
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",35,000010
+SHERMAN,Goodland Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",429,000010
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",43,000020
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",32,000020
+SHERMAN,Goodland Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",235,000020
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",54,000030
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",24,000030
+SHERMAN,Goodland Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",265,000030
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",59,000040
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",38,000040
+SHERMAN,Goodland Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",451,000040
+SHERMAN,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000050
+SHERMAN,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+SHERMAN,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+SHERMAN,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",27,000050
+SHERMAN,Iowa Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000060
+SHERMAN,Iowa Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+SHERMAN,Iowa Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+SHERMAN,Iowa Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000060
+SHERMAN,Itasca Township,United States House of Representatives,1,independent,"LaPolice, Alan",22,000070
+SHERMAN,Itasca Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000070
+SHERMAN,Itasca Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000070
+SHERMAN,Itasca Township,United States House of Representatives,1,Republican,"Marshall, Roger",127,000070
+SHERMAN,Kanorado City,United States House of Representatives,1,independent,"LaPolice, Alan",7,000080
+SHERMAN,Kanorado City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+SHERMAN,Kanorado City,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000080
+SHERMAN,Kanorado City,United States House of Representatives,1,Republican,"Marshall, Roger",44,000080
+SHERMAN,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000090
+SHERMAN,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+SHERMAN,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000090
+SHERMAN,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",29,000090
+SHERMAN,Llanos Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000100
+SHERMAN,Llanos Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000100
+SHERMAN,Llanos Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+SHERMAN,Llanos Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000100
+SHERMAN,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,00011A
+SHERMAN,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011A
+SHERMAN,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,00011A
+SHERMAN,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",110,00011A
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,independent,"LaPolice, Alan",0,00011C
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00011C
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00011C
+SHERMAN,Logan Township Enclave (B),United States House of Representatives,1,Republican,"Marshall, Roger",0,00011C
+SHERMAN,McPherson Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000120
+SHERMAN,McPherson Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000120
+SHERMAN,McPherson Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+SHERMAN,McPherson Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000120
+SHERMAN,Shermanville Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000130
+SHERMAN,Shermanville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+SHERMAN,Shermanville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+SHERMAN,Shermanville Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000130
+SHERMAN,Smoky Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000140
+SHERMAN,Smoky Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000140
+SHERMAN,Smoky Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000140
+SHERMAN,Smoky Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000140
+SHERMAN,State Line Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000150
+SHERMAN,State Line Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+SHERMAN,State Line Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000150
+SHERMAN,State Line Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000150
+SHERMAN,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000160
+SHERMAN,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000160
+SHERMAN,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+SHERMAN,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000160
+SHERMAN,Voltaire Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000170
+SHERMAN,Voltaire Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+SHERMAN,Voltaire Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000170
+SHERMAN,Voltaire Township,United States House of Representatives,1,Republican,"Marshall, Roger",98,000170
+SHERMAN,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000180
+SHERMAN,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+SHERMAN,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000180
+SHERMAN,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",37,000180
+SHERMAN,Goodland Ward 1,United States Senate,,write - in,"Smith, DJ",0,000010
+SHERMAN,Goodland Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",73,000010
+SHERMAN,Goodland Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",28,000010
+SHERMAN,Goodland Ward 1,United States Senate,,Republican,"Moran, Jerry",470,000010
+SHERMAN,Goodland Ward 2,United States Senate,,write - in,"Smith, DJ",0,000020
+SHERMAN,Goodland Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",51,000020
+SHERMAN,Goodland Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",22,000020
+SHERMAN,Goodland Ward 2,United States Senate,,Republican,"Moran, Jerry",248,000020
+SHERMAN,Goodland Ward 3,United States Senate,,write - in,"Smith, DJ",0,000030
+SHERMAN,Goodland Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",44,000030
+SHERMAN,Goodland Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",23,000030
+SHERMAN,Goodland Ward 3,United States Senate,,Republican,"Moran, Jerry",287,000030
+SHERMAN,Goodland Ward 4,United States Senate,,write - in,"Smith, DJ",0,000040
+SHERMAN,Goodland Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",59,000040
+SHERMAN,Goodland Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",26,000040
+SHERMAN,Goodland Ward 4,United States Senate,,Republican,"Moran, Jerry",477,000040
+SHERMAN,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000050
+SHERMAN,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000050
+SHERMAN,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+SHERMAN,Grant Township,United States Senate,,Republican,"Moran, Jerry",25,000050
+SHERMAN,Iowa Township,United States Senate,,write - in,"Smith, DJ",0,000060
+SHERMAN,Iowa Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000060
+SHERMAN,Iowa Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+SHERMAN,Iowa Township,United States Senate,,Republican,"Moran, Jerry",14,000060
+SHERMAN,Itasca Township,United States Senate,,write - in,"Smith, DJ",0,000070
+SHERMAN,Itasca Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000070
+SHERMAN,Itasca Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000070
+SHERMAN,Itasca Township,United States Senate,,Republican,"Moran, Jerry",134,000070
+SHERMAN,Kanorado City,United States Senate,,write - in,"Smith, DJ",0,000080
+SHERMAN,Kanorado City,United States Senate,,Democratic,"Wiesner, Patrick",4,000080
+SHERMAN,Kanorado City,United States Senate,,Libertarian,"Garrard, Robert D.",5,000080
+SHERMAN,Kanorado City,United States Senate,,Republican,"Moran, Jerry",50,000080
+SHERMAN,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000090
+SHERMAN,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000090
+SHERMAN,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000090
+SHERMAN,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",33,000090
+SHERMAN,Llanos Township,United States Senate,,write - in,"Smith, DJ",0,000100
+SHERMAN,Llanos Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+SHERMAN,Llanos Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+SHERMAN,Llanos Township,United States Senate,,Republican,"Moran, Jerry",23,000100
+SHERMAN,Logan Township,United States Senate,,write - in,"Smith, DJ",0,00011A
+SHERMAN,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",4,00011A
+SHERMAN,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,00011A
+SHERMAN,Logan Township,United States Senate,,Republican,"Moran, Jerry",119,00011A
+SHERMAN,Logan Township Enclave (B),United States Senate,,write - in,"Smith, DJ",0,00011C
+SHERMAN,Logan Township Enclave (B),United States Senate,,Democratic,"Wiesner, Patrick",0,00011C
+SHERMAN,Logan Township Enclave (B),United States Senate,,Libertarian,"Garrard, Robert D.",0,00011C
+SHERMAN,Logan Township Enclave (B),United States Senate,,Republican,"Moran, Jerry",0,00011C
+SHERMAN,McPherson Township,United States Senate,,write - in,"Smith, DJ",0,000120
+SHERMAN,McPherson Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000120
+SHERMAN,McPherson Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+SHERMAN,McPherson Township,United States Senate,,Republican,"Moran, Jerry",25,000120
+SHERMAN,Shermanville Township,United States Senate,,write - in,"Smith, DJ",0,000130
+SHERMAN,Shermanville Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000130
+SHERMAN,Shermanville Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000130
+SHERMAN,Shermanville Township,United States Senate,,Republican,"Moran, Jerry",18,000130
+SHERMAN,Smoky Township,United States Senate,,write - in,"Smith, DJ",0,000140
+SHERMAN,Smoky Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000140
+SHERMAN,Smoky Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000140
+SHERMAN,Smoky Township,United States Senate,,Republican,"Moran, Jerry",31,000140
+SHERMAN,State Line Township,United States Senate,,write - in,"Smith, DJ",0,000150
+SHERMAN,State Line Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000150
+SHERMAN,State Line Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000150
+SHERMAN,State Line Township,United States Senate,,Republican,"Moran, Jerry",35,000150
+SHERMAN,Union Township,United States Senate,,write - in,"Smith, DJ",0,000160
+SHERMAN,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000160
+SHERMAN,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+SHERMAN,Union Township,United States Senate,,Republican,"Moran, Jerry",27,000160
+SHERMAN,Voltaire Township,United States Senate,,write - in,"Smith, DJ",0,000170
+SHERMAN,Voltaire Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000170
+SHERMAN,Voltaire Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000170
+SHERMAN,Voltaire Township,United States Senate,,Republican,"Moran, Jerry",106,000170
+SHERMAN,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000180
+SHERMAN,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000180
+SHERMAN,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000180
+SHERMAN,Washington Township,United States Senate,,Republican,"Moran, Jerry",36,000180

--- a/2016/20161108__ks__general__smith__precinct.csv
+++ b/2016/20161108__ks__general__smith__precinct.csv
@@ -1,365 +1,1009 @@
-county,precinct,office,district,party,candidate,votes
-Smith,Banner Precinct,President,,R,Trump and Pence,31
-Smith,Beaver Precinct,President,,R,Trump and Pence,26
-Smith,Blaine Precinct,President,,R,Trump and Pence,25
-Smith,Cedar Precinct,President,,R,Trump and Pence,206
-Smith,Center I Precinct,President,,R,Trump and Pence,241
-Smith,Center II Precinct,President,,R,Trump and Pence,275
-Smith,Center III Precinct,President,,R,Trump and Pence,201
-Smith,Center IV Precinct,President,,R,Trump and Pence,60
-Smith,Cora Precinct,President,,R,Trump and Pence,14
-Smith,Crystal Plains Precinct,President,,R,Trump and Pence,15
-Smith,Dor Precinct,President,,R,Trump and Pence,19
-Smith,Garfield Precinct,President,,R,Trump and Pence,14
-Smith,German Precinct,President,,R,Trump and Pence,10
-Smith,Harlan Precinct,President,,R,Trump and Pence,39
-Smith,Harvey Precinct,President,,R,Trump and Pence,52
-Smith,Houston Precinct,President,,R,Trump and Pence,65
-Smith,Lane Precinct,President,,R,Trump and Pence,44
-Smith,Lincoln Precinct,President,,R,Trump and Pence,36
-Smith,Logan Precinct,President,,R,Trump and Pence,16
-Smith,Martin Precinct,President,,R,Trump and Pence,8
-Smith,Oak I Precinct,President,,R,Trump and Pence,125
-Smith,Pawnee Precinct,President,,R,Trump and Pence,14
-Smith,Pleasant Precinct,President,,R,Trump and Pence,19
-Smith,Swan Precinct,President,,R,Trump and Pence,13
-Smith,Valley Precinct,President,,R,Trump and Pence,24
-Smith,Washington Precinct,President,,R,Trump and Pence,26
-Smith,Webster Precinct,President,,R,Trump and Pence,24
-Smith,White Rock Precinct,President,,R,Trump and Pence,19
-Smith,Banner Precinct,President,,D,Clinton and Kaine,2
-Smith,Beaver Precinct,President,,D,Clinton and Kaine,1
-Smith,Blaine Precinct,President,,D,Clinton and Kaine,2
-Smith,Cedar Precinct,President,,D,Clinton and Kaine,44
-Smith,Center I Precinct,President,,D,Clinton and Kaine,47
-Smith,Center II Precinct,President,,D,Clinton and Kaine,70
-Smith,Center III Precinct,President,,D,Clinton and Kaine,22
-Smith,Center IV Precinct,President,,D,Clinton and Kaine,5
-Smith,Cora Precinct,President,,D,Clinton and Kaine,2
-Smith,Crystal Plains Precinct,President,,D,Clinton and Kaine,1
-Smith,Dor Precinct,President,,D,Clinton and Kaine,5
-Smith,Garfield Precinct,President,,D,Clinton and Kaine,1
-Smith,German Precinct,President,,D,Clinton and Kaine,4
-Smith,Harlan Precinct,President,,D,Clinton and Kaine,4
-Smith,Harvey Precinct,President,,D,Clinton and Kaine,7
-Smith,Houston Precinct,President,,D,Clinton and Kaine,8
-Smith,Lane Precinct,President,,D,Clinton and Kaine,14
-Smith,Lincoln Precinct,President,,D,Clinton and Kaine,3
-Smith,Logan Precinct,President,,D,Clinton and Kaine,5
-Smith,Martin Precinct,President,,D,Clinton and Kaine,1
-Smith,Oak I Precinct,President,,D,Clinton and Kaine,21
-Smith,Pawnee Precinct,President,,D,Clinton and Kaine,1
-Smith,Pleasant Precinct,President,,D,Clinton and Kaine,2
-Smith,Swan Precinct,President,,D,Clinton and Kaine,7
-Smith,Valley Precinct,President,,D,Clinton and Kaine,5
-Smith,Washington Precinct,President,,D,Clinton and Kaine,2
-Smith,Webster Precinct,President,,D,Clinton and Kaine,5
-Smith,White Rock Precinct,President,,D,Clinton and Kaine,6
-Smith,Banner Precinct,President,,L,Johnson and Weld,0
-Smith,Beaver Precinct,President,,L,Johnson and Weld,1
-Smith,Blaine Precinct,President,,L,Johnson and Weld,0
-Smith,Cedar Precinct,President,,L,Johnson and Weld,8
-Smith,Center I Precinct,President,,L,Johnson and Weld,8
-Smith,Center II Precinct,President,,L,Johnson and Weld,9
-Smith,Center III Precinct,President,,L,Johnson and Weld,6
-Smith,Center IV Precinct,President,,L,Johnson and Weld,2
-Smith,Cora Precinct,President,,L,Johnson and Weld,0
-Smith,Crystal Plains Precinct,President,,L,Johnson and Weld,0
-Smith,Dor Precinct,President,,L,Johnson and Weld,0
-Smith,Garfield Precinct,President,,L,Johnson and Weld,0
-Smith,German Precinct,President,,L,Johnson and Weld,0
-Smith,Harlan Precinct,President,,L,Johnson and Weld,0
-Smith,Harvey Precinct,President,,L,Johnson and Weld,3
-Smith,Houston Precinct,President,,L,Johnson and Weld,2
-Smith,Lane Precinct,President,,L,Johnson and Weld,2
-Smith,Lincoln Precinct,President,,L,Johnson and Weld,1
-Smith,Logan Precinct,President,,L,Johnson and Weld,0
-Smith,Martin Precinct,President,,L,Johnson and Weld,0
-Smith,Oak I Precinct,President,,L,Johnson and Weld,3
-Smith,Pawnee Precinct,President,,L,Johnson and Weld,2
-Smith,Pleasant Precinct,President,,L,Johnson and Weld,1
-Smith,Swan Precinct,President,,L,Johnson and Weld,0
-Smith,Valley Precinct,President,,L,Johnson and Weld,4
-Smith,Washington Precinct,President,,L,Johnson and Weld,2
-Smith,Webster Precinct,President,,L,Johnson and Weld,1
-Smith,White Rock Precinct,President,,L,Johnson and Weld,0
-Smith,Banner Precinct,President,,I,Stein and Baraka,1
-Smith,Beaver Precinct,President,,I,Stein and Baraka,0
-Smith,Blaine Precinct,President,,I,Stein and Baraka,0
-Smith,Cedar Precinct,President,,I,Stein and Baraka,1
-Smith,Center I Precinct,President,,I,Stein and Baraka,8
-Smith,Center II Precinct,President,,I,Stein and Baraka,6
-Smith,Center III Precinct,President,,I,Stein and Baraka,4
-Smith,Center IV Precinct,President,,I,Stein and Baraka,3
-Smith,Cora Precinct,President,,I,Stein and Baraka,0
-Smith,Crystal Plains Precinct,President,,I,Stein and Baraka,1
-Smith,Dor Precinct,President,,I,Stein and Baraka,0
-Smith,Garfield Precinct,President,,I,Stein and Baraka,0
-Smith,German Precinct,President,,I,Stein and Baraka,0
-Smith,Harlan Precinct,President,,I,Stein and Baraka,0
-Smith,Harvey Precinct,President,,I,Stein and Baraka,0
-Smith,Houston Precinct,President,,I,Stein and Baraka,0
-Smith,Lane Precinct,President,,I,Stein and Baraka,0
-Smith,Lincoln Precinct,President,,I,Stein and Baraka,0
-Smith,Logan Precinct,President,,I,Stein and Baraka,0
-Smith,Martin Precinct,President,,I,Stein and Baraka,0
-Smith,Oak I Precinct,President,,I,Stein and Baraka,2
-Smith,Pawnee Precinct,President,,I,Stein and Baraka,1
-Smith,Pleasant Precinct,President,,I,Stein and Baraka,0
-Smith,Swan Precinct,President,,I,Stein and Baraka,0
-Smith,Valley Precinct,President,,I,Stein and Baraka,1
-Smith,Washington Precinct,President,,I,Stein and Baraka,0
-Smith,Webster Precinct,President,,I,Stein and Baraka,1
-Smith,White Rock Precinct,President,,I,Stein and Baraka,0
-Smith,Banner Precinct,U.S. Senate,,D,Patrick Wiesner,2
-Smith,Beaver Precinct,U.S. Senate,,D,Patrick Wiesner,0
-Smith,Blaine Precinct,U.S. Senate,,D,Patrick Wiesner,2
-Smith,Cedar Precinct,U.S. Senate,,D,Patrick Wiesner,28
-Smith,Center I Precinct,U.S. Senate,,D,Patrick Wiesner,36
-Smith,Center II Precinct,U.S. Senate,,D,Patrick Wiesner,53
-Smith,Center III Precinct,U.S. Senate,,D,Patrick Wiesner,15
-Smith,Center IV Precinct,U.S. Senate,,D,Patrick Wiesner,6
-Smith,Cora Precinct,U.S. Senate,,D,Patrick Wiesner,0
-Smith,Crystal Plains Precinct,U.S. Senate,,D,Patrick Wiesner,5
-Smith,Dor Precinct,U.S. Senate,,D,Patrick Wiesner,3
-Smith,Garfield Precinct,U.S. Senate,,D,Patrick Wiesner,2
-Smith,German Precinct,U.S. Senate,,D,Patrick Wiesner,0
-Smith,Harlan Precinct,U.S. Senate,,D,Patrick Wiesner,2
-Smith,Harvey Precinct,U.S. Senate,,D,Patrick Wiesner,3
-Smith,Houston Precinct,U.S. Senate,,D,Patrick Wiesner,10
-Smith,Lane Precinct,U.S. Senate,,D,Patrick Wiesner,9
-Smith,Lincoln Precinct,U.S. Senate,,D,Patrick Wiesner,2
-Smith,Logan Precinct,U.S. Senate,,D,Patrick Wiesner,5
-Smith,Martin Precinct,U.S. Senate,,D,Patrick Wiesner,0
-Smith,Oak I Precinct,U.S. Senate,,D,Patrick Wiesner,20
-Smith,Pawnee Precinct,U.S. Senate,,D,Patrick Wiesner,1
-Smith,Pleasant Precinct,U.S. Senate,,D,Patrick Wiesner,3
-Smith,Swan Precinct,U.S. Senate,,D,Patrick Wiesner,3
-Smith,Valley Precinct,U.S. Senate,,D,Patrick Wiesner,2
-Smith,Washington Precinct,U.S. Senate,,D,Patrick Wiesner,3
-Smith,Webster Precinct,U.S. Senate,,D,Patrick Wiesner,1
-Smith,White Rock Precinct,U.S. Senate,,D,Patrick Wiesner,3
-Smith,Banner Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Beaver Precinct,U.S. Senate,,L,Robert D. Garrard,0
-Smith,Blaine Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Cedar Precinct,U.S. Senate,,L,Robert D. Garrard,8
-Smith,Center I Precinct,U.S. Senate,,L,Robert D. Garrard,8
-Smith,Center II Precinct,U.S. Senate,,L,Robert D. Garrard,18
-Smith,Center III Precinct,U.S. Senate,,L,Robert D. Garrard,13
-Smith,Center IV Precinct,U.S. Senate,,L,Robert D. Garrard,6
-Smith,Cora Precinct,U.S. Senate,,L,Robert D. Garrard,0
-Smith,Crystal Plains Precinct,U.S. Senate,,L,Robert D. Garrard,2
-Smith,Dor Precinct,U.S. Senate,,L,Robert D. Garrard,2
-Smith,Garfield Precinct,U.S. Senate,,L,Robert D. Garrard,0
-Smith,German Precinct,U.S. Senate,,L,Robert D. Garrard,0
-Smith,Harlan Precinct,U.S. Senate,,L,Robert D. Garrard,2
-Smith,Harvey Precinct,U.S. Senate,,L,Robert D. Garrard,4
-Smith,Houston Precinct,U.S. Senate,,L,Robert D. Garrard,2
-Smith,Lane Precinct,U.S. Senate,,L,Robert D. Garrard,0
-Smith,Lincoln Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Logan Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Martin Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Oak I Precinct,U.S. Senate,,L,Robert D. Garrard,5
-Smith,Pawnee Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Pleasant Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Swan Precinct,U.S. Senate,,L,Robert D. Garrard,0
-Smith,Valley Precinct,U.S. Senate,,L,Robert D. Garrard,1
-Smith,Washington Precinct,U.S. Senate,,L,Robert D. Garrard,4
-Smith,Webster Precinct,U.S. Senate,,L,Robert D. Garrard,2
-Smith,White Rock Precinct,U.S. Senate,,L,Robert D. Garrard,2
-Smith,Banner Precinct,U.S. Senate,,R,Jerry Moran,31
-Smith,Beaver Precinct,U.S. Senate,,R,Jerry Moran,27
-Smith,Blaine Precinct,U.S. Senate,,R,Jerry Moran,24
-Smith,Cedar Precinct,U.S. Senate,,R,Jerry Moran,224
-Smith,Center I Precinct,U.S. Senate,,R,Jerry Moran,260
-Smith,Center II Precinct,U.S. Senate,,R,Jerry Moran,289
-Smith,Center III Precinct,U.S. Senate,,R,Jerry Moran,206
-Smith,Center IV Precinct,U.S. Senate,,R,Jerry Moran,58
-Smith,Cora Precinct,U.S. Senate,,R,Jerry Moran,17
-Smith,Crystal Plains Precinct,U.S. Senate,,R,Jerry Moran,10
-Smith,Dor Precinct,U.S. Senate,,R,Jerry Moran,20
-Smith,Garfield Precinct,U.S. Senate,,R,Jerry Moran,15
-Smith,German Precinct,U.S. Senate,,R,Jerry Moran,12
-Smith,Harlan Precinct,U.S. Senate,,R,Jerry Moran,39
-Smith,Harvey Precinct,U.S. Senate,,R,Jerry Moran,55
-Smith,Houston Precinct,U.S. Senate,,R,Jerry Moran,65
-Smith,Lane Precinct,U.S. Senate,,R,Jerry Moran,52
-Smith,Lincoln Precinct,U.S. Senate,,R,Jerry Moran,38
-Smith,Logan Precinct,U.S. Senate,,R,Jerry Moran,15
-Smith,Martin Precinct,U.S. Senate,,R,Jerry Moran,8
-Smith,Oak I Precinct,U.S. Senate,,R,Jerry Moran,125
-Smith,Pawnee Precinct,U.S. Senate,,R,Jerry Moran,15
-Smith,Pleasant Precinct,U.S. Senate,,R,Jerry Moran,17
-Smith,Swan Precinct,U.S. Senate,,R,Jerry Moran,17
-Smith,Valley Precinct,U.S. Senate,,R,Jerry Moran,31
-Smith,Washington Precinct,U.S. Senate,,R,Jerry Moran,23
-Smith,Webster Precinct,U.S. Senate,,R,Jerry Moran,29
-Smith,White Rock Precinct,U.S. Senate,,R,Jerry Moran,22
-Smith,Banner Precinct,U.S. House,1,R,Roger Marshall,25
-Smith,Beaver Precinct,U.S. House,1,R,Roger Marshall,21
-Smith,Blaine Precinct,U.S. House,1,R,Roger Marshall,22
-Smith,Cedar Precinct,U.S. House,1,R,Roger Marshall,192
-Smith,Center I Precinct,U.S. House,1,R,Roger Marshall,230
-Smith,Center II Precinct,U.S. House,1,R,Roger Marshall,241
-Smith,Center III Precinct,U.S. House,1,R,Roger Marshall,191
-Smith,Center IV Precinct,U.S. House,1,R,Roger Marshall,56
-Smith,Cora Precinct,U.S. House,1,R,Roger Marshall,10
-Smith,Crystal Plains Precinct,U.S. House,1,R,Roger Marshall,11
-Smith,Dor Precinct,U.S. House,1,R,Roger Marshall,15
-Smith,Garfield Precinct,U.S. House,1,R,Roger Marshall,16
-Smith,German Precinct,U.S. House,1,R,Roger Marshall,8
-Smith,Harlan Precinct,U.S. House,1,R,Roger Marshall,34
-Smith,Harvey Precinct,U.S. House,1,R,Roger Marshall,51
-Smith,Houston Precinct,U.S. House,1,R,Roger Marshall,60
-Smith,Lane Precinct,U.S. House,1,R,Roger Marshall,44
-Smith,Lincoln Precinct,U.S. House,1,R,Roger Marshall,32
-Smith,Logan Precinct,U.S. House,1,R,Roger Marshall,13
-Smith,Martin Precinct,U.S. House,1,R,Roger Marshall,9
-Smith,Oak I Precinct,U.S. House,1,R,Roger Marshall,106
-Smith,Pawnee Precinct,U.S. House,1,R,Roger Marshall,10
-Smith,Pleasant Precinct,U.S. House,1,R,Roger Marshall,16
-Smith,Swan Precinct,U.S. House,1,R,Roger Marshall,12
-Smith,Valley Precinct,U.S. House,1,R,Roger Marshall,25
-Smith,Washington Precinct,U.S. House,1,R,Roger Marshall,23
-Smith,Webster Precinct,U.S. House,1,R,Roger Marshall,26
-Smith,White Rock Precinct,U.S. House,1,R,Roger Marshall,21
-Smith,Banner Precinct,U.S. House,1,L,Kerry Burt,1
-Smith,Beaver Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Blaine Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Cedar Precinct,U.S. House,1,L,Kerry Burt,5
-Smith,Center I Precinct,U.S. House,1,L,Kerry Burt,10
-Smith,Center II Precinct,U.S. House,1,L,Kerry Burt,14
-Smith,Center III Precinct,U.S. House,1,L,Kerry Burt,6
-Smith,Center IV Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Cora Precinct,U.S. House,1,L,Kerry Burt,1
-Smith,Crystal Plains Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Dor Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Garfield Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,German Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Harlan Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Harvey Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Houston Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Lane Precinct,U.S. House,1,L,Kerry Burt,4
-Smith,Lincoln Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Logan Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Martin Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Oak I Precinct,U.S. House,1,L,Kerry Burt,8
-Smith,Pawnee Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Pleasant Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Swan Precinct,U.S. House,1,L,Kerry Burt,3
-Smith,Valley Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Washington Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,Webster Precinct,U.S. House,1,L,Kerry Burt,2
-Smith,White Rock Precinct,U.S. House,1,L,Kerry Burt,0
-Smith,Banner Precinct,U.S. House,1,I,Alan LaPolice,6
-Smith,Beaver Precinct,U.S. House,1,I,Alan LaPolice,6
-Smith,Blaine Precinct,U.S. House,1,I,Alan LaPolice,3
-Smith,Cedar Precinct,U.S. House,1,I,Alan LaPolice,55
-Smith,Center I Precinct,U.S. House,1,I,Alan LaPolice,57
-Smith,Center II Precinct,U.S. House,1,I,Alan LaPolice,91
-Smith,Center III Precinct,U.S. House,1,I,Alan LaPolice,30
-Smith,Center IV Precinct,U.S. House,1,I,Alan LaPolice,11
-Smith,Cora Precinct,U.S. House,1,I,Alan LaPolice,5
-Smith,Crystal Plains Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,Dor Precinct,U.S. House,1,I,Alan LaPolice,7
-Smith,Garfield Precinct,U.S. House,1,I,Alan LaPolice,1
-Smith,German Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,Harlan Precinct,U.S. House,1,I,Alan LaPolice,8
-Smith,Harvey Precinct,U.S. House,1,I,Alan LaPolice,8
-Smith,Houston Precinct,U.S. House,1,I,Alan LaPolice,14
-Smith,Lane Precinct,U.S. House,1,I,Alan LaPolice,9
-Smith,Lincoln Precinct,U.S. House,1,I,Alan LaPolice,9
-Smith,Logan Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,Martin Precinct,U.S. House,1,I,Alan LaPolice,0
-Smith,Oak I Precinct,U.S. House,1,I,Alan LaPolice,30
-Smith,Pawnee Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,Pleasant Precinct,U.S. House,1,I,Alan LaPolice,5
-Smith,Swan Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,Valley Precinct,U.S. House,1,I,Alan LaPolice,7
-Smith,Washington Precinct,U.S. House,1,I,Alan LaPolice,5
-Smith,Webster Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,White Rock Precinct,U.S. House,1,I,Alan LaPolice,4
-Smith,Banner Precinct,State Senate,36,R,Elaine S. Bowers,27
-Smith,Beaver Precinct,State Senate,36,R,Elaine S. Bowers,28
-Smith,Blaine Precinct,State Senate,36,R,Elaine S. Bowers,22
-Smith,Cedar Precinct,State Senate,36,R,Elaine S. Bowers,207
-Smith,Center I Precinct,State Senate,36,R,Elaine S. Bowers,249
-Smith,Center II Precinct,State Senate,36,R,Elaine S. Bowers,287
-Smith,Center III Precinct,State Senate,36,R,Elaine S. Bowers,215
-Smith,Center IV Precinct,State Senate,36,R,Elaine S. Bowers,59
-Smith,Cora Precinct,State Senate,36,R,Elaine S. Bowers,16
-Smith,Crystal Plains Precinct,State Senate,36,R,Elaine S. Bowers,13
-Smith,Dor Precinct,State Senate,36,R,Elaine S. Bowers,19
-Smith,Garfield Precinct,State Senate,36,R,Elaine S. Bowers,14
-Smith,German Precinct,State Senate,36,R,Elaine S. Bowers,10
-Smith,Harlan Precinct,State Senate,36,R,Elaine S. Bowers,41
-Smith,Harvey Precinct,State Senate,36,R,Elaine S. Bowers,48
-Smith,Houston Precinct,State Senate,36,R,Elaine S. Bowers,65
-Smith,Lane Precinct,State Senate,36,R,Elaine S. Bowers,47
-Smith,Lincoln Precinct,State Senate,36,R,Elaine S. Bowers,36
-Smith,Logan Precinct,State Senate,36,R,Elaine S. Bowers,13
-Smith,Martin Precinct,State Senate,36,R,Elaine S. Bowers,9
-Smith,Oak I Precinct,State Senate,36,R,Elaine S. Bowers,116
-Smith,Pawnee Precinct,State Senate,36,R,Elaine S. Bowers,14
-Smith,Pleasant Precinct,State Senate,36,R,Elaine S. Bowers,19
-Smith,Swan Precinct,State Senate,36,R,Elaine S. Bowers,13
-Smith,Valley Precinct,State Senate,36,R,Elaine S. Bowers,29
-Smith,Washington Precinct,State Senate,36,R,Elaine S. Bowers,24
-Smith,Webster Precinct,State Senate,36,R,Elaine S. Bowers,25
-Smith,White Rock Precinct,State Senate,36,R,Elaine S. Bowers,23
-Smith,Banner Precinct,State Senate,36,D,Brian G. Angevine,2
-Smith,Beaver Precinct,State Senate,36,D,Brian G. Angevine,0
-Smith,Blaine Precinct,State Senate,36,D,Brian G. Angevine,3
-Smith,Cedar Precinct,State Senate,36,D,Brian G. Angevine,43
-Smith,Center I Precinct,State Senate,36,D,Brian G. Angevine,47
-Smith,Center II Precinct,State Senate,36,D,Brian G. Angevine,60
-Smith,Center III Precinct,State Senate,36,D,Brian G. Angevine,18
-Smith,Center IV Precinct,State Senate,36,D,Brian G. Angevine,8
-Smith,Cora Precinct,State Senate,36,D,Brian G. Angevine,0
-Smith,Crystal Plains Precinct,State Senate,36,D,Brian G. Angevine,3
-Smith,Dor Precinct,State Senate,36,D,Brian G. Angevine,6
-Smith,Garfield Precinct,State Senate,36,D,Brian G. Angevine,2
-Smith,German Precinct,State Senate,36,D,Brian G. Angevine,2
-Smith,Harlan Precinct,State Senate,36,D,Brian G. Angevine,3
-Smith,Harvey Precinct,State Senate,36,D,Brian G. Angevine,9
-Smith,Houston Precinct,State Senate,36,D,Brian G. Angevine,10
-Smith,Lane Precinct,State Senate,36,D,Brian G. Angevine,10
-Smith,Lincoln Precinct,State Senate,36,D,Brian G. Angevine,5
-Smith,Logan Precinct,State Senate,36,D,Brian G. Angevine,8
-Smith,Martin Precinct,State Senate,36,D,Brian G. Angevine,0
-Smith,Oak I Precinct,State Senate,36,D,Brian G. Angevine,25
-Smith,Pawnee Precinct,State Senate,36,D,Brian G. Angevine,1
-Smith,Pleasant Precinct,State Senate,36,D,Brian G. Angevine,3
-Smith,Swan Precinct,State Senate,36,D,Brian G. Angevine,6
-Smith,Valley Precinct,State Senate,36,D,Brian G. Angevine,2
-Smith,Washington Precinct,State Senate,36,D,Brian G. Angevine,4
-Smith,Webster Precinct,State Senate,36,D,Brian G. Angevine,6
-Smith,White Rock Precinct,State Senate,36,D,Brian G. Angevine,2
-Smith,Banner Precinct,State House,109,R,Troy L. Waymaster,25
-Smith,Beaver Precinct,State House,109,R,Troy L. Waymaster,24
-Smith,Blaine Precinct,State House,109,R,Troy L. Waymaster,19
-Smith,Cedar Precinct,State House,109,R,Troy L. Waymaster,232
-Smith,Center I Precinct,State House,109,R,Troy L. Waymaster,256
-Smith,Center II Precinct,State House,109,R,Troy L. Waymaster,301
-Smith,Center III Precinct,State House,109,R,Troy L. Waymaster,203
-Smith,Center IV Precinct,State House,109,R,Troy L. Waymaster,66
-Smith,Cora Precinct,State House,109,R,Troy L. Waymaster,16
-Smith,Crystal Plains Precinct,State House,109,R,Troy L. Waymaster,13
-Smith,Dor Precinct,State House,109,R,Troy L. Waymaster,24
-Smith,Garfield Precinct,State House,109,R,Troy L. Waymaster,15
-Smith,German Precinct,State House,109,R,Troy L. Waymaster,10
-Smith,Harlan Precinct,State House,109,R,Troy L. Waymaster,41
-Smith,Harvey Precinct,State House,109,R,Troy L. Waymaster,52
-Smith,Houston Precinct,State House,109,R,Troy L. Waymaster,65
-Smith,Lane Precinct,State House,109,R,Troy L. Waymaster,52
-Smith,Lincoln Precinct,State House,109,R,Troy L. Waymaster,38
-Smith,Logan Precinct,State House,109,R,Troy L. Waymaster,19
-Smith,Martin Precinct,State House,109,R,Troy L. Waymaster,9
-Smith,Oak I Precinct,State House,109,R,Troy L. Waymaster,130
-Smith,Pawnee Precinct,State House,109,R,Troy L. Waymaster,12
-Smith,Pleasant Precinct,State House,109,R,Troy L. Waymaster,21
-Smith,Swan Precinct,State House,109,R,Troy L. Waymaster,16
-Smith,Valley Precinct,State House,109,R,Troy L. Waymaster,30
-Smith,Washington Precinct,State House,109,R,Troy L. Waymaster,23
-Smith,Webster Precinct,State House,109,R,Troy L. Waymaster,30
-Smith,White Rock Precinct,State House,109,R,Troy L. Waymaster,24
+county,precinct,office,district,party,candidate,votes,vtd
+SMITH,Banner Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",25,000010
+SMITH,Beaver Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000020
+SMITH,Blaine Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000030
+SMITH,Cedar Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",232,000040
+SMITH,Cora Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000070
+SMITH,Crystal Plains Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",13,000080
+SMITH,Dor Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000090
+SMITH,Garfield Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",15,000100
+SMITH,German Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",10,000110
+SMITH,Harlan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",41,000120
+SMITH,Harvey Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000130
+SMITH,Houston Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",65,000140
+SMITH,Lane Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",52,000150
+SMITH,Lincoln Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",38,000160
+SMITH,Logan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",19,000170
+SMITH,Martin Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",9,000180
+SMITH,Pawnee Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",12,000210
+SMITH,Pleasant Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",21,000220
+SMITH,Swan Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",16,000230
+SMITH,Valley Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",30,000240
+SMITH,Washington Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",23,000250
+SMITH,Webster Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",30,000260
+SMITH,White Rock Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",24,000270
+SMITH,Oak Township,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",130,130010
+SMITH,Center 1,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",256,140010
+SMITH,Center 2,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",301,140020
+SMITH,Center 3,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",203,140030
+SMITH,Center 4,Kansas House of Representatives,109,Republican,"Waymaster, Troy L.",66,140040
+SMITH,Banner Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000010
+SMITH,Banner Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000010
+SMITH,Beaver Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000020
+SMITH,Beaver Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",28,000020
+SMITH,Blaine Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000030
+SMITH,Blaine Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",22,000030
+SMITH,Cedar Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",43,000040
+SMITH,Cedar Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",207,000040
+SMITH,Cora Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000070
+SMITH,Cora Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",16,000070
+SMITH,Crystal Plains Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000080
+SMITH,Crystal Plains Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000080
+SMITH,Dor Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000090
+SMITH,Dor Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000090
+SMITH,Garfield Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000100
+SMITH,Garfield Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",14,000100
+SMITH,German Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000110
+SMITH,German Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",10,000110
+SMITH,Harlan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000120
+SMITH,Harlan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000120
+SMITH,Harvey Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",9,000130
+SMITH,Harvey Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",48,000130
+SMITH,Houston Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000140
+SMITH,Houston Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",65,000140
+SMITH,Lane Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000150
+SMITH,Lane Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",47,000150
+SMITH,Lincoln Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000160
+SMITH,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",36,000160
+SMITH,Logan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000170
+SMITH,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000170
+SMITH,Martin Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000180
+SMITH,Martin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",9,000180
+SMITH,Pawnee Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000210
+SMITH,Pawnee Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",14,000210
+SMITH,Pleasant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000220
+SMITH,Pleasant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",19,000220
+SMITH,Swan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000230
+SMITH,Swan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000230
+SMITH,Valley Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000240
+SMITH,Valley Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000240
+SMITH,Washington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000250
+SMITH,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",24,000250
+SMITH,Webster Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000260
+SMITH,Webster Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000260
+SMITH,White Rock Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000270
+SMITH,White Rock Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",23,000270
+SMITH,Oak Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",25,130010
+SMITH,Oak Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",116,130010
+SMITH,Center 1,Kansas Senate,36,Democratic,"Angevine, Brian G.",47,140010
+SMITH,Center 1,Kansas Senate,36,Republican,"Bowers, Elaine S.",249,140010
+SMITH,Center 2,Kansas Senate,36,Democratic,"Angevine, Brian G.",60,140020
+SMITH,Center 2,Kansas Senate,36,Republican,"Bowers, Elaine S.",287,140020
+SMITH,Center 3,Kansas Senate,36,Democratic,"Angevine, Brian G.",18,140030
+SMITH,Center 3,Kansas Senate,36,Republican,"Bowers, Elaine S.",215,140030
+SMITH,Center 4,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,140040
+SMITH,Center 4,Kansas Senate,36,Republican,"Bowers, Elaine S.",59,140040
+SMITH,Banner Township,President / Vice President,,independent,"Stein, Jill",1,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SMITH,Banner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SMITH,Banner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+SMITH,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+SMITH,Banner Township,President / Vice President,,Republican,"Trump, Donald J.",31,000010
+SMITH,Beaver Township,President / Vice President,,independent,"Stein, Jill",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+SMITH,Beaver Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+SMITH,Beaver Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+SMITH,Beaver Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+SMITH,Beaver Township,President / Vice President,,Republican,"Trump, Donald J.",26,000020
+SMITH,Blaine Township,President / Vice President,,independent,"Stein, Jill",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+SMITH,Blaine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+SMITH,Blaine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000030
+SMITH,Blaine Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+SMITH,Blaine Township,President / Vice President,,Republican,"Trump, Donald J.",25,000030
+SMITH,Cedar Township,President / Vice President,,independent,"Stein, Jill",1,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SMITH,Cedar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SMITH,Cedar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",44,000040
+SMITH,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000040
+SMITH,Cedar Township,President / Vice President,,Republican,"Trump, Donald J.",206,000040
+SMITH,Cora Township,President / Vice President,,independent,"Stein, Jill",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SMITH,Cora Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SMITH,Cora Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000070
+SMITH,Cora Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+SMITH,Cora Township,President / Vice President,,Republican,"Trump, Donald J.",14,000070
+SMITH,Crystal Plains Township,President / Vice President,,independent,"Stein, Jill",1,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000080
+SMITH,Crystal Plains Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+SMITH,Crystal Plains Township,President / Vice President,,Republican,"Trump, Donald J.",15,000080
+SMITH,Dor Township,President / Vice President,,independent,"Stein, Jill",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SMITH,Dor Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SMITH,Dor Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000090
+SMITH,Dor Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000090
+SMITH,Dor Township,President / Vice President,,Republican,"Trump, Donald J.",19,000090
+SMITH,Garfield Township,President / Vice President,,independent,"Stein, Jill",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+SMITH,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+SMITH,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000100
+SMITH,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000100
+SMITH,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",14,000100
+SMITH,German Township,President / Vice President,,independent,"Stein, Jill",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+SMITH,German Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+SMITH,German Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+SMITH,German Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+SMITH,German Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+SMITH,German Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000110
+SMITH,German Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+SMITH,German Township,President / Vice President,,Republican,"Trump, Donald J.",10,000110
+SMITH,Harlan Township,President / Vice President,,independent,"Stein, Jill",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+SMITH,Harlan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+SMITH,Harlan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000120
+SMITH,Harlan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+SMITH,Harlan Township,President / Vice President,,Republican,"Trump, Donald J.",39,000120
+SMITH,Harvey Township,President / Vice President,,independent,"Stein, Jill",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+SMITH,Harvey Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+SMITH,Harvey Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000130
+SMITH,Harvey Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000130
+SMITH,Harvey Township,President / Vice President,,Republican,"Trump, Donald J.",52,000130
+SMITH,Houston Township,President / Vice President,,independent,"Stein, Jill",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+SMITH,Houston Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+SMITH,Houston Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000140
+SMITH,Houston Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000140
+SMITH,Houston Township,President / Vice President,,Republican,"Trump, Donald J.",65,000140
+SMITH,Lane Township,President / Vice President,,independent,"Stein, Jill",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+SMITH,Lane Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+SMITH,Lane Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000150
+SMITH,Lane Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+SMITH,Lane Township,President / Vice President,,Republican,"Trump, Donald J.",44,000150
+SMITH,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+SMITH,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+SMITH,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000160
+SMITH,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+SMITH,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",36,000160
+SMITH,Logan Township,President / Vice President,,independent,"Stein, Jill",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+SMITH,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+SMITH,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000170
+SMITH,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+SMITH,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",16,000170
+SMITH,Martin Township,President / Vice President,,independent,"Stein, Jill",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+SMITH,Martin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+SMITH,Martin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000180
+SMITH,Martin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000180
+SMITH,Martin Township,President / Vice President,,Republican,"Trump, Donald J.",8,000180
+SMITH,Pawnee Township,President / Vice President,,independent,"Stein, Jill",1,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+SMITH,Pawnee Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+SMITH,Pawnee Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000210
+SMITH,Pawnee Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000210
+SMITH,Pawnee Township,President / Vice President,,Republican,"Trump, Donald J.",14,000210
+SMITH,Pleasant Township,President / Vice President,,independent,"Stein, Jill",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+SMITH,Pleasant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+SMITH,Pleasant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000220
+SMITH,Pleasant Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000220
+SMITH,Pleasant Township,President / Vice President,,Republican,"Trump, Donald J.",19,000220
+SMITH,Swan Township,President / Vice President,,independent,"Stein, Jill",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+SMITH,Swan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+SMITH,Swan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000230
+SMITH,Swan Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000230
+SMITH,Swan Township,President / Vice President,,Republican,"Trump, Donald J.",13,000230
+SMITH,Valley Township,President / Vice President,,independent,"Stein, Jill",1,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+SMITH,Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+SMITH,Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000240
+SMITH,Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000240
+SMITH,Valley Township,President / Vice President,,Republican,"Trump, Donald J.",24,000240
+SMITH,Washington Township,President / Vice President,,independent,"Stein, Jill",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+SMITH,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+SMITH,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000250
+SMITH,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000250
+SMITH,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",26,000250
+SMITH,Webster Township,President / Vice President,,independent,"Stein, Jill",1,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+SMITH,Webster Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+SMITH,Webster Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000260
+SMITH,Webster Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000260
+SMITH,Webster Township,President / Vice President,,Republican,"Trump, Donald J.",24,000260
+SMITH,White Rock Township,President / Vice President,,independent,"Stein, Jill",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Castle, Darrell L",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Giordani, Rocky",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Hedges, James A",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Hoefling, Tom",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Kahn, Lynn",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"La Riva, Gloria",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Maturen, Michael A",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"McMullin, Evan",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Perry, Darryl",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Schriner, Joe C",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Smith, Mike",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Sood, Ajay",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Sterling, Shawna",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000270
+SMITH,White Rock Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000270
+SMITH,White Rock Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000270
+SMITH,White Rock Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000270
+SMITH,White Rock Township,President / Vice President,,Republican,"Trump, Donald J.",19,000270
+SMITH,Oak Township,President / Vice President,,independent,"Stein, Jill",2,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Castle, Darrell L",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Hedges, James A",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Maturen, Michael A",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"McMullin, Evan",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Perry, Darryl",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Smith, Mike",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Sood, Ajay",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+SMITH,Oak Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+SMITH,Oak Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,130010
+SMITH,Oak Township,President / Vice President,,Libertarian,"Johnson, Gary",3,130010
+SMITH,Oak Township,President / Vice President,,Republican,"Trump, Donald J.",125,130010
+SMITH,Center 1,President / Vice President,,independent,"Stein, Jill",8,140010
+SMITH,Center 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Castle, Darrell L",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Giordani, Rocky",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Hedges, James A",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Hoefling, Tom",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Kahn, Lynn",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"La Riva, Gloria",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Levinson, Michael S.",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Maturen, Michael A",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"McMullin, Evan",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Perry, Darryl",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Schriner, Joe C",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Smith, Mike",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Sood, Ajay",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Sterling, Shawna",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140010
+SMITH,Center 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140010
+SMITH,Center 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,140010
+SMITH,Center 1,President / Vice President,,Libertarian,"Johnson, Gary",8,140010
+SMITH,Center 1,President / Vice President,,Republican,"Trump, Donald J.",241,140010
+SMITH,Center 2,President / Vice President,,independent,"Stein, Jill",6,140020
+SMITH,Center 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Castle, Darrell L",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Giordani, Rocky",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Hedges, James A",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Hoefling, Tom",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Kahn, Lynn",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"La Riva, Gloria",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Levinson, Michael S.",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Maturen, Michael A",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"McMullin, Evan",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Perry, Darryl",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Schriner, Joe C",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Smith, Mike",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Sood, Ajay",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Sterling, Shawna",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140020
+SMITH,Center 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140020
+SMITH,Center 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",70,140020
+SMITH,Center 2,President / Vice President,,Libertarian,"Johnson, Gary",9,140020
+SMITH,Center 2,President / Vice President,,Republican,"Trump, Donald J.",275,140020
+SMITH,Center 3,President / Vice President,,independent,"Stein, Jill",4,140030
+SMITH,Center 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Castle, Darrell L",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Giordani, Rocky",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Hedges, James A",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Hoefling, Tom",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Kahn, Lynn",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"La Riva, Gloria",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Levinson, Michael S.",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Maturen, Michael A",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"McMullin, Evan",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Perry, Darryl",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Schriner, Joe C",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Smith, Mike",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Sood, Ajay",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Sterling, Shawna",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140030
+SMITH,Center 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140030
+SMITH,Center 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,140030
+SMITH,Center 3,President / Vice President,,Libertarian,"Johnson, Gary",6,140030
+SMITH,Center 3,President / Vice President,,Republican,"Trump, Donald J.",201,140030
+SMITH,Center 4,President / Vice President,,independent,"Stein, Jill",3,140040
+SMITH,Center 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Castle, Darrell L",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Giordani, Rocky",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Hedges, James A",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Hoefling, Tom",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Kahn, Lynn",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"La Riva, Gloria",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Levinson, Michael S.",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Maturen, Michael A",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"McMullin, Evan",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Perry, Darryl",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Schriner, Joe C",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Smith, Mike",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Sood, Ajay",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Sterling, Shawna",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,140040
+SMITH,Center 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,140040
+SMITH,Center 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,140040
+SMITH,Center 4,President / Vice President,,Libertarian,"Johnson, Gary",2,140040
+SMITH,Center 4,President / Vice President,,Republican,"Trump, Donald J.",60,140040
+SMITH,Banner Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000010
+SMITH,Banner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+SMITH,Banner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+SMITH,Banner Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000010
+SMITH,Beaver Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000020
+SMITH,Beaver Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+SMITH,Beaver Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+SMITH,Beaver Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000020
+SMITH,Blaine Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000030
+SMITH,Blaine Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+SMITH,Blaine Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000030
+SMITH,Blaine Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000030
+SMITH,Cedar Township,United States House of Representatives,1,independent,"LaPolice, Alan",55,000040
+SMITH,Cedar Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+SMITH,Cedar Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000040
+SMITH,Cedar Township,United States House of Representatives,1,Republican,"Marshall, Roger",192,000040
+SMITH,Cora Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000070
+SMITH,Cora Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+SMITH,Cora Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000070
+SMITH,Cora Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000070
+SMITH,Crystal Plains Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000080
+SMITH,Crystal Plains Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+SMITH,Crystal Plains Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+SMITH,Crystal Plains Township,United States House of Representatives,1,Republican,"Marshall, Roger",11,000080
+SMITH,Dor Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000090
+SMITH,Dor Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+SMITH,Dor Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000090
+SMITH,Dor Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000090
+SMITH,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",1,000100
+SMITH,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+SMITH,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+SMITH,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000100
+SMITH,German Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000110
+SMITH,German Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+SMITH,German Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+SMITH,German Township,United States House of Representatives,1,Republican,"Marshall, Roger",8,000110
+SMITH,Harlan Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000120
+SMITH,Harlan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+SMITH,Harlan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+SMITH,Harlan Township,United States House of Representatives,1,Republican,"Marshall, Roger",34,000120
+SMITH,Harvey Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000130
+SMITH,Harvey Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+SMITH,Harvey Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000130
+SMITH,Harvey Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000130
+SMITH,Houston Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000140
+SMITH,Houston Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+SMITH,Houston Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000140
+SMITH,Houston Township,United States House of Representatives,1,Republican,"Marshall, Roger",60,000140
+SMITH,Lane Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000150
+SMITH,Lane Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+SMITH,Lane Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000150
+SMITH,Lane Township,United States House of Representatives,1,Republican,"Marshall, Roger",44,000150
+SMITH,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",9,000160
+SMITH,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+SMITH,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000160
+SMITH,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000160
+SMITH,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000170
+SMITH,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+SMITH,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000170
+SMITH,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",13,000170
+SMITH,Martin Township,United States House of Representatives,1,independent,"LaPolice, Alan",0,000180
+SMITH,Martin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+SMITH,Martin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000180
+SMITH,Martin Township,United States House of Representatives,1,Republican,"Marshall, Roger",9,000180
+SMITH,Pawnee Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000210
+SMITH,Pawnee Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+SMITH,Pawnee Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000210
+SMITH,Pawnee Township,United States House of Representatives,1,Republican,"Marshall, Roger",10,000210
+SMITH,Pleasant Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000220
+SMITH,Pleasant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+SMITH,Pleasant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000220
+SMITH,Pleasant Township,United States House of Representatives,1,Republican,"Marshall, Roger",16,000220
+SMITH,Swan Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000230
+SMITH,Swan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+SMITH,Swan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000230
+SMITH,Swan Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000230
+SMITH,Valley Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000240
+SMITH,Valley Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+SMITH,Valley Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000240
+SMITH,Valley Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000240
+SMITH,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000250
+SMITH,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000250
+SMITH,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000250
+SMITH,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000250
+SMITH,Webster Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000260
+SMITH,Webster Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000260
+SMITH,Webster Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000260
+SMITH,Webster Township,United States House of Representatives,1,Republican,"Marshall, Roger",26,000260
+SMITH,White Rock Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000270
+SMITH,White Rock Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000270
+SMITH,White Rock Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000270
+SMITH,White Rock Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000270
+SMITH,Oak Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,130010
+SMITH,Oak Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,130010
+SMITH,Oak Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",8,130010
+SMITH,Oak Township,United States House of Representatives,1,Republican,"Marshall, Roger",106,130010
+SMITH,Center 1,United States House of Representatives,1,independent,"LaPolice, Alan",57,140010
+SMITH,Center 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140010
+SMITH,Center 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,140010
+SMITH,Center 1,United States House of Representatives,1,Republican,"Marshall, Roger",230,140010
+SMITH,Center 2,United States House of Representatives,1,independent,"LaPolice, Alan",91,140020
+SMITH,Center 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140020
+SMITH,Center 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,140020
+SMITH,Center 2,United States House of Representatives,1,Republican,"Marshall, Roger",241,140020
+SMITH,Center 3,United States House of Representatives,1,independent,"LaPolice, Alan",30,140030
+SMITH,Center 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140030
+SMITH,Center 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,140030
+SMITH,Center 3,United States House of Representatives,1,Republican,"Marshall, Roger",191,140030
+SMITH,Center 4,United States House of Representatives,1,independent,"LaPolice, Alan",11,140040
+SMITH,Center 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,140040
+SMITH,Center 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,140040
+SMITH,Center 4,United States House of Representatives,1,Republican,"Marshall, Roger",56,140040
+SMITH,Banner Township,United States Senate,,write - in,"Smith, DJ",0,000010
+SMITH,Banner Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000010
+SMITH,Banner Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000010
+SMITH,Banner Township,United States Senate,,Republican,"Moran, Jerry",31,000010
+SMITH,Beaver Township,United States Senate,,write - in,"Smith, DJ",0,000020
+SMITH,Beaver Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000020
+SMITH,Beaver Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+SMITH,Beaver Township,United States Senate,,Republican,"Moran, Jerry",27,000020
+SMITH,Blaine Township,United States Senate,,write - in,"Smith, DJ",0,000030
+SMITH,Blaine Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000030
+SMITH,Blaine Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+SMITH,Blaine Township,United States Senate,,Republican,"Moran, Jerry",24,000030
+SMITH,Cedar Township,United States Senate,,write - in,"Smith, DJ",0,000040
+SMITH,Cedar Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000040
+SMITH,Cedar Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000040
+SMITH,Cedar Township,United States Senate,,Republican,"Moran, Jerry",224,000040
+SMITH,Cora Township,United States Senate,,write - in,"Smith, DJ",0,000070
+SMITH,Cora Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000070
+SMITH,Cora Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+SMITH,Cora Township,United States Senate,,Republican,"Moran, Jerry",17,000070
+SMITH,Crystal Plains Township,United States Senate,,write - in,"Smith, DJ",0,000080
+SMITH,Crystal Plains Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000080
+SMITH,Crystal Plains Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000080
+SMITH,Crystal Plains Township,United States Senate,,Republican,"Moran, Jerry",10,000080
+SMITH,Dor Township,United States Senate,,write - in,"Smith, DJ",0,000090
+SMITH,Dor Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000090
+SMITH,Dor Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000090
+SMITH,Dor Township,United States Senate,,Republican,"Moran, Jerry",20,000090
+SMITH,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000100
+SMITH,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+SMITH,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000100
+SMITH,Garfield Township,United States Senate,,Republican,"Moran, Jerry",15,000100
+SMITH,German Township,United States Senate,,write - in,"Smith, DJ",0,000110
+SMITH,German Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000110
+SMITH,German Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+SMITH,German Township,United States Senate,,Republican,"Moran, Jerry",12,000110
+SMITH,Harlan Township,United States Senate,,write - in,"Smith, DJ",0,000120
+SMITH,Harlan Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000120
+SMITH,Harlan Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000120
+SMITH,Harlan Township,United States Senate,,Republican,"Moran, Jerry",39,000120
+SMITH,Harvey Township,United States Senate,,write - in,"Smith, DJ",0,000130
+SMITH,Harvey Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000130
+SMITH,Harvey Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000130
+SMITH,Harvey Township,United States Senate,,Republican,"Moran, Jerry",55,000130
+SMITH,Houston Township,United States Senate,,write - in,"Smith, DJ",0,000140
+SMITH,Houston Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000140
+SMITH,Houston Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000140
+SMITH,Houston Township,United States Senate,,Republican,"Moran, Jerry",65,000140
+SMITH,Lane Township,United States Senate,,write - in,"Smith, DJ",0,000150
+SMITH,Lane Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000150
+SMITH,Lane Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+SMITH,Lane Township,United States Senate,,Republican,"Moran, Jerry",52,000150
+SMITH,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000160
+SMITH,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000160
+SMITH,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+SMITH,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",38,000160
+SMITH,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000170
+SMITH,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000170
+SMITH,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000170
+SMITH,Logan Township,United States Senate,,Republican,"Moran, Jerry",15,000170
+SMITH,Martin Township,United States Senate,,write - in,"Smith, DJ",0,000180
+SMITH,Martin Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+SMITH,Martin Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000180
+SMITH,Martin Township,United States Senate,,Republican,"Moran, Jerry",8,000180
+SMITH,Pawnee Township,United States Senate,,write - in,"Smith, DJ",0,000210
+SMITH,Pawnee Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000210
+SMITH,Pawnee Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000210
+SMITH,Pawnee Township,United States Senate,,Republican,"Moran, Jerry",15,000210
+SMITH,Pleasant Township,United States Senate,,write - in,"Smith, DJ",0,000220
+SMITH,Pleasant Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000220
+SMITH,Pleasant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000220
+SMITH,Pleasant Township,United States Senate,,Republican,"Moran, Jerry",17,000220
+SMITH,Swan Township,United States Senate,,write - in,"Smith, DJ",0,000230
+SMITH,Swan Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000230
+SMITH,Swan Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000230
+SMITH,Swan Township,United States Senate,,Republican,"Moran, Jerry",17,000230
+SMITH,Valley Township,United States Senate,,write - in,"Smith, DJ",0,000240
+SMITH,Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000240
+SMITH,Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000240
+SMITH,Valley Township,United States Senate,,Republican,"Moran, Jerry",31,000240
+SMITH,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000250
+SMITH,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000250
+SMITH,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000250
+SMITH,Washington Township,United States Senate,,Republican,"Moran, Jerry",23,000250
+SMITH,Webster Township,United States Senate,,write - in,"Smith, DJ",0,000260
+SMITH,Webster Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000260
+SMITH,Webster Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000260
+SMITH,Webster Township,United States Senate,,Republican,"Moran, Jerry",29,000260
+SMITH,White Rock Township,United States Senate,,write - in,"Smith, DJ",0,000270
+SMITH,White Rock Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000270
+SMITH,White Rock Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000270
+SMITH,White Rock Township,United States Senate,,Republican,"Moran, Jerry",22,000270
+SMITH,Oak Township,United States Senate,,write - in,"Smith, DJ",0,130010
+SMITH,Oak Township,United States Senate,,Democratic,"Wiesner, Patrick",20,130010
+SMITH,Oak Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,130010
+SMITH,Oak Township,United States Senate,,Republican,"Moran, Jerry",125,130010
+SMITH,Center 1,United States Senate,,write - in,"Smith, DJ",0,140010
+SMITH,Center 1,United States Senate,,Democratic,"Wiesner, Patrick",36,140010
+SMITH,Center 1,United States Senate,,Libertarian,"Garrard, Robert D.",8,140010
+SMITH,Center 1,United States Senate,,Republican,"Moran, Jerry",260,140010
+SMITH,Center 2,United States Senate,,write - in,"Smith, DJ",0,140020
+SMITH,Center 2,United States Senate,,Democratic,"Wiesner, Patrick",53,140020
+SMITH,Center 2,United States Senate,,Libertarian,"Garrard, Robert D.",18,140020
+SMITH,Center 2,United States Senate,,Republican,"Moran, Jerry",289,140020
+SMITH,Center 3,United States Senate,,write - in,"Smith, DJ",0,140030
+SMITH,Center 3,United States Senate,,Democratic,"Wiesner, Patrick",15,140030
+SMITH,Center 3,United States Senate,,Libertarian,"Garrard, Robert D.",13,140030
+SMITH,Center 3,United States Senate,,Republican,"Moran, Jerry",206,140030
+SMITH,Center 4,United States Senate,,write - in,"Smith, DJ",0,140040
+SMITH,Center 4,United States Senate,,Democratic,"Wiesner, Patrick",6,140040
+SMITH,Center 4,United States Senate,,Libertarian,"Garrard, Robert D.",6,140040
+SMITH,Center 4,United States Senate,,Republican,"Moran, Jerry",58,140040

--- a/2016/20161108__ks__general__stafford__precinct.csv
+++ b/2016/20161108__ks__general__stafford__precinct.csv
@@ -1,385 +1,865 @@
-county,precinct,office,district,candidate,party,votes
-Stafford,N Stafford,President,,Trump and Pence,Rep,194
-Stafford,N Stafford,President,,Clinton and Kaine,Dem,48
-Stafford,N Stafford,President,,Johnson and Weld,Lib,11
-Stafford,N Stafford,President,,Stein and Baraka,Ind,5
-Stafford,N Stafford,President,,Michael Maturen,,0
-Stafford,N Stafford,President,,Evan McMullin,,0
-Stafford,N Stafford,U.S. Senate,,Patrick Wiesner,Dem,36
-Stafford,N Stafford,U.S. Senate,,Robert Garrard,Lib,13
-Stafford,N Stafford,U.S. Senate,,Jerry Moran,Rep,208
-Stafford,N Stafford,U.S. House,4,Daniel Giroux,Dem,28
-Stafford,N Stafford,U.S. House,4,Gorden Bakken,Lib,3
-Stafford,N Stafford,U.S. House,4,Michael Pompeo,Rep,200
-Stafford,N Stafford,U.S. House,4,Miranda Allen,Ind,23
-Stafford,N Stafford,State Senate ,33,Mary Jo Taylor,Rep,227
-Stafford,N Stafford,State Senate,33,Matt Bristow,Dem,28
-Stafford,N Stafford,State House,113,Greg Lewis,Rep,239
-Stafford,S Stafford,President,,Trump and Pence,Rep,171
-Stafford,S Stafford,President,,Clinton and Kaine,Dem,51
-Stafford,S Stafford,President,,Johnson and Weld,Lib,1
-Stafford,S Stafford,President,,Stein and Baraka,Ind,2
-Stafford,S Stafford,President,,Michael Maturen,,0
-Stafford,S Stafford,President,,Evan McMullin,,0
-Stafford,S Stafford,U.S. Senate,,Patrick Wiesner,Dem,42
-Stafford,S Stafford,U.S. Senate,,Robert Garrard,Lib,10
-Stafford,S Stafford,U.S. Senate,,Jerry Moran,Rep,172
-Stafford,S Stafford,U.S. House,4,Daniel Giroux,Dem,38
-Stafford,S Stafford,U.S. House,4,Gorden Bakken,Lib,5
-Stafford,S Stafford,U.S. House,4,Michael Pompeo,Rep,161
-Stafford,S Stafford,U.S. House,4,Miranda Allen,Ind,14
-Stafford,S Stafford,State Senate ,33,Mary Jo Taylor,Rep,184
-Stafford,S Stafford,State Senate,33,Matt Bristow,Dem,42
-Stafford,S Stafford,State House,113,Greg Lewis,Rep,207
-Stafford,E St John,President,,Trump and Pence,Rep,160
-Stafford,E St John,President,,Clinton and Kaine,Dem,47
-Stafford,E St John,President,,Johnson and Weld,Lib,5
-Stafford,E St John,President,,Stein and Baraka,Ind,3
-Stafford,E St John,President,,Michael Maturen,,1
-Stafford,E St John,President,,Evan McMullin,,5
-Stafford,E St John,U.S. Senate,,Patrick Wiesner,Dem,36
-Stafford,E St John,U.S. Senate,,Robert Garrard,Lib,12
-Stafford,E St John,U.S. Senate,,Jerry Moran,Rep,172
-Stafford,E St John,U.S. House,4,Daniel Giroux,Dem,29
-Stafford,E St John,U.S. House,4,Gorden Bakken,Lib,5
-Stafford,E St John,U.S. House,4,Michael Pompeo,Rep,172
-Stafford,E St John,U.S. House,4,Miranda Allen,Ind,18
-Stafford,E St John,State Senate ,33,Mary Jo Taylor,Rep,187
-Stafford,E St John,State Senate,33,Matt Bristow,Dem,31
-Stafford,E St John,State House,113,Greg Lewis,Rep,221
-Stafford,W St John,President,,Trump and Pence,Rep,166
-Stafford,W St John,President,,Clinton and Kaine,Dem,24
-Stafford,W St John,President,,Johnson and Weld,Lib,6
-Stafford,W St John,President,,Stein and Baraka,Ind,3
-Stafford,W St John,President,,Michael Maturen,,0
-Stafford,W St John,President,,Evan McMullin,,0
-Stafford,W St John,U.S. Senate,,Patrick Wiesner,Dem,17
-Stafford,W St John,U.S. Senate,,Robert Garrard,Lib,7
-Stafford,W St John,U.S. Senate,,Jerry Moran,Rep,165
-Stafford,W St John,U.S. House,4,Daniel Giroux,Dem,13
-Stafford,W St John,U.S. House,4,Gorden Bakken,Lib,2
-Stafford,W St John,U.S. House,4,Michael Pompeo,Rep,163
-Stafford,W St John,U.S. House,4,Miranda Allen,Ind,13
-Stafford,W St John,State Senate ,33,Mary Jo Taylor,Rep,169
-Stafford,W St John,State Senate,33,Matt Bristow,Dem,20
-Stafford,W St John,State House,113,Greg Lewis,Rep,178
-Stafford,S St John,President,,Trump and Pence,Rep,83
-Stafford,S St John,President,,Clinton and Kaine,Dem,19
-Stafford,S St John,President,,Johnson and Weld,Lib,8
-Stafford,S St John,President,,Stein and Baraka,Ind,5
-Stafford,S St John,President,,Michael Maturen,,0
-Stafford,S St John,President,,Evan McMullin,,0
-Stafford,S St John,U.S. Senate,,Patrick Wiesner,Dem,16
-Stafford,S St John,U.S. Senate,,Robert Garrard,Lib,6
-Stafford,S St John,U.S. Senate,,Jerry Moran,Rep,89
-Stafford,S St John,U.S. House,4,Daniel Giroux,Dem,16
-Stafford,S St John,U.S. House,4,Gorden Bakken,Lib,1
-Stafford,S St John,U.S. House,4,Michael Pompeo,Rep,86
-Stafford,S St John,U.S. House,4,Miranda Allen,Ind,10
-Stafford,S St John,State Senate ,33,Mary Jo Taylor,Rep,95
-Stafford,S St John,State Senate,33,Matt Bristow,Dem,17
-Stafford,S St John,State House,113,Greg Lewis,Rep,109
-Stafford,Albano,President,,Trump and Pence,Rep,22
-Stafford,Albano,President,,Clinton and Kaine,Dem,5
-Stafford,Albano,President,,Johnson and Weld,Lib,0
-Stafford,Albano,President,,Stein and Baraka,Ind,0
-Stafford,Albano,President,,Michael Maturen,,0
-Stafford,Albano,President,,Evan McMullin,,0
-Stafford,Albano,U.S. Senate,,Patrick Wiesner,Dem,4
-Stafford,Albano,U.S. Senate,,Robert Garrard,Lib,2
-Stafford,Albano,U.S. Senate,,Jerry Moran,Rep,19
-Stafford,Albano,U.S. House,4,Daniel Giroux,Dem,3
-Stafford,Albano,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Albano,U.S. House,4,Michael Pompeo,Rep,19
-Stafford,Albano,U.S. House,4,Miranda Allen,Ind,3
-Stafford,Albano,State Senate ,33,Mary Jo Taylor,Rep,22
-Stafford,Albano,State Senate,33,Matt Bristow,Dem,3
-Stafford,Albano,State House,113,Greg Lewis,Rep,22
-Stafford,Byron,President,,Trump and Pence,Rep,32
-Stafford,Byron,President,,Clinton and Kaine,Dem,1
-Stafford,Byron,President,,Johnson and Weld,Lib,0
-Stafford,Byron,President,,Stein and Baraka,Ind,0
-Stafford,Byron,President,,Michael Maturen,,0
-Stafford,Byron,President,,Evan McMullin,,0
-Stafford,Byron,U.S. Senate,,Patrick Wiesner,Dem,2
-Stafford,Byron,U.S. Senate,,Robert Garrard,Lib,1
-Stafford,Byron,U.S. Senate,,Jerry Moran,Rep,31
-Stafford,Byron,U.S. House,4,Daniel Giroux,Dem,1
-Stafford,Byron,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Byron,U.S. House,4,Michael Pompeo,Rep,32
-Stafford,Byron,U.S. House,4,Miranda Allen,Ind,0
-Stafford,Byron,State Senate ,33,Mary Jo Taylor,Rep,32
-Stafford,Byron,State Senate,33,Matt Bristow,Dem,0
-Stafford,Byron,State House,113,Greg Lewis,Rep,31
-Stafford,Clear Creek,President,,Trump and Pence,Rep,20
-Stafford,Clear Creek,President,,Clinton and Kaine,Dem,0
-Stafford,Clear Creek,President,,Johnson and Weld,Lib,0
-Stafford,Clear Creek,President,,Stein and Baraka,Ind,0
-Stafford,Clear Creek,President,,Michael Maturen,,0
-Stafford,Clear Creek,President,,Evan McMullin,,0
-Stafford,Clear Creek,U.S. Senate,,Patrick Wiesner,Dem,0
-Stafford,Clear Creek,U.S. Senate,,Robert Garrard,Lib,0
-Stafford,Clear Creek,U.S. Senate,,Jerry Moran,Rep,20
-Stafford,Clear Creek,U.S. House,4,Daniel Giroux,Dem,0
-Stafford,Clear Creek,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Clear Creek,U.S. House,4,Michael Pompeo,Rep,20
-Stafford,Clear Creek,U.S. House,4,Miranda Allen,Ind,0
-Stafford,Clear Creek,State Senate ,33,Mary Jo Taylor,Rep,17
-Stafford,Clear Creek,State Senate,33,Matt Bristow,Dem,0
-Stafford,Clear Creek,State House,113,Greg Lewis,Rep,20
-Stafford,Cleveland,President,,Trump and Pence,Rep,32
-Stafford,Cleveland,President,,Clinton and Kaine,Dem,6
-Stafford,Cleveland,President,,Johnson and Weld,Lib,1
-Stafford,Cleveland,President,,Stein and Baraka,Ind,0
-Stafford,Cleveland,President,,Michael Maturen,,0
-Stafford,Cleveland,President,,Evan McMullin,,0
-Stafford,Cleveland,U.S. Senate,,Patrick Wiesner,Dem,3
-Stafford,Cleveland,U.S. Senate,,Robert Garrard,Lib,2
-Stafford,Cleveland,U.S. Senate,,Jerry Moran,Rep,33
-Stafford,Cleveland,U.S. House,4,Daniel Giroux,Dem,1
-Stafford,Cleveland,U.S. House,4,Gorden Bakken,Lib,1
-Stafford,Cleveland,U.S. House,4,Michael Pompeo,Rep,31
-Stafford,Cleveland,U.S. House,4,Miranda Allen,Ind,4
-Stafford,Cleveland,State Senate ,33,Mary Jo Taylor,Rep,30
-Stafford,Cleveland,State Senate,33,Matt Bristow,Dem,6
-Stafford,Cleveland,State House,113,Greg Lewis,Rep,39
-Stafford,Cooper E,President,,Trump and Pence,Rep,18
-Stafford,Cooper E,President,,Clinton and Kaine,Dem,1
-Stafford,Cooper E,President,,Johnson and Weld,Lib,3
-Stafford,Cooper E,President,,Stein and Baraka,Ind,0
-Stafford,Cooper E,President,,Michael Maturen,,0
-Stafford,Cooper E,President,,Evan McMullin,,0
-Stafford,Cooper E,U.S. Senate,,Patrick Wiesner,Dem,3
-Stafford,Cooper E,U.S. Senate,,Robert Garrard,Lib,0
-Stafford,Cooper E,U.S. Senate,,Jerry Moran,Rep,21
-Stafford,Cooper E,U.S. House,4,Daniel Giroux,Dem,3
-Stafford,Cooper E,U.S. House,4,Gorden Bakken,Lib,1
-Stafford,Cooper E,U.S. House,4,Michael Pompeo,Rep,19
-Stafford,Cooper E,U.S. House,4,Miranda Allen,Ind,1
-Stafford,Cooper E,State Senate ,33,Mary Jo Taylor,Rep,20
-Stafford,Cooper E,State Senate,33,Matt Bristow,Dem,3
-Stafford,Cooper E,State House,113,Greg Lewis,Rep,22
-Stafford,Cooper W,President,,Trump and Pence,Rep,32
-Stafford,Cooper W,President,,Clinton and Kaine,Dem,4
-Stafford,Cooper W,President,,Johnson and Weld,Lib,0
-Stafford,Cooper W,President,,Stein and Baraka,Ind,0
-Stafford,Cooper W,President,,Michael Maturen,,0
-Stafford,Cooper W,President,,Evan McMullin,,0
-Stafford,Cooper W,U.S. Senate,,Patrick Wiesner,Dem,1
-Stafford,Cooper W,U.S. Senate,,Robert Garrard,Lib,3
-Stafford,Cooper W,U.S. Senate,,Jerry Moran,Rep,31
-Stafford,Cooper W,U.S. House,4,Daniel Giroux,Dem,2
-Stafford,Cooper W,U.S. House,4,Gorden Bakken,Lib,1
-Stafford,Cooper W,U.S. House,4,Michael Pompeo,Rep,30
-Stafford,Cooper W,U.S. House,4,Miranda Allen,Ind,2
-Stafford,Cooper W,State Senate ,33,Mary Jo Taylor,Rep,23
-Stafford,Cooper W,State Senate,33,Matt Bristow,Dem,11
-Stafford,Cooper W,State House,113,Greg Lewis,Rep,30
-Stafford,Douglas,President,,Trump and Pence,Rep,41
-Stafford,Douglas,President,,Clinton and Kaine,Dem,9
-Stafford,Douglas,President,,Johnson and Weld,Lib,3
-Stafford,Douglas,President,,Stein and Baraka,Ind,1
-Stafford,Douglas,President,,Michael Maturen,,0
-Stafford,Douglas,President,,Evan McMullin,,0
-Stafford,Douglas,U.S. Senate,,Patrick Wiesner,Dem,7
-Stafford,Douglas,U.S. Senate,,Robert Garrard,Lib,3
-Stafford,Douglas,U.S. Senate,,Jerry Moran,Rep,42
-Stafford,Douglas,U.S. House,4,Daniel Giroux,Dem,8
-Stafford,Douglas,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Douglas,U.S. House,4,Michael Pompeo,Rep,37
-Stafford,Douglas,U.S. House,4,Miranda Allen,Ind,7
-Stafford,Douglas,State Senate ,33,Mary Jo Taylor,Rep,42
-Stafford,Douglas,State Senate,33,Matt Bristow,Dem,11
-Stafford,Douglas,State House,113,Greg Lewis,Rep,53
-Stafford,Fairview,President,,Trump and Pence,Rep,37
-Stafford,Fairview,President,,Clinton and Kaine,Dem,12
-Stafford,Fairview,President,,Johnson and Weld,Lib,3
-Stafford,Fairview,President,,Stein and Baraka,Ind,0
-Stafford,Fairview,President,,Michael Maturen,,0
-Stafford,Fairview,President,,Evan McMullin,,0
-Stafford,Fairview,U.S. Senate,,Patrick Wiesner,Dem,6
-Stafford,Fairview,U.S. Senate,,Robert Garrard,Lib,1
-Stafford,Fairview,U.S. Senate,,Jerry Moran,Rep,46
-Stafford,Fairview,U.S. House,4,Daniel Giroux,Dem,5
-Stafford,Fairview,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Fairview,U.S. House,4,Michael Pompeo,Rep,42
-Stafford,Fairview,U.S. House,4,Miranda Allen,Ind,6
-Stafford,Fairview,State Senate ,33,Mary Jo Taylor,Rep,47
-Stafford,Fairview,State Senate,33,Matt Bristow,Dem,3
-Stafford,Fairview,State House,113,Greg Lewis,Rep,53
-Stafford,Farmington,President,,Trump and Pence,Rep,151
-Stafford,Farmington,President,,Clinton and Kaine,Dem,30
-Stafford,Farmington,President,,Johnson and Weld,Lib,6
-Stafford,Farmington,President,,Stein and Baraka,Ind,6
-Stafford,Farmington,President,,Michael Maturen,,0
-Stafford,Farmington,President,,Evan McMullin,,0
-Stafford,Farmington,U.S. Senate,,Patrick Wiesner,Dem,21
-Stafford,Farmington,U.S. Senate,,Robert Garrard,Lib,6
-Stafford,Farmington,U.S. Senate,,Jerry Moran,Rep,163
-Stafford,Farmington,U.S. House,4,Daniel Giroux,Dem,19
-Stafford,Farmington,U.S. House,4,Gorden Bakken,Lib,3
-Stafford,Farmington,U.S. House,4,Michael Pompeo,Rep,152
-Stafford,Farmington,U.S. House,4,Miranda Allen,Ind,17
-Stafford,Farmington,State Senate ,33,Mary Jo Taylor,Rep,158
-Stafford,Farmington,State Senate,33,Matt Bristow,Dem,33
-Stafford,Farmington,State House,113,Greg Lewis,Rep,177
-Stafford,Hayes,President,,Trump and Pence,Rep,71
-Stafford,Hayes,President,,Clinton and Kaine,Dem,12
-Stafford,Hayes,President,,Johnson and Weld,Lib,2
-Stafford,Hayes,President,,Stein and Baraka,Ind,4
-Stafford,Hayes,President,,Michael Maturen,,0
-Stafford,Hayes,President,,Evan McMullin,,0
-Stafford,Hayes,U.S. Senate,,Patrick Wiesner,Dem,9
-Stafford,Hayes,U.S. Senate,,Robert Garrard,Lib,4
-Stafford,Hayes,U.S. Senate,,Jerry Moran,Rep,81
-Stafford,Hayes,U.S. House,4,Daniel Giroux,Dem,8
-Stafford,Hayes,U.S. House,4,Gorden Bakken,Lib,3
-Stafford,Hayes,U.S. House,4,Michael Pompeo,Rep,69
-Stafford,Hayes,U.S. House,4,Miranda Allen,Ind,14
-Stafford,Hayes,State Senate ,33,Mary Jo Taylor,Rep,84
-Stafford,Hayes,State Senate,33,Matt Bristow,Dem,12
-Stafford,Hayes,State House,113,Greg Lewis,Rep,93
-Stafford,Lincoln,President,,Trump and Pence,Rep,49
-Stafford,Lincoln,President,,Clinton and Kaine,Dem,4
-Stafford,Lincoln,President,,Johnson and Weld,Lib,3
-Stafford,Lincoln,President,,Stein and Baraka,Ind,1
-Stafford,Lincoln,President,,Michael Maturen,,0
-Stafford,Lincoln,President,,Evan McMullin,,0
-Stafford,Lincoln,U.S. Senate,,Patrick Wiesner,Dem,3
-Stafford,Lincoln,U.S. Senate,,Robert Garrard,Lib,0
-Stafford,Lincoln,U.S. Senate,,Jerry Moran,Rep,53
-Stafford,Lincoln,U.S. House,4,Daniel Giroux,Dem,4
-Stafford,Lincoln,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Lincoln,U.S. House,4,Michael Pompeo,Rep,50
-Stafford,Lincoln,U.S. House,4,Miranda Allen,Ind,1
-Stafford,Lincoln,State Senate ,33,Mary Jo Taylor,Rep,48
-Stafford,Lincoln,State Senate,33,Matt Bristow,Dem,7
-Stafford,Lincoln,State House,113,Greg Lewis,Rep,56
-Stafford,Ohio,President,,Trump and Pence,Rep,38
-Stafford,Ohio,President,,Clinton and Kaine,Dem,5
-Stafford,Ohio,President,,Johnson and Weld,Lib,1
-Stafford,Ohio,President,,Stein and Baraka,Ind,1
-Stafford,Ohio,President,,Michael Maturen,,0
-Stafford,Ohio,President,,Evan McMullin,,0
-Stafford,Ohio,U.S. Senate,,Patrick Wiesner,Dem,3
-Stafford,Ohio,U.S. Senate,,Robert Garrard,Lib,2
-Stafford,Ohio,U.S. Senate,,Jerry Moran,Rep,40
-Stafford,Ohio,U.S. House,4,Daniel Giroux,Dem,4
-Stafford,Ohio,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Ohio,U.S. House,4,Michael Pompeo,Rep,38
-Stafford,Ohio,U.S. House,4,Miranda Allen,Ind,1
-Stafford,Ohio,State Senate ,33,Mary Jo Taylor,Rep,36
-Stafford,Ohio,State Senate,33,Matt Bristow,Dem,7
-Stafford,Ohio,State House,113,Greg Lewis,Rep,40
-Stafford,Putnam,President,,Trump and Pence,Rep,7
-Stafford,Putnam,President,,Clinton and Kaine,Dem,3
-Stafford,Putnam,President,,Johnson and Weld,Lib,1
-Stafford,Putnam,President,,Stein and Baraka,Ind,0
-Stafford,Putnam,President,,Michael Maturen,,0
-Stafford,Putnam,President,,Evan McMullin,,0
-Stafford,Putnam,U.S. Senate,,Patrick Wiesner,Dem,2
-Stafford,Putnam,U.S. Senate,,Robert Garrard,Lib,0
-Stafford,Putnam,U.S. Senate,,Jerry Moran,Rep,9
-Stafford,Putnam,U.S. House,4,Daniel Giroux,Dem,0
-Stafford,Putnam,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Putnam,U.S. House,4,Michael Pompeo,Rep,11
-Stafford,Putnam,U.S. House,4,Miranda Allen,Ind,0
-Stafford,Putnam,State Senate ,33,Mary Jo Taylor,Rep,10
-Stafford,Putnam,State Senate,33,Matt Bristow,Dem,1
-Stafford,Putnam,State House,113,Greg Lewis,Rep,11
-Stafford,Richland,President,,Trump and Pence,Rep,19
-Stafford,Richland,President,,Clinton and Kaine,Dem,3
-Stafford,Richland,President,,Johnson and Weld,Lib,0
-Stafford,Richland,President,,Stein and Baraka,Ind,1
-Stafford,Richland,President,,Michael Maturen,,0
-Stafford,Richland,President,,Evan McMullin,,0
-Stafford,Richland,U.S. Senate,,Patrick Wiesner,Dem,1
-Stafford,Richland,U.S. Senate,,Robert Garrard,Lib,1
-Stafford,Richland,U.S. Senate,,Jerry Moran,Rep,20
-Stafford,Richland,U.S. House,4,Daniel Giroux,Dem,1
-Stafford,Richland,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Richland,U.S. House,4,Michael Pompeo,Rep,20
-Stafford,Richland,U.S. House,4,Miranda Allen,Ind,1
-Stafford,Richland,State Senate ,33,Mary Jo Taylor,Rep,21
-Stafford,Richland,State Senate,33,Matt Bristow,Dem,2
-Stafford,Richland,State House,113,Greg Lewis,Rep,23
-Stafford,Rose Valley,President,,Trump and Pence,Rep,22
-Stafford,Rose Valley,President,,Clinton and Kaine,Dem,11
-Stafford,Rose Valley,President,,Johnson and Weld,Lib,2
-Stafford,Rose Valley,President,,Stein and Baraka,Ind,0
-Stafford,Rose Valley,President,,Michael Maturen,,0
-Stafford,Rose Valley,President,,Evan McMullin,,0
-Stafford,Rose Valley,U.S. Senate,,Patrick Wiesner,Dem,7
-Stafford,Rose Valley,U.S. Senate,,Robert Garrard,Lib,2
-Stafford,Rose Valley,U.S. Senate,,Jerry Moran,Rep,24
-Stafford,Rose Valley,U.S. House,4,Daniel Giroux,Dem,6
-Stafford,Rose Valley,U.S. House,4,Gorden Bakken,Lib,1
-Stafford,Rose Valley,U.S. House,4,Michael Pompeo,Rep,23
-Stafford,Rose Valley,U.S. House,4,Miranda Allen,Ind,2
-Stafford,Rose Valley,State Senate ,33,Mary Jo Taylor,Rep,27
-Stafford,Rose Valley,State Senate,33,Matt Bristow,Dem,7
-Stafford,Rose Valley,State House,113,Greg Lewis,Rep,31
-Stafford,Seward N,President,,Trump and Pence,Rep,66
-Stafford,Seward N,President,,Clinton and Kaine,Dem,7
-Stafford,Seward N,President,,Johnson and Weld,Lib,3
-Stafford,Seward N,President,,Stein and Baraka,Ind,1
-Stafford,Seward N,President,,Michael Maturen,,0
-Stafford,Seward N,President,,Evan McMullin,,0
-Stafford,Seward N,U.S. Senate,,Patrick Wiesner,Dem,6
-Stafford,Seward N,U.S. Senate,,Robert Garrard,Lib,3
-Stafford,Seward N,U.S. Senate,,Jerry Moran,Rep,68
-Stafford,Seward N,U.S. House,4,Daniel Giroux,Dem,7
-Stafford,Seward N,U.S. House,4,Gorden Bakken,Lib,1
-Stafford,Seward N,U.S. House,4,Michael Pompeo,Rep,63
-Stafford,Seward N,U.S. House,4,Miranda Allen,Ind,6
-Stafford,Seward N,State Senate ,33,Mary Jo Taylor,Rep,65
-Stafford,Seward N,State Senate,33,Matt Bristow,Dem,11
-Stafford,Seward N,State House,113,Greg Lewis,Rep,70
-Stafford,Seward S,President,,Trump and Pence,Rep,26
-Stafford,Seward S,President,,Clinton and Kaine,Dem,0
-Stafford,Seward S,President,,Johnson and Weld,Lib,2
-Stafford,Seward S,President,,Stein and Baraka,Ind,0
-Stafford,Seward S,President,,Michael Maturen,,0
-Stafford,Seward S,President,,Evan McMullin,,0
-Stafford,Seward S,U.S. Senate,,Patrick Wiesner,Dem,0
-Stafford,Seward S,U.S. Senate,,Robert Garrard,Lib,2
-Stafford,Seward S,U.S. Senate,,Jerry Moran,Rep,26
-Stafford,Seward S,U.S. House,4,Daniel Giroux,Dem,1
-Stafford,Seward S,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Seward S,U.S. House,4,Michael Pompeo,Rep,23
-Stafford,Seward S,U.S. House,4,Miranda Allen,Ind,1
-Stafford,Seward S,State Senate ,33,Mary Jo Taylor,Rep,24
-Stafford,Seward S,State Senate,33,Matt Bristow,Dem,3
-Stafford,Seward S,State House,113,Greg Lewis,Rep,27
-Stafford,Union,President,,Trump and Pence,Rep,12
-Stafford,Union,President,,Clinton and Kaine,Dem,1
-Stafford,Union,President,,Johnson and Weld,Lib,1
-Stafford,Union,President,,Stein and Baraka,Ind,1
-Stafford,Union,President,,Michael Maturen,,0
-Stafford,Union,President,,Evan McMullin,,0
-Stafford,Union,U.S. Senate,,Patrick Wiesner,Dem,4
-Stafford,Union,U.S. Senate,,Robert Garrard,Lib,0
-Stafford,Union,U.S. Senate,,Jerry Moran,Rep,10
-Stafford,Union,U.S. House,4,Daniel Giroux,Dem,4
-Stafford,Union,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,Union,U.S. House,4,Michael Pompeo,Rep,10
-Stafford,Union,U.S. House,4,Miranda Allen,Ind,1
-Stafford,Union,State Senate ,33,Mary Jo Taylor,Rep,10
-Stafford,Union,State Senate,33,Matt Bristow,Dem,4
-Stafford,Union,State House,113,Greg Lewis,Rep,11
-Stafford,York,President,,Trump and Pence,Rep,21
-Stafford,York,President,,Clinton and Kaine,Dem,1
-Stafford,York,President,,Johnson and Weld,Lib,0
-Stafford,York,President,,Stein and Baraka,Ind,0
-Stafford,York,President,,Michael Maturen,,0
-Stafford,York,President,,Evan McMullin,,0
-Stafford,York,U.S. Senate,,Patrick Wiesner,Dem,1
-Stafford,York,U.S. Senate,,Robert Garrard,Lib,0
-Stafford,York,U.S. Senate,,Jerry Moran,Rep,20
-Stafford,York,U.S. House,4,Daniel Giroux,Dem,0
-Stafford,York,U.S. House,4,Gorden Bakken,Lib,0
-Stafford,York,U.S. House,4,Michael Pompeo,Rep,17
-Stafford,York,U.S. House,4,Miranda Allen,Ind,3
-Stafford,York,State Senate ,33,Mary Jo Taylor,Rep,17
-Stafford,York,State Senate,33,Matt Bristow,Dem,2
-Stafford,York,State House,113,Greg Lewis,Rep,20
+county,precinct,office,district,party,candidate,votes,vtd
+STAFFORD,Albano Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",22,000010
+STAFFORD,Byron Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",31,000020
+STAFFORD,Clear Creek Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",20,000030
+STAFFORD,Cleveland Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",39,000040
+STAFFORD,Douglas Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",53,000050
+STAFFORD,East Cooper Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",22,000060
+STAFFORD,East St. John,Kansas House of Representatives,113,Republican,"Lewis, Greg",221,000070
+STAFFORD,Fairview Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",53,000080
+STAFFORD,Farmington Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",177,000090
+STAFFORD,Hayes Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",93,000100
+STAFFORD,Lincoln Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",56,000110
+STAFFORD,North Seward Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",70,000120
+STAFFORD,North Stafford,Kansas House of Representatives,113,Republican,"Lewis, Greg",239,000130
+STAFFORD,Ohio Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",40,000140
+STAFFORD,Putnam Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",11,000150
+STAFFORD,Richland Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",23,000160
+STAFFORD,Rose Valley Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",31,000170
+STAFFORD,South Seward Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",27,000180
+STAFFORD,South St. John,Kansas House of Representatives,113,Republican,"Lewis, Greg",109,000190
+STAFFORD,South Stafford,Kansas House of Representatives,113,Republican,"Lewis, Greg",207,000200
+STAFFORD,Union Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",11,000210
+STAFFORD,West Cooper Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",30,000220
+STAFFORD,West St. John,Kansas House of Representatives,113,Republican,"Lewis, Greg",178,000230
+STAFFORD,York Township,Kansas House of Representatives,113,Republican,"Lewis, Greg",20,000240
+STAFFORD,Albano Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000010
+STAFFORD,Albano Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",22,000010
+STAFFORD,Byron Township,Kansas Senate,33,Democratic,"Bristow, Matt",0,000020
+STAFFORD,Byron Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",32,000020
+STAFFORD,Clear Creek Township,Kansas Senate,33,Democratic,"Bristow, Matt",0,000030
+STAFFORD,Clear Creek Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",17,000030
+STAFFORD,Cleveland Township,Kansas Senate,33,Democratic,"Bristow, Matt",6,000040
+STAFFORD,Cleveland Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",30,000040
+STAFFORD,Douglas Township,Kansas Senate,33,Democratic,"Bristow, Matt",11,000050
+STAFFORD,Douglas Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",42,000050
+STAFFORD,East Cooper Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000060
+STAFFORD,East Cooper Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",20,000060
+STAFFORD,East St. John,Kansas Senate,33,Democratic,"Bristow, Matt",31,000070
+STAFFORD,East St. John,Kansas Senate,33,Republican,"Taylor, Mary Jo",187,000070
+STAFFORD,Fairview Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000080
+STAFFORD,Fairview Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",47,000080
+STAFFORD,Farmington Township,Kansas Senate,33,Democratic,"Bristow, Matt",33,000090
+STAFFORD,Farmington Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",158,000090
+STAFFORD,Hayes Township,Kansas Senate,33,Democratic,"Bristow, Matt",12,000100
+STAFFORD,Hayes Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",84,000100
+STAFFORD,Lincoln Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000110
+STAFFORD,Lincoln Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",48,000110
+STAFFORD,North Seward Township,Kansas Senate,33,Democratic,"Bristow, Matt",11,000120
+STAFFORD,North Seward Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",65,000120
+STAFFORD,North Stafford,Kansas Senate,33,Democratic,"Bristow, Matt",28,000130
+STAFFORD,North Stafford,Kansas Senate,33,Republican,"Taylor, Mary Jo",227,000130
+STAFFORD,Ohio Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000140
+STAFFORD,Ohio Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",36,000140
+STAFFORD,Putnam Township,Kansas Senate,33,Democratic,"Bristow, Matt",1,000150
+STAFFORD,Putnam Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",10,000150
+STAFFORD,Richland Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000160
+STAFFORD,Richland Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",21,000160
+STAFFORD,Rose Valley Township,Kansas Senate,33,Democratic,"Bristow, Matt",7,000170
+STAFFORD,Rose Valley Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",27,000170
+STAFFORD,South Seward Township,Kansas Senate,33,Democratic,"Bristow, Matt",3,000180
+STAFFORD,South Seward Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",24,000180
+STAFFORD,South St. John,Kansas Senate,33,Democratic,"Bristow, Matt",17,000190
+STAFFORD,South St. John,Kansas Senate,33,Republican,"Taylor, Mary Jo",95,000190
+STAFFORD,South Stafford,Kansas Senate,33,Democratic,"Bristow, Matt",42,000200
+STAFFORD,South Stafford,Kansas Senate,33,Republican,"Taylor, Mary Jo",184,000200
+STAFFORD,Union Township,Kansas Senate,33,Democratic,"Bristow, Matt",4,000210
+STAFFORD,Union Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",10,000210
+STAFFORD,West Cooper Township,Kansas Senate,33,Democratic,"Bristow, Matt",11,000220
+STAFFORD,West Cooper Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",23,000220
+STAFFORD,West St. John,Kansas Senate,33,Democratic,"Bristow, Matt",20,000230
+STAFFORD,West St. John,Kansas Senate,33,Republican,"Taylor, Mary Jo",169,000230
+STAFFORD,York Township,Kansas Senate,33,Democratic,"Bristow, Matt",2,000240
+STAFFORD,York Township,Kansas Senate,33,Republican,"Taylor, Mary Jo",17,000240
+STAFFORD,Albano Township,President / Vice President,,independent,"Stein, Jill",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+STAFFORD,Albano Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+STAFFORD,Albano Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000010
+STAFFORD,Albano Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+STAFFORD,Albano Township,President / Vice President,,Republican,"Trump, Donald J.",22,000010
+STAFFORD,Byron Township,President / Vice President,,independent,"Stein, Jill",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+STAFFORD,Byron Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+STAFFORD,Byron Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+STAFFORD,Byron Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+STAFFORD,Byron Township,President / Vice President,,Republican,"Trump, Donald J.",32,000020
+STAFFORD,Clear Creek Township,President / Vice President,,independent,"Stein, Jill",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+STAFFORD,Clear Creek Township,President / Vice President,,Republican,"Trump, Donald J.",20,000030
+STAFFORD,Cleveland Township,President / Vice President,,independent,"Stein, Jill",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+STAFFORD,Cleveland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000040
+STAFFORD,Cleveland Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+STAFFORD,Cleveland Township,President / Vice President,,Republican,"Trump, Donald J.",32,000040
+STAFFORD,Douglas Township,President / Vice President,,independent,"Stein, Jill",1,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+STAFFORD,Douglas Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+STAFFORD,Douglas Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000050
+STAFFORD,Douglas Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000050
+STAFFORD,Douglas Township,President / Vice President,,Republican,"Trump, Donald J.",41,000050
+STAFFORD,East Cooper Township,President / Vice President,,independent,"Stein, Jill",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+STAFFORD,East Cooper Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000060
+STAFFORD,East Cooper Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+STAFFORD,East Cooper Township,President / Vice President,,Republican,"Trump, Donald J.",18,000060
+STAFFORD,East St. John,President / Vice President,,independent,"Stein, Jill",3,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Hedges, James A",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Maturen, Michael A",1,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"McMullin, Evan",5,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Perry, Darryl",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Smith, Mike",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Sood, Ajay",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+STAFFORD,East St. John,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+STAFFORD,East St. John,President / Vice President,,Democratic,"Clinton, Hillary Rodham",47,000070
+STAFFORD,East St. John,President / Vice President,,Libertarian,"Johnson, Gary",5,000070
+STAFFORD,East St. John,President / Vice President,,Republican,"Trump, Donald J.",160,000070
+STAFFORD,Fairview Township,President / Vice President,,independent,"Stein, Jill",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+STAFFORD,Fairview Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+STAFFORD,Fairview Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000080
+STAFFORD,Fairview Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000080
+STAFFORD,Fairview Township,President / Vice President,,Republican,"Trump, Donald J.",37,000080
+STAFFORD,Farmington Township,President / Vice President,,independent,"Stein, Jill",6,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+STAFFORD,Farmington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+STAFFORD,Farmington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",30,000090
+STAFFORD,Farmington Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000090
+STAFFORD,Farmington Township,President / Vice President,,Republican,"Trump, Donald J.",151,000090
+STAFFORD,Hayes Township,President / Vice President,,independent,"Stein, Jill",4,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+STAFFORD,Hayes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+STAFFORD,Hayes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000100
+STAFFORD,Hayes Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+STAFFORD,Hayes Township,President / Vice President,,Republican,"Trump, Donald J.",71,000100
+STAFFORD,Lincoln Township,President / Vice President,,independent,"Stein, Jill",1,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+STAFFORD,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000110
+STAFFORD,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000110
+STAFFORD,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",49,000110
+STAFFORD,North Seward Township,President / Vice President,,independent,"Stein, Jill",1,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+STAFFORD,North Seward Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+STAFFORD,North Seward Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000120
+STAFFORD,North Seward Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000120
+STAFFORD,North Seward Township,President / Vice President,,Republican,"Trump, Donald J.",66,000120
+STAFFORD,North Stafford,President / Vice President,,independent,"Stein, Jill",5,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Hedges, James A",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"McMullin, Evan",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Perry, Darryl",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Smith, Mike",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Sood, Ajay",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+STAFFORD,North Stafford,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+STAFFORD,North Stafford,President / Vice President,,Democratic,"Clinton, Hillary Rodham",48,000130
+STAFFORD,North Stafford,President / Vice President,,Libertarian,"Johnson, Gary",11,000130
+STAFFORD,North Stafford,President / Vice President,,Republican,"Trump, Donald J.",194,000130
+STAFFORD,Ohio Township,President / Vice President,,independent,"Stein, Jill",1,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+STAFFORD,Ohio Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+STAFFORD,Ohio Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000140
+STAFFORD,Ohio Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000140
+STAFFORD,Ohio Township,President / Vice President,,Republican,"Trump, Donald J.",38,000140
+STAFFORD,Putnam Township,President / Vice President,,independent,"Stein, Jill",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+STAFFORD,Putnam Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+STAFFORD,Putnam Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000150
+STAFFORD,Putnam Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+STAFFORD,Putnam Township,President / Vice President,,Republican,"Trump, Donald J.",7,000150
+STAFFORD,Richland Township,President / Vice President,,independent,"Stein, Jill",1,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+STAFFORD,Richland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+STAFFORD,Richland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000160
+STAFFORD,Richland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000160
+STAFFORD,Richland Township,President / Vice President,,Republican,"Trump, Donald J.",19,000160
+STAFFORD,Rose Valley Township,President / Vice President,,independent,"Stein, Jill",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000170
+STAFFORD,Rose Valley Township,President / Vice President,,Republican,"Trump, Donald J.",22,000170
+STAFFORD,South Seward Township,President / Vice President,,independent,"Stein, Jill",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+STAFFORD,South Seward Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+STAFFORD,South Seward Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000180
+STAFFORD,South Seward Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000180
+STAFFORD,South Seward Township,President / Vice President,,Republican,"Trump, Donald J.",26,000180
+STAFFORD,South St. John,President / Vice President,,independent,"Stein, Jill",5,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Hedges, James A",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"McMullin, Evan",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Perry, Darryl",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Smith, Mike",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Sood, Ajay",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+STAFFORD,South St. John,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+STAFFORD,South St. John,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000190
+STAFFORD,South St. John,President / Vice President,,Libertarian,"Johnson, Gary",8,000190
+STAFFORD,South St. John,President / Vice President,,Republican,"Trump, Donald J.",83,000190
+STAFFORD,South Stafford,President / Vice President,,independent,"Stein, Jill",2,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Hedges, James A",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"McMullin, Evan",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Perry, Darryl",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Smith, Mike",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Sood, Ajay",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+STAFFORD,South Stafford,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+STAFFORD,South Stafford,President / Vice President,,Democratic,"Clinton, Hillary Rodham",51,000200
+STAFFORD,South Stafford,President / Vice President,,Libertarian,"Johnson, Gary",1,000200
+STAFFORD,South Stafford,President / Vice President,,Republican,"Trump, Donald J.",171,000200
+STAFFORD,Union Township,President / Vice President,,independent,"Stein, Jill",1,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+STAFFORD,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+STAFFORD,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000210
+STAFFORD,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+STAFFORD,Union Township,President / Vice President,,Republican,"Trump, Donald J.",12,000210
+STAFFORD,West Cooper Township,President / Vice President,,independent,"Stein, Jill",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000220
+STAFFORD,West Cooper Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000220
+STAFFORD,West Cooper Township,President / Vice President,,Republican,"Trump, Donald J.",32,000220
+STAFFORD,West St. John,President / Vice President,,independent,"Stein, Jill",3,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Hedges, James A",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"McMullin, Evan",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Perry, Darryl",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Smith, Mike",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Sood, Ajay",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+STAFFORD,West St. John,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+STAFFORD,West St. John,President / Vice President,,Democratic,"Clinton, Hillary Rodham",24,000230
+STAFFORD,West St. John,President / Vice President,,Libertarian,"Johnson, Gary",6,000230
+STAFFORD,West St. John,President / Vice President,,Republican,"Trump, Donald J.",166,000230
+STAFFORD,York Township,President / Vice President,,independent,"Stein, Jill",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+STAFFORD,York Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+STAFFORD,York Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000240
+STAFFORD,York Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000240
+STAFFORD,York Township,President / Vice President,,Republican,"Trump, Donald J.",21,000240
+STAFFORD,Albano Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000010
+STAFFORD,Albano Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000010
+STAFFORD,Albano Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000010
+STAFFORD,Albano Township,United States House of Representatives,4,Republican,"Pompeo, Michael",19,000010
+STAFFORD,Byron Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000020
+STAFFORD,Byron Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000020
+STAFFORD,Byron Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000020
+STAFFORD,Byron Township,United States House of Representatives,4,Republican,"Pompeo, Michael",32,000020
+STAFFORD,Clear Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000030
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000030
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000030
+STAFFORD,Clear Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",20,000030
+STAFFORD,Cleveland Township,United States House of Representatives,4,independent,"Allen, Miranda",4,000040
+STAFFORD,Cleveland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000040
+STAFFORD,Cleveland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000040
+STAFFORD,Cleveland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",31,000040
+STAFFORD,Douglas Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000050
+STAFFORD,Douglas Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000050
+STAFFORD,Douglas Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000050
+STAFFORD,Douglas Township,United States House of Representatives,4,Republican,"Pompeo, Michael",37,000050
+STAFFORD,East Cooper Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000060
+STAFFORD,East Cooper Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",3,000060
+STAFFORD,East Cooper Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000060
+STAFFORD,East Cooper Township,United States House of Representatives,4,Republican,"Pompeo, Michael",19,000060
+STAFFORD,East St. John,United States House of Representatives,4,independent,"Allen, Miranda",18,000070
+STAFFORD,East St. John,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",29,000070
+STAFFORD,East St. John,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000070
+STAFFORD,East St. John,United States House of Representatives,4,Republican,"Pompeo, Michael",172,000070
+STAFFORD,Fairview Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000080
+STAFFORD,Fairview Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",5,000080
+STAFFORD,Fairview Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000080
+STAFFORD,Fairview Township,United States House of Representatives,4,Republican,"Pompeo, Michael",42,000080
+STAFFORD,Farmington Township,United States House of Representatives,4,independent,"Allen, Miranda",17,000090
+STAFFORD,Farmington Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",19,000090
+STAFFORD,Farmington Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000090
+STAFFORD,Farmington Township,United States House of Representatives,4,Republican,"Pompeo, Michael",152,000090
+STAFFORD,Hayes Township,United States House of Representatives,4,independent,"Allen, Miranda",14,000100
+STAFFORD,Hayes Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000100
+STAFFORD,Hayes Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000100
+STAFFORD,Hayes Township,United States House of Representatives,4,Republican,"Pompeo, Michael",69,000100
+STAFFORD,Lincoln Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000110
+STAFFORD,Lincoln Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000110
+STAFFORD,Lincoln Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000110
+STAFFORD,Lincoln Township,United States House of Representatives,4,Republican,"Pompeo, Michael",50,000110
+STAFFORD,North Seward Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000120
+STAFFORD,North Seward Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",7,000120
+STAFFORD,North Seward Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000120
+STAFFORD,North Seward Township,United States House of Representatives,4,Republican,"Pompeo, Michael",63,000120
+STAFFORD,North Stafford,United States House of Representatives,4,independent,"Allen, Miranda",23,000130
+STAFFORD,North Stafford,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",28,000130
+STAFFORD,North Stafford,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000130
+STAFFORD,North Stafford,United States House of Representatives,4,Republican,"Pompeo, Michael",200,000130
+STAFFORD,Ohio Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000140
+STAFFORD,Ohio Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000140
+STAFFORD,Ohio Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000140
+STAFFORD,Ohio Township,United States House of Representatives,4,Republican,"Pompeo, Michael",38,000140
+STAFFORD,Putnam Township,United States House of Representatives,4,independent,"Allen, Miranda",0,000150
+STAFFORD,Putnam Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000150
+STAFFORD,Putnam Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000150
+STAFFORD,Putnam Township,United States House of Representatives,4,Republican,"Pompeo, Michael",11,000150
+STAFFORD,Richland Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000160
+STAFFORD,Richland Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000160
+STAFFORD,Richland Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000160
+STAFFORD,Richland Township,United States House of Representatives,4,Republican,"Pompeo, Michael",20,000160
+STAFFORD,Rose Valley Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000170
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000170
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000170
+STAFFORD,Rose Valley Township,United States House of Representatives,4,Republican,"Pompeo, Michael",23,000170
+STAFFORD,South Seward Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000180
+STAFFORD,South Seward Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000180
+STAFFORD,South Seward Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000180
+STAFFORD,South Seward Township,United States House of Representatives,4,Republican,"Pompeo, Michael",23,000180
+STAFFORD,South St. John,United States House of Representatives,4,independent,"Allen, Miranda",10,000190
+STAFFORD,South St. John,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",16,000190
+STAFFORD,South St. John,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000190
+STAFFORD,South St. John,United States House of Representatives,4,Republican,"Pompeo, Michael",86,000190
+STAFFORD,South Stafford,United States House of Representatives,4,independent,"Allen, Miranda",14,000200
+STAFFORD,South Stafford,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",38,000200
+STAFFORD,South Stafford,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000200
+STAFFORD,South Stafford,United States House of Representatives,4,Republican,"Pompeo, Michael",161,000200
+STAFFORD,Union Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000210
+STAFFORD,Union Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000210
+STAFFORD,Union Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000210
+STAFFORD,Union Township,United States House of Representatives,4,Republican,"Pompeo, Michael",10,000210
+STAFFORD,West Cooper Township,United States House of Representatives,4,independent,"Allen, Miranda",2,000220
+STAFFORD,West Cooper Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,000220
+STAFFORD,West Cooper Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000220
+STAFFORD,West Cooper Township,United States House of Representatives,4,Republican,"Pompeo, Michael",30,000220
+STAFFORD,West St. John,United States House of Representatives,4,independent,"Allen, Miranda",13,000230
+STAFFORD,West St. John,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000230
+STAFFORD,West St. John,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000230
+STAFFORD,West St. John,United States House of Representatives,4,Republican,"Pompeo, Michael",163,000230
+STAFFORD,York Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000240
+STAFFORD,York Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,000240
+STAFFORD,York Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000240
+STAFFORD,York Township,United States House of Representatives,4,Republican,"Pompeo, Michael",17,000240
+STAFFORD,Albano Township,United States Senate,,write - in,"Smith, DJ",0,000010
+STAFFORD,Albano Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000010
+STAFFORD,Albano Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+STAFFORD,Albano Township,United States Senate,,Republican,"Moran, Jerry",19,000010
+STAFFORD,Byron Township,United States Senate,,write - in,"Smith, DJ",0,000020
+STAFFORD,Byron Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000020
+STAFFORD,Byron Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000020
+STAFFORD,Byron Township,United States Senate,,Republican,"Moran, Jerry",31,000020
+STAFFORD,Clear Creek Township,United States Senate,,write - in,"Smith, DJ",0,000030
+STAFFORD,Clear Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000030
+STAFFORD,Clear Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+STAFFORD,Clear Creek Township,United States Senate,,Republican,"Moran, Jerry",20,000030
+STAFFORD,Cleveland Township,United States Senate,,write - in,"Smith, DJ",0,000040
+STAFFORD,Cleveland Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000040
+STAFFORD,Cleveland Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000040
+STAFFORD,Cleveland Township,United States Senate,,Republican,"Moran, Jerry",33,000040
+STAFFORD,Douglas Township,United States Senate,,write - in,"Smith, DJ",0,000050
+STAFFORD,Douglas Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000050
+STAFFORD,Douglas Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000050
+STAFFORD,Douglas Township,United States Senate,,Republican,"Moran, Jerry",42,000050
+STAFFORD,East Cooper Township,United States Senate,,write - in,"Smith, DJ",0,000060
+STAFFORD,East Cooper Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+STAFFORD,East Cooper Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+STAFFORD,East Cooper Township,United States Senate,,Republican,"Moran, Jerry",21,000060
+STAFFORD,East St. John,United States Senate,,write - in,"Smith, DJ",0,000070
+STAFFORD,East St. John,United States Senate,,Democratic,"Wiesner, Patrick",36,000070
+STAFFORD,East St. John,United States Senate,,Libertarian,"Garrard, Robert D.",12,000070
+STAFFORD,East St. John,United States Senate,,Republican,"Moran, Jerry",172,000070
+STAFFORD,Fairview Township,United States Senate,,write - in,"Smith, DJ",0,000080
+STAFFORD,Fairview Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000080
+STAFFORD,Fairview Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+STAFFORD,Fairview Township,United States Senate,,Republican,"Moran, Jerry",46,000080
+STAFFORD,Farmington Township,United States Senate,,write - in,"Smith, DJ",0,000090
+STAFFORD,Farmington Township,United States Senate,,Democratic,"Wiesner, Patrick",21,000090
+STAFFORD,Farmington Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000090
+STAFFORD,Farmington Township,United States Senate,,Republican,"Moran, Jerry",163,000090
+STAFFORD,Hayes Township,United States Senate,,write - in,"Smith, DJ",0,000100
+STAFFORD,Hayes Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000100
+STAFFORD,Hayes Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000100
+STAFFORD,Hayes Township,United States Senate,,Republican,"Moran, Jerry",81,000100
+STAFFORD,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000110
+STAFFORD,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000110
+STAFFORD,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000110
+STAFFORD,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",53,000110
+STAFFORD,North Seward Township,United States Senate,,write - in,"Smith, DJ",0,000120
+STAFFORD,North Seward Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000120
+STAFFORD,North Seward Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000120
+STAFFORD,North Seward Township,United States Senate,,Republican,"Moran, Jerry",68,000120
+STAFFORD,North Stafford,United States Senate,,write - in,"Smith, DJ",0,000130
+STAFFORD,North Stafford,United States Senate,,Democratic,"Wiesner, Patrick",36,000130
+STAFFORD,North Stafford,United States Senate,,Libertarian,"Garrard, Robert D.",13,000130
+STAFFORD,North Stafford,United States Senate,,Republican,"Moran, Jerry",208,000130
+STAFFORD,Ohio Township,United States Senate,,write - in,"Smith, DJ",0,000140
+STAFFORD,Ohio Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000140
+STAFFORD,Ohio Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000140
+STAFFORD,Ohio Township,United States Senate,,Republican,"Moran, Jerry",40,000140
+STAFFORD,Putnam Township,United States Senate,,write - in,"Smith, DJ",0,000150
+STAFFORD,Putnam Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000150
+STAFFORD,Putnam Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000150
+STAFFORD,Putnam Township,United States Senate,,Republican,"Moran, Jerry",9,000150
+STAFFORD,Richland Township,United States Senate,,write - in,"Smith, DJ",0,000160
+STAFFORD,Richland Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000160
+STAFFORD,Richland Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000160
+STAFFORD,Richland Township,United States Senate,,Republican,"Moran, Jerry",20,000160
+STAFFORD,Rose Valley Township,United States Senate,,write - in,"Smith, DJ",0,000170
+STAFFORD,Rose Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000170
+STAFFORD,Rose Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000170
+STAFFORD,Rose Valley Township,United States Senate,,Republican,"Moran, Jerry",24,000170
+STAFFORD,South Seward Township,United States Senate,,write - in,"Smith, DJ",0,000180
+STAFFORD,South Seward Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000180
+STAFFORD,South Seward Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000180
+STAFFORD,South Seward Township,United States Senate,,Republican,"Moran, Jerry",26,000180
+STAFFORD,South St. John,United States Senate,,write - in,"Smith, DJ",0,000190
+STAFFORD,South St. John,United States Senate,,Democratic,"Wiesner, Patrick",16,000190
+STAFFORD,South St. John,United States Senate,,Libertarian,"Garrard, Robert D.",6,000190
+STAFFORD,South St. John,United States Senate,,Republican,"Moran, Jerry",89,000190
+STAFFORD,South Stafford,United States Senate,,write - in,"Smith, DJ",0,000200
+STAFFORD,South Stafford,United States Senate,,Democratic,"Wiesner, Patrick",42,000200
+STAFFORD,South Stafford,United States Senate,,Libertarian,"Garrard, Robert D.",10,000200
+STAFFORD,South Stafford,United States Senate,,Republican,"Moran, Jerry",172,000200
+STAFFORD,Union Township,United States Senate,,write - in,"Smith, DJ",0,000210
+STAFFORD,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000210
+STAFFORD,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000210
+STAFFORD,Union Township,United States Senate,,Republican,"Moran, Jerry",10,000210
+STAFFORD,West Cooper Township,United States Senate,,write - in,"Smith, DJ",0,000220
+STAFFORD,West Cooper Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000220
+STAFFORD,West Cooper Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000220
+STAFFORD,West Cooper Township,United States Senate,,Republican,"Moran, Jerry",31,000220
+STAFFORD,West St. John,United States Senate,,write - in,"Smith, DJ",0,000230
+STAFFORD,West St. John,United States Senate,,Democratic,"Wiesner, Patrick",17,000230
+STAFFORD,West St. John,United States Senate,,Libertarian,"Garrard, Robert D.",7,000230
+STAFFORD,West St. John,United States Senate,,Republican,"Moran, Jerry",165,000230
+STAFFORD,York Township,United States Senate,,write - in,"Smith, DJ",0,000240
+STAFFORD,York Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000240
+STAFFORD,York Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000240
+STAFFORD,York Township,United States Senate,,Republican,"Moran, Jerry",20,000240

--- a/2016/20161108__ks__general__stanton__precinct.csv
+++ b/2016/20161108__ks__general__stanton__precinct.csv
@@ -1,42 +1,109 @@
-county,precinct,office,district,party,candidate,votes
-Stanton,Big Bow,President,,R,Trump/Pence,72
-Stanton,Big Bow,President,,D,Clinton/Kaine,13
-Stanton,Big Bow,President,,L,Johnson/Weld,2
-Stanton,Big Bow,President,,,Evan McMullin,2
-Stanton,Manter,President,,R,Trump/Pence,76
-Stanton,Manter,President,,D,Clinton/Kaine,8
-Stanton,Manter,President,,L,Johnson/Weld,1
-Stanton,Stanton,President,,R,Trump/Pence,344
-Stanton,Stanton,President,,D,Clinton/Kaine,94
-Stanton,Stanton,President,,L,Johnson/Weld,16
-Stanton,Stanton,President,,,Evan McMullin,2
-Stanton,Big Bow,U.S. Senate,,R,Jerry Moran,77
-Stanton,Big Bow,U.S. Senate,,D,Patrick Wiesner,9
-Stanton,Big Bow,U.S. Senate,,L,Robert D Garrad,6
-Stanton,Manter,U.S. Senate,,R,Jerry Moran,70
-Stanton,Manter,U.S. Senate,,D,Patrick Wiesner,10
-Stanton,Manter,U.S. Senate,,L,Robert D Garrad,4
-Stanton,Stanton,U.S. Senate,,R,Jerry Moran,359
-Stanton,Stanton,U.S. Senate,,D,Patrick Wiesner,59
-Stanton,Stanton,U.S. Senate,,L,Robert D Garrad,26
-Stanton,Big Bow,U.S. House,1,R,Roger Marshall,81
-Stanton,Big Bow,U.S. House,1,I,Alan LaPolice,5
-Stanton,Big Bow,U.S. House,1,L,Kerry Burt,3
-Stanton,Manter,U.S. House,1,R,Roger Marshall,71
-Stanton,Manter,U.S. House,1,I,Alan LaPolice,9
-Stanton,Manter,U.S. House,1,L,Kerry Burt,6
-Stanton,Stanton,U.S. House,1,R,Roger Marshall,348
-Stanton,Stanton,U.S. House,1,I,Alan LaPolice,46
-Stanton,Stanton,U.S. House,1,L,Kerry Burt,39
-Stanton,Stanton,U.S. House,1,,Tim Huelskamp,2
-Stanton,Big Bow,State Senate,39,R,John Doll,78
-Stanton,Big Bow,State Senate,39,D,A Zacheriah Wolf,9
-Stanton,Big Bow,State Senate,39,,Larry Powell,1
-Stanton,Manter,State Senate,39,R,John Doll,73
-Stanton,Manter,State Senate,39,D,A Zacheriah Wolf,7
-Stanton,Stanton,State Senate,39,R,John Doll,363
-Stanton,Stanton,State Senate,39,D,A Zacheriah Wolf,57
-Stanton,Stanton,State Senate,39,,Larry Powell,2
-Stanton,Big Bow,State House,124,R,J Stephen Alford,87
-Stanton,Manter,State House,124,R,J Stephen Alford,75
-Stanton,Stanton,State House,124,R,J Stephen Alford,394
+county,precinct,office,district,party,candidate,votes,vtd
+STANTON,Big Bow,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",87,000010
+STANTON,Manter,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",75,000020
+STANTON,Stanton,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",394,000030
+STANTON,Big Bow,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",9,000010
+STANTON,Big Bow,Kansas Senate,39,Republican,"Doll, John",78,000010
+STANTON,Manter,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",7,000020
+STANTON,Manter,Kansas Senate,39,Republican,"Doll, John",73,000020
+STANTON,Stanton,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",57,000030
+STANTON,Stanton,Kansas Senate,39,Republican,"Doll, John",363,000030
+STANTON,Big Bow,President / Vice President,,independent,"Stein, Jill",1,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Hedges, James A",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"McMullin, Evan",2,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Perry, Darryl",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Smith, Mike",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Sood, Ajay",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+STANTON,Big Bow,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+STANTON,Big Bow,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000010
+STANTON,Big Bow,President / Vice President,,Libertarian,"Johnson, Gary",2,000010
+STANTON,Big Bow,President / Vice President,,Republican,"Trump, Donald J.",72,000010
+STANTON,Manter,President / Vice President,,independent,"Stein, Jill",1,000020
+STANTON,Manter,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+STANTON,Manter,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Hedges, James A",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+STANTON,Manter,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+STANTON,Manter,President / Vice President,,write - in,"McMullin, Evan",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Perry, Darryl",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Smith, Mike",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Sood, Ajay",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+STANTON,Manter,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+STANTON,Manter,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000020
+STANTON,Manter,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+STANTON,Manter,President / Vice President,,Republican,"Trump, Donald J.",76,000020
+STANTON,Stanton,President / Vice President,,independent,"Stein, Jill",5,000030
+STANTON,Stanton,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Hedges, James A",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"McMullin, Evan",2,000030
+STANTON,Stanton,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Perry, Darryl",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Smith, Mike",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Sood, Ajay",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+STANTON,Stanton,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+STANTON,Stanton,President / Vice President,,Democratic,"Clinton, Hillary Rodham",94,000030
+STANTON,Stanton,President / Vice President,,Libertarian,"Johnson, Gary",16,000030
+STANTON,Stanton,President / Vice President,,Republican,"Trump, Donald J.",344,000030
+STANTON,Big Bow,United States House of Representatives,1,independent,"LaPolice, Alan",5,000010
+STANTON,Big Bow,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+STANTON,Big Bow,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000010
+STANTON,Big Bow,United States House of Representatives,1,Republican,"Marshall, Roger",81,000010
+STANTON,Manter,United States House of Representatives,1,independent,"LaPolice, Alan",9,000020
+STANTON,Manter,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+STANTON,Manter,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000020
+STANTON,Manter,United States House of Representatives,1,Republican,"Marshall, Roger",71,000020
+STANTON,Stanton,United States House of Representatives,1,independent,"LaPolice, Alan",46,000030
+STANTON,Stanton,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000030
+STANTON,Stanton,United States House of Representatives,1,Libertarian,"Burt, Kerry",39,000030
+STANTON,Stanton,United States House of Representatives,1,Republican,"Marshall, Roger",348,000030
+STANTON,Big Bow,United States Senate,,write - in,"Smith, DJ",0,000010
+STANTON,Big Bow,United States Senate,,Democratic,"Wiesner, Patrick",9,000010
+STANTON,Big Bow,United States Senate,,Libertarian,"Garrard, Robert D.",6,000010
+STANTON,Big Bow,United States Senate,,Republican,"Moran, Jerry",77,000010
+STANTON,Manter,United States Senate,,write - in,"Smith, DJ",0,000020
+STANTON,Manter,United States Senate,,Democratic,"Wiesner, Patrick",10,000020
+STANTON,Manter,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+STANTON,Manter,United States Senate,,Republican,"Moran, Jerry",70,000020
+STANTON,Stanton,United States Senate,,write - in,"Smith, DJ",0,000030
+STANTON,Stanton,United States Senate,,Democratic,"Wiesner, Patrick",59,000030
+STANTON,Stanton,United States Senate,,Libertarian,"Garrard, Robert D.",26,000030
+STANTON,Stanton,United States Senate,,Republican,"Moran, Jerry",359,000030

--- a/2016/20161108__ks__general__stevens__precinct.csv
+++ b/2016/20161108__ks__general__stevens__precinct.csv
@@ -1,399 +1,649 @@
-county,precinct,office,district,candidate,party,votes
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Stein, Jill  ",independent,1
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Castle, Darrell L ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Hedges, James A ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Maturen, Michael A ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"McMullin, Evan  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Perry, Darryl  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Schriner, Joe C ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Smith, Mike  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Sood, Ajay  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Clinton, Hillary Rodham ",Democratic,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Johnson, Gary  ",Libertarian,0
-Stevens,Hugoton Ward 05 Precinct 02,President,,"Trump, Donald J. ",Republican,9
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Stein, Jill  ",independent,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Castle, Darrell L ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Hedges, James A ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Maturen, Michael A ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"McMullin, Evan  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Perry, Darryl  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Schriner, Joe C ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Smith, Mike  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Sood, Ajay  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Johnson, Gary  ",Libertarian,0
-Stevens,Hugoton Ward 6 Precinct 2,President,,"Trump, Donald J. ",Republican,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Stein, Jill  ",independent,1
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Castle, Darrell L ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Hedges, James A ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Maturen, Michael A ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"McMullin, Evan  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Perry, Darryl  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Schriner, Joe C ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Smith, Mike  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Sood, Ajay  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,1
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Johnson, Gary  ",Libertarian,0
-Stevens,Hugoton Ward 7 Precinct 2,President,,"Trump, Donald J. ",Republican,1
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Stein, Jill  ",independent,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Castle, Darrell L ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Hedges, James A ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Maturen, Michael A ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"McMullin, Evan  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Perry, Darryl  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Schriner, Joe C ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Smith, Mike  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Sood, Ajay  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Clinton, Hillary Rodham ",Democratic,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Johnson, Gary  ",Libertarian,0
-Stevens,Hugoton Ward 8 Precinct 2,President,,"Trump, Donald J. ",Republican,1
-Stevens,Moscow City,President,,"Stein, Jill  ",independent,1
-Stevens,Moscow City,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Moscow City,President,,"Castle, Darrell L ",write - in,0
-Stevens,Moscow City,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Moscow City,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Moscow City,President,,"Hedges, James A ",write - in,0
-Stevens,Moscow City,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Moscow City,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Moscow City,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Moscow City,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Moscow City,President,,"Maturen, Michael A ",write - in,0
-Stevens,Moscow City,President,,"McMullin, Evan  ",write - in,0
-Stevens,Moscow City,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Moscow City,President,,"Perry, Darryl  ",write - in,0
-Stevens,Moscow City,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Moscow City,President,,"Schriner, Joe C ",write - in,0
-Stevens,Moscow City,President,,"Smith, Mike  ",write - in,0
-Stevens,Moscow City,President,,"Sood, Ajay  ",write - in,0
-Stevens,Moscow City,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Moscow City,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Moscow City,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Moscow City,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Moscow City,President,,"Clinton, Hillary Rodham ",Democratic,11
-Stevens,Moscow City,President,,"Johnson, Gary  ",Libertarian,3
-Stevens,Moscow City,President,,"Trump, Donald J. ",Republican,69
-Stevens,Moscow Township,President,,"Stein, Jill  ",independent,1
-Stevens,Moscow Township,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Moscow Township,President,,"Castle, Darrell L ",write - in,0
-Stevens,Moscow Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Moscow Township,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Moscow Township,President,,"Hedges, James A ",write - in,0
-Stevens,Moscow Township,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Moscow Township,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Moscow Township,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Moscow Township,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Moscow Township,President,,"Maturen, Michael A ",write - in,0
-Stevens,Moscow Township,President,,"McMullin, Evan  ",write - in,0
-Stevens,Moscow Township,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Moscow Township,President,,"Perry, Darryl  ",write - in,0
-Stevens,Moscow Township,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Moscow Township,President,,"Schriner, Joe C ",write - in,0
-Stevens,Moscow Township,President,,"Smith, Mike  ",write - in,0
-Stevens,Moscow Township,President,,"Sood, Ajay  ",write - in,0
-Stevens,Moscow Township,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Moscow Township,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Moscow Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Moscow Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Moscow Township,President,,"Clinton, Hillary Rodham ",Democratic,12
-Stevens,Moscow Township,President,,"Johnson, Gary  ",Libertarian,2
-Stevens,Moscow Township,President,,"Trump, Donald J. ",Republican,115
-Stevens,Voorhees Township,President,,"Stein, Jill  ",independent,0
-Stevens,Voorhees Township,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,Voorhees Township,President,,"Castle, Darrell L ",write - in,0
-Stevens,Voorhees Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,Voorhees Township,President,,"Giordani, Rocky  ",write - in,0
-Stevens,Voorhees Township,President,,"Hedges, James A ",write - in,0
-Stevens,Voorhees Township,President,,"Hoefling, Tom  ",write - in,0
-Stevens,Voorhees Township,President,,"Kahn, Lynn  ",write - in,0
-Stevens,Voorhees Township,President,,"La Riva, Gloria  ",write - in,0
-Stevens,Voorhees Township,President,,"Levinson, Michael S. ",write - in,0
-Stevens,Voorhees Township,President,,"Maturen, Michael A ",write - in,0
-Stevens,Voorhees Township,President,,"McMullin, Evan  ",write - in,0
-Stevens,Voorhees Township,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,Voorhees Township,President,,"Perry, Darryl  ",write - in,0
-Stevens,Voorhees Township,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,Voorhees Township,President,,"Schriner, Joe C ",write - in,0
-Stevens,Voorhees Township,President,,"Smith, Mike  ",write - in,0
-Stevens,Voorhees Township,President,,"Sood, Ajay  ",write - in,0
-Stevens,Voorhees Township,President,,"Sterling, Shawna  ",write - in,0
-Stevens,Voorhees Township,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,Voorhees Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,Voorhees Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,Voorhees Township,President,,"Clinton, Hillary Rodham ",Democratic,4
-Stevens,Voorhees Township,President,,"Johnson, Gary  ",Libertarian,0
-Stevens,Voorhees Township,President,,"Trump, Donald J. ",Republican,63
-Stevens,West Center Township,President,,"Stein, Jill  ",independent,1
-Stevens,West Center Township,President,,"Basiago, Andrew D. ",write - in,0
-Stevens,West Center Township,President,,"Castle, Darrell L ",write - in,0
-Stevens,West Center Township,President,,"De La Fuente, ""Rocky"" Roque  ",write - in,0
-Stevens,West Center Township,President,,"Giordani, Rocky  ",write - in,0
-Stevens,West Center Township,President,,"Hedges, James A ",write - in,0
-Stevens,West Center Township,President,,"Hoefling, Tom  ",write - in,0
-Stevens,West Center Township,President,,"Kahn, Lynn  ",write - in,0
-Stevens,West Center Township,President,,"La Riva, Gloria  ",write - in,0
-Stevens,West Center Township,President,,"Levinson, Michael S. ",write - in,0
-Stevens,West Center Township,President,,"Maturen, Michael A ",write - in,0
-Stevens,West Center Township,President,,"McMullin, Evan  ",write - in,0
-Stevens,West Center Township,President,,"Moorehead, Monica G. ",write - in,0
-Stevens,West Center Township,President,,"Perry, Darryl  ",write - in,0
-Stevens,West Center Township,President,,"Schoenke, Marshall R. ",write - in,0
-Stevens,West Center Township,President,,"Schriner, Joe C ",write - in,0
-Stevens,West Center Township,President,,"Smith, Mike  ",write - in,0
-Stevens,West Center Township,President,,"Sood, Ajay  ",write - in,0
-Stevens,West Center Township,President,,"Sterling, Shawna  ",write - in,0
-Stevens,West Center Township,President,,"Valdivia, Anthony J ",write - in,0
-Stevens,West Center Township,President,,"Vogel-Walcutt, J.J.  ",write - in,0
-Stevens,West Center Township,President,,"Wysinger, Demetra Jefferson ",write - in,0
-Stevens,West Center Township,President,,"Clinton, Hillary Rodham ",Democratic,6
-Stevens,West Center Township,President,,"Johnson, Gary  ",Libertarian,1
-Stevens,West Center Township,President,,"Trump, Donald J. ",Republican,54
-Stevens,Hugoton Ward 1 Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Stevens,Hugoton Ward 1 Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,139
-Stevens,Hugoton Ward 1 Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 1 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,24
-Stevens,Hugoton Ward 1 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,12
-Stevens,Hugoton Ward 1 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,222
-Stevens,Hugoton Ward 2 Precinct 1,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 2 Precinct 1,U.S. Senate,,"Wiesner, Patrick  ",Democratic,5
-Stevens,Hugoton Ward 2 Precinct 1,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Stevens,Hugoton Ward 2 Precinct 1,U.S. Senate,,"Moran, Jerry  ",Republican,32
-Stevens,Hugoton Ward 2 Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 2 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,50
-Stevens,Hugoton Ward 2 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,19
-Stevens,Hugoton Ward 2 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,368
-Stevens,Hugoton Ward 03 Precinct 02,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 03 Precinct 02,U.S. Senate,,"Wiesner, Patrick  ",Democratic,3
-Stevens,Hugoton Ward 03 Precinct 02,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Stevens,Hugoton Ward 03 Precinct 02,U.S. Senate,,"Moran, Jerry  ",Republican,59
-Stevens,Hugoton Ward 04 Precinct 02,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 04 Precinct 02,U.S. Senate,,"Wiesner, Patrick  ",Democratic,25
-Stevens,Hugoton Ward 04 Precinct 02,U.S. Senate,,"Garrard, Robert D. ",Libertarian,10
-Stevens,Hugoton Ward 04 Precinct 02,U.S. Senate,,"Moran, Jerry  ",Republican,202
-Stevens,Hugoton Ward 05 Precinct 02,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Stevens,Hugoton Ward 05 Precinct 02,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Stevens,Hugoton Ward 05 Precinct 02,U.S. Senate,,"Moran, Jerry  ",Republican,8
-Stevens,Hugoton Ward 6 Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Stevens,Hugoton Ward 6 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Stevens,Hugoton Ward 6 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,1
-Stevens,Hugoton Ward 7 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,2
-Stevens,Hugoton Ward 8 Precinct 2,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,U.S. Senate,,"Wiesner, Patrick  ",Democratic,0
-Stevens,Hugoton Ward 8 Precinct 2,U.S. Senate,,"Garrard, Robert D. ",Libertarian,1
-Stevens,Hugoton Ward 8 Precinct 2,U.S. Senate,,"Moran, Jerry  ",Republican,0
-Stevens,Moscow City,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Moscow City,U.S. Senate,,"Wiesner, Patrick  ",Democratic,13
-Stevens,Moscow City,U.S. Senate,,"Garrard, Robert D. ",Libertarian,5
-Stevens,Moscow City,U.S. Senate,,"Moran, Jerry  ",Republican,64
-Stevens,Moscow Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Moscow Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,6
-Stevens,Moscow Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Stevens,Moscow Township,U.S. Senate,,"Moran, Jerry  ",Republican,122
-Stevens,Voorhees Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,Voorhees Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,4
-Stevens,Voorhees Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,2
-Stevens,Voorhees Township,U.S. Senate,,"Moran, Jerry  ",Republican,59
-Stevens,West Center Township,U.S. Senate,,"Smith, DJ  ",write - in,0
-Stevens,West Center Township,U.S. Senate,,"Wiesner, Patrick  ",Democratic,8
-Stevens,West Center Township,U.S. Senate,,"Garrard, Robert D. ",Libertarian,3
-Stevens,West Center Township,U.S. Senate,,"Moran, Jerry  ",Republican,49
-Stevens,Banner Township,U.S. House,1,"LaPolice, Alan  ",independent,7
-Stevens,Banner Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Banner Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Stevens,Banner Township,U.S. House,1,"Marshall, Roger  ",Republican,74
-Stevens,Center Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,2
-Stevens,Center Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Center Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Stevens,Center Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,18
-Stevens,Center Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,15
-Stevens,Center Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Center Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Stevens,Center Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,137
-Stevens,Harmony Township,U.S. House,1,"LaPolice, Alan  ",independent,4
-Stevens,Harmony Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Harmony Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Stevens,Harmony Township,U.S. House,1,"Marshall, Roger  ",Republican,28
-Stevens,Hugoton Ward 1 Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,17
-Stevens,Hugoton Ward 1 Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 1 Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,6
-Stevens,Hugoton Ward 1 Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,137
-Stevens,Hugoton Ward 1 Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,18
-Stevens,Hugoton Ward 1 Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 1 Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,18
-Stevens,Hugoton Ward 1 Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,209
-Stevens,Hugoton Ward 2 Precinct 1,U.S. House,1,"LaPolice, Alan  ",independent,1
-Stevens,Hugoton Ward 2 Precinct 1,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 2 Precinct 1,U.S. House,1,"Burt, Kerry  ",Libertarian,4
-Stevens,Hugoton Ward 2 Precinct 1,U.S. House,1,"Marshall, Roger  ",Republican,32
-Stevens,Hugoton Ward 2 Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,41
-Stevens,Hugoton Ward 2 Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 2 Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,25
-Stevens,Hugoton Ward 2 Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,360
-Stevens,Hugoton Ward 03 Precinct 02,U.S. House,1,"LaPolice, Alan  ",independent,9
-Stevens,Hugoton Ward 03 Precinct 02,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 03 Precinct 02,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Stevens,Hugoton Ward 03 Precinct 02,U.S. House,1,"Marshall, Roger  ",Republican,56
-Stevens,Hugoton Ward 04 Precinct 02,U.S. House,1,"LaPolice, Alan  ",independent,16
-Stevens,Hugoton Ward 04 Precinct 02,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 04 Precinct 02,U.S. House,1,"Burt, Kerry  ",Libertarian,15
-Stevens,Hugoton Ward 04 Precinct 02,U.S. House,1,"Marshall, Roger  ",Republican,199
-Stevens,Hugoton Ward 05 Precinct 02,U.S. House,1,"LaPolice, Alan  ",independent,1
-Stevens,Hugoton Ward 05 Precinct 02,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 05 Precinct 02,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Stevens,Hugoton Ward 05 Precinct 02,U.S. House,1,"Marshall, Roger  ",Republican,7
-Stevens,Hugoton Ward 6 Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,0
-Stevens,Hugoton Ward 6 Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 6 Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Stevens,Hugoton Ward 6 Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Stevens,Hugoton Ward 7 Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,3
-Stevens,Hugoton Ward 8 Precinct 2,U.S. House,1,"LaPolice, Alan  ",independent,0
-Stevens,Hugoton Ward 8 Precinct 2,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Hugoton Ward 8 Precinct 2,U.S. House,1,"Burt, Kerry  ",Libertarian,0
-Stevens,Hugoton Ward 8 Precinct 2,U.S. House,1,"Marshall, Roger  ",Republican,1
-Stevens,Moscow City,U.S. House,1,"LaPolice, Alan  ",independent,17
-Stevens,Moscow City,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Moscow City,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Stevens,Moscow City,U.S. House,1,"Marshall, Roger  ",Republican,60
-Stevens,Moscow Township,U.S. House,1,"LaPolice, Alan  ",independent,12
-Stevens,Moscow Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Moscow Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Stevens,Moscow Township,U.S. House,1,"Marshall, Roger  ",Republican,113
-Stevens,Voorhees Township,U.S. House,1,"LaPolice, Alan  ",independent,3
-Stevens,Voorhees Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,Voorhees Township,U.S. House,1,"Burt, Kerry  ",Libertarian,3
-Stevens,Voorhees Township,U.S. House,1,"Marshall, Roger  ",Republican,56
-Stevens,West Center Township,U.S. House,1,"LaPolice, Alan  ",independent,3
-Stevens,West Center Township,U.S. House,1,"Huelskamp, Tim  ",write - in,0
-Stevens,West Center Township,U.S. House,1,"Burt, Kerry  ",Libertarian,1
-Stevens,West Center Township,U.S. House,1,"Marshall, Roger  ",Republican,51
-Stevens,Banner Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,8
-Stevens,Banner Township,State Senate,39,"Doll, John  ",Republican,73
-Stevens,Center Precinct 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,Center Precinct 1,State Senate,39,"Doll, John  ",Republican,17
-Stevens,Center Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,15
-Stevens,Center Precinct 2,State Senate,39,"Doll, John  ",Republican,137
-Stevens,Harmony Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,Harmony Township,State Senate,39,"Doll, John  ",Republican,28
-Stevens,Hugoton Ward 1 Precinct 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,19
-Stevens,Hugoton Ward 1 Precinct 1,State Senate,39,"Doll, John  ",Republican,138
-Stevens,Hugoton Ward 1 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,35
-Stevens,Hugoton Ward 1 Precinct 2,State Senate,39,"Doll, John  ",Republican,214
-Stevens,Hugoton Ward 2 Precinct 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,4
-Stevens,Hugoton Ward 2 Precinct 1,State Senate,39,"Doll, John  ",Republican,33
-Stevens,Hugoton Ward 2 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,52
-Stevens,Hugoton Ward 2 Precinct 2,State Senate,39,"Doll, John  ",Republican,368
-Stevens,Hugoton Ward 03 Precinct 02,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,Hugoton Ward 03 Precinct 02,State Senate,39,"Doll, John  ",Republican,60
-Stevens,Hugoton Ward 04 Precinct 02,State Senate,39,"Worf, A. Zacheriah ",Democratic,21
-Stevens,Hugoton Ward 04 Precinct 02,State Senate,39,"Doll, John  ",Republican,211
-Stevens,Hugoton Ward 05 Precinct 02,State Senate,39,"Worf, A. Zacheriah ",Democratic,1
-Stevens,Hugoton Ward 05 Precinct 02,State Senate,39,"Doll, John  ",Republican,8
-Stevens,Hugoton Ward 6 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,0
-Stevens,Hugoton Ward 6 Precinct 2,State Senate,39,"Doll, John  ",Republican,0
-Stevens,Hugoton Ward 7 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,1
-Stevens,Hugoton Ward 7 Precinct 2,State Senate,39,"Doll, John  ",Republican,2
-Stevens,Hugoton Ward 8 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,1
-Stevens,Hugoton Ward 8 Precinct 2,State Senate,39,"Doll, John  ",Republican,0
-Stevens,Moscow City,State Senate,39,"Worf, A. Zacheriah ",Democratic,17
-Stevens,Moscow City,State Senate,39,"Doll, John  ",Republican,62
-Stevens,Moscow Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,11
-Stevens,Moscow Township,State Senate,39,"Doll, John  ",Republican,117
-Stevens,Voorhees Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,4
-Stevens,Voorhees Township,State Senate,39,"Doll, John  ",Republican,59
-Stevens,West Center Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,West Center Township,State Senate,39,"Doll, John  ",Republican,52
-Stevens,Banner Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,8
-Stevens,Banner Township,State Senate,39,"Doll, John  ",Republican,73
-Stevens,Center Precinct 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,Center Precinct 1,State Senate,39,"Doll, John  ",Republican,17
-Stevens,Center Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,15
-Stevens,Center Precinct 2,State Senate,39,"Doll, John  ",Republican,137
-Stevens,Harmony Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,Harmony Township,State Senate,39,"Doll, John  ",Republican,28
-Stevens,Hugoton Ward 1 Precinct 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,19
-Stevens,Hugoton Ward 1 Precinct 1,State Senate,39,"Doll, John  ",Republican,138
-Stevens,Hugoton Ward 1 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,35
-Stevens,Hugoton Ward 1 Precinct 2,State Senate,39,"Doll, John  ",Republican,214
-Stevens,Hugoton Ward 2 Precinct 1,State Senate,39,"Worf, A. Zacheriah ",Democratic,4
-Stevens,Hugoton Ward 2 Precinct 1,State Senate,39,"Doll, John  ",Republican,33
-Stevens,Hugoton Ward 2 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,52
-Stevens,Hugoton Ward 2 Precinct 2,State Senate,39,"Doll, John  ",Republican,368
-Stevens,Hugoton Ward 03 Precinct 02,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,Hugoton Ward 03 Precinct 02,State Senate,39,"Doll, John  ",Republican,60
-Stevens,Hugoton Ward 04 Precinct 02,State Senate,39,"Worf, A. Zacheriah ",Democratic,21
-Stevens,Hugoton Ward 04 Precinct 02,State Senate,39,"Doll, John  ",Republican,211
-Stevens,Hugoton Ward 05 Precinct 02,State Senate,39,"Worf, A. Zacheriah ",Democratic,1
-Stevens,Hugoton Ward 05 Precinct 02,State Senate,39,"Doll, John  ",Republican,8
-Stevens,Hugoton Ward 6 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,0
-Stevens,Hugoton Ward 6 Precinct 2,State Senate,39,"Doll, John  ",Republican,0
-Stevens,Hugoton Ward 7 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,1
-Stevens,Hugoton Ward 7 Precinct 2,State Senate,39,"Doll, John  ",Republican,2
-Stevens,Hugoton Ward 8 Precinct 2,State Senate,39,"Worf, A. Zacheriah ",Democratic,1
-Stevens,Hugoton Ward 8 Precinct 2,State Senate,39,"Doll, John  ",Republican,0
-Stevens,Moscow City,State Senate,39,"Worf, A. Zacheriah ",Democratic,17
-Stevens,Moscow City,State Senate,39,"Doll, John  ",Republican,62
-Stevens,Moscow Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,11
-Stevens,Moscow Township,State Senate,39,"Doll, John  ",Republican,117
-Stevens,Voorhees Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,4
-Stevens,Voorhees Township,State Senate,39,"Doll, John  ",Republican,59
-Stevens,West Center Township,State Senate,39,"Worf, A. Zacheriah ",Democratic,3
-Stevens,West Center Township,State Senate,39,"Doll, John  ",Republican,52
+county,precinct,office,district,party,candidate,votes,vtd
+STEVENS,Banner Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",73,000010
+STEVENS,Center Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",22,000020
+STEVENS,Center Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",141,000030
+STEVENS,Harmony Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",31,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",145,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",210,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",37,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",365,000080
+STEVENS,Hugoton Ward 03 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",59,000090
+STEVENS,Hugoton Ward 04 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",209,000100
+STEVENS,Hugoton Ward 05 Precinct 02,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",7,000110
+STEVENS,Hugoton Ward 6 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",0,000120
+STEVENS,Hugoton Ward 7 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",3,000130
+STEVENS,Hugoton Ward 8 Precinct 2,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",1,000140
+STEVENS,Moscow City,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",70,000150
+STEVENS,Moscow Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",118,000160
+STEVENS,Voorhees Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",59,000170
+STEVENS,West Center Township,Kansas House of Representatives,124,Republican,"Alford, J. Stephen",49,000180
+STEVENS,Banner Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",8,000010
+STEVENS,Banner Township,Kansas Senate,39,Republican,"Doll, John",73,000010
+STEVENS,Center Precinct 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",3,000020
+STEVENS,Center Precinct 1,Kansas Senate,39,Republican,"Doll, John",17,000020
+STEVENS,Center Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",15,000030
+STEVENS,Center Precinct 2,Kansas Senate,39,Republican,"Doll, John",137,000030
+STEVENS,Harmony Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",3,000040
+STEVENS,Harmony Township,Kansas Senate,39,Republican,"Doll, John",28,000040
+STEVENS,Hugoton Ward 1 Precinct 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",19,000050
+STEVENS,Hugoton Ward 1 Precinct 1,Kansas Senate,39,Republican,"Doll, John",138,000050
+STEVENS,Hugoton Ward 1 Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",35,000060
+STEVENS,Hugoton Ward 1 Precinct 2,Kansas Senate,39,Republican,"Doll, John",214,000060
+STEVENS,Hugoton Ward 2 Precinct 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",4,000070
+STEVENS,Hugoton Ward 2 Precinct 1,Kansas Senate,39,Republican,"Doll, John",33,000070
+STEVENS,Hugoton Ward 2 Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",52,000080
+STEVENS,Hugoton Ward 2 Precinct 2,Kansas Senate,39,Republican,"Doll, John",368,000080
+STEVENS,Hugoton Ward 03 Precinct 02,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",3,000090
+STEVENS,Hugoton Ward 03 Precinct 02,Kansas Senate,39,Republican,"Doll, John",60,000090
+STEVENS,Hugoton Ward 04 Precinct 02,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",21,000100
+STEVENS,Hugoton Ward 04 Precinct 02,Kansas Senate,39,Republican,"Doll, John",211,000100
+STEVENS,Hugoton Ward 05 Precinct 02,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",1,000110
+STEVENS,Hugoton Ward 05 Precinct 02,Kansas Senate,39,Republican,"Doll, John",8,000110
+STEVENS,Hugoton Ward 6 Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,Kansas Senate,39,Republican,"Doll, John",0,000120
+STEVENS,Hugoton Ward 7 Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",1,000130
+STEVENS,Hugoton Ward 7 Precinct 2,Kansas Senate,39,Republican,"Doll, John",2,000130
+STEVENS,Hugoton Ward 8 Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",1,000140
+STEVENS,Hugoton Ward 8 Precinct 2,Kansas Senate,39,Republican,"Doll, John",0,000140
+STEVENS,Moscow City,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",17,000150
+STEVENS,Moscow City,Kansas Senate,39,Republican,"Doll, John",62,000150
+STEVENS,Moscow Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",11,000160
+STEVENS,Moscow Township,Kansas Senate,39,Republican,"Doll, John",117,000160
+STEVENS,Voorhees Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",4,000170
+STEVENS,Voorhees Township,Kansas Senate,39,Republican,"Doll, John",59,000170
+STEVENS,West Center Township,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",3,000180
+STEVENS,West Center Township,Kansas Senate,39,Republican,"Doll, John",52,000180
+STEVENS,Banner Township,President / Vice President,,independent,"Stein, Jill",1,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+STEVENS,Banner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+STEVENS,Banner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000010
+STEVENS,Banner Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+STEVENS,Banner Township,President / Vice President,,Republican,"Trump, Donald J.",80,000010
+STEVENS,Center Precinct 1,President / Vice President,,independent,"Stein, Jill",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000020
+STEVENS,Center Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+STEVENS,Center Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",21,000020
+STEVENS,Center Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+STEVENS,Center Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000030
+STEVENS,Center Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+STEVENS,Center Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",144,000030
+STEVENS,Harmony Township,President / Vice President,,independent,"Stein, Jill",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+STEVENS,Harmony Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+STEVENS,Harmony Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+STEVENS,Harmony Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+STEVENS,Harmony Township,President / Vice President,,Republican,"Trump, Donald J.",37,000040
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,independent,"Stein, Jill",4,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+STEVENS,Hugoton Ward 1 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",127,000050
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,independent,"Stein, Jill",4,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000060
+STEVENS,Hugoton Ward 1 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",215,000060
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,independent,"Stein, Jill",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+STEVENS,Hugoton Ward 2 Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",29,000070
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,independent,"Stein, Jill",5,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",65,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",17,000080
+STEVENS,Hugoton Ward 2 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",368,000080
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,independent,"Stein, Jill",1,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+STEVENS,Hugoton Ward 03 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",61,000090
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,independent,"Stein, Jill",3,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",5,000100
+STEVENS,Hugoton Ward 04 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",205,000100
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,independent,"Stein, Jill",1,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Hedges, James A",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"McMullin, Evan",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Perry, Darryl",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Smith, Mike",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Sood, Ajay",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,President / Vice President,,Republican,"Trump, Donald J.",9,000110
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",0,000120
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,independent,"Stein, Jill",1,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",1,000130
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,independent,"Stein, Jill",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"McMullin, Evan",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",1,000140
+STEVENS,Moscow City,President / Vice President,,independent,"Stein, Jill",1,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Hedges, James A",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"McMullin, Evan",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Perry, Darryl",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Smith, Mike",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Sood, Ajay",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+STEVENS,Moscow City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+STEVENS,Moscow City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000150
+STEVENS,Moscow City,President / Vice President,,Libertarian,"Johnson, Gary",3,000150
+STEVENS,Moscow City,President / Vice President,,Republican,"Trump, Donald J.",69,000150
+STEVENS,Moscow Township,President / Vice President,,independent,"Stein, Jill",1,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+STEVENS,Moscow Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+STEVENS,Moscow Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000160
+STEVENS,Moscow Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000160
+STEVENS,Moscow Township,President / Vice President,,Republican,"Trump, Donald J.",115,000160
+STEVENS,Voorhees Township,President / Vice President,,independent,"Stein, Jill",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+STEVENS,Voorhees Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+STEVENS,Voorhees Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000170
+STEVENS,Voorhees Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000170
+STEVENS,Voorhees Township,President / Vice President,,Republican,"Trump, Donald J.",63,000170
+STEVENS,West Center Township,President / Vice President,,independent,"Stein, Jill",1,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+STEVENS,West Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+STEVENS,West Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000180
+STEVENS,West Center Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000180
+STEVENS,West Center Township,President / Vice President,,Republican,"Trump, Donald J.",54,000180
+STEVENS,Banner Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000010
+STEVENS,Banner Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+STEVENS,Banner Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000010
+STEVENS,Banner Township,United States House of Representatives,1,Republican,"Marshall, Roger",74,000010
+STEVENS,Center Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",2,000020
+STEVENS,Center Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+STEVENS,Center Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000020
+STEVENS,Center Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",18,000020
+STEVENS,Center Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",15,000030
+STEVENS,Center Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+STEVENS,Center Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000030
+STEVENS,Center Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",137,000030
+STEVENS,Harmony Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000040
+STEVENS,Harmony Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+STEVENS,Harmony Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000040
+STEVENS,Harmony Township,United States House of Representatives,1,Republican,"Marshall, Roger",28,000040
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",17,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",137,000050
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",18,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",209,000060
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",1,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",32,000070
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",41,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",25,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",360,000080
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",9,000090
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",56,000090
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",16,000100
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000100
+STEVENS,Hugoton Ward 04 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",199,000100
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,independent,"LaPolice, Alan",1,000110
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,United States House of Representatives,1,Republican,"Marshall, Roger",7,000110
+STEVENS,Hugoton Ward 6 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,000120
+STEVENS,Hugoton Ward 7 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",3,000130
+STEVENS,Hugoton Ward 8 Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",1,000140
+STEVENS,Moscow City,United States House of Representatives,1,independent,"LaPolice, Alan",17,000150
+STEVENS,Moscow City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+STEVENS,Moscow City,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000150
+STEVENS,Moscow City,United States House of Representatives,1,Republican,"Marshall, Roger",60,000150
+STEVENS,Moscow Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000160
+STEVENS,Moscow Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+STEVENS,Moscow Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000160
+STEVENS,Moscow Township,United States House of Representatives,1,Republican,"Marshall, Roger",113,000160
+STEVENS,Voorhees Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000170
+STEVENS,Voorhees Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+STEVENS,Voorhees Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000170
+STEVENS,Voorhees Township,United States House of Representatives,1,Republican,"Marshall, Roger",56,000170
+STEVENS,West Center Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000180
+STEVENS,West Center Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+STEVENS,West Center Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000180
+STEVENS,West Center Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000180
+STEVENS,Banner Township,United States Senate,,write - in,"Smith, DJ",0,000010
+STEVENS,Banner Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000010
+STEVENS,Banner Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000010
+STEVENS,Banner Township,United States Senate,,Republican,"Moran, Jerry",79,000010
+STEVENS,Center Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000020
+STEVENS,Center Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",1,000020
+STEVENS,Center Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+STEVENS,Center Precinct 1,United States Senate,,Republican,"Moran, Jerry",19,000020
+STEVENS,Center Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000030
+STEVENS,Center Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",7,000030
+STEVENS,Center Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",7,000030
+STEVENS,Center Precinct 2,United States Senate,,Republican,"Moran, Jerry",144,000030
+STEVENS,Harmony Township,United States Senate,,write - in,"Smith, DJ",0,000040
+STEVENS,Harmony Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+STEVENS,Harmony Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+STEVENS,Harmony Township,United States Senate,,Republican,"Moran, Jerry",32,000040
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",16,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",3,000050
+STEVENS,Hugoton Ward 1 Precinct 1,United States Senate,,Republican,"Moran, Jerry",139,000050
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",24,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",12,000060
+STEVENS,Hugoton Ward 1 Precinct 2,United States Senate,,Republican,"Moran, Jerry",222,000060
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",5,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,000070
+STEVENS,Hugoton Ward 2 Precinct 1,United States Senate,,Republican,"Moran, Jerry",32,000070
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",50,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,000080
+STEVENS,Hugoton Ward 2 Precinct 2,United States Senate,,Republican,"Moran, Jerry",368,000080
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000090
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",3,000090
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",3,000090
+STEVENS,Hugoton Ward 03 Precinct 02,United States Senate,,Republican,"Moran, Jerry",59,000090
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000100
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",25,000100
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",10,000100
+STEVENS,Hugoton Ward 04 Precinct 02,United States Senate,,Republican,"Moran, Jerry",202,000100
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,write - in,"Smith, DJ",0,000110
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+STEVENS,Hugoton Ward 05 Precinct 02,United States Senate,,Republican,"Moran, Jerry",8,000110
+STEVENS,Hugoton Ward 6 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+STEVENS,Hugoton Ward 6 Precinct 2,United States Senate,,Republican,"Moran, Jerry",0,000120
+STEVENS,Hugoton Ward 7 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",1,000130
+STEVENS,Hugoton Ward 7 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,000130
+STEVENS,Hugoton Ward 7 Precinct 2,United States Senate,,Republican,"Moran, Jerry",2,000130
+STEVENS,Hugoton Ward 8 Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",0,000140
+STEVENS,Hugoton Ward 8 Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+STEVENS,Hugoton Ward 8 Precinct 2,United States Senate,,Republican,"Moran, Jerry",0,000140
+STEVENS,Moscow City,United States Senate,,write - in,"Smith, DJ",0,000150
+STEVENS,Moscow City,United States Senate,,Democratic,"Wiesner, Patrick",13,000150
+STEVENS,Moscow City,United States Senate,,Libertarian,"Garrard, Robert D.",5,000150
+STEVENS,Moscow City,United States Senate,,Republican,"Moran, Jerry",64,000150
+STEVENS,Moscow Township,United States Senate,,write - in,"Smith, DJ",0,000160
+STEVENS,Moscow Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000160
+STEVENS,Moscow Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000160
+STEVENS,Moscow Township,United States Senate,,Republican,"Moran, Jerry",122,000160
+STEVENS,Voorhees Township,United States Senate,,write - in,"Smith, DJ",0,000170
+STEVENS,Voorhees Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000170
+STEVENS,Voorhees Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000170
+STEVENS,Voorhees Township,United States Senate,,Republican,"Moran, Jerry",59,000170
+STEVENS,West Center Township,United States Senate,,write - in,"Smith, DJ",0,000180
+STEVENS,West Center Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000180
+STEVENS,West Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000180
+STEVENS,West Center Township,United States Senate,,Republican,"Moran, Jerry",49,000180

--- a/2016/20161108__ks__general__sumner__precinct.csv
+++ b/2016/20161108__ks__general__sumner__precinct.csv
@@ -1,580 +1,1679 @@
-county,precinct,office,district,party,candidate,votes
-Sumner,Wellington 2,President,,R,Donald J. Trump,1217
-Sumner,Belle Plaine twp H79,President,,R,Donald J. Trump,968
-Sumner,Wellington 1,President,,R,Donald J. Trump,641
-Sumner,Oxford twp,President,,R,Donald J. Trump,411
-Sumner,Conway,President,,R,Donald J. Trump,355
-Sumner,Gore H79,President,,R,Donald J. Trump,301
-Sumner,London,President,,R,Donald J. Trump,271
-Sumner,Springdale,President,,R,Donald J. Trump,213
-Sumner,Caldwell City W2,President,,R,Donald J. Trump,210
-Sumner,Mulvane City,President,,R,Donald J. Trump,207
-Sumner,Dixon,President,,R,Donald J. Trump,205
-Sumner,South Haven twp,President,,R,Donald J. Trump,196
-Sumner,Walton,President,,R,Donald J. Trump,132
-Sumner,Eden,President,,R,Donald J. Trump,130
-Sumner,Avon,President,,R,Donald J. Trump,117
-Sumner,Harmon,President,,R,Donald J. Trump,115
-Sumner,Seventy-Six,President,,R,Donald J. Trump,112
-Sumner,Caldwell City W1,President,,R,Donald J. Trump,110
-Sumner,Wellington twp H116,President,,R,Donald J. Trump,102
-Sumner,Osborne,President,,R,Donald J. Trump,98
-Sumner,Creek,President,,R,Donald J. Trump,79
-Sumner,Palestine,President,,R,Donald J. Trump,75
-Sumner,Gore H82,President,,R,Donald J. Trump,74
-Sumner,Illinois,President,,R,Donald J. Trump,74
-Sumner,Wellington twp H80,President,,R,Donald J. Trump,62
-Sumner,Guelph,President,,R,Donald J. Trump,60
-Sumner,Falls,President,,R,Donald J. Trump,56
-Sumner,Downs,President,,R,Donald J. Trump,55
-Sumner,Ryan,President,,R,Donald J. Trump,52
-Sumner,Jackson,President,,R,Donald J. Trump,50
-Sumner,Valverde,President,,R,Donald J. Trump,50
-Sumner,Caldwell twp,President,,R,Donald J. Trump,47
-Sumner,Sumner,President,,R,Donald J. Trump,44
-Sumner,Greene,President,,R,Donald J. Trump,30
-Sumner,Chikaskia,President,,R,Donald J. Trump,25
-Sumner,Bluff,President,,R,Donald J. Trump,20
-Sumner,Morris,President,,R,Donald J. Trump,11
-Sumner,Mulvane City H79,President,,R,Donald J. Trump,5
-Sumner,Belle Plaine twp H82,President,,R,Donald J. Trump,4
-Sumner,Wellington 2,President,,IND,Jill Stein,65
-Sumner,Belle Plaine twp H79,President,,IND,Jill Stein,34
-Sumner,Wellington 1,President,,IND,Jill Stein,19
-Sumner,Conway,President,,IND,Jill Stein,11
-Sumner,Oxford twp,President,,IND,Jill Stein,11
-Sumner,Gore H79,President,,IND,Jill Stein,7
-Sumner,Dixon,President,,IND,Jill Stein,5
-Sumner,London,President,,IND,Jill Stein,5
-Sumner,Walton,President,,IND,Jill Stein,5
-Sumner,Eden,President,,IND,Jill Stein,4
-Sumner,Caldwell City W2,President,,IND,Jill Stein,4
-Sumner,Mulvane City,President,,IND,Jill Stein,4
-Sumner,Palestine,President,,IND,Jill Stein,3
-Sumner,Springdale,President,,IND,Jill Stein,3
-Sumner,Avon,President,,IND,Jill Stein,2
-Sumner,Gore H82,President,,IND,Jill Stein,2
-Sumner,Harmon,President,,IND,Jill Stein,2
-Sumner,Osborne,President,,IND,Jill Stein,2
-Sumner,South Haven twp,President,,IND,Jill Stein,2
-Sumner,Sumner,President,,IND,Jill Stein,2
-Sumner,Valverde,President,,IND,Jill Stein,2
-Sumner,Bluff,President,,IND,Jill Stein,1
-Sumner,Caldwell twp,President,,IND,Jill Stein,1
-Sumner,Chikaskia,President,,IND,Jill Stein,1
-Sumner,Creek,President,,IND,Jill Stein,1
-Sumner,Downs,President,,IND,Jill Stein,1
-Sumner,Falls,President,,IND,Jill Stein,1
-Sumner,Guelph,President,,IND,Jill Stein,1
-Sumner,Illinois,President,,IND,Jill Stein,1
-Sumner,Ryan,President,,IND,Jill Stein,1
-Sumner,Seventy-Six,President,,IND,Jill Stein,1
-Sumner,Caldwell City W1,President,,IND,Jill Stein,1
-Sumner,Belle Plaine twp H82,President,,IND,Jill Stein,0
-Sumner,Greene,President,,IND,Jill Stein,0
-Sumner,Jackson,President,,IND,Jill Stein,0
-Sumner,Morris,President,,IND,Jill Stein,0
-Sumner,Wellington twp H80,President,,IND,Jill Stein,0
-Sumner,Wellington twp H116,President,,IND,Jill Stein,0
-Sumner,Mulvane City H79,President,,IND,Jill Stein,0
-Sumner,Wellington 2,U.S. Senate,,LBT,Robert D. Garrard,128
-Sumner,Belle Plaine twp H79,U.S. Senate,,LBT,Robert D. Garrard,98
-Sumner,Wellington 1,U.S. Senate,,LBT,Robert D. Garrard,80
-Sumner,Oxford twp,U.S. Senate,,LBT,Robert D. Garrard,43
-Sumner,Conway,U.S. Senate,,LBT,Robert D. Garrard,36
-Sumner,Gore H79,U.S. Senate,,LBT,Robert D. Garrard,31
-Sumner,London,U.S. Senate,,LBT,Robert D. Garrard,28
-Sumner,Walton,U.S. Senate,,LBT,Robert D. Garrard,18
-Sumner,South Haven twp,U.S. Senate,,LBT,Robert D. Garrard,17
-Sumner,Mulvane City,U.S. Senate,,LBT,Robert D. Garrard,17
-Sumner,Caldwell City W2,U.S. Senate,,LBT,Robert D. Garrard,16
-Sumner,Dixon,U.S. Senate,,LBT,Robert D. Garrard,13
-Sumner,Springdale,U.S. Senate,,LBT,Robert D. Garrard,13
-Sumner,Gore H82,U.S. Senate,,LBT,Robert D. Garrard,12
-Sumner,Avon,U.S. Senate,,LBT,Robert D. Garrard,11
-Sumner,Caldwell City W1,U.S. Senate,,LBT,Robert D. Garrard,11
-Sumner,Seventy-Six,U.S. Senate,,LBT,Robert D. Garrard,10
-Sumner,Wellington twp H80,U.S. Senate,,LBT,Robert D. Garrard,10
-Sumner,Eden,U.S. Senate,,LBT,Robert D. Garrard,9
-Sumner,Harmon,U.S. Senate,,LBT,Robert D. Garrard,9
-Sumner,Valverde,U.S. Senate,,LBT,Robert D. Garrard,8
-Sumner,Jackson,U.S. Senate,,LBT,Robert D. Garrard,7
-Sumner,Palestine,U.S. Senate,,LBT,Robert D. Garrard,6
-Sumner,Wellington twp H116,U.S. Senate,,LBT,Robert D. Garrard,6
-Sumner,Osborne,U.S. Senate,,LBT,Robert D. Garrard,5
-Sumner,Creek,U.S. Senate,,LBT,Robert D. Garrard,4
-Sumner,Guelph,U.S. Senate,,LBT,Robert D. Garrard,4
-Sumner,Ryan,U.S. Senate,,LBT,Robert D. Garrard,4
-Sumner,Chikaskia,U.S. Senate,,LBT,Robert D. Garrard,3
-Sumner,Downs,U.S. Senate,,LBT,Robert D. Garrard,3
-Sumner,Illinois,U.S. Senate,,LBT,Robert D. Garrard,3
-Sumner,Sumner,U.S. Senate,,LBT,Robert D. Garrard,3
-Sumner,Falls,U.S. Senate,,LBT,Robert D. Garrard,2
-Sumner,Bluff,U.S. Senate,,LBT,Robert D. Garrard,1
-Sumner,Greene,U.S. Senate,,LBT,Robert D. Garrard,1
-Sumner,Belle Plaine twp H82,U.S. Senate,,LBT,Robert D. Garrard,0
-Sumner,Caldwell twp,U.S. Senate,,LBT,Robert D. Garrard,0
-Sumner,Morris,U.S. Senate,,LBT,Robert D. Garrard,0
-Sumner,Mulvane City H79,U.S. Senate,,LBT,Robert D. Garrard,0
-Sumner,Mulvane City,State House,82,R,Pete DeGraaf,153
-Sumner,Gore H82,State House,82,R,Pete DeGraaf,56
-Sumner,Belle Plaine twp H82,State House,82,R,Pete DeGraaf,4
-Sumner,Wellington 2,U.S. Senate,,D,Patrick Wiesner,504
-Sumner,Wellington 1,U.S. Senate,,D,Patrick Wiesner,329
-Sumner,Belle Plaine twp H79,U.S. Senate,,D,Patrick Wiesner,287
-Sumner,Oxford twp,U.S. Senate,,D,Patrick Wiesner,136
-Sumner,Conway,U.S. Senate,,D,Patrick Wiesner,93
-Sumner,Gore H79,U.S. Senate,,D,Patrick Wiesner,67
-Sumner,Mulvane City,U.S. Senate,,D,Patrick Wiesner,64
-Sumner,Caldwell City W2,U.S. Senate,,D,Patrick Wiesner,62
-Sumner,Springdale,U.S. Senate,,D,Patrick Wiesner,53
-Sumner,London,U.S. Senate,,D,Patrick Wiesner,45
-Sumner,Caldwell City W1,U.S. Senate,,D,Patrick Wiesner,44
-Sumner,South Haven twp,U.S. Senate,,D,Patrick Wiesner,43
-Sumner,Dixon,U.S. Senate,,D,Patrick Wiesner,41
-Sumner,Wellington twp H116,U.S. Senate,,D,Patrick Wiesner,36
-Sumner,Avon,U.S. Senate,,D,Patrick Wiesner,32
-Sumner,Osborne,U.S. Senate,,D,Patrick Wiesner,29
-Sumner,Eden,U.S. Senate,,D,Patrick Wiesner,26
-Sumner,Harmon,U.S. Senate,,D,Patrick Wiesner,23
-Sumner,Palestine,U.S. Senate,,D,Patrick Wiesner,23
-Sumner,Gore H82,U.S. Senate,,D,Patrick Wiesner,22
-Sumner,Caldwell twp,U.S. Senate,,D,Patrick Wiesner,17
-Sumner,Creek,U.S. Senate,,D,Patrick Wiesner,16
-Sumner,Walton,U.S. Senate,,D,Patrick Wiesner,16
-Sumner,Ryan,U.S. Senate,,D,Patrick Wiesner,14
-Sumner,Wellington twp H80,U.S. Senate,,D,Patrick Wiesner,14
-Sumner,Falls,U.S. Senate,,D,Patrick Wiesner,13
-Sumner,Guelph,U.S. Senate,,D,Patrick Wiesner,13
-Sumner,Sumner,U.S. Senate,,D,Patrick Wiesner,12
-Sumner,Downs,U.S. Senate,,D,Patrick Wiesner,11
-Sumner,Jackson,U.S. Senate,,D,Patrick Wiesner,9
-Sumner,Seventy-Six,U.S. Senate,,D,Patrick Wiesner,9
-Sumner,Illinois,U.S. Senate,,D,Patrick Wiesner,7
-Sumner,Greene,U.S. Senate,,D,Patrick Wiesner,4
-Sumner,Bluff,U.S. Senate,,D,Patrick Wiesner,3
-Sumner,Chikaskia,U.S. Senate,,D,Patrick Wiesner,3
-Sumner,Belle Plaine twp H82,U.S. Senate,,D,Patrick Wiesner,2
-Sumner,Valverde,U.S. Senate,,D,Patrick Wiesner,2
-Sumner,Morris,U.S. Senate,,D,Patrick Wiesner,0
-Sumner,Mulvane City H79,U.S. Senate,,D,Patrick Wiesner,0
-Sumner,Wellington 2,U.S. House,4,IND,Miranda Allen,258
-Sumner,Wellington 1,U.S. House,4,IND,Miranda Allen,139
-Sumner,Belle Plaine twp H79,U.S. House,4,IND,Miranda Allen,109
-Sumner,Oxford twp,U.S. House,4,IND,Miranda Allen,70
-Sumner,Conway,U.S. House,4,IND,Miranda Allen,42
-Sumner,Gore H79,U.S. House,4,IND,Miranda Allen,37
-Sumner,South Haven twp,U.S. House,4,IND,Miranda Allen,33
-Sumner,Walton,U.S. House,4,IND,Miranda Allen,27
-Sumner,Caldwell City W2,U.S. House,4,IND,Miranda Allen,26
-Sumner,Dixon,U.S. House,4,IND,Miranda Allen,25
-Sumner,London,U.S. House,4,IND,Miranda Allen,19
-Sumner,Springdale,U.S. House,4,IND,Miranda Allen,18
-Sumner,Mulvane City,U.S. House,4,IND,Miranda Allen,16
-Sumner,Wellington twp H116,U.S. House,4,IND,Miranda Allen,15
-Sumner,Avon,U.S. House,4,IND,Miranda Allen,14
-Sumner,Eden,U.S. House,4,IND,Miranda Allen,13
-Sumner,Harmon,U.S. House,4,IND,Miranda Allen,12
-Sumner,Osborne,U.S. House,4,IND,Miranda Allen,12
-Sumner,Sumner,U.S. House,4,IND,Miranda Allen,12
-Sumner,Wellington twp H80,U.S. House,4,IND,Miranda Allen,12
-Sumner,Falls,U.S. House,4,IND,Miranda Allen,11
-Sumner,Palestine,U.S. House,4,IND,Miranda Allen,10
-Sumner,Caldwell City W1,U.S. House,4,IND,Miranda Allen,10
-Sumner,Seventy-Six,U.S. House,4,IND,Miranda Allen,9
-Sumner,Downs,U.S. House,4,IND,Miranda Allen,8
-Sumner,Guelph,U.S. House,4,IND,Miranda Allen,8
-Sumner,Caldwell twp,U.S. House,4,IND,Miranda Allen,7
-Sumner,Ryan,U.S. House,4,IND,Miranda Allen,7
-Sumner,Illinois,U.S. House,4,IND,Miranda Allen,6
-Sumner,Jackson,U.S. House,4,IND,Miranda Allen,6
-Sumner,Valverde,U.S. House,4,IND,Miranda Allen,6
-Sumner,Chikaskia,U.S. House,4,IND,Miranda Allen,5
-Sumner,Gore H82,U.S. House,4,IND,Miranda Allen,5
-Sumner,Greene,U.S. House,4,IND,Miranda Allen,5
-Sumner,Creek,U.S. House,4,IND,Miranda Allen,4
-Sumner,Bluff,U.S. House,4,IND,Miranda Allen,3
-Sumner,Morris,U.S. House,4,IND,Miranda Allen,1
-Sumner,Belle Plaine twp H82,U.S. House,4,IND,Miranda Allen,0
-Sumner,Mulvane City H79,U.S. House,4,IND,Miranda Allen,0
-Sumner,Wellington 1,State House,80,D,Michelle Schiltz,452
-Sumner,Caldwell City W2,State House,80,D,Michelle Schiltz,181
-Sumner,Caldwell City W1,State House,80,D,Michelle Schiltz,133
-Sumner,South Haven twp,State House,80,D,Michelle Schiltz,90
-Sumner,Avon,State House,80,D,Michelle Schiltz,55
-Sumner,Caldwell twp,State House,80,D,Michelle Schiltz,45
-Sumner,Falls,State House,80,D,Michelle Schiltz,38
-Sumner,Walton,State House,80,D,Michelle Schiltz,38
-Sumner,Wellington twp H80,State House,80,D,Michelle Schiltz,24
-Sumner,Downs,State House,80,D,Michelle Schiltz,22
-Sumner,Bluff,State House,80,D,Michelle Schiltz,20
-Sumner,Jackson,State House,80,D,Michelle Schiltz,19
-Sumner,Guelph,State House,80,D,Michelle Schiltz,17
-Sumner,Chikaskia,State House,80,D,Michelle Schiltz,12
-Sumner,Valverde,State House,80,D,Michelle Schiltz,11
-Sumner,Greene,State House,80,D,Michelle Schiltz,9
-Sumner,Morris,State House,80,D,Michelle Schiltz,6
-Sumner,Wellington 2,U.S. House,4,R,Michael Pompeo,1101
-Sumner,Belle Plaine twp H79,U.S. House,4,R,Michael Pompeo,912
-Sumner,Wellington 1,U.S. House,4,R,Michael Pompeo,570
-Sumner,Oxford twp,U.S. House,4,R,Michael Pompeo,367
-Sumner,Conway,U.S. House,4,R,Michael Pompeo,320
-Sumner,Gore H79,U.S. House,4,R,Michael Pompeo,275
-Sumner,London,U.S. House,4,R,Michael Pompeo,249
-Sumner,Springdale,U.S. House,4,R,Michael Pompeo,204
-Sumner,Mulvane City,U.S. House,4,R,Michael Pompeo,191
-Sumner,Caldwell City W2,U.S. House,4,R,Michael Pompeo,188
-Sumner,Dixon,U.S. House,4,R,Michael Pompeo,182
-Sumner,South Haven twp,U.S. House,4,R,Michael Pompeo,179
-Sumner,Eden,U.S. House,4,R,Michael Pompeo,126
-Sumner,Walton,U.S. House,4,R,Michael Pompeo,115
-Sumner,Harmon,U.S. House,4,R,Michael Pompeo,112
-Sumner,Caldwell City W1,U.S. House,4,R,Michael Pompeo,108
-Sumner,Avon,U.S. House,4,R,Michael Pompeo,106
-Sumner,Seventy-Six,U.S. House,4,R,Michael Pompeo,99
-Sumner,Wellington twp H116,U.S. House,4,R,Michael Pompeo,95
-Sumner,Osborne,U.S. House,4,R,Michael Pompeo,89
-Sumner,Creek,U.S. House,4,R,Michael Pompeo,74
-Sumner,Gore H82,U.S. House,4,R,Michael Pompeo,74
-Sumner,Palestine,U.S. House,4,R,Michael Pompeo,73
-Sumner,Illinois,U.S. House,4,R,Michael Pompeo,63
-Sumner,Guelph,U.S. House,4,R,Michael Pompeo,53
-Sumner,Ryan,U.S. House,4,R,Michael Pompeo,53
-Sumner,Jackson,U.S. House,4,R,Michael Pompeo,51
-Sumner,Wellington twp H80,U.S. House,4,R,Michael Pompeo,51
-Sumner,Falls,U.S. House,4,R,Michael Pompeo,49
-Sumner,Downs,U.S. House,4,R,Michael Pompeo,46
-Sumner,Caldwell twp,U.S. House,4,R,Michael Pompeo,44
-Sumner,Sumner,U.S. House,4,R,Michael Pompeo,41
-Sumner,Valverde,U.S. House,4,R,Michael Pompeo,41
-Sumner,Chikaskia,U.S. House,4,R,Michael Pompeo,25
-Sumner,Greene,U.S. House,4,R,Michael Pompeo,22
-Sumner,Bluff,U.S. House,4,R,Michael Pompeo,21
-Sumner,Morris,U.S. House,4,R,Michael Pompeo,12
-Sumner,Mulvane City H79,U.S. House,4,R,Michael Pompeo,6
-Sumner,Belle Plaine twp H82,U.S. House,4,R,Michael Pompeo,4
-Sumner,Belle Plaine twp H79,State Senate,32,R,Larry W. Alley,892
-Sumner,Wellington 2,State Senate,32,R,Larry W. Alley,885
-Sumner,Wellington 1,State Senate,32,R,Larry W. Alley,492
-Sumner,Conway,State Senate,32,R,Larry W. Alley,325
-Sumner,Gore H79,State Senate,32,R,Larry W. Alley,281
-Sumner,Oxford twp,State Senate,32,R,Larry W. Alley,263
-Sumner,London,State Senate,32,R,Larry W. Alley,254
-Sumner,Mulvane City,State Senate,32,R,Larry W. Alley,192
-Sumner,Springdale,State Senate,32,R,Larry W. Alley,189
-Sumner,Dixon,State Senate,32,R,Larry W. Alley,171
-Sumner,Caldwell City W2,State Senate,32,R,Larry W. Alley,151
-Sumner,South Haven twp,State Senate,32,R,Larry W. Alley,123
-Sumner,Eden,State Senate,32,R,Larry W. Alley,121
-Sumner,Harmon,State Senate,32,R,Larry W. Alley,94
-Sumner,Avon,State Senate,32,R,Larry W. Alley,93
-Sumner,Seventy-Six,State Senate,32,R,Larry W. Alley,91
-Sumner,Walton,State Senate,32,R,Larry W. Alley,86
-Sumner,Gore H82,State Senate,32,R,Larry W. Alley,76
-Sumner,Osborne,State Senate,32,R,Larry W. Alley,76
-Sumner,Wellington twp H116,State Senate,32,R,Larry W. Alley,74
-Sumner,Caldwell City W1,State Senate,32,R,Larry W. Alley,73
-Sumner,Creek,State Senate,32,R,Larry W. Alley,70
-Sumner,Illinois,State Senate,32,R,Larry W. Alley,69
-Sumner,Palestine,State Senate,32,R,Larry W. Alley,66
-Sumner,Ryan,State Senate,32,R,Larry W. Alley,49
-Sumner,Wellington twp H80,State Senate,32,R,Larry W. Alley,46
-Sumner,Guelph,State Senate,32,R,Larry W. Alley,45
-Sumner,Sumner,State Senate,32,R,Larry W. Alley,42
-Sumner,Downs,State Senate,32,R,Larry W. Alley,40
-Sumner,Caldwell twp,State Senate,32,R,Larry W. Alley,39
-Sumner,Falls,State Senate,32,R,Larry W. Alley,38
-Sumner,Jackson,State Senate,32,R,Larry W. Alley,37
-Sumner,Valverde,State Senate,32,R,Larry W. Alley,34
-Sumner,Chikaskia,State Senate,32,R,Larry W. Alley,23
-Sumner,Greene,State Senate,32,R,Larry W. Alley,17
-Sumner,Bluff,State Senate,32,R,Larry W. Alley,13
-Sumner,Morris,State Senate,32,R,Larry W. Alley,9
-Sumner,Belle Plaine twp H82,State Senate,32,R,Larry W. Alley,4
-Sumner,Mulvane City H79,State Senate,32,R,Larry W. Alley,4
-Sumner,Wellington 2,State House,116,R,Kyle D. Hoffman,658
-Sumner,Conway,State House,116,R,Kyle D. Hoffman,293
-Sumner,London,State House,116,R,Kyle D. Hoffman,242
-Sumner,Springdale,State House,116,R,Kyle D. Hoffman,164
-Sumner,Dixon,State House,116,R,Kyle D. Hoffman,152
-Sumner,Eden,State House,116,R,Kyle D. Hoffman,120
-Sumner,Seventy-Six,State House,116,R,Kyle D. Hoffman,82
-Sumner,Creek,State House,116,R,Kyle D. Hoffman,65
-Sumner,Illinois,State House,116,R,Kyle D. Hoffman,65
-Sumner,Wellington twp H116,State House,116,R,Kyle D. Hoffman,63
-Sumner,Osborne,State House,116,R,Kyle D. Hoffman,58
-Sumner,Ryan,State House,116,R,Kyle D. Hoffman,43
-Sumner,Sumner,State House,116,R,Kyle D. Hoffman,39
-Sumner,Wellington 2,State House,116,D,Jolene E. Roitman,1173
-Sumner,Conway,State House,116,D,Jolene E. Roitman,166
-Sumner,Springdale,State House,116,D,Jolene E. Roitman,104
-Sumner,Dixon,State House,116,D,Jolene E. Roitman,94
-Sumner,London,State House,116,D,Jolene E. Roitman,85
-Sumner,Wellington twp H116,State House,116,D,Jolene E. Roitman,74
-Sumner,Osborne,State House,116,D,Jolene E. Roitman,69
-Sumner,Eden,State House,116,D,Jolene E. Roitman,39
-Sumner,Seventy-Six,State House,116,D,Jolene E. Roitman,37
-Sumner,Creek,State House,116,D,Jolene E. Roitman,26
-Sumner,Ryan,State House,116,D,Jolene E. Roitman,25
-Sumner,Sumner,State House,116,D,Jolene E. Roitman,24
-Sumner,Illinois,State House,116,D,Jolene E. Roitman,20
-Sumner,Wellington 2,President,,LBT,Gary Johnson,82
-Sumner,Belle Plaine twp H79,President,,LBT,Gary Johnson,62
-Sumner,Wellington 1,President,,LBT,Gary Johnson,52
-Sumner,Oxford twp,President,,LBT,Gary Johnson,31
-Sumner,Conway,President,,LBT,Gary Johnson,20
-Sumner,Gore H79,President,,LBT,Gary Johnson,18
-Sumner,London,President,,LBT,Gary Johnson,15
-Sumner,Springdale,President,,LBT,Gary Johnson,13
-Sumner,Eden,President,,LBT,Gary Johnson,10
-Sumner,Mulvane City,President,,LBT,Gary Johnson,10
-Sumner,Caldwell City W1,President,,LBT,Gary Johnson,9
-Sumner,Gore H82,President,,LBT,Gary Johnson,8
-Sumner,Jackson,President,,LBT,Gary Johnson,8
-Sumner,South Haven twp,President,,LBT,Gary Johnson,8
-Sumner,Walton,President,,LBT,Gary Johnson,7
-Sumner,Caldwell City W2,President,,LBT,Gary Johnson,7
-Sumner,Avon,President,,LBT,Gary Johnson,6
-Sumner,Dixon,President,,LBT,Gary Johnson,6
-Sumner,Creek,President,,LBT,Gary Johnson,5
-Sumner,Harmon,President,,LBT,Gary Johnson,5
-Sumner,Osborne,President,,LBT,Gary Johnson,5
-Sumner,Palestine,President,,LBT,Gary Johnson,5
-Sumner,Wellington twp H116,President,,LBT,Gary Johnson,4
-Sumner,Caldwell twp,President,,LBT,Gary Johnson,3
-Sumner,Guelph,President,,LBT,Gary Johnson,3
-Sumner,Illinois,President,,LBT,Gary Johnson,3
-Sumner,Wellington twp H80,President,,LBT,Gary Johnson,3
-Sumner,Falls,President,,LBT,Gary Johnson,2
-Sumner,Ryan,President,,LBT,Gary Johnson,2
-Sumner,Seventy-Six,President,,LBT,Gary Johnson,2
-Sumner,Sumner,President,,LBT,Gary Johnson,2
-Sumner,Valverde,President,,LBT,Gary Johnson,2
-Sumner,Bluff,President,,LBT,Gary Johnson,1
-Sumner,Greene,President,,LBT,Gary Johnson,1
-Sumner,Belle Plaine twp H82,President,,LBT,Gary Johnson,0
-Sumner,Chikaskia,President,,LBT,Gary Johnson,0
-Sumner,Downs,President,,LBT,Gary Johnson,0
-Sumner,Morris,President,,LBT,Gary Johnson,0
-Sumner,Mulvane City H79,President,,LBT,Gary Johnson,0
-Sumner,Wellington 2,U.S. Senate,,R,Jerry Moran,1214
-Sumner,Belle Plaine twp H79,U.S. Senate,,R,Jerry Moran,957
-Sumner,Wellington 1,U.S. Senate,,R,Jerry Moran,619
-Sumner,Oxford twp,U.S. Senate,,R,Jerry Moran,391
-Sumner,Conway,U.S. Senate,,R,Jerry Moran,339
-Sumner,Gore H79,U.S. Senate,,R,Jerry Moran,293
-Sumner,London,U.S. Senate,,R,Jerry Moran,262
-Sumner,Springdale,U.S. Senate,,R,Jerry Moran,211
-Sumner,Caldwell City W2,U.S. Senate,,R,Jerry Moran,205
-Sumner,Mulvane City,U.S. Senate,,R,Jerry Moran,203
-Sumner,Dixon,U.S. Senate,,R,Jerry Moran,193
-Sumner,South Haven twp,U.S. Senate,,R,Jerry Moran,185
-Sumner,Eden,U.S. Senate,,R,Jerry Moran,132
-Sumner,Walton,U.S. Senate,,R,Jerry Moran,126
-Sumner,Harmon,U.S. Senate,,R,Jerry Moran,118
-Sumner,Caldwell City W1,U.S. Senate,,R,Jerry Moran,114
-Sumner,Avon,U.S. Senate,,R,Jerry Moran,113
-Sumner,Seventy-Six,U.S. Senate,,R,Jerry Moran,101
-Sumner,Wellington twp H116,U.S. Senate,,R,Jerry Moran,96
-Sumner,Osborne,U.S. Senate,,R,Jerry Moran,94
-Sumner,Gore H82,U.S. Senate,,R,Jerry Moran,75
-Sumner,Illinois,U.S. Senate,,R,Jerry Moran,74
-Sumner,Palestine,U.S. Senate,,R,Jerry Moran,73
-Sumner,Creek,U.S. Senate,,R,Jerry Moran,70
-Sumner,Guelph,U.S. Senate,,R,Jerry Moran,55
-Sumner,Falls,U.S. Senate,,R,Jerry Moran,54
-Sumner,Jackson,U.S. Senate,,R,Jerry Moran,53
-Sumner,Wellington twp H80,U.S. Senate,,R,Jerry Moran,53
-Sumner,Caldwell twp,U.S. Senate,,R,Jerry Moran,52
-Sumner,Valverde,U.S. Senate,,R,Jerry Moran,51
-Sumner,Ryan,U.S. Senate,,R,Jerry Moran,50
-Sumner,Sumner,U.S. Senate,,R,Jerry Moran,50
-Sumner,Downs,U.S. Senate,,R,Jerry Moran,49
-Sumner,Greene,U.S. Senate,,R,Jerry Moran,27
-Sumner,Chikaskia,U.S. Senate,,R,Jerry Moran,25
-Sumner,Bluff,U.S. Senate,,R,Jerry Moran,24
-Sumner,Morris,U.S. Senate,,R,Jerry Moran,14
-Sumner,Mulvane City H79,U.S. Senate,,R,Jerry Moran,6
-Sumner,Belle Plaine twp H82,U.S. Senate,,R,Jerry Moran,4
-Sumner,Wellington 2,U.S. House,4,LBT,Gorden J. Bakken,61
-Sumner,Belle Plaine twp H79,U.S. House,4,LBT,Gorden J. Bakken,54
-Sumner,Wellington 1,U.S. House,4,LBT,Gorden J. Bakken,35
-Sumner,London,U.S. House,4,LBT,Gorden J. Bakken,20
-Sumner,Oxford twp,U.S. House,4,LBT,Gorden J. Bakken,16
-Sumner,Gore H79,U.S. House,4,LBT,Gorden J. Bakken,15
-Sumner,Conway,U.S. House,4,LBT,Gorden J. Bakken,13
-Sumner,Mulvane City,U.S. House,4,LBT,Gorden J. Bakken,10
-Sumner,Caldwell City W2,U.S. House,4,LBT,Gorden J. Bakken,8
-Sumner,Gore H82,U.S. House,4,LBT,Gorden J. Bakken,7
-Sumner,Walton,U.S. House,4,LBT,Gorden J. Bakken,7
-Sumner,Valverde,U.S. House,4,LBT,Gorden J. Bakken,6
-Sumner,Eden,U.S. House,4,LBT,Gorden J. Bakken,5
-Sumner,Illinois,U.S. House,4,LBT,Gorden J. Bakken,5
-Sumner,South Haven twp,U.S. House,4,LBT,Gorden J. Bakken,5
-Sumner,Wellington twp H80,U.S. House,4,LBT,Gorden J. Bakken,5
-Sumner,Avon,U.S. House,4,LBT,Gorden J. Bakken,4
-Sumner,Harmon,U.S. House,4,LBT,Gorden J. Bakken,3
-Sumner,Jackson,U.S. House,4,LBT,Gorden J. Bakken,3
-Sumner,Wellington twp H116,U.S. House,4,LBT,Gorden J. Bakken,3
-Sumner,Caldwell City W1,U.S. House,4,LBT,Gorden J. Bakken,3
-Sumner,Dixon,U.S. House,4,LBT,Gorden J. Bakken,2
-Sumner,Osborne,U.S. House,4,LBT,Gorden J. Bakken,2
-Sumner,Palestine,U.S. House,4,LBT,Gorden J. Bakken,2
-Sumner,Springdale,U.S. House,4,LBT,Gorden J. Bakken,2
-Sumner,Caldwell twp,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Downs,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Falls,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Greene,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Ryan,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Seventy-Six,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Sumner,U.S. House,4,LBT,Gorden J. Bakken,1
-Sumner,Belle Plaine twp H82,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Bluff,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Chikaskia,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Creek,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Guelph,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Morris,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Mulvane City H79,U.S. House,4,LBT,Gorden J. Bakken,0
-Sumner,Belle Plaine twp H79,State House 79,79,D,Ed Trimmer,1009
-Sumner,Oxford twp,State House 79,79,D,Ed Trimmer,431
-Sumner,Gore H79,State House 79,79,D,Ed Trimmer,282
-Sumner,Harmon,State House 79,79,D,Ed Trimmer,100
-Sumner,Palestine,State House 79,79,D,Ed Trimmer,72
-Sumner,Mulvane City H79,State House 79,79,D,Ed Trimmer,5
-Sumner,Wellington 2,State Senate,32,D,Don Shimkus,944
-Sumner,Wellington 1,State Senate,32,D,Don Shimkus,533
-Sumner,Belle Plaine twp H79,State Senate,32,D,Don Shimkus,426
-Sumner,Oxford twp,State Senate,32,D,Don Shimkus,322
-Sumner,Conway,State Senate,32,D,Don Shimkus,135
-Sumner,Caldwell City W2,State Senate,32,D,Don Shimkus,122
-Sumner,South Haven twp,State Senate,32,D,Don Shimkus,121
-Sumner,Caldwell City W1,State Senate,32,D,Don Shimkus,95
-Sumner,Gore H79,State Senate,32,D,Don Shimkus,94
-Sumner,Springdale,State Senate,32,D,Don Shimkus,82
-Sumner,Mulvane City,State Senate,32,D,Don Shimkus,81
-Sumner,Walton,State Senate,32,D,Don Shimkus,76
-Sumner,Dixon,State Senate,32,D,Don Shimkus,75
-Sumner,London,State Senate,32,D,Don Shimkus,69
-Sumner,Wellington twp H116,State Senate,32,D,Don Shimkus,64
-Sumner,Avon,State Senate,32,D,Don Shimkus,62
-Sumner,Harmon,State Senate,32,D,Don Shimkus,54
-Sumner,Osborne,State Senate,32,D,Don Shimkus,49
-Sumner,Eden,State Senate,32,D,Don Shimkus,39
-Sumner,Palestine,State Senate,32,D,Don Shimkus,36
-Sumner,Gore H82,State Senate,32,D,Don Shimkus,31
-Sumner,Caldwell twp,State Senate,32,D,Don Shimkus,30
-Sumner,Falls,State Senate,32,D,Don Shimkus,29
-Sumner,Jackson,State Senate,32,D,Don Shimkus,29
-Sumner,Seventy-Six,State Senate,32,D,Don Shimkus,28
-Sumner,Guelph,State Senate,32,D,Don Shimkus,27
-Sumner,Wellington twp H80,State Senate,32,D,Don Shimkus,26
-Sumner,Valverde,State Senate,32,D,Don Shimkus,25
-Sumner,Sumner,State Senate,32,D,Don Shimkus,21
-Sumner,Creek,State Senate,32,D,Don Shimkus,20
-Sumner,Ryan,State Senate,32,D,Don Shimkus,20
-Sumner,Downs,State Senate,32,D,Don Shimkus,18
-Sumner,Greene,State Senate,32,D,Don Shimkus,16
-Sumner,Bluff,State Senate,32,D,Don Shimkus,14
-Sumner,Illinois,State Senate,32,D,Don Shimkus,14
-Sumner,Chikaskia,State Senate,32,D,Don Shimkus,7
-Sumner,Morris,State Senate,32,D,Don Shimkus,5
-Sumner,Belle Plaine twp H82,State Senate,32,D,Don Shimkus,2
-Sumner,Mulvane City H79,State Senate,32,D,Don Shimkus,1
-Sumner,Mulvane City,State House 82,82,D,Dannette Harris,126
-Sumner,Gore H82,State House 82,82,D,Dannette Harris,55
-Sumner,Belle Plaine twp H82,State House 82,82,D,Dannette Harris,2
-Sumner,Wellington 2,U.S. House,4,D,Daniel B. Giroux,426
-Sumner,Wellington 1,U.S. House,4,D,Daniel B. Giroux,281
-Sumner,Belle Plaine twp H79,U.S. House,4,D,Daniel B. Giroux,271
-Sumner,Oxford twp,U.S. House,4,D,Daniel B. Giroux,120
-Sumner,Conway,U.S. House,4,D,Daniel B. Giroux,93
-Sumner,Mulvane City,U.S. House,4,D,Daniel B. Giroux,66
-Sumner,Gore H79,U.S. House,4,D,Daniel B. Giroux,63
-Sumner,Caldwell City W2,U.S. House,4,D,Daniel B. Giroux,62
-Sumner,Springdale,U.S. House,4,D,Daniel B. Giroux,51
-Sumner,Caldwell City W1,U.S. House,4,D,Daniel B. Giroux,51
-Sumner,London,U.S. House,4,D,Daniel B. Giroux,45
-Sumner,Dixon,U.S. House,4,D,Daniel B. Giroux,43
-Sumner,Avon,U.S. House,4,D,Daniel B. Giroux,33
-Sumner,South Haven twp,U.S. House,4,D,Daniel B. Giroux,30
-Sumner,Wellington twp H116,U.S. House,4,D,Daniel B. Giroux,25
-Sumner,Eden,U.S. House,4,D,Daniel B. Giroux,23
-Sumner,Gore H82,U.S. House,4,D,Daniel B. Giroux,23
-Sumner,Harmon,U.S. House,4,D,Daniel B. Giroux,23
-Sumner,Osborne,U.S. House,4,D,Daniel B. Giroux,23
-Sumner,Palestine,U.S. House,4,D,Daniel B. Giroux,18
-Sumner,Caldwell twp,U.S. House,4,D,Daniel B. Giroux,16
-Sumner,Walton,U.S. House,4,D,Daniel B. Giroux,16
-Sumner,Seventy-Six,U.S. House,4,D,Daniel B. Giroux,14
-Sumner,Creek,U.S. House,4,D,Daniel B. Giroux,13
-Sumner,Illinois,U.S. House,4,D,Daniel B. Giroux,12
-Sumner,Guelph,U.S. House,4,D,Daniel B. Giroux,11
-Sumner,Sumner,U.S. House,4,D,Daniel B. Giroux,11
-Sumner,Jackson,U.S. House,4,D,Daniel B. Giroux,9
-Sumner,Wellington twp H80,U.S. House,4,D,Daniel B. Giroux,9
-Sumner,Downs,U.S. House,4,D,Daniel B. Giroux,8
-Sumner,Falls,U.S. House,4,D,Daniel B. Giroux,8
-Sumner,Ryan,U.S. House,4,D,Daniel B. Giroux,8
-Sumner,Valverde,U.S. House,4,D,Daniel B. Giroux,6
-Sumner,Bluff,U.S. House,4,D,Daniel B. Giroux,4
-Sumner,Greene,U.S. House,4,D,Daniel B. Giroux,4
-Sumner,Belle Plaine twp H82,U.S. House,4,D,Daniel B. Giroux,2
-Sumner,Chikaskia,U.S. House,4,D,Daniel B. Giroux,1
-Sumner,Morris,U.S. House,4,D,Daniel B. Giroux,1
-Sumner,Mulvane City H79,U.S. House,4,D,Daniel B. Giroux,0
-Sumner,Wellington 2,President,,D,Hillary Clinton,485
-Sumner,Wellington 1,President,,D,Hillary Clinton,325
-Sumner,Belle Plaine twp H79,President,,D,Hillary Clinton,283
-Sumner,Oxford twp,President,,D,Hillary Clinton,123
-Sumner,Conway,President,,D,Hillary Clinton,88
-Sumner,Mulvane City,President,,D,Hillary Clinton,68
-Sumner,Gore H79,President,,D,Hillary Clinton,66
-Sumner,Springdale,President,,D,Hillary Clinton,57
-Sumner,Caldwell City W2,President,,D,Hillary Clinton,57
-Sumner,Caldwell City W1,President,,D,Hillary Clinton,53
-Sumner,London,President,,D,Hillary Clinton,49
-Sumner,South Haven twp,President,,D,Hillary Clinton,38
-Sumner,Dixon,President,,D,Hillary Clinton,35
-Sumner,Wellington twp H116,President,,D,Hillary Clinton,34
-Sumner,Avon,President,,D,Hillary Clinton,31
-Sumner,Harmon,President,,D,Hillary Clinton,27
-Sumner,Eden,President,,D,Hillary Clinton,25
-Sumner,Gore H82,President,,D,Hillary Clinton,23
-Sumner,Osborne,President,,D,Hillary Clinton,23
-Sumner,Palestine,President,,D,Hillary Clinton,20
-Sumner,Walton,President,,D,Hillary Clinton,20
-Sumner,Caldwell twp,President,,D,Hillary Clinton,17
-Sumner,Sumner,President,,D,Hillary Clinton,15
-Sumner,Ryan,President,,D,Hillary Clinton,13
-Sumner,Falls,President,,D,Hillary Clinton,11
-Sumner,Jackson,President,,D,Hillary Clinton,11
-Sumner,Creek,President,,D,Hillary Clinton,10
-Sumner,Downs,President,,D,Hillary Clinton,9
-Sumner,Wellington twp H80,President,,D,Hillary Clinton,9
-Sumner,Guelph,President,,D,Hillary Clinton,8
-Sumner,Seventy-Six,President,,D,Hillary Clinton,8
-Sumner,Valverde,President,,D,Hillary Clinton,8
-Sumner,Illinois,President,,D,Hillary Clinton,7
-Sumner,Bluff,President,,D,Hillary Clinton,6
-Sumner,Chikaskia,President,,D,Hillary Clinton,5
-Sumner,Greene,President,,D,Hillary Clinton,3
-Sumner,Morris,President,,D,Hillary Clinton,3
-Sumner,Belle Plaine twp H82,President,,D,Hillary Clinton,2
-Sumner,Mulvane City H79,President,,D,Hillary Clinton,1
-Sumner,Wellington 1,State House,80,R,Anita Judd-Jenkins,555
-Sumner,South Haven twp,State House,80,R,Anita Judd-Jenkins,151
-Sumner,Walton,State House,80,R,Anita Judd-Jenkins,101
-Sumner,Avon,State House,80,R,Anita Judd-Jenkins,99
-Sumner,Caldwell City W2,State House,80,R,Anita Judd-Jenkins,98
-Sumner,Guelph,State House,80,R,Anita Judd-Jenkins,49
-Sumner,Valverde,State House,80,R,Anita Judd-Jenkins,48
-Sumner,Jackson,State House,80,R,Anita Judd-Jenkins,47
-Sumner,Wellington twp H80,State House,80,R,Anita Judd-Jenkins,46
-Sumner,Caldwell City W1,State House,80,R,Anita Judd-Jenkins,38
-Sumner,Downs,State House,80,R,Anita Judd-Jenkins,32
-Sumner,Falls,State House,80,R,Anita Judd-Jenkins,28
-Sumner,Caldwell twp,State House,80,R,Anita Judd-Jenkins,23
-Sumner,Greene,State House,80,R,Anita Judd-Jenkins,21
-Sumner,Chikaskia,State House,80,R,Anita Judd-Jenkins,16
-Sumner,Bluff,State House,80,R,Anita Judd-Jenkins,7
-Sumner,Morris,State House,80,R,Anita Judd-Jenkins,7
+county,precinct,office,district,party,candidate,votes,vtd
+SUMNER,Avon Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",1,000010
+SUMNER,Avon Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",55,000010
+SUMNER,Avon Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",99,000010
+SUMNER,Bluff Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000030
+SUMNER,Bluff Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",20,000030
+SUMNER,Bluff Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",7,000030
+SUMNER,Caldwell City Ward 1,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000040
+SUMNER,Caldwell City Ward 1,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",133,000040
+SUMNER,Caldwell City Ward 1,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",38,000040
+SUMNER,Caldwell City Ward 2,Kansas House of Representatives,80,write - in,"Kelley, Kasha",3,000050
+SUMNER,Caldwell City Ward 2,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",181,000050
+SUMNER,Caldwell City Ward 2,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",98,000050
+SUMNER,Caldwell Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",1,000060
+SUMNER,Caldwell Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",45,000060
+SUMNER,Caldwell Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",23,000060
+SUMNER,Chikaskia Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",1,000070
+SUMNER,Chikaskia Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",12,000070
+SUMNER,Chikaskia Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",16,000070
+SUMNER,Conway Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",166,000080
+SUMNER,Conway Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",293,000080
+SUMNER,Creek Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",26,000090
+SUMNER,Creek Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",65,000090
+SUMNER,Dixon Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",94,000100
+SUMNER,Dixon Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",152,000100
+SUMNER,Downs Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",1,000110
+SUMNER,Downs Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",22,000110
+SUMNER,Downs Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",32,000110
+SUMNER,Eden Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",39,000120
+SUMNER,Eden Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",120,000120
+SUMNER,Falls Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",2,000130
+SUMNER,Falls Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",38,000130
+SUMNER,Falls Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",28,000130
+SUMNER,Greene Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000150
+SUMNER,Greene Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",9,000150
+SUMNER,Greene Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",21,000150
+SUMNER,Guelph Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",2,000160
+SUMNER,Guelph Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",17,000160
+SUMNER,Guelph Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",49,000160
+SUMNER,Harmon Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",100,000170
+SUMNER,Illinois Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",20,000180
+SUMNER,Illinois Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",65,000180
+SUMNER,Jackson Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000190
+SUMNER,Jackson Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",19,000190
+SUMNER,Jackson Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",47,000190
+SUMNER,London Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",85,000200
+SUMNER,London Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",242,000200
+SUMNER,Morris Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000210
+SUMNER,Morris Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",6,000210
+SUMNER,Morris Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",7,000210
+SUMNER,Mulvane City,Kansas House of Representatives,82,Democratic,"Harris, Danette",126,000220
+SUMNER,Mulvane City,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",153,000220
+SUMNER,Osborne Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",69,000230
+SUMNER,Osborne Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",58,000230
+SUMNER,Oxford Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",431,000240
+SUMNER,Palestine Township,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",72,000250
+SUMNER,Ryan Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",25,000260
+SUMNER,Ryan Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",43,000260
+SUMNER,South Haven Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",2,000280
+SUMNER,South Haven Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",90,000280
+SUMNER,South Haven Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",151,000280
+SUMNER,Springdale Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",104,000290
+SUMNER,Springdale Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",164,000290
+SUMNER,Sumner Township,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",24,000300
+SUMNER,Sumner Township,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",39,000300
+SUMNER,Valverde Township,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,000310
+SUMNER,Valverde Township,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",11,000310
+SUMNER,Valverde Township,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",48,000310
+SUMNER,Walton Precinct,Kansas House of Representatives,80,write - in,"Kelley, Kasha",22,000320
+SUMNER,Walton Precinct,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",38,000320
+SUMNER,Walton Precinct,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",101,000320
+SUMNER,Belle Plaine Township H79,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",1009,120020
+SUMNER,Belle Plaine Township H82,Kansas House of Representatives,82,Democratic,"Harris, Danette",2,120030
+SUMNER,Belle Plaine Township H82,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",4,120030
+SUMNER,Gore Township H79,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",282,120040
+SUMNER,Gore Township H82,Kansas House of Representatives,82,Democratic,"Harris, Danette",55,120050
+SUMNER,Gore Township H82,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",56,120050
+SUMNER,Seventy - Six Township H116,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",37,120060
+SUMNER,Seventy - Six Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",82,120060
+SUMNER,Seventy - Six Township H80,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,120070
+SUMNER,Seventy - Six Township H80,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,120070
+SUMNER,Seventy - Six Township H80,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,120070
+SUMNER,Wellington Township H116,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",74,120120
+SUMNER,Wellington Township H116,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",63,120120
+SUMNER,Wellington Township H80 A,Kansas House of Representatives,80,write - in,"Kelley, Kasha",0,12013A
+SUMNER,Wellington Township H80 A,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",0,12013A
+SUMNER,Wellington Township H80 A,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",0,12013A
+SUMNER,Wellington Township H80,Kansas House of Representatives,80,write - in,"Kelley, Kasha",5,120130
+SUMNER,Wellington Township H80,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",24,120130
+SUMNER,Wellington Township H80,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",46,120130
+SUMNER,Wellington City Precinct 1,Kansas House of Representatives,80,write - in,"Kelley, Kasha",8,130010
+SUMNER,Wellington City Precinct 1,Kansas House of Representatives,80,Democratic,"Schiltz, Michelle",452,130010
+SUMNER,Wellington City Precinct 1,Kansas House of Representatives,80,Republican,"Judd-Jenkins, Anita",555,130010
+SUMNER,Wellington City Precinct 2,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",1173,130020
+SUMNER,Wellington City Precinct 2,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",658,130020
+SUMNER,Wellington City Airport,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",0,900020
+SUMNER,Wellington City Airport,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900020
+SUMNER,Wellington Lake Exclave,Kansas House of Representatives,116,Democratic,"Roitman, Jolene E.",0,900030
+SUMNER,Wellington Lake Exclave,Kansas House of Representatives,116,Republican,"Hoffman, Kyle D.",0,900030
+SUMNER,Gore Township Enclave,Kansas House of Representatives,82,Democratic,"Harris, Danette",0,900040
+SUMNER,Gore Township Enclave,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",0,900040
+SUMNER,Mulvane City Exclave A,Kansas House of Representatives,82,Democratic,"Harris, Danette",0,900050
+SUMNER,Mulvane City Exclave A,Kansas House of Representatives,82,Republican,"DeGraaf, Pete",0,900050
+SUMNER,Mulvane City Exclave B,Kansas House of Representatives,79,Democratic,"Trimmer, Ed",5,900060
+SUMNER,Avon Township,Kansas Senate,32,Democratic,"Shimkus, Don",62,000010
+SUMNER,Avon Township,Kansas Senate,32,Republican,"Alley, Larry W.",93,000010
+SUMNER,Bluff Township,Kansas Senate,32,Democratic,"Shimkus, Don",14,000030
+SUMNER,Bluff Township,Kansas Senate,32,Republican,"Alley, Larry W.",13,000030
+SUMNER,Caldwell City Ward 1,Kansas Senate,32,Democratic,"Shimkus, Don",95,000040
+SUMNER,Caldwell City Ward 1,Kansas Senate,32,Republican,"Alley, Larry W.",73,000040
+SUMNER,Caldwell City Ward 2,Kansas Senate,32,Democratic,"Shimkus, Don",122,000050
+SUMNER,Caldwell City Ward 2,Kansas Senate,32,Republican,"Alley, Larry W.",151,000050
+SUMNER,Caldwell Township,Kansas Senate,32,Democratic,"Shimkus, Don",30,000060
+SUMNER,Caldwell Township,Kansas Senate,32,Republican,"Alley, Larry W.",39,000060
+SUMNER,Chikaskia Township,Kansas Senate,32,Democratic,"Shimkus, Don",7,000070
+SUMNER,Chikaskia Township,Kansas Senate,32,Republican,"Alley, Larry W.",23,000070
+SUMNER,Conway Township,Kansas Senate,32,Democratic,"Shimkus, Don",135,000080
+SUMNER,Conway Township,Kansas Senate,32,Republican,"Alley, Larry W.",325,000080
+SUMNER,Creek Township,Kansas Senate,32,Democratic,"Shimkus, Don",20,000090
+SUMNER,Creek Township,Kansas Senate,32,Republican,"Alley, Larry W.",70,000090
+SUMNER,Dixon Township,Kansas Senate,32,Democratic,"Shimkus, Don",75,000100
+SUMNER,Dixon Township,Kansas Senate,32,Republican,"Alley, Larry W.",171,000100
+SUMNER,Downs Township,Kansas Senate,32,Democratic,"Shimkus, Don",18,000110
+SUMNER,Downs Township,Kansas Senate,32,Republican,"Alley, Larry W.",40,000110
+SUMNER,Eden Township,Kansas Senate,32,Democratic,"Shimkus, Don",39,000120
+SUMNER,Eden Township,Kansas Senate,32,Republican,"Alley, Larry W.",121,000120
+SUMNER,Falls Township,Kansas Senate,32,Democratic,"Shimkus, Don",29,000130
+SUMNER,Falls Township,Kansas Senate,32,Republican,"Alley, Larry W.",38,000130
+SUMNER,Greene Township,Kansas Senate,32,Democratic,"Shimkus, Don",16,000150
+SUMNER,Greene Township,Kansas Senate,32,Republican,"Alley, Larry W.",17,000150
+SUMNER,Guelph Township,Kansas Senate,32,Democratic,"Shimkus, Don",27,000160
+SUMNER,Guelph Township,Kansas Senate,32,Republican,"Alley, Larry W.",45,000160
+SUMNER,Harmon Township,Kansas Senate,32,Democratic,"Shimkus, Don",54,000170
+SUMNER,Harmon Township,Kansas Senate,32,Republican,"Alley, Larry W.",94,000170
+SUMNER,Illinois Township,Kansas Senate,32,Democratic,"Shimkus, Don",14,000180
+SUMNER,Illinois Township,Kansas Senate,32,Republican,"Alley, Larry W.",69,000180
+SUMNER,Jackson Township,Kansas Senate,32,Democratic,"Shimkus, Don",29,000190
+SUMNER,Jackson Township,Kansas Senate,32,Republican,"Alley, Larry W.",37,000190
+SUMNER,London Township,Kansas Senate,32,Democratic,"Shimkus, Don",69,000200
+SUMNER,London Township,Kansas Senate,32,Republican,"Alley, Larry W.",254,000200
+SUMNER,Morris Township,Kansas Senate,32,Democratic,"Shimkus, Don",5,000210
+SUMNER,Morris Township,Kansas Senate,32,Republican,"Alley, Larry W.",9,000210
+SUMNER,Mulvane City,Kansas Senate,32,Democratic,"Shimkus, Don",81,000220
+SUMNER,Mulvane City,Kansas Senate,32,Republican,"Alley, Larry W.",192,000220
+SUMNER,Osborne Township,Kansas Senate,32,Democratic,"Shimkus, Don",49,000230
+SUMNER,Osborne Township,Kansas Senate,32,Republican,"Alley, Larry W.",76,000230
+SUMNER,Oxford Township,Kansas Senate,32,Democratic,"Shimkus, Don",322,000240
+SUMNER,Oxford Township,Kansas Senate,32,Republican,"Alley, Larry W.",263,000240
+SUMNER,Palestine Township,Kansas Senate,32,Democratic,"Shimkus, Don",36,000250
+SUMNER,Palestine Township,Kansas Senate,32,Republican,"Alley, Larry W.",66,000250
+SUMNER,Ryan Township,Kansas Senate,32,Democratic,"Shimkus, Don",20,000260
+SUMNER,Ryan Township,Kansas Senate,32,Republican,"Alley, Larry W.",49,000260
+SUMNER,South Haven Township,Kansas Senate,32,Democratic,"Shimkus, Don",121,000280
+SUMNER,South Haven Township,Kansas Senate,32,Republican,"Alley, Larry W.",123,000280
+SUMNER,Springdale Township,Kansas Senate,32,Democratic,"Shimkus, Don",82,000290
+SUMNER,Springdale Township,Kansas Senate,32,Republican,"Alley, Larry W.",189,000290
+SUMNER,Sumner Township,Kansas Senate,32,Democratic,"Shimkus, Don",21,000300
+SUMNER,Sumner Township,Kansas Senate,32,Republican,"Alley, Larry W.",42,000300
+SUMNER,Valverde Township,Kansas Senate,32,Democratic,"Shimkus, Don",25,000310
+SUMNER,Valverde Township,Kansas Senate,32,Republican,"Alley, Larry W.",34,000310
+SUMNER,Walton Precinct,Kansas Senate,32,Democratic,"Shimkus, Don",76,000320
+SUMNER,Walton Precinct,Kansas Senate,32,Republican,"Alley, Larry W.",86,000320
+SUMNER,Belle Plaine Township H79,Kansas Senate,32,Democratic,"Shimkus, Don",426,120020
+SUMNER,Belle Plaine Township H79,Kansas Senate,32,Republican,"Alley, Larry W.",892,120020
+SUMNER,Belle Plaine Township H82,Kansas Senate,32,Democratic,"Shimkus, Don",2,120030
+SUMNER,Belle Plaine Township H82,Kansas Senate,32,Republican,"Alley, Larry W.",4,120030
+SUMNER,Gore Township H79,Kansas Senate,32,Democratic,"Shimkus, Don",94,120040
+SUMNER,Gore Township H79,Kansas Senate,32,Republican,"Alley, Larry W.",281,120040
+SUMNER,Gore Township H82,Kansas Senate,32,Democratic,"Shimkus, Don",31,120050
+SUMNER,Gore Township H82,Kansas Senate,32,Republican,"Alley, Larry W.",76,120050
+SUMNER,Seventy - Six Township H116,Kansas Senate,32,Democratic,"Shimkus, Don",28,120060
+SUMNER,Seventy - Six Township H116,Kansas Senate,32,Republican,"Alley, Larry W.",91,120060
+SUMNER,Seventy - Six Township H80,Kansas Senate,32,Democratic,"Shimkus, Don",0,120070
+SUMNER,Seventy - Six Township H80,Kansas Senate,32,Republican,"Alley, Larry W.",0,120070
+SUMNER,Wellington Township H116,Kansas Senate,32,Democratic,"Shimkus, Don",64,120120
+SUMNER,Wellington Township H116,Kansas Senate,32,Republican,"Alley, Larry W.",74,120120
+SUMNER,Wellington Township H80 A,Kansas Senate,32,Democratic,"Shimkus, Don",0,12013A
+SUMNER,Wellington Township H80 A,Kansas Senate,32,Republican,"Alley, Larry W.",0,12013A
+SUMNER,Wellington Township H80,Kansas Senate,32,Democratic,"Shimkus, Don",26,120130
+SUMNER,Wellington Township H80,Kansas Senate,32,Republican,"Alley, Larry W.",46,120130
+SUMNER,Wellington City Precinct 1,Kansas Senate,32,Democratic,"Shimkus, Don",533,130010
+SUMNER,Wellington City Precinct 1,Kansas Senate,32,Republican,"Alley, Larry W.",492,130010
+SUMNER,Wellington City Precinct 2,Kansas Senate,32,Democratic,"Shimkus, Don",944,130020
+SUMNER,Wellington City Precinct 2,Kansas Senate,32,Republican,"Alley, Larry W.",885,130020
+SUMNER,Wellington City Airport,Kansas Senate,32,Democratic,"Shimkus, Don",0,900020
+SUMNER,Wellington City Airport,Kansas Senate,32,Republican,"Alley, Larry W.",0,900020
+SUMNER,Wellington Lake Exclave,Kansas Senate,32,Democratic,"Shimkus, Don",0,900030
+SUMNER,Wellington Lake Exclave,Kansas Senate,32,Republican,"Alley, Larry W.",0,900030
+SUMNER,Gore Township Enclave,Kansas Senate,32,Democratic,"Shimkus, Don",0,900040
+SUMNER,Gore Township Enclave,Kansas Senate,32,Republican,"Alley, Larry W.",0,900040
+SUMNER,Mulvane City Exclave A,Kansas Senate,32,Democratic,"Shimkus, Don",0,900050
+SUMNER,Mulvane City Exclave A,Kansas Senate,32,Republican,"Alley, Larry W.",0,900050
+SUMNER,Mulvane City Exclave B,Kansas Senate,32,Democratic,"Shimkus, Don",1,900060
+SUMNER,Mulvane City Exclave B,Kansas Senate,32,Republican,"Alley, Larry W.",4,900060
+SUMNER,Avon Township,President / Vice President,,independent,"Stein, Jill",2,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"McMullin, Evan",3,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+SUMNER,Avon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+SUMNER,Avon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",31,000010
+SUMNER,Avon Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000010
+SUMNER,Avon Township,President / Vice President,,Republican,"Trump, Donald J.",117,000010
+SUMNER,Bluff Township,President / Vice President,,independent,"Stein, Jill",1,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+SUMNER,Bluff Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+SUMNER,Bluff Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000030
+SUMNER,Bluff Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+SUMNER,Bluff Township,President / Vice President,,Republican,"Trump, Donald J.",20,000030
+SUMNER,Caldwell City Ward 1,President / Vice President,,independent,"Stein, Jill",1,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",53,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",9,000040
+SUMNER,Caldwell City Ward 1,President / Vice President,,Republican,"Trump, Donald J.",110,000040
+SUMNER,Caldwell City Ward 2,President / Vice President,,independent,"Stein, Jill",4,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"McMullin, Evan",3,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000050
+SUMNER,Caldwell City Ward 2,President / Vice President,,Republican,"Trump, Donald J.",210,000050
+SUMNER,Caldwell Township,President / Vice President,,independent,"Stein, Jill",1,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"McMullin, Evan",1,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+SUMNER,Caldwell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+SUMNER,Caldwell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000060
+SUMNER,Caldwell Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000060
+SUMNER,Caldwell Township,President / Vice President,,Republican,"Trump, Donald J.",47,000060
+SUMNER,Chikaskia Township,President / Vice President,,independent,"Stein, Jill",1,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000070
+SUMNER,Chikaskia Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+SUMNER,Chikaskia Township,President / Vice President,,Republican,"Trump, Donald J.",25,000070
+SUMNER,Conway Township,President / Vice President,,independent,"Stein, Jill",11,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Maturen, Michael A",1,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+SUMNER,Conway Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+SUMNER,Conway Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000080
+SUMNER,Conway Township,President / Vice President,,Libertarian,"Johnson, Gary",20,000080
+SUMNER,Conway Township,President / Vice President,,Republican,"Trump, Donald J.",355,000080
+SUMNER,Creek Township,President / Vice President,,independent,"Stein, Jill",1,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+SUMNER,Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+SUMNER,Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000090
+SUMNER,Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+SUMNER,Creek Township,President / Vice President,,Republican,"Trump, Donald J.",79,000090
+SUMNER,Dixon Township,President / Vice President,,independent,"Stein, Jill",5,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Castle, Darrell L",2,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+SUMNER,Dixon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+SUMNER,Dixon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000100
+SUMNER,Dixon Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000100
+SUMNER,Dixon Township,President / Vice President,,Republican,"Trump, Donald J.",205,000100
+SUMNER,Downs Township,President / Vice President,,independent,"Stein, Jill",1,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+SUMNER,Downs Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+SUMNER,Downs Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000110
+SUMNER,Downs Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000110
+SUMNER,Downs Township,President / Vice President,,Republican,"Trump, Donald J.",55,000110
+SUMNER,Eden Township,President / Vice President,,independent,"Stein, Jill",4,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"McMullin, Evan",1,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+SUMNER,Eden Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+SUMNER,Eden Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000120
+SUMNER,Eden Township,President / Vice President,,Libertarian,"Johnson, Gary",10,000120
+SUMNER,Eden Township,President / Vice President,,Republican,"Trump, Donald J.",130,000120
+SUMNER,Falls Township,President / Vice President,,independent,"Stein, Jill",1,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+SUMNER,Falls Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+SUMNER,Falls Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000130
+SUMNER,Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000130
+SUMNER,Falls Township,President / Vice President,,Republican,"Trump, Donald J.",56,000130
+SUMNER,Greene Township,President / Vice President,,independent,"Stein, Jill",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+SUMNER,Greene Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+SUMNER,Greene Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000150
+SUMNER,Greene Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000150
+SUMNER,Greene Township,President / Vice President,,Republican,"Trump, Donald J.",30,000150
+SUMNER,Guelph Township,President / Vice President,,independent,"Stein, Jill",1,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+SUMNER,Guelph Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+SUMNER,Guelph Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000160
+SUMNER,Guelph Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000160
+SUMNER,Guelph Township,President / Vice President,,Republican,"Trump, Donald J.",60,000160
+SUMNER,Harmon Township,President / Vice President,,independent,"Stein, Jill",2,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"McMullin, Evan",1,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+SUMNER,Harmon Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+SUMNER,Harmon Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,000170
+SUMNER,Harmon Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000170
+SUMNER,Harmon Township,President / Vice President,,Republican,"Trump, Donald J.",115,000170
+SUMNER,Illinois Township,President / Vice President,,independent,"Stein, Jill",1,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+SUMNER,Illinois Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+SUMNER,Illinois Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000180
+SUMNER,Illinois Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000180
+SUMNER,Illinois Township,President / Vice President,,Republican,"Trump, Donald J.",74,000180
+SUMNER,Jackson Township,President / Vice President,,independent,"Stein, Jill",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+SUMNER,Jackson Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+SUMNER,Jackson Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000190
+SUMNER,Jackson Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000190
+SUMNER,Jackson Township,President / Vice President,,Republican,"Trump, Donald J.",50,000190
+SUMNER,London Township,President / Vice President,,independent,"Stein, Jill",5,000200
+SUMNER,London Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"McMullin, Evan",2,000200
+SUMNER,London Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+SUMNER,London Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+SUMNER,London Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",49,000200
+SUMNER,London Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000200
+SUMNER,London Township,President / Vice President,,Republican,"Trump, Donald J.",271,000200
+SUMNER,Morris Township,President / Vice President,,independent,"Stein, Jill",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+SUMNER,Morris Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+SUMNER,Morris Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000210
+SUMNER,Morris Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000210
+SUMNER,Morris Township,President / Vice President,,Republican,"Trump, Donald J.",11,000210
+SUMNER,Mulvane City,President / Vice President,,independent,"Stein, Jill",4,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Hedges, James A",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"McMullin, Evan",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Perry, Darryl",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Smith, Mike",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Sood, Ajay",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+SUMNER,Mulvane City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+SUMNER,Mulvane City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",68,000220
+SUMNER,Mulvane City,President / Vice President,,Libertarian,"Johnson, Gary",10,000220
+SUMNER,Mulvane City,President / Vice President,,Republican,"Trump, Donald J.",207,000220
+SUMNER,Osborne Township,President / Vice President,,independent,"Stein, Jill",2,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+SUMNER,Osborne Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+SUMNER,Osborne Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,000230
+SUMNER,Osborne Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000230
+SUMNER,Osborne Township,President / Vice President,,Republican,"Trump, Donald J.",98,000230
+SUMNER,Oxford Township,President / Vice President,,independent,"Stein, Jill",11,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Castle, Darrell L",1,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Hoefling, Tom",2,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"McMullin, Evan",1,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+SUMNER,Oxford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+SUMNER,Oxford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",123,000240
+SUMNER,Oxford Township,President / Vice President,,Libertarian,"Johnson, Gary",31,000240
+SUMNER,Oxford Township,President / Vice President,,Republican,"Trump, Donald J.",411,000240
+SUMNER,Palestine Township,President / Vice President,,independent,"Stein, Jill",3,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Castle, Darrell L",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Giordani, Rocky",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Hedges, James A",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Hoefling, Tom",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Kahn, Lynn",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"La Riva, Gloria",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Maturen, Michael A",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"McMullin, Evan",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Perry, Darryl",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Schriner, Joe C",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Smith, Mike",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Sood, Ajay",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Sterling, Shawna",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000250
+SUMNER,Palestine Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000250
+SUMNER,Palestine Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000250
+SUMNER,Palestine Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000250
+SUMNER,Palestine Township,President / Vice President,,Republican,"Trump, Donald J.",75,000250
+SUMNER,Ryan Township,President / Vice President,,independent,"Stein, Jill",1,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Hedges, James A",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"McMullin, Evan",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Perry, Darryl",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Smith, Mike",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Sood, Ajay",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000260
+SUMNER,Ryan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000260
+SUMNER,Ryan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000260
+SUMNER,Ryan Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000260
+SUMNER,Ryan Township,President / Vice President,,Republican,"Trump, Donald J.",52,000260
+SUMNER,South Haven Township,President / Vice President,,independent,"Stein, Jill",2,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Castle, Darrell L",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Giordani, Rocky",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Hedges, James A",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Hoefling, Tom",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Kahn, Lynn",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"La Riva, Gloria",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Maturen, Michael A",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"McMullin, Evan",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Perry, Darryl",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Schriner, Joe C",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Smith, Mike",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Sood, Ajay",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Sterling, Shawna",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000280
+SUMNER,South Haven Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000280
+SUMNER,South Haven Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",38,000280
+SUMNER,South Haven Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000280
+SUMNER,South Haven Township,President / Vice President,,Republican,"Trump, Donald J.",196,000280
+SUMNER,Springdale Township,President / Vice President,,independent,"Stein, Jill",3,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Hedges, James A",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"McMullin, Evan",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Perry, Darryl",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Smith, Mike",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Sood, Ajay",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000290
+SUMNER,Springdale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000290
+SUMNER,Springdale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",57,000290
+SUMNER,Springdale Township,President / Vice President,,Libertarian,"Johnson, Gary",13,000290
+SUMNER,Springdale Township,President / Vice President,,Republican,"Trump, Donald J.",213,000290
+SUMNER,Sumner Township,President / Vice President,,independent,"Stein, Jill",2,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Castle, Darrell L",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Giordani, Rocky",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Hedges, James A",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Hoefling, Tom",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Kahn, Lynn",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"La Riva, Gloria",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Maturen, Michael A",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"McMullin, Evan",1,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Perry, Darryl",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Schriner, Joe C",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Smith, Mike",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Sood, Ajay",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Sterling, Shawna",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000300
+SUMNER,Sumner Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000300
+SUMNER,Sumner Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000300
+SUMNER,Sumner Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000300
+SUMNER,Sumner Township,President / Vice President,,Republican,"Trump, Donald J.",44,000300
+SUMNER,Valverde Township,President / Vice President,,independent,"Stein, Jill",2,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Castle, Darrell L",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Giordani, Rocky",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Hedges, James A",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Hoefling, Tom",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Kahn, Lynn",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"La Riva, Gloria",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Maturen, Michael A",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"McMullin, Evan",1,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Perry, Darryl",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Schriner, Joe C",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Smith, Mike",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Sood, Ajay",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Sterling, Shawna",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000310
+SUMNER,Valverde Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000310
+SUMNER,Valverde Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000310
+SUMNER,Valverde Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000310
+SUMNER,Valverde Township,President / Vice President,,Republican,"Trump, Donald J.",50,000310
+SUMNER,Walton Precinct,President / Vice President,,independent,"Stein, Jill",5,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Hedges, James A",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"McMullin, Evan",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Smith, Mike",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000320
+SUMNER,Walton Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000320
+SUMNER,Walton Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",20,000320
+SUMNER,Walton Precinct,President / Vice President,,Libertarian,"Johnson, Gary",7,000320
+SUMNER,Walton Precinct,President / Vice President,,Republican,"Trump, Donald J.",132,000320
+SUMNER,Belle Plaine Township H79,President / Vice President,,independent,"Stein, Jill",34,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Hedges, James A",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"McMullin, Evan",3,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Perry, Darryl",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Smith, Mike",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Sood, Ajay",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Democratic,"Clinton, Hillary Rodham",283,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Libertarian,"Johnson, Gary",62,120020
+SUMNER,Belle Plaine Township H79,President / Vice President,,Republican,"Trump, Donald J.",968,120020
+SUMNER,Belle Plaine Township H82,President / Vice President,,independent,"Stein, Jill",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Hedges, James A",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"McMullin, Evan",1,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Perry, Darryl",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Smith, Mike",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Sood, Ajay",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+SUMNER,Belle Plaine Township H82,President / Vice President,,Republican,"Trump, Donald J.",4,120030
+SUMNER,Gore Township H79,President / Vice President,,independent,"Stein, Jill",7,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Basiago, Andrew D.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Castle, Darrell L",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Giordani, Rocky",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Hedges, James A",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Hoefling, Tom",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Kahn, Lynn",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"La Riva, Gloria",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Levinson, Michael S.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Maturen, Michael A",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"McMullin, Evan",2,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Moorehead, Monica G.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Perry, Darryl",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Schriner, Joe C",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Smith, Mike",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Sood, Ajay",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Sterling, Shawna",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Valdivia, Anthony J",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120040
+SUMNER,Gore Township H79,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120040
+SUMNER,Gore Township H79,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,120040
+SUMNER,Gore Township H79,President / Vice President,,Libertarian,"Johnson, Gary",18,120040
+SUMNER,Gore Township H79,President / Vice President,,Republican,"Trump, Donald J.",301,120040
+SUMNER,Gore Township H82,President / Vice President,,independent,"Stein, Jill",2,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Basiago, Andrew D.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Castle, Darrell L",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Giordani, Rocky",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Hedges, James A",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Hoefling, Tom",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Kahn, Lynn",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"La Riva, Gloria",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Levinson, Michael S.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Maturen, Michael A",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"McMullin, Evan",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Moorehead, Monica G.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Perry, Darryl",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Schriner, Joe C",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Smith, Mike",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Sood, Ajay",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Sterling, Shawna",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Valdivia, Anthony J",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120050
+SUMNER,Gore Township H82,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120050
+SUMNER,Gore Township H82,President / Vice President,,Democratic,"Clinton, Hillary Rodham",23,120050
+SUMNER,Gore Township H82,President / Vice President,,Libertarian,"Johnson, Gary",8,120050
+SUMNER,Gore Township H82,President / Vice President,,Republican,"Trump, Donald J.",74,120050
+SUMNER,Seventy - Six Township H116,President / Vice President,,independent,"Stein, Jill",1,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Basiago, Andrew D.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Castle, Darrell L",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Giordani, Rocky",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Hedges, James A",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Hoefling, Tom",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Kahn, Lynn",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"La Riva, Gloria",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Levinson, Michael S.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Maturen, Michael A",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"McMullin, Evan",2,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Moorehead, Monica G.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Perry, Darryl",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Schriner, Joe C",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Smith, Mike",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Sood, Ajay",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Sterling, Shawna",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Valdivia, Anthony J",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Libertarian,"Johnson, Gary",2,120060
+SUMNER,Seventy - Six Township H116,President / Vice President,,Republican,"Trump, Donald J.",112,120060
+SUMNER,Seventy - Six Township H80,President / Vice President,,independent,"Stein, Jill",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Basiago, Andrew D.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Castle, Darrell L",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Giordani, Rocky",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Hedges, James A",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Hoefling, Tom",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Kahn, Lynn",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"La Riva, Gloria",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Levinson, Michael S.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Maturen, Michael A",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"McMullin, Evan",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Moorehead, Monica G.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Perry, Darryl",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Schriner, Joe C",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Smith, Mike",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Sood, Ajay",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Sterling, Shawna",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Valdivia, Anthony J",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Libertarian,"Johnson, Gary",0,120070
+SUMNER,Seventy - Six Township H80,President / Vice President,,Republican,"Trump, Donald J.",0,120070
+SUMNER,Wellington Township H116,President / Vice President,,independent,"Stein, Jill",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Basiago, Andrew D.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Castle, Darrell L",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Giordani, Rocky",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Hedges, James A",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Hoefling, Tom",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Kahn, Lynn",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"La Riva, Gloria",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Levinson, Michael S.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Maturen, Michael A",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"McMullin, Evan",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Moorehead, Monica G.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Perry, Darryl",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Schriner, Joe C",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Smith, Mike",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Sood, Ajay",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Sterling, Shawna",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Valdivia, Anthony J",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120120
+SUMNER,Wellington Township H116,President / Vice President,,Democratic,"Clinton, Hillary Rodham",34,120120
+SUMNER,Wellington Township H116,President / Vice President,,Libertarian,"Johnson, Gary",4,120120
+SUMNER,Wellington Township H116,President / Vice President,,Republican,"Trump, Donald J.",102,120120
+SUMNER,Wellington Township H80 A,President / Vice President,,independent,"Stein, Jill",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Basiago, Andrew D.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Castle, Darrell L",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Giordani, Rocky",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Hedges, James A",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Hoefling, Tom",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Kahn, Lynn",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"La Riva, Gloria",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Levinson, Michael S.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Maturen, Michael A",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"McMullin, Evan",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Moorehead, Monica G.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Perry, Darryl",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Schriner, Joe C",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Smith, Mike",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Sood, Ajay",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Sterling, Shawna",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Valdivia, Anthony J",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Libertarian,"Johnson, Gary",0,12013A
+SUMNER,Wellington Township H80 A,President / Vice President,,Republican,"Trump, Donald J.",0,12013A
+SUMNER,Wellington Township H80,President / Vice President,,independent,"Stein, Jill",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Basiago, Andrew D.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Castle, Darrell L",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Giordani, Rocky",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Hedges, James A",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Hoefling, Tom",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Kahn, Lynn",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"La Riva, Gloria",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Levinson, Michael S.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Maturen, Michael A",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"McMullin, Evan",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Moorehead, Monica G.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Perry, Darryl",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Schriner, Joe C",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Smith, Mike",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Sood, Ajay",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Sterling, Shawna",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Valdivia, Anthony J",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120130
+SUMNER,Wellington Township H80,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,120130
+SUMNER,Wellington Township H80,President / Vice President,,Libertarian,"Johnson, Gary",3,120130
+SUMNER,Wellington Township H80,President / Vice President,,Republican,"Trump, Donald J.",62,120130
+SUMNER,Wellington City Precinct 1,President / Vice President,,independent,"Stein, Jill",19,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"McMullin, Evan",1,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",325,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",52,130010
+SUMNER,Wellington City Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",641,130010
+SUMNER,Wellington City Precinct 2,President / Vice President,,independent,"Stein, Jill",65,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",2,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"McMullin, Evan",6,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",485,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",82,130020
+SUMNER,Wellington City Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",1217,130020
+SUMNER,Wellington City Airport,President / Vice President,,independent,"Stein, Jill",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Hedges, James A",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"McMullin, Evan",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Perry, Darryl",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Smith, Mike",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Sood, Ajay",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+SUMNER,Wellington City Airport,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+SUMNER,Wellington Lake Exclave,President / Vice President,,independent,"Stein, Jill",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Hedges, James A",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Smith, Mike",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+SUMNER,Wellington Lake Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+SUMNER,Gore Township Enclave,President / Vice President,,independent,"Stein, Jill",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Hedges, James A",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"McMullin, Evan",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Perry, Darryl",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Smith, Mike",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Sood, Ajay",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+SUMNER,Gore Township Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+SUMNER,Mulvane City Exclave A,President / Vice President,,independent,"Stein, Jill",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Basiago, Andrew D.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Castle, Darrell L",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Giordani, Rocky",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Hedges, James A",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Hoefling, Tom",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Kahn, Lynn",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"La Riva, Gloria",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Levinson, Michael S.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Maturen, Michael A",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"McMullin, Evan",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Moorehead, Monica G.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Perry, Darryl",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Schriner, Joe C",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Smith, Mike",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Sood, Ajay",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Sterling, Shawna",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Valdivia, Anthony J",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Libertarian,"Johnson, Gary",0,900050
+SUMNER,Mulvane City Exclave A,President / Vice President,,Republican,"Trump, Donald J.",0,900050
+SUMNER,Mulvane City Exclave B,President / Vice President,,independent,"Stein, Jill",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Hedges, James A",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"McMullin, Evan",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Perry, Darryl",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Smith, Mike",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Sood, Ajay",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900060
+SUMNER,Mulvane City Exclave B,President / Vice President,,Republican,"Trump, Donald J.",5,900060
+SUMNER,Avon Township,United States House of Representatives,4,independent,"Allen, Miranda",14,000010
+SUMNER,Avon Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",33,000010
+SUMNER,Avon Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",4,000010
+SUMNER,Avon Township,United States House of Representatives,4,Republican,"Pompeo, Michael",106,000010
+SUMNER,Bluff Township,United States House of Representatives,4,independent,"Allen, Miranda",3,000030
+SUMNER,Bluff Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000030
+SUMNER,Bluff Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000030
+SUMNER,Bluff Township,United States House of Representatives,4,Republican,"Pompeo, Michael",21,000030
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,independent,"Allen, Miranda",10,000040
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",51,000040
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000040
+SUMNER,Caldwell City Ward 1,United States House of Representatives,4,Republican,"Pompeo, Michael",108,000040
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,independent,"Allen, Miranda",26,000050
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",62,000050
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",8,000050
+SUMNER,Caldwell City Ward 2,United States House of Representatives,4,Republican,"Pompeo, Michael",188,000050
+SUMNER,Caldwell Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000060
+SUMNER,Caldwell Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",16,000060
+SUMNER,Caldwell Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000060
+SUMNER,Caldwell Township,United States House of Representatives,4,Republican,"Pompeo, Michael",44,000060
+SUMNER,Chikaskia Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000070
+SUMNER,Chikaskia Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000070
+SUMNER,Chikaskia Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000070
+SUMNER,Chikaskia Township,United States House of Representatives,4,Republican,"Pompeo, Michael",25,000070
+SUMNER,Conway Township,United States House of Representatives,4,independent,"Allen, Miranda",42,000080
+SUMNER,Conway Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",93,000080
+SUMNER,Conway Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",13,000080
+SUMNER,Conway Township,United States House of Representatives,4,Republican,"Pompeo, Michael",320,000080
+SUMNER,Creek Township,United States House of Representatives,4,independent,"Allen, Miranda",4,000090
+SUMNER,Creek Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",13,000090
+SUMNER,Creek Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000090
+SUMNER,Creek Township,United States House of Representatives,4,Republican,"Pompeo, Michael",74,000090
+SUMNER,Dixon Township,United States House of Representatives,4,independent,"Allen, Miranda",25,000100
+SUMNER,Dixon Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",43,000100
+SUMNER,Dixon Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000100
+SUMNER,Dixon Township,United States House of Representatives,4,Republican,"Pompeo, Michael",182,000100
+SUMNER,Downs Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000110
+SUMNER,Downs Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000110
+SUMNER,Downs Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000110
+SUMNER,Downs Township,United States House of Representatives,4,Republican,"Pompeo, Michael",46,000110
+SUMNER,Eden Township,United States House of Representatives,4,independent,"Allen, Miranda",13,000120
+SUMNER,Eden Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,000120
+SUMNER,Eden Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000120
+SUMNER,Eden Township,United States House of Representatives,4,Republican,"Pompeo, Michael",126,000120
+SUMNER,Falls Township,United States House of Representatives,4,independent,"Allen, Miranda",11,000130
+SUMNER,Falls Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000130
+SUMNER,Falls Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000130
+SUMNER,Falls Township,United States House of Representatives,4,Republican,"Pompeo, Michael",49,000130
+SUMNER,Greene Township,United States House of Representatives,4,independent,"Allen, Miranda",5,000150
+SUMNER,Greene Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",4,000150
+SUMNER,Greene Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000150
+SUMNER,Greene Township,United States House of Representatives,4,Republican,"Pompeo, Michael",22,000150
+SUMNER,Guelph Township,United States House of Representatives,4,independent,"Allen, Miranda",8,000160
+SUMNER,Guelph Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000160
+SUMNER,Guelph Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000160
+SUMNER,Guelph Township,United States House of Representatives,4,Republican,"Pompeo, Michael",53,000160
+SUMNER,Harmon Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000170
+SUMNER,Harmon Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,000170
+SUMNER,Harmon Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000170
+SUMNER,Harmon Township,United States House of Representatives,4,Republican,"Pompeo, Michael",112,000170
+SUMNER,Illinois Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000180
+SUMNER,Illinois Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",12,000180
+SUMNER,Illinois Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000180
+SUMNER,Illinois Township,United States House of Representatives,4,Republican,"Pompeo, Michael",63,000180
+SUMNER,Jackson Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000190
+SUMNER,Jackson Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",9,000190
+SUMNER,Jackson Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,000190
+SUMNER,Jackson Township,United States House of Representatives,4,Republican,"Pompeo, Michael",51,000190
+SUMNER,London Township,United States House of Representatives,4,independent,"Allen, Miranda",19,000200
+SUMNER,London Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",45,000200
+SUMNER,London Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",20,000200
+SUMNER,London Township,United States House of Representatives,4,Republican,"Pompeo, Michael",249,000200
+SUMNER,Morris Township,United States House of Representatives,4,independent,"Allen, Miranda",1,000210
+SUMNER,Morris Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",1,000210
+SUMNER,Morris Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,000210
+SUMNER,Morris Township,United States House of Representatives,4,Republican,"Pompeo, Michael",12,000210
+SUMNER,Mulvane City,United States House of Representatives,4,independent,"Allen, Miranda",16,000220
+SUMNER,Mulvane City,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",66,000220
+SUMNER,Mulvane City,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",10,000220
+SUMNER,Mulvane City,United States House of Representatives,4,Republican,"Pompeo, Michael",191,000220
+SUMNER,Osborne Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000230
+SUMNER,Osborne Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,000230
+SUMNER,Osborne Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000230
+SUMNER,Osborne Township,United States House of Representatives,4,Republican,"Pompeo, Michael",89,000230
+SUMNER,Oxford Township,United States House of Representatives,4,independent,"Allen, Miranda",70,000240
+SUMNER,Oxford Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",120,000240
+SUMNER,Oxford Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",16,000240
+SUMNER,Oxford Township,United States House of Representatives,4,Republican,"Pompeo, Michael",367,000240
+SUMNER,Palestine Township,United States House of Representatives,4,independent,"Allen, Miranda",10,000250
+SUMNER,Palestine Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",18,000250
+SUMNER,Palestine Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000250
+SUMNER,Palestine Township,United States House of Representatives,4,Republican,"Pompeo, Michael",73,000250
+SUMNER,Ryan Township,United States House of Representatives,4,independent,"Allen, Miranda",7,000260
+SUMNER,Ryan Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",8,000260
+SUMNER,Ryan Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000260
+SUMNER,Ryan Township,United States House of Representatives,4,Republican,"Pompeo, Michael",53,000260
+SUMNER,South Haven Township,United States House of Representatives,4,independent,"Allen, Miranda",33,000280
+SUMNER,South Haven Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",30,000280
+SUMNER,South Haven Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,000280
+SUMNER,South Haven Township,United States House of Representatives,4,Republican,"Pompeo, Michael",179,000280
+SUMNER,Springdale Township,United States House of Representatives,4,independent,"Allen, Miranda",18,000290
+SUMNER,Springdale Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",51,000290
+SUMNER,Springdale Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",2,000290
+SUMNER,Springdale Township,United States House of Representatives,4,Republican,"Pompeo, Michael",204,000290
+SUMNER,Sumner Township,United States House of Representatives,4,independent,"Allen, Miranda",12,000300
+SUMNER,Sumner Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",11,000300
+SUMNER,Sumner Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,000300
+SUMNER,Sumner Township,United States House of Representatives,4,Republican,"Pompeo, Michael",41,000300
+SUMNER,Valverde Township,United States House of Representatives,4,independent,"Allen, Miranda",6,000310
+SUMNER,Valverde Township,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",6,000310
+SUMNER,Valverde Township,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",6,000310
+SUMNER,Valverde Township,United States House of Representatives,4,Republican,"Pompeo, Michael",41,000310
+SUMNER,Walton Precinct,United States House of Representatives,4,independent,"Allen, Miranda",27,000320
+SUMNER,Walton Precinct,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",16,000320
+SUMNER,Walton Precinct,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,000320
+SUMNER,Walton Precinct,United States House of Representatives,4,Republican,"Pompeo, Michael",115,000320
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,independent,"Allen, Miranda",109,120020
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",271,120020
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",54,120020
+SUMNER,Belle Plaine Township H79,United States House of Representatives,4,Republican,"Pompeo, Michael",912,120020
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,independent,"Allen, Miranda",0,120030
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",2,120030
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,120030
+SUMNER,Belle Plaine Township H82,United States House of Representatives,4,Republican,"Pompeo, Michael",4,120030
+SUMNER,Gore Township H79,United States House of Representatives,4,independent,"Allen, Miranda",37,120040
+SUMNER,Gore Township H79,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",63,120040
+SUMNER,Gore Township H79,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",15,120040
+SUMNER,Gore Township H79,United States House of Representatives,4,Republican,"Pompeo, Michael",275,120040
+SUMNER,Gore Township H82,United States House of Representatives,4,independent,"Allen, Miranda",5,120050
+SUMNER,Gore Township H82,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",23,120050
+SUMNER,Gore Township H82,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",7,120050
+SUMNER,Gore Township H82,United States House of Representatives,4,Republican,"Pompeo, Michael",74,120050
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,independent,"Allen, Miranda",9,120060
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",14,120060
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",1,120060
+SUMNER,Seventy - Six Township H116,United States House of Representatives,4,Republican,"Pompeo, Michael",99,120060
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,independent,"Allen, Miranda",0,120070
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,120070
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,120070
+SUMNER,Seventy - Six Township H80,United States House of Representatives,4,Republican,"Pompeo, Michael",0,120070
+SUMNER,Wellington Township H116,United States House of Representatives,4,independent,"Allen, Miranda",15,120120
+SUMNER,Wellington Township H116,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",25,120120
+SUMNER,Wellington Township H116,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",3,120120
+SUMNER,Wellington Township H116,United States House of Representatives,4,Republican,"Pompeo, Michael",95,120120
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,independent,"Allen, Miranda",0,12013A
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,12013A
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,12013A
+SUMNER,Wellington Township H80 A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,12013A
+SUMNER,Wellington Township H80,United States House of Representatives,4,independent,"Allen, Miranda",12,120130
+SUMNER,Wellington Township H80,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",9,120130
+SUMNER,Wellington Township H80,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",5,120130
+SUMNER,Wellington Township H80,United States House of Representatives,4,Republican,"Pompeo, Michael",51,120130
+SUMNER,Wellington City Precinct 1,United States House of Representatives,4,independent,"Allen, Miranda",139,130010
+SUMNER,Wellington City Precinct 1,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",281,130010
+SUMNER,Wellington City Precinct 1,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",35,130010
+SUMNER,Wellington City Precinct 1,United States House of Representatives,4,Republican,"Pompeo, Michael",570,130010
+SUMNER,Wellington City Precinct 2,United States House of Representatives,4,independent,"Allen, Miranda",258,130020
+SUMNER,Wellington City Precinct 2,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",426,130020
+SUMNER,Wellington City Precinct 2,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",61,130020
+SUMNER,Wellington City Precinct 2,United States House of Representatives,4,Republican,"Pompeo, Michael",1101,130020
+SUMNER,Wellington City Airport,United States House of Representatives,4,independent,"Allen, Miranda",0,900020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900020
+SUMNER,Wellington City Airport,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900020
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,independent,"Allen, Miranda",0,900030
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900030
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900030
+SUMNER,Wellington Lake Exclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900030
+SUMNER,Gore Township Enclave,United States House of Representatives,4,independent,"Allen, Miranda",0,900040
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900040
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900040
+SUMNER,Gore Township Enclave,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900040
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,independent,"Allen, Miranda",0,900050
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900050
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900050
+SUMNER,Mulvane City Exclave A,United States House of Representatives,4,Republican,"Pompeo, Michael",0,900050
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,independent,"Allen, Miranda",0,900060
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Democratic,"Giroux, Daniel B.",0,900060
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Libertarian,"Bakken, Gorden J.",0,900060
+SUMNER,Mulvane City Exclave B,United States House of Representatives,4,Republican,"Pompeo, Michael",6,900060
+SUMNER,Avon Township,United States Senate,,write - in,"Smith, DJ",0,000010
+SUMNER,Avon Township,United States Senate,,Democratic,"Wiesner, Patrick",32,000010
+SUMNER,Avon Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000010
+SUMNER,Avon Township,United States Senate,,Republican,"Moran, Jerry",113,000010
+SUMNER,Bluff Township,United States Senate,,write - in,"Smith, DJ",0,000030
+SUMNER,Bluff Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000030
+SUMNER,Bluff Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000030
+SUMNER,Bluff Township,United States Senate,,Republican,"Moran, Jerry",24,000030
+SUMNER,Caldwell City Ward 1,United States Senate,,write - in,"Smith, DJ",0,000040
+SUMNER,Caldwell City Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",44,000040
+SUMNER,Caldwell City Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",11,000040
+SUMNER,Caldwell City Ward 1,United States Senate,,Republican,"Moran, Jerry",114,000040
+SUMNER,Caldwell City Ward 2,United States Senate,,write - in,"Smith, DJ",0,000050
+SUMNER,Caldwell City Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",62,000050
+SUMNER,Caldwell City Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000050
+SUMNER,Caldwell City Ward 2,United States Senate,,Republican,"Moran, Jerry",205,000050
+SUMNER,Caldwell Township,United States Senate,,write - in,"Smith, DJ",0,000060
+SUMNER,Caldwell Township,United States Senate,,Democratic,"Wiesner, Patrick",17,000060
+SUMNER,Caldwell Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+SUMNER,Caldwell Township,United States Senate,,Republican,"Moran, Jerry",52,000060
+SUMNER,Chikaskia Township,United States Senate,,write - in,"Smith, DJ",0,000070
+SUMNER,Chikaskia Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000070
+SUMNER,Chikaskia Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000070
+SUMNER,Chikaskia Township,United States Senate,,Republican,"Moran, Jerry",25,000070
+SUMNER,Conway Township,United States Senate,,write - in,"Smith, DJ",0,000080
+SUMNER,Conway Township,United States Senate,,Democratic,"Wiesner, Patrick",93,000080
+SUMNER,Conway Township,United States Senate,,Libertarian,"Garrard, Robert D.",36,000080
+SUMNER,Conway Township,United States Senate,,Republican,"Moran, Jerry",339,000080
+SUMNER,Creek Township,United States Senate,,write - in,"Smith, DJ",0,000090
+SUMNER,Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000090
+SUMNER,Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000090
+SUMNER,Creek Township,United States Senate,,Republican,"Moran, Jerry",70,000090
+SUMNER,Dixon Township,United States Senate,,write - in,"Smith, DJ",0,000100
+SUMNER,Dixon Township,United States Senate,,Democratic,"Wiesner, Patrick",41,000100
+SUMNER,Dixon Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000100
+SUMNER,Dixon Township,United States Senate,,Republican,"Moran, Jerry",193,000100
+SUMNER,Downs Township,United States Senate,,write - in,"Smith, DJ",0,000110
+SUMNER,Downs Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000110
+SUMNER,Downs Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000110
+SUMNER,Downs Township,United States Senate,,Republican,"Moran, Jerry",49,000110
+SUMNER,Eden Township,United States Senate,,write - in,"Smith, DJ",0,000120
+SUMNER,Eden Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000120
+SUMNER,Eden Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000120
+SUMNER,Eden Township,United States Senate,,Republican,"Moran, Jerry",132,000120
+SUMNER,Falls Township,United States Senate,,write - in,"Smith, DJ",0,000130
+SUMNER,Falls Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000130
+SUMNER,Falls Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000130
+SUMNER,Falls Township,United States Senate,,Republican,"Moran, Jerry",54,000130
+SUMNER,Greene Township,United States Senate,,write - in,"Smith, DJ",0,000150
+SUMNER,Greene Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000150
+SUMNER,Greene Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000150
+SUMNER,Greene Township,United States Senate,,Republican,"Moran, Jerry",27,000150
+SUMNER,Guelph Township,United States Senate,,write - in,"Smith, DJ",0,000160
+SUMNER,Guelph Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000160
+SUMNER,Guelph Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000160
+SUMNER,Guelph Township,United States Senate,,Republican,"Moran, Jerry",55,000160
+SUMNER,Harmon Township,United States Senate,,write - in,"Smith, DJ",0,000170
+SUMNER,Harmon Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000170
+SUMNER,Harmon Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000170
+SUMNER,Harmon Township,United States Senate,,Republican,"Moran, Jerry",118,000170
+SUMNER,Illinois Township,United States Senate,,write - in,"Smith, DJ",0,000180
+SUMNER,Illinois Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000180
+SUMNER,Illinois Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000180
+SUMNER,Illinois Township,United States Senate,,Republican,"Moran, Jerry",74,000180
+SUMNER,Jackson Township,United States Senate,,write - in,"Smith, DJ",0,000190
+SUMNER,Jackson Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000190
+SUMNER,Jackson Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000190
+SUMNER,Jackson Township,United States Senate,,Republican,"Moran, Jerry",53,000190
+SUMNER,London Township,United States Senate,,write - in,"Smith, DJ",0,000200
+SUMNER,London Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000200
+SUMNER,London Township,United States Senate,,Libertarian,"Garrard, Robert D.",28,000200
+SUMNER,London Township,United States Senate,,Republican,"Moran, Jerry",262,000200
+SUMNER,Morris Township,United States Senate,,write - in,"Smith, DJ",0,000210
+SUMNER,Morris Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000210
+SUMNER,Morris Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000210
+SUMNER,Morris Township,United States Senate,,Republican,"Moran, Jerry",14,000210
+SUMNER,Mulvane City,United States Senate,,write - in,"Smith, DJ",0,000220
+SUMNER,Mulvane City,United States Senate,,Democratic,"Wiesner, Patrick",64,000220
+SUMNER,Mulvane City,United States Senate,,Libertarian,"Garrard, Robert D.",17,000220
+SUMNER,Mulvane City,United States Senate,,Republican,"Moran, Jerry",203,000220
+SUMNER,Osborne Township,United States Senate,,write - in,"Smith, DJ",0,000230
+SUMNER,Osborne Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000230
+SUMNER,Osborne Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000230
+SUMNER,Osborne Township,United States Senate,,Republican,"Moran, Jerry",94,000230
+SUMNER,Oxford Township,United States Senate,,write - in,"Smith, DJ",0,000240
+SUMNER,Oxford Township,United States Senate,,Democratic,"Wiesner, Patrick",136,000240
+SUMNER,Oxford Township,United States Senate,,Libertarian,"Garrard, Robert D.",43,000240
+SUMNER,Oxford Township,United States Senate,,Republican,"Moran, Jerry",391,000240
+SUMNER,Palestine Township,United States Senate,,write - in,"Smith, DJ",0,000250
+SUMNER,Palestine Township,United States Senate,,Democratic,"Wiesner, Patrick",23,000250
+SUMNER,Palestine Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000250
+SUMNER,Palestine Township,United States Senate,,Republican,"Moran, Jerry",73,000250
+SUMNER,Ryan Township,United States Senate,,write - in,"Smith, DJ",0,000260
+SUMNER,Ryan Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000260
+SUMNER,Ryan Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000260
+SUMNER,Ryan Township,United States Senate,,Republican,"Moran, Jerry",50,000260
+SUMNER,South Haven Township,United States Senate,,write - in,"Smith, DJ",0,000280
+SUMNER,South Haven Township,United States Senate,,Democratic,"Wiesner, Patrick",43,000280
+SUMNER,South Haven Township,United States Senate,,Libertarian,"Garrard, Robert D.",17,000280
+SUMNER,South Haven Township,United States Senate,,Republican,"Moran, Jerry",185,000280
+SUMNER,Springdale Township,United States Senate,,write - in,"Smith, DJ",0,000290
+SUMNER,Springdale Township,United States Senate,,Democratic,"Wiesner, Patrick",53,000290
+SUMNER,Springdale Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000290
+SUMNER,Springdale Township,United States Senate,,Republican,"Moran, Jerry",211,000290
+SUMNER,Sumner Township,United States Senate,,write - in,"Smith, DJ",0,000300
+SUMNER,Sumner Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000300
+SUMNER,Sumner Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000300
+SUMNER,Sumner Township,United States Senate,,Republican,"Moran, Jerry",50,000300
+SUMNER,Valverde Township,United States Senate,,write - in,"Smith, DJ",0,000310
+SUMNER,Valverde Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000310
+SUMNER,Valverde Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000310
+SUMNER,Valverde Township,United States Senate,,Republican,"Moran, Jerry",51,000310
+SUMNER,Walton Precinct,United States Senate,,write - in,"Smith, DJ",0,000320
+SUMNER,Walton Precinct,United States Senate,,Democratic,"Wiesner, Patrick",16,000320
+SUMNER,Walton Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",18,000320
+SUMNER,Walton Precinct,United States Senate,,Republican,"Moran, Jerry",126,000320
+SUMNER,Belle Plaine Township H79,United States Senate,,write - in,"Smith, DJ",0,120020
+SUMNER,Belle Plaine Township H79,United States Senate,,Democratic,"Wiesner, Patrick",287,120020
+SUMNER,Belle Plaine Township H79,United States Senate,,Libertarian,"Garrard, Robert D.",98,120020
+SUMNER,Belle Plaine Township H79,United States Senate,,Republican,"Moran, Jerry",957,120020
+SUMNER,Belle Plaine Township H82,United States Senate,,write - in,"Smith, DJ",0,120030
+SUMNER,Belle Plaine Township H82,United States Senate,,Democratic,"Wiesner, Patrick",2,120030
+SUMNER,Belle Plaine Township H82,United States Senate,,Libertarian,"Garrard, Robert D.",0,120030
+SUMNER,Belle Plaine Township H82,United States Senate,,Republican,"Moran, Jerry",4,120030
+SUMNER,Gore Township H79,United States Senate,,write - in,"Smith, DJ",0,120040
+SUMNER,Gore Township H79,United States Senate,,Democratic,"Wiesner, Patrick",67,120040
+SUMNER,Gore Township H79,United States Senate,,Libertarian,"Garrard, Robert D.",31,120040
+SUMNER,Gore Township H79,United States Senate,,Republican,"Moran, Jerry",293,120040
+SUMNER,Gore Township H82,United States Senate,,write - in,"Smith, DJ",0,120050
+SUMNER,Gore Township H82,United States Senate,,Democratic,"Wiesner, Patrick",22,120050
+SUMNER,Gore Township H82,United States Senate,,Libertarian,"Garrard, Robert D.",12,120050
+SUMNER,Gore Township H82,United States Senate,,Republican,"Moran, Jerry",75,120050
+SUMNER,Seventy - Six Township H116,United States Senate,,write - in,"Smith, DJ",0,120060
+SUMNER,Seventy - Six Township H116,United States Senate,,Democratic,"Wiesner, Patrick",9,120060
+SUMNER,Seventy - Six Township H116,United States Senate,,Libertarian,"Garrard, Robert D.",10,120060
+SUMNER,Seventy - Six Township H116,United States Senate,,Republican,"Moran, Jerry",101,120060
+SUMNER,Seventy - Six Township H80,United States Senate,,write - in,"Smith, DJ",0,120070
+SUMNER,Seventy - Six Township H80,United States Senate,,Democratic,"Wiesner, Patrick",0,120070
+SUMNER,Seventy - Six Township H80,United States Senate,,Libertarian,"Garrard, Robert D.",0,120070
+SUMNER,Seventy - Six Township H80,United States Senate,,Republican,"Moran, Jerry",0,120070
+SUMNER,Wellington Township H116,United States Senate,,write - in,"Smith, DJ",0,120120
+SUMNER,Wellington Township H116,United States Senate,,Democratic,"Wiesner, Patrick",36,120120
+SUMNER,Wellington Township H116,United States Senate,,Libertarian,"Garrard, Robert D.",6,120120
+SUMNER,Wellington Township H116,United States Senate,,Republican,"Moran, Jerry",96,120120
+SUMNER,Wellington Township H80 A,United States Senate,,write - in,"Smith, DJ",0,12013A
+SUMNER,Wellington Township H80 A,United States Senate,,Democratic,"Wiesner, Patrick",0,12013A
+SUMNER,Wellington Township H80 A,United States Senate,,Libertarian,"Garrard, Robert D.",0,12013A
+SUMNER,Wellington Township H80 A,United States Senate,,Republican,"Moran, Jerry",0,12013A
+SUMNER,Wellington Township H80,United States Senate,,write - in,"Smith, DJ",0,120130
+SUMNER,Wellington Township H80,United States Senate,,Democratic,"Wiesner, Patrick",14,120130
+SUMNER,Wellington Township H80,United States Senate,,Libertarian,"Garrard, Robert D.",10,120130
+SUMNER,Wellington Township H80,United States Senate,,Republican,"Moran, Jerry",53,120130
+SUMNER,Wellington City Precinct 1,United States Senate,,write - in,"Smith, DJ",0,130010
+SUMNER,Wellington City Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",329,130010
+SUMNER,Wellington City Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",80,130010
+SUMNER,Wellington City Precinct 1,United States Senate,,Republican,"Moran, Jerry",619,130010
+SUMNER,Wellington City Precinct 2,United States Senate,,write - in,"Smith, DJ",0,130020
+SUMNER,Wellington City Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",504,130020
+SUMNER,Wellington City Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",128,130020
+SUMNER,Wellington City Precinct 2,United States Senate,,Republican,"Moran, Jerry",1214,130020
+SUMNER,Wellington City Airport,United States Senate,,write - in,"Smith, DJ",0,900020
+SUMNER,Wellington City Airport,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+SUMNER,Wellington City Airport,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+SUMNER,Wellington City Airport,United States Senate,,Republican,"Moran, Jerry",0,900020
+SUMNER,Wellington Lake Exclave,United States Senate,,write - in,"Smith, DJ",0,900030
+SUMNER,Wellington Lake Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+SUMNER,Wellington Lake Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+SUMNER,Wellington Lake Exclave,United States Senate,,Republican,"Moran, Jerry",0,900030
+SUMNER,Gore Township Enclave,United States Senate,,write - in,"Smith, DJ",0,900040
+SUMNER,Gore Township Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+SUMNER,Gore Township Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+SUMNER,Gore Township Enclave,United States Senate,,Republican,"Moran, Jerry",0,900040
+SUMNER,Mulvane City Exclave A,United States Senate,,write - in,"Smith, DJ",0,900050
+SUMNER,Mulvane City Exclave A,United States Senate,,Democratic,"Wiesner, Patrick",0,900050
+SUMNER,Mulvane City Exclave A,United States Senate,,Libertarian,"Garrard, Robert D.",0,900050
+SUMNER,Mulvane City Exclave A,United States Senate,,Republican,"Moran, Jerry",0,900050
+SUMNER,Mulvane City Exclave B,United States Senate,,write - in,"Smith, DJ",0,900060
+SUMNER,Mulvane City Exclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900060
+SUMNER,Mulvane City Exclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900060
+SUMNER,Mulvane City Exclave B,United States Senate,,Republican,"Moran, Jerry",6,900060

--- a/2016/20161108__ks__general__thomas__precinct.csv
+++ b/2016/20161108__ks__general__thomas__precinct.csv
@@ -1,267 +1,844 @@
-county,precinct,office,district,party,candidate,votes,
-Thomas,Barrett,President,,D,Clinton & Kaine,5,
-Thomas,Barrett,President,,R,Trump & Pence,47,
-Thomas,Barrett,President,,L,Johnson & Weld,0,
-Thomas,Barrett,President,,i,Stein & Baraka,0,
-Thomas,Barrett,U.S. Senate,,D,Patrick Wiesner,6,
-Thomas,Barrett,U.S. Senate,,R,Jerry Moran,46,
-Thomas,Barrett,U.S. Senate,,L,Robert D Garrard,0,
-Thomas,Barrett,U.S. House,1,R,Roger Marshall,45,
-Thomas,Barrett,U.S. House,1,L,Kerry Burt,1,
-Thomas,Barrett,U.S. House,1,i,Alan LaPolice,6,
-Thomas,Barrett,State Senate,40,D,Alex Herman,8,
-Thomas,Barrett,State Senate,40,R,Richard (Rick) Billinger,45,
-Thomas,Barrett,State House,120,D,Bonita L. Peterson,9,
-Thomas,Barrett,State House,120,R,Adam Smith,44,
-Thomas,West Hale,President,,D,Clinton & Kaine,2,
-Thomas,West Hale,President,,R,Trump & Pence,56,
-Thomas,West Hale,President,,L,Johnson & Weld,2,
-Thomas,West Hale,President,,i,Stein & Baraka,0,
-Thomas,West Hale,U.S. Senate,,D,Patrick Wiesner,3,
-Thomas,West Hale,U.S. Senate,,R,Jerry Moran,56,
-Thomas,West Hale,U.S. Senate,,L,Robert D Garrard,0,
-Thomas,West Hale,U.S. House,1,R,Roger Marshall,45,
-Thomas,West Hale,U.S. House,1,L,Kerry Burt,1,
-Thomas,West Hale,U.S. House,1,i,Alan LaPolice,14,
-Thomas,West Hale,State Senate,40,D,Alex Herman,3,
-Thomas,West Hale,State Senate,40,R,Richard (Rick) Billinger,57,
-Thomas,West Hale,State House,120,D,Bonita L. Peterson,5,
-Thomas,West Hale,State House,120,R,Adam Smith,55,
-Thomas,Kingery,President,,D,Clinton & Kaine,2,
-Thomas,Kingery,President,,R,Trump & Pence,49,
-Thomas,Kingery,President,,L,Johnson & Weld,0,
-Thomas,Kingery,President,,i,Stein & Baraka,0,
-Thomas,Kingery,U.S. Senate,,D,Patrick Wiesner,2,
-Thomas,Kingery,U.S. Senate,,R,Jerry Moran,46,
-Thomas,Kingery,U.S. Senate,,L,Robert D Garrard,1,
-Thomas,Kingery,U.S. House,1,R,Roger Marshall,38,
-Thomas,Kingery,U.S. House,1,L,Kerry Burt,0,
-Thomas,Kingery,U.S. House,1,i,Alan LaPolice,11,
-Thomas,Kingery,State Senate,40,D,Alex Herman,2,
-Thomas,Kingery,State Senate,40,R,Richard (Rick) Billinger,47,
-Thomas,Kingery,State House,118,R,Don Hineman,46,
-Thomas,Lacey,President,,D,Clinton & Kaine,6,
-Thomas,Lacey,President,,R,Trump & Pence,53,
-Thomas,Lacey,President,,L,Johnson & Weld,1,
-Thomas,Lacey,President,,i,Stein & Baraka,2,
-Thomas,Lacey,U.S. Senate,,D,Patrick Wiesner,7,
-Thomas,Lacey,U.S. Senate,,R,Jerry Moran,55,
-Thomas,Lacey,U.S. Senate,,L,Robert D Garrard,1,
-Thomas,Lacey,U.S. House,1,R,Roger Marshall,52,
-Thomas,Lacey,U.S. House,1,L,Kerry Burt,0,
-Thomas,Lacey,U.S. House,1,i,Alan LaPolice,12,
-Thomas,Lacey,State Senate,40,D,Alex Herman,7,
-Thomas,Lacey,State Senate,40,R,Richard (Rick) Billinger,56,
-Thomas,Lacey,State House,118,R,Don Hineman,55,
-Thomas,Menlo,President,,D,Clinton & Kaine,8,
-Thomas,Menlo,President,,R,Trump & Pence,27,
-Thomas,Menlo,President,,L,Johnson & Weld,1,
-Thomas,Menlo,President,,i,Stein & Baraka,0,
-Thomas,Menlo,U.S. Senate,,D,Patrick Wiesner,2,
-Thomas,Menlo,U.S. Senate,,R,Jerry Moran,33,
-Thomas,Menlo,U.S. Senate,,L,Robert D Garrard,1,
-Thomas,Menlo,U.S. House,1,R,Roger Marshall,33,
-Thomas,Menlo,U.S. House,1,L,Kerry Burt,0,
-Thomas,Menlo,U.S. House,1,i,Alan LaPolice,3,
-Thomas,Menlo,State Senate,40,D,Alex Herman,4,
-Thomas,Menlo,State Senate,40,R,Richard (Rick) Billinger,33,
-Thomas,Menlo,State House,118,R,Don Hineman,34,
-Thomas,East Morgan,President,,D,Clinton & Kaine,14,
-Thomas,East Morgan,President,,R,Trump & Pence,122,
-Thomas,East Morgan,President,,L,Johnson & Weld,3,
-Thomas,East Morgan,President,,i,Stein & Baraka,1,
-Thomas,East Morgan,U.S. Senate,,D,Patrick Wiesner,16,
-Thomas,East Morgan,U.S. Senate,,R,Jerry Moran,123,
-Thomas,East Morgan,U.S. Senate,,L,Robert D Garrard,4,
-Thomas,East Morgan,U.S. House,1,R,Roger Marshall,111,
-Thomas,East Morgan,U.S. House,1,L,Kerry Burt,3,
-Thomas,East Morgan,U.S. House,1,i,Alan LaPolice,24,
-Thomas,East Morgan,State Senate,40,D,Alex Herman,15,
-Thomas,East Morgan,State Senate,40,R,Richard (Rick) Billinger,125,
-Thomas,East Morgan,State House,120,D,Bonita L. Peterson,17,
-Thomas,East Morgan,State House,120,R,Adam Smith,123,
-Thomas,West Morgan,President,,D,Clinton & Kaine,35,
-Thomas,West Morgan,President,,R,Trump & Pence,201,
-Thomas,West Morgan,President,,L,Johnson & Weld,3,
-Thomas,West Morgan,President,,i,Stein & Baraka,1,
-Thomas,West Morgan,U.S. Senate,,D,Patrick Wiesner,28,
-Thomas,West Morgan,U.S. Senate,,R,Jerry Moran,206,
-Thomas,West Morgan,U.S. Senate,,L,Robert D Garrard,5,
-Thomas,West Morgan,U.S. House,1,R,Roger Marshall,187,
-Thomas,West Morgan,U.S. House,1,L,Kerry Burt,10,
-Thomas,West Morgan,U.S. House,1,i,Alan LaPolice,39,
-Thomas,West Morgan,State Senate,40,D,Alex Herman,33,
-Thomas,West Morgan,State Senate,40,R,Richard (Rick) Billinger,207,
-Thomas,West Morgan,State House,120,D,Bonita L. Peterson,30,
-Thomas,West Morgan,State House,120,R,Adam Smith,200,
-Thomas,North Randall,President,,D,Clinton & Kaine,1,
-Thomas,North Randall,President,,R,Trump & Pence,38,
-Thomas,North Randall,President,,L,Johnson & Weld,2,
-Thomas,North Randall,President,,i,Stein & Baraka,0,
-Thomas,North Randall,U.S. Senate,,D,Patrick Wiesner,1,
-Thomas,North Randall,U.S. Senate,,R,Jerry Moran,37,
-Thomas,North Randall,U.S. Senate,,L,Robert D Garrard,2,
-Thomas,North Randall,U.S. House,1,R,Roger Marshall,29,
-Thomas,North Randall,U.S. House,1,L,Kerry Burt,1,
-Thomas,North Randall,U.S. House,1,i,Alan LaPolice,5,
-Thomas,North Randall,State Senate,40,D,Alex Herman,0,
-Thomas,North Randall,State Senate,40,R,Richard (Rick) Billinger,41,
-Thomas,North Randall,State House,118,R,Don Hineman,41,
-Thomas,South Randall,President,,D,Clinton & Kaine,17,
-Thomas,South Randall,President,,R,Trump & Pence,102,
-Thomas,South Randall,President,,L,Johnson & Weld,4,
-Thomas,South Randall,President,,i,Stein & Baraka,1,
-Thomas,South Randall,U.S. Senate,,D,Patrick Wiesner,15,
-Thomas,South Randall,U.S. Senate,,R,Jerry Moran,105,
-Thomas,South Randall,U.S. Senate,,L,Robert D Garrard,3,
-Thomas,South Randall,U.S. House,1,R,Roger Marshall,97,
-Thomas,South Randall,U.S. House,1,L,Kerry Burt,5,
-Thomas,South Randall,U.S. House,1,i,Alan LaPolice,20,
-Thomas,South Randall,State Senate,40,D,Alex Herman,22,
-Thomas,South Randall,State Senate,40,R,Richard (Rick) Billinger,99,
-Thomas,South Randall,State House,118,R,Don Hineman,111,
-Thomas,Rovohl,President,,D,Clinton & Kaine,5,
-Thomas,Rovohl,President,,R,Trump & Pence,73,
-Thomas,Rovohl,President,,L,Johnson & Weld,5,
-Thomas,Rovohl,President,,i,Stein & Baraka,2,
-Thomas,Rovohl,U.S. Senate,,D,Patrick Wiesner,6,
-Thomas,Rovohl,U.S. Senate,,R,Jerry Moran,74,
-Thomas,Rovohl,U.S. Senate,,L,Robert D Garrard,4,
-Thomas,Rovohl,U.S. House,1,R,Roger Marshall,67,
-Thomas,Rovohl,U.S. House,1,L,Kerry Burt,3,
-Thomas,Rovohl,U.S. House,1,i,Alan LaPolice,15,
-Thomas,Rovohl,State Senate,40,D,Alex Herman,7,
-Thomas,Rovohl,State Senate,40,R,Richard (Rick) Billinger,77,
-Thomas,Rovohl,State House,120,D,Bonita L. Peterson,10,
-Thomas,Rovohl,State House,120,R,Adam Smith,74,
-Thomas,Smith,President,,D,Clinton & Kaine,4,
-Thomas,Smith,President,,R,Trump & Pence,77,
-Thomas,Smith,President,,L,Johnson & Weld,3,
-Thomas,Smith,President,,i,Stein & Baraka,2,
-Thomas,Smith,U.S. Senate,,D,Patrick Wiesner,5,
-Thomas,Smith,U.S. Senate,,R,Jerry Moran,79,
-Thomas,Smith,U.S. Senate,,L,Robert D Garrard,2,
-Thomas,Smith,U.S. House,1,R,Roger Marshall,77,
-Thomas,Smith,U.S. House,1,L,Kerry Burt,1,
-Thomas,Smith,U.S. House,1,i,Alan LaPolice,7,
-Thomas,Smith,State Senate,40,D,Alex Herman,9,
-Thomas,Smith,State Senate,40,R,Richard (Rick) Billinger,75,
-Thomas,Smith,State House,118,R,Don Hineman,78,
-Thomas,Summers,President,,D,Clinton & Kaine,5,
-Thomas,Summers,President,,R,Trump & Pence,97,
-Thomas,Summers,President,,L,Johnson & Weld,4,
-Thomas,Summers,President,,i,Stein & Baraka,0,
-Thomas,Summers,U.S. Senate,,D,Patrick Wiesner,6,
-Thomas,Summers,U.S. Senate,,R,Jerry Moran,95,
-Thomas,Summers,U.S. Senate,,L,Robert D Garrard,5,
-Thomas,Summers,U.S. House,1,R,Roger Marshall,83,
-Thomas,Summers,U.S. House,1,L,Kerry Burt,6,
-Thomas,Summers,U.S. House,1,i,Alan LaPolice,12,
-Thomas,Summers,State Senate,40,D,Alex Herman,8,
-Thomas,Summers,State Senate,40,R,Richard (Rick) Billinger,97,
-Thomas,Summers,State House,118,R,Don Hineman,95,
-Thomas,Wendell,President,,D,Clinton & Kaine,3,
-Thomas,Wendell,President,,R,Trump & Pence,36,
-Thomas,Wendell,President,,L,Johnson & Weld,1,
-Thomas,Wendell,President,,i,Stein & Baraka,0,
-Thomas,Wendell,U.S. Senate,,D,Patrick Wiesner,3,
-Thomas,Wendell,U.S. Senate,,R,Jerry Moran,34,
-Thomas,Wendell,U.S. Senate,,L,Robert D Garrard,3,
-Thomas,Wendell,U.S. House,1,R,Roger Marshall,33,
-Thomas,Wendell,U.S. House,1,L,Kerry Burt,1,
-Thomas,Wendell,U.S. House,1,i,Alan LaPolice,6,
-Thomas,Wendell,State Senate,40,D,Alex Herman,3,
-Thomas,Wendell,State Senate,40,R,Richard (Rick) Billinger,37,
-Thomas,Wendell,State House,118,R,Don Hineman,38,
-Thomas,Ward 1,President,,D,Clinton & Kaine,75,
-Thomas,Ward 1,President,,R,Trump & Pence,341,
-Thomas,Ward 1,President,,L,Johnson & Weld,27,
-Thomas,Ward 1,President,,i,Stein & Baraka,10,
-Thomas,Ward 1,U.S. Senate,,D,Patrick Wiesner,68,
-Thomas,Ward 1,U.S. Senate,,R,Jerry Moran,368,
-Thomas,Ward 1,U.S. Senate,,L,Robert D Garrard,20,
-Thomas,Ward 1,U.S. House,1,R,Roger Marshall,352,
-Thomas,Ward 1,U.S. House,1,L,Kerry Burt,20,
-Thomas,Ward 1,U.S. House,1,i,Alan LaPolice,72,
-Thomas,Ward 1,State Senate,40,D,Alex Herman,97,
-Thomas,Ward 1,State Senate,40,R,Richard (Rick) Billinger,353,
-Thomas,Ward 1,State House,120,D,Bonita L. Peterson,82,
-Thomas,Ward 1,State House,120,R,Adam Smith,369,
-Thomas,Ward 2,President,,D,Clinton & Kaine,71,
-Thomas,Ward 2,President,,R,Trump & Pence,371,
-Thomas,Ward 2,President,,L,Johnson & Weld,15,
-Thomas,Ward 2,President,,i,Stein & Baraka,9,
-Thomas,Ward 2,U.S. Senate,,D,Patrick Wiesner,66,
-Thomas,Ward 2,U.S. Senate,,R,Jerry Moran,390,
-Thomas,Ward 2,U.S. Senate,,L,Robert D Garrard,17,
-Thomas,Ward 2,U.S. House,1,R,Roger Marshall,374,
-Thomas,Ward 2,U.S. House,1,L,Kerry Burt,15,
-Thomas,Ward 2,U.S. House,1,i,Alan LaPolice,73,
-Thomas,Ward 2,State Senate,40,D,Alex Herman,92,
-Thomas,Ward 2,State Senate,40,R,Richard (Rick) Billinger,378,
-Thomas,Ward 2,State House,120,D,Bonita L. Peterson,77,
-Thomas,Ward 2,State House,120,R,Adam Smith,389,
-Thomas,Ward 3,President,,D,Clinton & Kaine,92,
-Thomas,Ward 3,President,,R,Trump & Pence,554,
-Thomas,Ward 3,President,,L,Johnson & Weld,28,
-Thomas,Ward 3,President,,i,Stein & Baraka,20,
-Thomas,Ward 3,U.S. Senate,,D,Patrick Wiesner,78,
-Thomas,Ward 3,U.S. Senate,,R,Jerry Moran,579,
-Thomas,Ward 3,U.S. Senate,,L,Robert D Garrard,35,
-Thomas,Ward 3,U.S. House,1,R,Roger Marshall,539,
-Thomas,Ward 3,U.S. House,1,L,Kerry Burt,35,
-Thomas,Ward 3,U.S. House,1,i,Alan LaPolice,109,
-Thomas,Ward 3,State Senate,40,D,Alex Herman,121,
-Thomas,Ward 3,State Senate,40,R,Richard (Rick) Billinger,560,
-Thomas,Ward 3,State House,120,D,Bonita L. Peterson,106,
-Thomas,Ward 3,State House,120,R,Adam Smith,570,
-Thomas,Ward 4,President,,D,Clinton & Kaine,106,
-Thomas,Ward 4,President,,R,Trump & Pence,452,
-Thomas,Ward 4,President,,L,Johnson & Weld,24,
-Thomas,Ward 4,President,,i,Stein & Baraka,6,
-Thomas,Ward 4,U.S. Senate,,D,Patrick Wiesner,80,
-Thomas,Ward 4,U.S. Senate,,R,Jerry Moran,489,
-Thomas,Ward 4,U.S. Senate,,L,Robert D Garrard,27,
-Thomas,Ward 4,U.S. House,1,R,Roger Marshall,453,
-Thomas,Ward 4,U.S. House,1,L,Kerry Burt,29,
-Thomas,Ward 4,U.S. House,1,i,Alan LaPolice,102,
-Thomas,Ward 4,State Senate,40,D,Alex Herman,112,
-Thomas,Ward 4,State Senate,40,R,Richard (Rick) Billinger,478,
-Thomas,Ward 4,State House,120,D,Bonita L. Peterson,99,
-Thomas,Ward 4,State House,120,R,Adam Smith,486,
-Thomas,Provisional,President,,D,Clinton & Kaine,6,
-Thomas,Provisional,President,,R,Trump & Pence,76,
-Thomas,Provisional,President,,L,Johnson & Weld,2,
-Thomas,Provisional,President,,i,Stein & Baraka,1,
-Thomas,Provisional,U.S. Senate,,D,Patrick Wiesner,7,
-Thomas,Provisional,U.S. Senate,,R,Jerry Moran,66,
-Thomas,Provisional,U.S. Senate,,L,Robert D Garrard,7,
-Thomas,Provisional,U.S. House,1,R,Roger Marshall,65,
-Thomas,Provisional,U.S. House,1,L,Kerry Burt,3,
-Thomas,Provisional,U.S. House,1,i,Alan LaPolice,10,
-Thomas,Provisional,State Senate,40,D,Alex Herman,15,
-Thomas,Provisional,State Senate,40,R,Richard (Rick) Billinger,63,
-Thomas,Provisional,State House,118,R,Don Hineman,1,
-Thomas,Provisional,State House,120,D,Bonita L. Peterson,8,
-Thomas,Provisional,State House,120,R,Adam Smith,63,
-Thomas,Total,President,,D,Clinton & Kaine,473,
-Thomas,Total,President,,R,Trump & Pence,2908,
-Thomas,Total,President,,L,Johnson & Weld,131,
-Thomas,Total,President,,i,Stein & Baraka,56,
-Thomas,Total,U.S. Senate,,D,Patrick Wiesner,417,
-Thomas,Total,U.S. Senate,,R,Jerry Moran,3012,
-Thomas,Total,U.S. Senate,,L,Robert D Garrard,147,
-Thomas,Total,U.S. House,1,R,Roger Marshall,2787,
-Thomas,Total,U.S. House,1,L,Kerry Burt,141,
-Thomas,Total,U.S. House,1,i,Alan LaPolice,583,
-Thomas,Total,State Senate,40,D,Alex Herman,574,
-Thomas,Total,State Senate,40,R,Richard (Rick) Billinger,2970,
-Thomas,Total,State House,118,R,Don Hineman,499,
-Thomas,Total,State House,120,D,Bonita L. Peterson,463,
-Thomas,Total,State House,120,R,Adam Smith,2510,
-Thomas,Colby Ward 1,President,,,"McMullin, Evan  ",7,
-Thomas,Colby Ward 2,President,,,"Castle, Darrell L ",1,
-Thomas,North Randall Township,U. S. House,1,,"Huelskamp, Tim  ",3,
-Thomas,Colby Ward 1,U. S. House,1,,"Huelskamp, Tim  ",1,
-Thomas,Colby Ward 2,U. S. House,1,,"Huelskamp, Tim  ",1,
-Thomas,Colby Ward 4,U. S. House,1,,"Huelskamp, Tim  ",1,
+county,precinct,office,district,party,candidate,votes,vtd
+THOMAS,Barrett Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",9,000010
+THOMAS,Barrett Township,Kansas House of Representatives,120,Republican,"Smith, Adam",45,000010
+THOMAS,Colby Ward 1,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",84,000020
+THOMAS,Colby Ward 1,Kansas House of Representatives,120,Republican,"Smith, Adam",382,000020
+THOMAS,Colby Ward 2,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",79,00003A
+THOMAS,Colby Ward 2,Kansas House of Representatives,120,Republican,"Smith, Adam",399,00003A
+THOMAS,Colby Ward 2 Exclave,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,00003B
+THOMAS,Colby Ward 2 Exclave,Kansas House of Representatives,120,Republican,"Smith, Adam",0,00003B
+THOMAS,Colby Ward 3,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",107,00004A
+THOMAS,Colby Ward 3,Kansas House of Representatives,120,Republican,"Smith, Adam",590,00004A
+THOMAS,Colby Ward 3 Exclave,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,00004B
+THOMAS,Colby Ward 3 Exclave,Kansas House of Representatives,120,Republican,"Smith, Adam",0,00004B
+THOMAS,Colby Ward 4,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",101,000050
+THOMAS,Colby Ward 4,Kansas House of Representatives,120,Republican,"Smith, Adam",498,000050
+THOMAS,East Hale Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",5,000060
+THOMAS,East Hale Township,Kansas House of Representatives,120,Republican,"Smith, Adam",55,000060
+THOMAS,East Morgan Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",17,00007A
+THOMAS,East Morgan Township,Kansas House of Representatives,120,Republican,"Smith, Adam",123,00007A
+THOMAS,East Morgan Township Enclave Voting District,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Kansas House of Representatives,120,Republican,"Smith, Adam",0,00007B
+THOMAS,Kingery Township,Kansas House of Representatives,118,Republican,"Hineman, Don",46,000080
+THOMAS,Lacey Township,Kansas House of Representatives,118,Republican,"Hineman, Don",55,000090
+THOMAS,Menlo Township,Kansas House of Representatives,118,Republican,"Hineman, Don",34,000100
+THOMAS,North Randall Township,Kansas House of Representatives,118,Republican,"Hineman, Don",41,000110
+THOMAS,Rovohl Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",10,000120
+THOMAS,Rovohl Township,Kansas House of Representatives,120,Republican,"Smith, Adam",74,000120
+THOMAS,Smith Township,Kansas House of Representatives,118,Republican,"Hineman, Don",79,000130
+THOMAS,South Randall Township,Kansas House of Representatives,118,Republican,"Hineman, Don",111,000140
+THOMAS,Summers Township,Kansas House of Representatives,118,Republican,"Hineman, Don",95,000150
+THOMAS,Wendell Township,Kansas House of Representatives,118,Republican,"Hineman, Don",38,000160
+THOMAS,West Hale Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",21,000170
+THOMAS,West Hale Township,Kansas House of Representatives,120,Republican,"Smith, Adam",142,000170
+THOMAS,West Morgan Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",30,000180
+THOMAS,West Morgan Township,Kansas House of Representatives,120,Republican,"Smith, Adam",202,000180
+THOMAS,Colby Ward 4 Exclave,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,900010
+THOMAS,Colby Ward 4 Exclave,Kansas House of Representatives,120,Republican,"Smith, Adam",0,900010
+THOMAS,East Morgan Township Enclave 2,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",0,900020
+THOMAS,East Morgan Township Enclave 2,Kansas House of Representatives,120,Republican,"Smith, Adam",0,900020
+THOMAS,Barrett Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000010
+THOMAS,Barrett Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",46,000010
+THOMAS,Colby Ward 1,Kansas Senate,40,Democratic,"Herman, Alex",102,000020
+THOMAS,Colby Ward 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",364,000020
+THOMAS,Colby Ward 2,Kansas Senate,40,Democratic,"Herman, Alex",92,00003A
+THOMAS,Colby Ward 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",391,00003A
+THOMAS,Colby Ward 2 Exclave,Kansas Senate,40,Democratic,"Herman, Alex",0,00003B
+THOMAS,Colby Ward 2 Exclave,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,00003B
+THOMAS,Colby Ward 3,Kansas Senate,40,Democratic,"Herman, Alex",126,00004A
+THOMAS,Colby Ward 3,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",578,00004A
+THOMAS,Colby Ward 3 Exclave,Kansas Senate,40,Democratic,"Herman, Alex",0,00004B
+THOMAS,Colby Ward 3 Exclave,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,00004B
+THOMAS,Colby Ward 4,Kansas Senate,40,Democratic,"Herman, Alex",116,000050
+THOMAS,Colby Ward 4,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",487,000050
+THOMAS,East Hale Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000060
+THOMAS,East Hale Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",57,000060
+THOMAS,East Morgan Township,Kansas Senate,40,Democratic,"Herman, Alex",15,00007A
+THOMAS,East Morgan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",125,00007A
+THOMAS,East Morgan Township Enclave Voting District,Kansas Senate,40,Democratic,"Herman, Alex",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,00007B
+THOMAS,Kingery Township,Kansas Senate,40,Democratic,"Herman, Alex",2,000080
+THOMAS,Kingery Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",47,000080
+THOMAS,Lacey Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000090
+THOMAS,Lacey Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",56,000090
+THOMAS,Menlo Township,Kansas Senate,40,Democratic,"Herman, Alex",4,000100
+THOMAS,Menlo Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",33,000100
+THOMAS,North Randall Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000110
+THOMAS,North Randall Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",42,000110
+THOMAS,Rovohl Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000120
+THOMAS,Rovohl Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",77,000120
+THOMAS,Smith Township,Kansas Senate,40,Democratic,"Herman, Alex",10,000130
+THOMAS,Smith Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",76,000130
+THOMAS,South Randall Township,Kansas Senate,40,Democratic,"Herman, Alex",22,000140
+THOMAS,South Randall Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",99,000140
+THOMAS,Summers Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000150
+THOMAS,Summers Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",98,000150
+THOMAS,Wendell Township,Kansas Senate,40,Democratic,"Herman, Alex",3,000160
+THOMAS,Wendell Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",37,000160
+THOMAS,West Hale Township,Kansas Senate,40,Democratic,"Herman, Alex",16,000170
+THOMAS,West Hale Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",148,000170
+THOMAS,West Morgan Township,Kansas Senate,40,Democratic,"Herman, Alex",33,000180
+THOMAS,West Morgan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",209,000180
+THOMAS,Colby Ward 4 Exclave,Kansas Senate,40,Democratic,"Herman, Alex",0,900010
+THOMAS,Colby Ward 4 Exclave,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900010
+THOMAS,East Morgan Township Enclave 2,Kansas Senate,40,Democratic,"Herman, Alex",0,900020
+THOMAS,East Morgan Township Enclave 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",0,900020
+THOMAS,Barrett Township,President / Vice President,,independent,"Stein, Jill",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+THOMAS,Barrett Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+THOMAS,Barrett Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000010
+THOMAS,Barrett Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+THOMAS,Barrett Township,President / Vice President,,Republican,"Trump, Donald J.",48,000010
+THOMAS,Colby Ward 1,President / Vice President,,independent,"Stein, Jill",10,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"McMullin, Evan",7,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+THOMAS,Colby Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",75,000020
+THOMAS,Colby Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",27,000020
+THOMAS,Colby Ward 1,President / Vice President,,Republican,"Trump, Donald J.",358,000020
+THOMAS,Colby Ward 2,President / Vice President,,independent,"Stein, Jill",10,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Castle, Darrell L",1,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Hedges, James A",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Smith, Mike",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",15,00003A
+THOMAS,Colby Ward 2,President / Vice President,,Republican,"Trump, Donald J.",385,00003A
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,independent,"Stein, Jill",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00003B
+THOMAS,Colby Ward 2 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00003B
+THOMAS,Colby Ward 3,President / Vice President,,independent,"Stein, Jill",20,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",96,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",28,00004A
+THOMAS,Colby Ward 3,President / Vice President,,Republican,"Trump, Donald J.",576,00004A
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00004B
+THOMAS,Colby Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00004B
+THOMAS,Colby Ward 4,President / Vice President,,independent,"Stein, Jill",6,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"McMullin, Evan",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+THOMAS,Colby Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",107,000050
+THOMAS,Colby Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",24,000050
+THOMAS,Colby Ward 4,President / Vice President,,Republican,"Trump, Donald J.",465,000050
+THOMAS,East Hale Township,President / Vice President,,independent,"Stein, Jill",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+THOMAS,East Hale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+THOMAS,East Hale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000060
+THOMAS,East Hale Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+THOMAS,East Hale Township,President / Vice President,,Republican,"Trump, Donald J.",56,000060
+THOMAS,East Morgan Township,President / Vice President,,independent,"Stein, Jill",1,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Castle, Darrell L",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Giordani, Rocky",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Hedges, James A",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Hoefling, Tom",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Kahn, Lynn",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"La Riva, Gloria",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Maturen, Michael A",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"McMullin, Evan",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Perry, Darryl",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Schriner, Joe C",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Smith, Mike",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Sood, Ajay",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Sterling, Shawna",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007A
+THOMAS,East Morgan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,00007A
+THOMAS,East Morgan Township,President / Vice President,,Libertarian,"Johnson, Gary",3,00007A
+THOMAS,East Morgan Township,President / Vice President,,Republican,"Trump, Donald J.",122,00007A
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,independent,"Stein, Jill",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Basiago, Andrew D.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Castle, Darrell L",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Giordani, Rocky",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Hedges, James A",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Hoefling, Tom",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Kahn, Lynn",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"La Riva, Gloria",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Levinson, Michael S.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Maturen, Michael A",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"McMullin, Evan",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Moorehead, Monica G.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Perry, Darryl",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Schriner, Joe C",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Smith, Mike",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Sood, Ajay",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Sterling, Shawna",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Valdivia, Anthony J",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Libertarian,"Johnson, Gary",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,President / Vice President,,Republican,"Trump, Donald J.",0,00007B
+THOMAS,Kingery Township,President / Vice President,,independent,"Stein, Jill",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+THOMAS,Kingery Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+THOMAS,Kingery Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000080
+THOMAS,Kingery Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+THOMAS,Kingery Township,President / Vice President,,Republican,"Trump, Donald J.",49,000080
+THOMAS,Lacey Township,President / Vice President,,independent,"Stein, Jill",2,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"McMullin, Evan",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+THOMAS,Lacey Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+THOMAS,Lacey Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000090
+THOMAS,Lacey Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000090
+THOMAS,Lacey Township,President / Vice President,,Republican,"Trump, Donald J.",53,000090
+THOMAS,Menlo Township,President / Vice President,,independent,"Stein, Jill",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+THOMAS,Menlo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+THOMAS,Menlo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000100
+THOMAS,Menlo Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+THOMAS,Menlo Township,President / Vice President,,Republican,"Trump, Donald J.",27,000100
+THOMAS,North Randall Township,President / Vice President,,independent,"Stein, Jill",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+THOMAS,North Randall Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+THOMAS,North Randall Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000110
+THOMAS,North Randall Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+THOMAS,North Randall Township,President / Vice President,,Republican,"Trump, Donald J.",39,000110
+THOMAS,Rovohl Township,President / Vice President,,independent,"Stein, Jill",2,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+THOMAS,Rovohl Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+THOMAS,Rovohl Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000120
+THOMAS,Rovohl Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000120
+THOMAS,Rovohl Township,President / Vice President,,Republican,"Trump, Donald J.",73,000120
+THOMAS,Smith Township,President / Vice President,,independent,"Stein, Jill",2,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+THOMAS,Smith Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+THOMAS,Smith Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000130
+THOMAS,Smith Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000130
+THOMAS,Smith Township,President / Vice President,,Republican,"Trump, Donald J.",78,000130
+THOMAS,South Randall Township,President / Vice President,,independent,"Stein, Jill",1,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+THOMAS,South Randall Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+THOMAS,South Randall Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000140
+THOMAS,South Randall Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000140
+THOMAS,South Randall Township,President / Vice President,,Republican,"Trump, Donald J.",102,000140
+THOMAS,Summers Township,President / Vice President,,independent,"Stein, Jill",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+THOMAS,Summers Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+THOMAS,Summers Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000150
+THOMAS,Summers Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000150
+THOMAS,Summers Township,President / Vice President,,Republican,"Trump, Donald J.",98,000150
+THOMAS,Wendell Township,President / Vice President,,independent,"Stein, Jill",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+THOMAS,Wendell Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+THOMAS,Wendell Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000160
+THOMAS,Wendell Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000160
+THOMAS,Wendell Township,President / Vice President,,Republican,"Trump, Donald J.",36,000160
+THOMAS,West Hale Township,President / Vice President,,independent,"Stein, Jill",1,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+THOMAS,West Hale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+THOMAS,West Hale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000170
+THOMAS,West Hale Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000170
+THOMAS,West Hale Township,President / Vice President,,Republican,"Trump, Donald J.",140,000170
+THOMAS,West Morgan Township,President / Vice President,,independent,"Stein, Jill",1,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+THOMAS,West Morgan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+THOMAS,West Morgan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000180
+THOMAS,West Morgan Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000180
+THOMAS,West Morgan Township,President / Vice President,,Republican,"Trump, Donald J.",203,000180
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+THOMAS,Colby Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,independent,"Stein, Jill",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Hedges, James A",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Smith, Mike",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+THOMAS,East Morgan Township Enclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+THOMAS,Barrett Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000010
+THOMAS,Barrett Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+THOMAS,Barrett Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+THOMAS,Barrett Township,United States House of Representatives,1,Republican,"Marshall, Roger",46,000010
+THOMAS,Colby Ward 1,United States House of Representatives,1,independent,"LaPolice, Alan",74,000020
+THOMAS,Colby Ward 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+THOMAS,Colby Ward 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,000020
+THOMAS,Colby Ward 1,United States House of Representatives,1,Republican,"Marshall, Roger",365,000020
+THOMAS,Colby Ward 2,United States House of Representatives,1,independent,"LaPolice, Alan",74,00003A
+THOMAS,Colby Ward 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,00003A
+THOMAS,Colby Ward 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,00003A
+THOMAS,Colby Ward 2,United States House of Representatives,1,Republican,"Marshall, Roger",384,00003A
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00003B
+THOMAS,Colby Ward 3,United States House of Representatives,1,independent,"LaPolice, Alan",112,00004A
+THOMAS,Colby Ward 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00004A
+THOMAS,Colby Ward 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",36,00004A
+THOMAS,Colby Ward 3,United States House of Representatives,1,Republican,"Marshall, Roger",559,00004A
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00004B
+THOMAS,Colby Ward 4,United States House of Representatives,1,independent,"LaPolice, Alan",105,000050
+THOMAS,Colby Ward 4,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000050
+THOMAS,Colby Ward 4,United States House of Representatives,1,Libertarian,"Burt, Kerry",29,000050
+THOMAS,Colby Ward 4,United States House of Representatives,1,Republican,"Marshall, Roger",464,000050
+THOMAS,East Hale Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000060
+THOMAS,East Hale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+THOMAS,East Hale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000060
+THOMAS,East Hale Township,United States House of Representatives,1,Republican,"Marshall, Roger",45,000060
+THOMAS,East Morgan Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,00007A
+THOMAS,East Morgan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00007A
+THOMAS,East Morgan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,00007A
+THOMAS,East Morgan Township,United States House of Representatives,1,Republican,"Marshall, Roger",111,00007A
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,independent,"LaPolice, Alan",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States House of Representatives,1,Republican,"Marshall, Roger",0,00007B
+THOMAS,Kingery Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000080
+THOMAS,Kingery Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+THOMAS,Kingery Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+THOMAS,Kingery Township,United States House of Representatives,1,Republican,"Marshall, Roger",38,000080
+THOMAS,Lacey Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000090
+THOMAS,Lacey Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+THOMAS,Lacey Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000090
+THOMAS,Lacey Township,United States House of Representatives,1,Republican,"Marshall, Roger",52,000090
+THOMAS,Menlo Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000100
+THOMAS,Menlo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+THOMAS,Menlo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000100
+THOMAS,Menlo Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000100
+THOMAS,North Randall Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000110
+THOMAS,North Randall Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000110
+THOMAS,North Randall Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000110
+THOMAS,North Randall Township,United States House of Representatives,1,Republican,"Marshall, Roger",30,000110
+THOMAS,Rovohl Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000120
+THOMAS,Rovohl Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+THOMAS,Rovohl Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000120
+THOMAS,Rovohl Township,United States House of Representatives,1,Republican,"Marshall, Roger",67,000120
+THOMAS,Smith Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000130
+THOMAS,Smith Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+THOMAS,Smith Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000130
+THOMAS,Smith Township,United States House of Representatives,1,Republican,"Marshall, Roger",78,000130
+THOMAS,South Randall Township,United States House of Representatives,1,independent,"LaPolice, Alan",20,000140
+THOMAS,South Randall Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+THOMAS,South Randall Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000140
+THOMAS,South Randall Township,United States House of Representatives,1,Republican,"Marshall, Roger",97,000140
+THOMAS,Summers Township,United States House of Representatives,1,independent,"LaPolice, Alan",12,000150
+THOMAS,Summers Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+THOMAS,Summers Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000150
+THOMAS,Summers Township,United States House of Representatives,1,Republican,"Marshall, Roger",84,000150
+THOMAS,Wendell Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000160
+THOMAS,Wendell Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+THOMAS,Wendell Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000160
+THOMAS,Wendell Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000160
+THOMAS,West Hale Township,United States House of Representatives,1,independent,"LaPolice, Alan",44,000170
+THOMAS,West Hale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+THOMAS,West Hale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000170
+THOMAS,West Hale Township,United States House of Representatives,1,Republican,"Marshall, Roger",112,000170
+THOMAS,West Morgan Township,United States House of Representatives,1,independent,"LaPolice, Alan",39,000180
+THOMAS,West Morgan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+THOMAS,West Morgan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000180
+THOMAS,West Morgan Township,United States House of Representatives,1,Republican,"Marshall, Roger",189,000180
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+THOMAS,Colby Ward 4 Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,independent,"LaPolice, Alan",0,900020
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900020
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900020
+THOMAS,East Morgan Township Enclave 2,United States House of Representatives,1,Republican,"Marshall, Roger",0,900020
+THOMAS,Barrett Township,United States Senate,,write - in,"Smith, DJ",0,000010
+THOMAS,Barrett Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000010
+THOMAS,Barrett Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000010
+THOMAS,Barrett Township,United States Senate,,Republican,"Moran, Jerry",47,000010
+THOMAS,Colby Ward 1,United States Senate,,write - in,"Smith, DJ",0,000020
+THOMAS,Colby Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",71,000020
+THOMAS,Colby Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",21,000020
+THOMAS,Colby Ward 1,United States Senate,,Republican,"Moran, Jerry",379,000020
+THOMAS,Colby Ward 2,United States Senate,,write - in,"Smith, DJ",0,00003A
+THOMAS,Colby Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",66,00003A
+THOMAS,Colby Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",19,00003A
+THOMAS,Colby Ward 2,United States Senate,,Republican,"Moran, Jerry",402,00003A
+THOMAS,Colby Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00003B
+THOMAS,Colby Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00003B
+THOMAS,Colby Ward 3,United States Senate,,write - in,"Smith, DJ",0,00004A
+THOMAS,Colby Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",79,00004A
+THOMAS,Colby Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",36,00004A
+THOMAS,Colby Ward 3,United States Senate,,Republican,"Moran, Jerry",601,00004A
+THOMAS,Colby Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00004B
+THOMAS,Colby Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00004B
+THOMAS,Colby Ward 4,United States Senate,,write - in,"Smith, DJ",0,000050
+THOMAS,Colby Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",82,000050
+THOMAS,Colby Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",29,000050
+THOMAS,Colby Ward 4,United States Senate,,Republican,"Moran, Jerry",499,000050
+THOMAS,East Hale Township,United States Senate,,write - in,"Smith, DJ",0,000060
+THOMAS,East Hale Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000060
+THOMAS,East Hale Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000060
+THOMAS,East Hale Township,United States Senate,,Republican,"Moran, Jerry",56,000060
+THOMAS,East Morgan Township,United States Senate,,write - in,"Smith, DJ",0,00007A
+THOMAS,East Morgan Township,United States Senate,,Democratic,"Wiesner, Patrick",16,00007A
+THOMAS,East Morgan Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,00007A
+THOMAS,East Morgan Township,United States Senate,,Republican,"Moran, Jerry",123,00007A
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,write - in,"Smith, DJ",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,Democratic,"Wiesner, Patrick",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,Libertarian,"Garrard, Robert D.",0,00007B
+THOMAS,East Morgan Township Enclave Voting District,United States Senate,,Republican,"Moran, Jerry",0,00007B
+THOMAS,Kingery Township,United States Senate,,write - in,"Smith, DJ",0,000080
+THOMAS,Kingery Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000080
+THOMAS,Kingery Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+THOMAS,Kingery Township,United States Senate,,Republican,"Moran, Jerry",46,000080
+THOMAS,Lacey Township,United States Senate,,write - in,"Smith, DJ",0,000090
+THOMAS,Lacey Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000090
+THOMAS,Lacey Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000090
+THOMAS,Lacey Township,United States Senate,,Republican,"Moran, Jerry",55,000090
+THOMAS,Menlo Township,United States Senate,,write - in,"Smith, DJ",0,000100
+THOMAS,Menlo Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000100
+THOMAS,Menlo Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000100
+THOMAS,Menlo Township,United States Senate,,Republican,"Moran, Jerry",33,000100
+THOMAS,North Randall Township,United States Senate,,write - in,"Smith, DJ",0,000110
+THOMAS,North Randall Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000110
+THOMAS,North Randall Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000110
+THOMAS,North Randall Township,United States Senate,,Republican,"Moran, Jerry",38,000110
+THOMAS,Rovohl Township,United States Senate,,write - in,"Smith, DJ",0,000120
+THOMAS,Rovohl Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000120
+THOMAS,Rovohl Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000120
+THOMAS,Rovohl Township,United States Senate,,Republican,"Moran, Jerry",74,000120
+THOMAS,Smith Township,United States Senate,,write - in,"Smith, DJ",0,000130
+THOMAS,Smith Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000130
+THOMAS,Smith Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000130
+THOMAS,Smith Township,United States Senate,,Republican,"Moran, Jerry",80,000130
+THOMAS,South Randall Township,United States Senate,,write - in,"Smith, DJ",0,000140
+THOMAS,South Randall Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000140
+THOMAS,South Randall Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000140
+THOMAS,South Randall Township,United States Senate,,Republican,"Moran, Jerry",105,000140
+THOMAS,Summers Township,United States Senate,,write - in,"Smith, DJ",0,000150
+THOMAS,Summers Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000150
+THOMAS,Summers Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000150
+THOMAS,Summers Township,United States Senate,,Republican,"Moran, Jerry",96,000150
+THOMAS,Wendell Township,United States Senate,,write - in,"Smith, DJ",0,000160
+THOMAS,Wendell Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000160
+THOMAS,Wendell Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000160
+THOMAS,Wendell Township,United States Senate,,Republican,"Moran, Jerry",34,000160
+THOMAS,West Hale Township,United States Senate,,write - in,"Smith, DJ",0,000170
+THOMAS,West Hale Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000170
+THOMAS,West Hale Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000170
+THOMAS,West Hale Township,United States Senate,,Republican,"Moran, Jerry",136,000170
+THOMAS,West Morgan Township,United States Senate,,write - in,"Smith, DJ",0,000180
+THOMAS,West Morgan Township,United States Senate,,Democratic,"Wiesner, Patrick",28,000180
+THOMAS,West Morgan Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000180
+THOMAS,West Morgan Township,United States Senate,,Republican,"Moran, Jerry",208,000180
+THOMAS,Colby Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+THOMAS,Colby Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+THOMAS,Colby Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+THOMAS,Colby Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010
+THOMAS,East Morgan Township Enclave 2,United States Senate,,write - in,"Smith, DJ",0,900020
+THOMAS,East Morgan Township Enclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+THOMAS,East Morgan Township Enclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+THOMAS,East Morgan Township Enclave 2,United States Senate,,Republican,"Moran, Jerry",0,900020

--- a/2016/20161108__ks__general__trego__precinct.csv
+++ b/2016/20161108__ks__general__trego__precinct.csv
@@ -1,169 +1,397 @@
-county,precinct,office,district,party,candidate,votes
-Trego,Collyer City,,,,Ballots Cast,46
-Trego,WaKeeney City East,,,,Ballots Cast,293
-Trego,WaKeeney City Central ,,,,Ballots Cast,293
-Trego,WaKeeney City West,,,,Ballots Cast,323
-Trego,Collyer Township,,,,Ballots Cast,100
-Trego,Franklin Township,,,,Ballots Cast,26
-Trego,Glencoe Township,,,,Ballots Cast,41
-Trego,Ogallah Township,,,,Ballots Cast,89
-Trego,Riverside Township,,,,Ballots Cast,49
-Trego,WaKeeney Township,,,,Ballots Cast,208
-Trego,Wilcox Township,,,,Ballots Cast,44
-Trego,Total,,,,Ballots Cast,1512
-Trego,Collyer City,President,,REP,Trump and Pence,42
-Trego,WaKeeney City East,President,,REP,Trump and Pence,239
-Trego,WaKeeney City Central ,President,,REP,Trump and Pence,235
-Trego,WaKeeney City West,President,,REP,Trump and Pence,240
-Trego,Collyer Township,President,,REP,Trump and Pence,84
-Trego,Franklin Township,President,,REP,Trump and Pence,20
-Trego,Glencoe Township,President,,REP,Trump and Pence,41
-Trego,Ogallah Township,President,,REP,Trump and Pence,66
-Trego,Riverside Township,President,,REP,Trump and Pence,38
-Trego,WaKeeney Township,President,,REP,Trump and Pence,183
-Trego,Wilcox Township,President,,REP,Trump and Pence,38
-Trego,Total,President,,REP,Trump and Pence,1226
-Trego,Collyer City,President,,DEM,Clinton and Kaine,2
-Trego,WaKeeney City East,President,,DEM,Clinton and Kaine,40
-Trego,WaKeeney City Central ,President,,DEM,Clinton and Kaine,35
-Trego,WaKeeney City West,President,,DEM,Clinton and Kaine,55
-Trego,Collyer Township,President,,DEM,Clinton and Kaine,12
-Trego,Franklin Township,President,,DEM,Clinton and Kaine,6
-Trego,Glencoe Township,President,,DEM,Clinton and Kaine,0
-Trego,Ogallah Township,President,,DEM,Clinton and Kaine,15
-Trego,Riverside Township,President,,DEM,Clinton and Kaine,8
-Trego,WaKeeney Township,President,,DEM,Clinton and Kaine,22
-Trego,Wilcox Township,President,,DEM,Clinton and Kaine,3
-Trego,Total,President,,DEM,Clinton and Kaine,198
-Trego,Collyer City,President,,LIB,Johnson and Weld,1
-Trego,WaKeeney City East,President,,LIB,Johnson and Weld,2
-Trego,WaKeeney City Central ,President,,LIB,Johnson and Weld,13
-Trego,WaKeeney City West,President,,LIB,Johnson and Weld,13
-Trego,Collyer Township,President,,LIB,Johnson and Weld,1
-Trego,Franklin Township,President,,LIB,Johnson and Weld,0
-Trego,Glencoe Township,President,,LIB,Johnson and Weld,0
-Trego,Ogallah Township,President,,LIB,Johnson and Weld,5
-Trego,Riverside Township,President,,LIB,Johnson and Weld,2
-Trego,WaKeeney Township,President,,LIB,Johnson and Weld,1
-Trego,Wilcox Township,President,,LIB,Johnson and Weld,2
-Trego,Total,President,,LIB,Johnson and Weld,40
-Trego,Collyer City,President,,IND,Stein and Baraka,0
-Trego,WaKeeney City East,President,,IND,Stein and Baraka,5
-Trego,WaKeeney City Central ,President,,IND,Stein and Baraka,4
-Trego,WaKeeney City West,President,,IND,Stein and Baraka,6
-Trego,Collyer Township,President,,IND,Stein and Baraka,1
-Trego,Franklin Township,President,,IND,Stein and Baraka,0
-Trego,Glencoe Township,President,,IND,Stein and Baraka,0
-Trego,Ogallah Township,President,,IND,Stein and Baraka,1
-Trego,Riverside Township,President,,IND,Stein and Baraka,0
-Trego,WaKeeney Township,President,,IND,Stein and Baraka,0
-Trego,Wilcox Township,President,,IND,Stein and Baraka,0
-Trego,Total,President,,IND,Stein and Baraka,17
-Trego,Collyer City,U.S. Senate,,DEM,Patrick Wiesner,1
-Trego,WaKeeney City East,U.S. Senate,,DEM,Patrick Wiesner,31
-Trego,WaKeeney City Central ,U.S. Senate,,DEM,Patrick Wiesner,37
-Trego,WaKeeney City West,U.S. Senate,,DEM,Patrick Wiesner,51
-Trego,Collyer Township,U.S. Senate,,DEM,Patrick Wiesner,19
-Trego,Franklin Township,U.S. Senate,,DEM,Patrick Wiesner,6
-Trego,Glencoe Township,U.S. Senate,,DEM,Patrick Wiesner,5
-Trego,Ogallah Township,U.S. Senate,,DEM,Patrick Wiesner,19
-Trego,Riverside Township,U.S. Senate,,DEM,Patrick Wiesner,11
-Trego,WaKeeney Township,U.S. Senate,,DEM,Patrick Wiesner,20
-Trego,Wilcox Township,U.S. Senate,,DEM,Patrick Wiesner,3
-Trego,Total,U.S. Senate,,DEM,Patrick Wiesner,203
-Trego,Collyer City,U.S. Senate,,LIB,Robert D. Garrard,5
-Trego,WaKeeney City East,U.S. Senate,,LIB,Robert D. Garrard,10
-Trego,WaKeeney City Central ,U.S. Senate,,LIB,Robert D. Garrard,15
-Trego,WaKeeney City West,U.S. Senate,,LIB,Robert D. Garrard,14
-Trego,Collyer Township,U.S. Senate,,LIB,Robert D. Garrard,6
-Trego,Franklin Township,U.S. Senate,,LIB,Robert D. Garrard,0
-Trego,Glencoe Township,U.S. Senate,,LIB,Robert D. Garrard,1
-Trego,Ogallah Township,U.S. Senate,,LIB,Robert D. Garrard,2
-Trego,Riverside Township,U.S. Senate,,LIB,Robert D. Garrard,1
-Trego,WaKeeney Township,U.S. Senate,,LIB,Robert D. Garrard,7
-Trego,Wilcox Township,U.S. Senate,,LIB,Robert D. Garrard,1
-Trego,Total,U.S. Senate,,LIB,Robert D. Garrard,62
-Trego,Collyer City,U.S. Senate,,REP,Jerry Moran,36
-Trego,WaKeeney City East,U.S. Senate,,REP,Jerry Moran,237
-Trego,WaKeeney City Central ,U.S. Senate,,REP,Jerry Moran,235
-Trego,WaKeeney City West,U.S. Senate,,REP,Jerry Moran,249
-Trego,Collyer Township,U.S. Senate,,REP,Jerry Moran,71
-Trego,Franklin Township,U.S. Senate,,REP,Jerry Moran,20
-Trego,Glencoe Township,U.S. Senate,,REP,Jerry Moran,35
-Trego,Ogallah Township,U.S. Senate,,REP,Jerry Moran,66
-Trego,Riverside Township,U.S. Senate,,REP,Jerry Moran,35
-Trego,WaKeeney Township,U.S. Senate,,REP,Jerry Moran,179
-Trego,Wilcox Township,U.S. Senate,,REP,Jerry Moran,39
-Trego,Total,U.S. Senate,,REP,Jerry Moran,1202
-Trego,Collyer City,U.S. House,1,REP,Roger Marshall,31
-Trego,WaKeeney City East,U.S. House,1,REP,Roger Marshall,198
-Trego,WaKeeney City Central ,U.S. House,1,REP,Roger Marshall,221
-Trego,WaKeeney City West,U.S. House,1,REP,Roger Marshall,219
-Trego,Collyer Township,U.S. House,1,REP,Roger Marshall,70
-Trego,Franklin Township,U.S. House,1,REP,Roger Marshall,15
-Trego,Glencoe Township,U.S. House,1,REP,Roger Marshall,35
-Trego,Ogallah Township,U.S. House,1,REP,Roger Marshall,59
-Trego,Riverside Township,U.S. House,1,REP,Roger Marshall,32
-Trego,WaKeeney Township,U.S. House,1,REP,Roger Marshall,153
-Trego,Wilcox Township,U.S. House,1,REP,Roger Marshall,33
-Trego,Total,U.S. House,1,REP,Roger Marshall,1066
-Trego,Collyer City,U.S. House,1,LIB,Kerry Burt,2
-Trego,WaKeeney City East,U.S. House,1,LIB,Kerry Burt,12
-Trego,WaKeeney City Central ,U.S. House,1,LIB,Kerry Burt,10
-Trego,WaKeeney City West,U.S. House,1,LIB,Kerry Burt,22
-Trego,Collyer Township,U.S. House,1,LIB,Kerry Burt,3
-Trego,Franklin Township,U.S. House,1,LIB,Kerry Burt,1
-Trego,Glencoe Township,U.S. House,1,LIB,Kerry Burt,0
-Trego,Ogallah Township,U.S. House,1,LIB,Kerry Burt,4
-Trego,Riverside Township,U.S. House,1,LIB,Kerry Burt,3
-Trego,WaKeeney Township,U.S. House,1,LIB,Kerry Burt,7
-Trego,Wilcox Township,U.S. House,1,LIB,Kerry Burt,2
-Trego,Total,U.S. House,1,LIB,Kerry Burt,66
-Trego,Collyer City,U.S. House,1,IND,Alan LaPolice,10
-Trego,WaKeeney City East,U.S. House,1,IND,Alan LaPolice,60
-Trego,WaKeeney City Central ,U.S. House,1,IND,Alan LaPolice,50
-Trego,WaKeeney City West,U.S. House,1,IND,Alan LaPolice,60
-Trego,Collyer Township,U.S. House,1,IND,Alan LaPolice,23
-Trego,Franklin Township,U.S. House,1,IND,Alan LaPolice,7
-Trego,Glencoe Township,U.S. House,1,IND,Alan LaPolice,6
-Trego,Ogallah Township,U.S. House,1,IND,Alan LaPolice,23
-Trego,Riverside Township,U.S. House,1,IND,Alan LaPolice,13
-Trego,WaKeeney Township,U.S. House,1,IND,Alan LaPolice,38
-Trego,Wilcox Township,U.S. House,1,IND,Alan LaPolice,6
-Trego,Total,U.S. House,1,IND,Alan LaPolice,296
-Trego,Collyer City,State Senate,40,DEM,Alex Herman,10
-Trego,WaKeeney City East,State Senate,40,DEM,Alex Herman,65
-Trego,WaKeeney City Central ,State Senate,40,DEM,Alex Herman,76
-Trego,WaKeeney City West,State Senate,40,DEM,Alex Herman,111
-Trego,Collyer Township,State Senate,40,DEM,Alex Herman,29
-Trego,Franklin Township,State Senate,40,DEM,Alex Herman,7
-Trego,Glencoe Township,State Senate,40,DEM,Alex Herman,8
-Trego,Ogallah Township,State Senate,40,DEM,Alex Herman,26
-Trego,Riverside Township,State Senate,40,DEM,Alex Herman,14
-Trego,WaKeeney Township,State Senate,40,DEM,Alex Herman,39
-Trego,Wilcox Township,State Senate,40,DEM,Alex Herman,6
-Trego,Total,State Senate,40,DEM,Alex Herman,391
-Trego,Collyer City,State Senate,40,REP,Richard (Rick) Billinger,30
-Trego,WaKeeney City East,State Senate,40,REP,Richard (Rick) Billinger,218
-Trego,WaKeeney City Central ,State Senate,40,REP,Richard (Rick) Billinger,208
-Trego,WaKeeney City West,State Senate,40,REP,Richard (Rick) Billinger,195
-Trego,Collyer Township,State Senate,40,REP,Richard (Rick) Billinger,70
-Trego,Franklin Township,State Senate,40,REP,Richard (Rick) Billinger,19
-Trego,Glencoe Township,State Senate,40,REP,Richard (Rick) Billinger,32
-Trego,Ogallah Township,State Senate,40,REP,Richard (Rick) Billinger,62
-Trego,Riverside Township,State Senate,40,REP,Richard (Rick) Billinger,32
-Trego,WaKeeney Township,State Senate,40,REP,Richard (Rick) Billinger,162
-Trego,Wilcox Township,State Senate,40,REP,Richard (Rick) Billinger,37
-Trego,Total,State Senate,40,REP,Richard (Rick) Billinger,1065
-Trego,Collyer City,State House,118,REP,Don Hineman,37
-Trego,WaKeeney City East,State House,118,REP,Don Hineman,251
-Trego,WaKeeney City Central ,State House,118,REP,Don Hineman,252
-Trego,WaKeeney City West,State House,118,REP,Don Hineman,258
-Trego,Collyer Township,State House,118,REP,Don Hineman,87
-Trego,Franklin Township,State House,118,REP,Don Hineman,24
-Trego,Glencoe Township,State House,118,REP,Don Hineman,40
-Trego,Ogallah Township,State House,118,REP,Don Hineman,83
-Trego,Riverside Township,State House,118,REP,Don Hineman,43
-Trego,WaKeeney Township,State House,118,REP,Don Hineman,183
-Trego,Wilcox Township,State House,118,REP,Don Hineman,39
-Trego,Total,State House,118,REP,Don Hineman,1297
+county,precinct,office,district,party,candidate,votes,vtd
+TREGO,Collyer City,Kansas House of Representatives,118,Republican,"Hineman, Don",37,000010
+TREGO,Collyer Township,Kansas House of Representatives,118,Republican,"Hineman, Don",87,000020
+TREGO,Franklin Township,Kansas House of Representatives,118,Republican,"Hineman, Don",24,000030
+TREGO,Glencoe Township,Kansas House of Representatives,118,Republican,"Hineman, Don",40,000040
+TREGO,Ogallah Township,Kansas House of Representatives,118,Republican,"Hineman, Don",83,000050
+TREGO,Riverside Township,Kansas House of Representatives,118,Republican,"Hineman, Don",43,000060
+TREGO,WaKeeney City Central Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",252,000070
+TREGO,WaKeeney City East Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",251,000080
+TREGO,WaKeeney City West Precinct,Kansas House of Representatives,118,Republican,"Hineman, Don",258,000090
+TREGO,WaKeeney Township,Kansas House of Representatives,118,Republican,"Hineman, Don",183,000100
+TREGO,Wilcox Township,Kansas House of Representatives,118,Republican,"Hineman, Don",39,000110
+TREGO,Collyer City,Kansas Senate,40,Democratic,"Herman, Alex",10,000010
+TREGO,Collyer City,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",30,000010
+TREGO,Collyer Township,Kansas Senate,40,Democratic,"Herman, Alex",29,000020
+TREGO,Collyer Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",70,000020
+TREGO,Franklin Township,Kansas Senate,40,Democratic,"Herman, Alex",7,000030
+TREGO,Franklin Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",19,000030
+TREGO,Glencoe Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000040
+TREGO,Glencoe Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",32,000040
+TREGO,Ogallah Township,Kansas Senate,40,Democratic,"Herman, Alex",26,000050
+TREGO,Ogallah Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",62,000050
+TREGO,Riverside Township,Kansas Senate,40,Democratic,"Herman, Alex",14,000060
+TREGO,Riverside Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",32,000060
+TREGO,WaKeeney City Central Precinct,Kansas Senate,40,Democratic,"Herman, Alex",76,000070
+TREGO,WaKeeney City Central Precinct,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",208,000070
+TREGO,WaKeeney City East Precinct,Kansas Senate,40,Democratic,"Herman, Alex",65,000080
+TREGO,WaKeeney City East Precinct,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",218,000080
+TREGO,WaKeeney City West Precinct,Kansas Senate,40,Democratic,"Herman, Alex",111,000090
+TREGO,WaKeeney City West Precinct,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",195,000090
+TREGO,WaKeeney Township,Kansas Senate,40,Democratic,"Herman, Alex",39,000100
+TREGO,WaKeeney Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",162,000100
+TREGO,Wilcox Township,Kansas Senate,40,Democratic,"Herman, Alex",6,000110
+TREGO,Wilcox Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",37,000110
+TREGO,Collyer City,President / Vice President,,independent,"Stein, Jill",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Hedges, James A",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"McMullin, Evan",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Perry, Darryl",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Smith, Mike",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Sood, Ajay",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+TREGO,Collyer City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+TREGO,Collyer City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000010
+TREGO,Collyer City,President / Vice President,,Libertarian,"Johnson, Gary",1,000010
+TREGO,Collyer City,President / Vice President,,Republican,"Trump, Donald J.",42,000010
+TREGO,Collyer Township,President / Vice President,,independent,"Stein, Jill",1,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+TREGO,Collyer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+TREGO,Collyer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000020
+TREGO,Collyer Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+TREGO,Collyer Township,President / Vice President,,Republican,"Trump, Donald J.",84,000020
+TREGO,Franklin Township,President / Vice President,,independent,"Stein, Jill",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+TREGO,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+TREGO,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000030
+TREGO,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+TREGO,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",20,000030
+TREGO,Glencoe Township,President / Vice President,,independent,"Stein, Jill",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+TREGO,Glencoe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+TREGO,Glencoe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000040
+TREGO,Glencoe Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000040
+TREGO,Glencoe Township,President / Vice President,,Republican,"Trump, Donald J.",41,000040
+TREGO,Ogallah Township,President / Vice President,,independent,"Stein, Jill",1,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+TREGO,Ogallah Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+TREGO,Ogallah Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000050
+TREGO,Ogallah Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000050
+TREGO,Ogallah Township,President / Vice President,,Republican,"Trump, Donald J.",66,000050
+TREGO,Riverside Township,President / Vice President,,independent,"Stein, Jill",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+TREGO,Riverside Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+TREGO,Riverside Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,000060
+TREGO,Riverside Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000060
+TREGO,Riverside Township,President / Vice President,,Republican,"Trump, Donald J.",38,000060
+TREGO,WaKeeney City Central Precinct,President / Vice President,,independent,"Stein, Jill",4,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Hedges, James A",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"McMullin, Evan",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Smith, Mike",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Libertarian,"Johnson, Gary",13,000070
+TREGO,WaKeeney City Central Precinct,President / Vice President,,Republican,"Trump, Donald J.",235,000070
+TREGO,WaKeeney City East Precinct,President / Vice President,,independent,"Stein, Jill",5,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Hedges, James A",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"McMullin, Evan",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Smith, Mike",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Libertarian,"Johnson, Gary",2,000080
+TREGO,WaKeeney City East Precinct,President / Vice President,,Republican,"Trump, Donald J.",240,000080
+TREGO,WaKeeney City West Precinct,President / Vice President,,independent,"Stein, Jill",6,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Hedges, James A",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"McMullin, Evan",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Perry, Darryl",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Smith, Mike",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Sood, Ajay",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Democratic,"Clinton, Hillary Rodham",55,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Libertarian,"Johnson, Gary",13,000090
+TREGO,WaKeeney City West Precinct,President / Vice President,,Republican,"Trump, Donald J.",240,000090
+TREGO,WaKeeney Township,President / Vice President,,independent,"Stein, Jill",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+TREGO,WaKeeney Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+TREGO,WaKeeney Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000100
+TREGO,WaKeeney Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000100
+TREGO,WaKeeney Township,President / Vice President,,Republican,"Trump, Donald J.",183,000100
+TREGO,Wilcox Township,President / Vice President,,independent,"Stein, Jill",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+TREGO,Wilcox Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+TREGO,Wilcox Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000110
+TREGO,Wilcox Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000110
+TREGO,Wilcox Township,President / Vice President,,Republican,"Trump, Donald J.",38,000110
+TREGO,Collyer City,United States House of Representatives,1,independent,"LaPolice, Alan",10,000010
+TREGO,Collyer City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+TREGO,Collyer City,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+TREGO,Collyer City,United States House of Representatives,1,Republican,"Marshall, Roger",31,000010
+TREGO,Collyer Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000020
+TREGO,Collyer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+TREGO,Collyer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000020
+TREGO,Collyer Township,United States House of Representatives,1,Republican,"Marshall, Roger",70,000020
+TREGO,Franklin Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000030
+TREGO,Franklin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+TREGO,Franklin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+TREGO,Franklin Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000030
+TREGO,Glencoe Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000040
+TREGO,Glencoe Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+TREGO,Glencoe Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+TREGO,Glencoe Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000040
+TREGO,Ogallah Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000050
+TREGO,Ogallah Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+TREGO,Ogallah Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000050
+TREGO,Ogallah Township,United States House of Representatives,1,Republican,"Marshall, Roger",59,000050
+TREGO,Riverside Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000060
+TREGO,Riverside Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+TREGO,Riverside Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000060
+TREGO,Riverside Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000060
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,independent,"LaPolice, Alan",50,000070
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,Libertarian,"Burt, Kerry",10,000070
+TREGO,WaKeeney City Central Precinct,United States House of Representatives,1,Republican,"Marshall, Roger",221,000070
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,independent,"LaPolice, Alan",60,000080
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000080
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000080
+TREGO,WaKeeney City East Precinct,United States House of Representatives,1,Republican,"Marshall, Roger",198,000080
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,independent,"LaPolice, Alan",60,000090
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000090
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,Libertarian,"Burt, Kerry",22,000090
+TREGO,WaKeeney City West Precinct,United States House of Representatives,1,Republican,"Marshall, Roger",219,000090
+TREGO,WaKeeney Township,United States House of Representatives,1,independent,"LaPolice, Alan",38,000100
+TREGO,WaKeeney Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+TREGO,WaKeeney Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",7,000100
+TREGO,WaKeeney Township,United States House of Representatives,1,Republican,"Marshall, Roger",153,000100
+TREGO,Wilcox Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000110
+TREGO,Wilcox Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000110
+TREGO,Wilcox Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000110
+TREGO,Wilcox Township,United States House of Representatives,1,Republican,"Marshall, Roger",33,000110
+TREGO,Collyer City,United States Senate,,write - in,"Smith, DJ",0,000010
+TREGO,Collyer City,United States Senate,,Democratic,"Wiesner, Patrick",1,000010
+TREGO,Collyer City,United States Senate,,Libertarian,"Garrard, Robert D.",5,000010
+TREGO,Collyer City,United States Senate,,Republican,"Moran, Jerry",36,000010
+TREGO,Collyer Township,United States Senate,,write - in,"Smith, DJ",0,000020
+TREGO,Collyer Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000020
+TREGO,Collyer Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000020
+TREGO,Collyer Township,United States Senate,,Republican,"Moran, Jerry",71,000020
+TREGO,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000030
+TREGO,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000030
+TREGO,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+TREGO,Franklin Township,United States Senate,,Republican,"Moran, Jerry",20,000030
+TREGO,Glencoe Township,United States Senate,,write - in,"Smith, DJ",0,000040
+TREGO,Glencoe Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000040
+TREGO,Glencoe Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+TREGO,Glencoe Township,United States Senate,,Republican,"Moran, Jerry",35,000040
+TREGO,Ogallah Township,United States Senate,,write - in,"Smith, DJ",0,000050
+TREGO,Ogallah Township,United States Senate,,Democratic,"Wiesner, Patrick",19,000050
+TREGO,Ogallah Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+TREGO,Ogallah Township,United States Senate,,Republican,"Moran, Jerry",66,000050
+TREGO,Riverside Township,United States Senate,,write - in,"Smith, DJ",0,000060
+TREGO,Riverside Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000060
+TREGO,Riverside Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+TREGO,Riverside Township,United States Senate,,Republican,"Moran, Jerry",35,000060
+TREGO,WaKeeney City Central Precinct,United States Senate,,write - in,"Smith, DJ",0,000070
+TREGO,WaKeeney City Central Precinct,United States Senate,,Democratic,"Wiesner, Patrick",37,000070
+TREGO,WaKeeney City Central Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",15,000070
+TREGO,WaKeeney City Central Precinct,United States Senate,,Republican,"Moran, Jerry",235,000070
+TREGO,WaKeeney City East Precinct,United States Senate,,write - in,"Smith, DJ",0,000080
+TREGO,WaKeeney City East Precinct,United States Senate,,Democratic,"Wiesner, Patrick",31,000080
+TREGO,WaKeeney City East Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",10,000080
+TREGO,WaKeeney City East Precinct,United States Senate,,Republican,"Moran, Jerry",237,000080
+TREGO,WaKeeney City West Precinct,United States Senate,,write - in,"Smith, DJ",0,000090
+TREGO,WaKeeney City West Precinct,United States Senate,,Democratic,"Wiesner, Patrick",51,000090
+TREGO,WaKeeney City West Precinct,United States Senate,,Libertarian,"Garrard, Robert D.",14,000090
+TREGO,WaKeeney City West Precinct,United States Senate,,Republican,"Moran, Jerry",249,000090
+TREGO,WaKeeney Township,United States Senate,,write - in,"Smith, DJ",0,000100
+TREGO,WaKeeney Township,United States Senate,,Democratic,"Wiesner, Patrick",20,000100
+TREGO,WaKeeney Township,United States Senate,,Libertarian,"Garrard, Robert D.",7,000100
+TREGO,WaKeeney Township,United States Senate,,Republican,"Moran, Jerry",179,000100
+TREGO,Wilcox Township,United States Senate,,write - in,"Smith, DJ",0,000110
+TREGO,Wilcox Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000110
+TREGO,Wilcox Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000110
+TREGO,Wilcox Township,United States Senate,,Republican,"Moran, Jerry",39,000110

--- a/2016/20161108__ks__general__wabaunsee__precinct.csv
+++ b/2016/20161108__ks__general__wabaunsee__precinct.csv
@@ -1,288 +1,556 @@
-county,precinct,office,district,party,candidate,votes,
-Wabaunsee,Alma,President,,REP,Donald Trump,398,
-Wabaunsee,Alma,President,,DEM,Hillary Clinton,139,
-Wabaunsee,Alma,President,,LBT,Gary Johnson,24,
-Wabaunsee,Alma,President,,IND,Jill Stein,12,
-Wabaunsee,Chalk,President,,REP,Donald Trump,18,
-Wabaunsee,Chalk,President,,DEM,Hillary Clinton,3,
-Wabaunsee,Chalk,President,,LBT,Gary Johnson,1,
-Wabaunsee,Chalk,President,,IND,Jill Stein,1,
-Wabaunsee,Farmer,President,,REP,Donald Trump,50,
-Wabaunsee,Farmer,President,,DEM,Hillary Clinton,14,
-Wabaunsee,Farmer,President,,LBT,Gary Johnson,1,
-Wabaunsee,Farmer,President,,IND,Jill Stein,1,
-Wabaunsee,Alta Vista,President,,REP,Donald Trump,197,
-Wabaunsee,Alta Vista,President,,DEM,Hillary Clinton,54,
-Wabaunsee,Alta Vista,President,,LBT,Gary Johnson,16,
-Wabaunsee,Alta Vista,President,,IND,Jill Stein,2,
-Wabaunsee,Harveyville,President,,REP,Donald Trump,189,
-Wabaunsee,Harveyville,President,,DEM,Hillary Clinton,67,
-Wabaunsee,Harveyville,President,,LBT,Gary Johnson,15,
-Wabaunsee,Harveyville,President,,IND,Jill Stein,7,
-Wabaunsee,Hessdale,President,,REP,Donald Trump,89,
-Wabaunsee,Hessdale,President,,DEM,Hillary Clinton,43,
-Wabaunsee,Hessdale,President,,LBT,Gary Johnson,7,
-Wabaunsee,Hessdale,President,,IND,Jill Stein,1,
-Wabaunsee,Kaw,President,,REP,Donald Trump,64,
-Wabaunsee,Kaw,President,,DEM,Hillary Clinton,14,
-Wabaunsee,Kaw,President,,LBT,Gary Johnson,2,
-Wabaunsee,Kaw,President,,IND,Jill Stein,1,
-Wabaunsee,Kaw USD320,President,,REP,Donald Trump,38,
-Wabaunsee,Kaw USD320,President,,DEM,Hillary Clinton,4,
-Wabaunsee,Kaw USD320,President,,LBT,Gary Johnson,1,
-Wabaunsee,Kaw USD320,President,,IND,Jill Stein,0,
-Wabaunsee,Keene,President,,REP,Donald Trump,173,
-Wabaunsee,Keene,President,,DEM,Hillary Clinton,78,
-Wabaunsee,Keene,President,,LBT,Gary Johnson,18,
-Wabaunsee,Keene,President,,IND,Jill Stein,8,
-Wabaunsee,Maple Hill,President,,REP,Donald Trump,384,
-Wabaunsee,Maple Hill,President,,DEM,Hillary Clinton,119,
-Wabaunsee,Maple Hill,President,,LBT,Gary Johnson,14,
-Wabaunsee,Maple Hill,President,,IND,Jill Stein,12,
-Wabaunsee,McFarland,President,,REP,Donald Trump,104,
-Wabaunsee,McFarland,President,,DEM,Hillary Clinton,28,
-Wabaunsee,McFarland,President,,LBT,Gary Johnson,11,
-Wabaunsee,McFarland,President,,IND,Jill Stein,5,
-Wabaunsee,Paxico,President,,REP,Donald Trump,286,
-Wabaunsee,Paxico,President,,DEM,Hillary Clinton,61,
-Wabaunsee,Paxico,President,,LBT,Gary Johnson,11,
-Wabaunsee,Paxico,President,,IND,Jill Stein,3,
-Wabaunsee,Paxico USD 320,President,,REP,Donald Trump,0,
-Wabaunsee,Paxico USD 320,President,,DEM,Hillary Clinton,2,
-Wabaunsee,Paxico USD 320,President,,LBT,Gary Johnson,0,
-Wabaunsee,Paxico USD 320,President,,IND,Jill Stein,0,
-Wabaunsee,Wabaunsee 17,President,,REP,Donald Trump,63,
-Wabaunsee,Wabaunsee 17,President,,DEM,Hillary Clinton,12,
-Wabaunsee,Wabaunsee 17,President,,LBT,Gary Johnson,3,
-Wabaunsee,Wabaunsee 17,President,,IND,Jill Stein,2,
-Wabaunsee,Wabaunsee 17 USD320,President,,REP,Donald Trump,118,
-Wabaunsee,Wabaunsee 17 USD320,President,,DEM,Hillary Clinton,52,
-Wabaunsee,Wabaunsee 17 USD320,President,,LBT,Gary Johnson,6,
-Wabaunsee,Wabaunsee 17 USD320,President,,IND,Jill Stein,7,
-Wabaunsee,Wabaunsee 18 USD320,President,,REP,Donald Trump,8,
-Wabaunsee,Wabaunsee 18 USD320,President,,DEM,Hillary Clinton,4,
-Wabaunsee,Wabaunsee 18 USD320,President,,LBT,Gary Johnson,0,
-Wabaunsee,Wabaunsee 18 USD320,President,,IND,Jill Stein,0,
-Wabaunsee,Washington,President,,REP,Donald Trump,34,
-Wabaunsee,Washington,President,,DEM,Hillary Clinton,11,
-Wabaunsee,Washington,President,,LBT,Gary Johnson,1,
-Wabaunsee,Washington,President,,IND,Jill Stein,1,
-Wabaunsee,Eskridge,President,,REP,Donald Trump,159,
-Wabaunsee,Eskridge,President,,DEM,Hillary Clinton,71,
-Wabaunsee,Eskridge,President,,LBT,Gary Johnson,12,
-Wabaunsee,Eskridge,President,,IND,Jill Stein,6,
-Wabaunsee,Total,President,,REP,Donald Trump,2372,
-Wabaunsee,Total,President,,DEM,Hillary Clinton,776,
-Wabaunsee,Total,President,,LBT,Gary Johnson,143,
-Wabaunsee,Total,President,,IND,Jill Stein,69,
-Wabaunsee,Alma,U.S. Senate,,DEM,Patrick Wiesner,102,
-Wabaunsee,Alma,U.S. Senate,,LBT,Robert Garrard,36,
-Wabaunsee,Alma,U.S. Senate,,REP,Jerry Moran,439,
-Wabaunsee,Alma,U.S. House,1,REP,Roger Marshall,407,
-Wabaunsee,Alma,U.S. House,1,LBT,Kerry Burt,49,
-Wabaunsee,Alma,U.S. House,1,IND,Alan LaPolice,94,
-Wabaunsee,Chalk,U.S. Senate,,DEM,Patrick Wiesner,2,
-Wabaunsee,Chalk,U.S. Senate,,LBT,Robert Garrard,2,
-Wabaunsee,Chalk,U.S. Senate,,REP,Jerry Moran,18,
-Wabaunsee,Chalk,U.S. House,1,REP,Roger Marshall,15,
-Wabaunsee,Chalk,U.S. House,1,LBT,Kerry Burt,4,
-Wabaunsee,Chalk,U.S. House,1,IND,Alan LaPolice,2,
-Wabaunsee,Farmer,U.S. Senate,,DEM,Patrick Wiesner,13,
-Wabaunsee,Farmer,U.S. Senate,,LBT,Robert Garrard,4,
-Wabaunsee,Farmer,U.S. Senate,,REP,Jerry Moran,49,
-Wabaunsee,Farmer,U.S. House,1,REP,Roger Marshall,49,
-Wabaunsee,Farmer,U.S. House,1,LBT,Kerry Burt,5,
-Wabaunsee,Farmer,U.S. House,1,IND,Alan LaPolice,11,
-Wabaunsee,Alta Vista,U.S. Senate,,DEM,Patrick Wiesner,47,
-Wabaunsee,Alta Vista,U.S. Senate,,LBT,Robert Garrard,20,
-Wabaunsee,Alta Vista,U.S. Senate,,REP,Jerry Moran,203,
-Wabaunsee,Alta Vista,U.S. House,1,REP,Roger Marshall,199,
-Wabaunsee,Alta Vista,U.S. House,1,LBT,Kerry Burt,18,
-Wabaunsee,Alta Vista,U.S. House,1,IND,Alan LaPolice,48,
-Wabaunsee,Harveyville,U.S. Senate,,DEM,Patrick Wiesner,57,
-Wabaunsee,Harveyville,U.S. Senate,,LBT,Robert Garrard,21,
-Wabaunsee,Harveyville,U.S. Senate,,REP,Jerry Moran,200,
-Wabaunsee,Harveyville,U.S. House,1,REP,Roger Marshall,194,
-Wabaunsee,Harveyville,U.S. House,1,LBT,Kerry Burt,26,
-Wabaunsee,Harveyville,U.S. House,1,IND,Alan LaPolice,51,
-Wabaunsee,Hessdale,U.S. Senate,,DEM,Patrick Wiesner,41,
-Wabaunsee,Hessdale,U.S. Senate,,LBT,Robert Garrard,4,
-Wabaunsee,Hessdale,U.S. Senate,,REP,Jerry Moran,100,
-Wabaunsee,Hessdale,U.S. House,1,REP,Roger Marshall,99,
-Wabaunsee,Hessdale,U.S. House,1,LBT,Kerry Burt,11,
-Wabaunsee,Hessdale,U.S. House,1,IND,Alan LaPolice,30,
-Wabaunsee,Kaw,U.S. Senate,,DEM,Patrick Wiesner,6,
-Wabaunsee,Kaw,U.S. Senate,,LBT,Robert Garrard,4,
-Wabaunsee,Kaw,U.S. Senate,,REP,Jerry Moran,72,
-Wabaunsee,Kaw,U.S. House,1,REP,Roger Marshall,65,
-Wabaunsee,Kaw,U.S. House,1,LBT,Kerry Burt,5,
-Wabaunsee,Kaw,U.S. House,1,IND,Alan LaPolice,9,
-Wabaunsee,Kaw USD320,U.S. Senate,,DEM,Patrick Wiesner,2,
-Wabaunsee,Kaw USD320,U.S. Senate,,LBT,Robert Garrard,2,
-Wabaunsee,Kaw USD320,U.S. Senate,,REP,Jerry Moran,39,
-Wabaunsee,Kaw USD320,U.S. House,1,REP,Roger Marshall,37,
-Wabaunsee,Kaw USD320,U.S. House,1,LBT,Kerry Burt,1,
-Wabaunsee,Kaw USD320,U.S. House,1,IND,Alan LaPolice,4,
-Wabaunsee,Keene,U.S. Senate,,DEM,Patrick Wiesner,69,
-Wabaunsee,Keene,U.S. Senate,,LBT,Robert Garrard,21,
-Wabaunsee,Keene,U.S. Senate,,REP,Jerry Moran,191,
-Wabaunsee,Keene,U.S. House,1,REP,Roger Marshall,191,
-Wabaunsee,Keene,U.S. House,1,LBT,Kerry Burt,31,
-Wabaunsee,Keene,U.S. House,1,IND,Alan LaPolice,49,
-Wabaunsee,Maple Hill,U.S. Senate,,DEM,Patrick Wiesner,97,
-Wabaunsee,Maple Hill,U.S. Senate,,LBT,Robert Garrard,21,
-Wabaunsee,Maple Hill,U.S. Senate,,REP,Jerry Moran,409,
-Wabaunsee,Maple Hill,U.S. House,1,REP,Roger Marshall,381,
-Wabaunsee,Maple Hill,U.S. House,1,LBT,Kerry Burt,36,
-Wabaunsee,Maple Hill,U.S. House,1,IND,Alan LaPolice,84,
-Wabaunsee,McFarland,U.S. Senate,,DEM,Patrick Wiesner,24,
-Wabaunsee,McFarland,U.S. Senate,,LBT,Robert Garrard,8,
-Wabaunsee,McFarland,U.S. Senate,,REP,Jerry Moran,120,
-Wabaunsee,McFarland,U.S. House,1,REP,Roger Marshall,107,
-Wabaunsee,McFarland,U.S. House,1,LBT,Kerry Burt,14,
-Wabaunsee,McFarland,U.S. House,1,IND,Alan LaPolice,30,
-Wabaunsee,Paxico,U.S. Senate,,DEM,Patrick Wiesner,44,
-Wabaunsee,Paxico,U.S. Senate,,LBT,Robert Garrard,16,
-Wabaunsee,Paxico,U.S. Senate,,REP,Jerry Moran,310,
-Wabaunsee,Paxico,U.S. House,1,REP,Roger Marshall,272,
-Wabaunsee,Paxico,U.S. House,1,LBT,Kerry Burt,16,
-Wabaunsee,Paxico,U.S. House,1,IND,Alan LaPolice,65,
-Wabaunsee,Paxico USD 320,U.S. Senate,,DEM,Patrick Wiesner,0,
-Wabaunsee,Paxico USD 320,U.S. Senate,,LBT,Robert Garrard,0,
-Wabaunsee,Paxico USD 320,U.S. Senate,,REP,Jerry Moran,2,
-Wabaunsee,Paxico USD 320,U.S. House,1,REP,Roger Marshall,0,
-Wabaunsee,Paxico USD 320,U.S. House,1,LBT,Kerry Burt,0,
-Wabaunsee,Paxico USD 320,U.S. House,1,IND,Alan LaPolice,2,
-Wabaunsee,Wabaunsee 17,U.S. Senate,,DEM,Patrick Wiesner,11,
-Wabaunsee,Wabaunsee 17,U.S. Senate,,LBT,Robert Garrard,3,
-Wabaunsee,Wabaunsee 17,U.S. Senate,,REP,Jerry Moran,70,
-Wabaunsee,Wabaunsee 17,U.S. House,1,REP,Roger Marshall,59,
-Wabaunsee,Wabaunsee 17,U.S. House,1,LBT,Kerry Burt,4,
-Wabaunsee,Wabaunsee 17,U.S. House,1,IND,Alan LaPolice,12,
-Wabaunsee,Wabaunsee 17 USD320,U.S. Senate,,DEM,Patrick Wiesner,41,
-Wabaunsee,Wabaunsee 17 USD320,U.S. Senate,,LBT,Robert Garrard,13,
-Wabaunsee,Wabaunsee 17 USD320,U.S. Senate,,REP,Jerry Moran,133,
-Wabaunsee,Wabaunsee 17 USD320,U.S. House,1,REP,Roger Marshall,116,
-Wabaunsee,Wabaunsee 17 USD320,U.S. House,1,LBT,Kerry Burt,16,
-Wabaunsee,Wabaunsee 17 USD320,U.S. House,1,IND,Alan LaPolice,39,
-Wabaunsee,Wabaunsee 18 USD320,U.S. Senate,,DEM,Patrick Wiesner,2,
-Wabaunsee,Wabaunsee 18 USD320,U.S. Senate,,LBT,Robert Garrard,1,
-Wabaunsee,Wabaunsee 18 USD320,U.S. Senate,,REP,Jerry Moran,11,
-Wabaunsee,Wabaunsee 18 USD320,U.S. House,1,REP,Roger Marshall,4,
-Wabaunsee,Wabaunsee 18 USD320,U.S. House,1,LBT,Kerry Burt,0,
-Wabaunsee,Wabaunsee 18 USD320,U.S. House,1,IND,Alan LaPolice,8,
-Wabaunsee,Washington,U.S. Senate,,DEM,Patrick Wiesner,8,
-Wabaunsee,Washington,U.S. Senate,,LBT,Robert Garrard,1,
-Wabaunsee,Washington,U.S. Senate,,REP,Jerry Moran,41,
-Wabaunsee,Washington,U.S. House,1,REP,Roger Marshall,35,
-Wabaunsee,Washington,U.S. House,1,LBT,Kerry Burt,4,
-Wabaunsee,Washington,U.S. House,1,IND,Alan LaPolice,8,
-Wabaunsee,Eskridge,U.S. Senate,,DEM,Patrick Wiesner,53,
-Wabaunsee,Eskridge,U.S. Senate,,LBT,Robert Garrard,22,
-Wabaunsee,Eskridge,U.S. Senate,,REP,Jerry Moran,173,
-Wabaunsee,Eskridge,U.S. House,1,REP,Roger Marshall,157,
-Wabaunsee,Eskridge,U.S. House,1,LBT,Kerry Burt,28,
-Wabaunsee,Eskridge,U.S. House,1,IND,Alan LaPolice,48,
-Wabaunsee,Total,U.S. Senate,,DEM,Patrick Wiesner,619,
-Wabaunsee,Total,U.S. Senate,,LBT,Robert Garrard,199,
-Wabaunsee,Total,U.S. Senate,,REP,Jerry Moran,2580,
-Wabaunsee,Total,U.S. House,1,REP,Roger Marshall,2387,
-Wabaunsee,Total,U.S. House,1,LBT,Kerry Burt,268,
-Wabaunsee,Total,U.S. House,1,IND,Alan LaPolice,594,
-Wabaunsee,Alma,State Senate,17,DEM,Susan Fowler,166,
-Wabaunsee,Alma,State Senate,17,REP,Jeff Longbine,398,
-Wabaunsee,Alma,State House,51,REP,Ron Highland,273,
-Wabaunsee,Alma,State House,51,DEM,Adrienne Olejnik,304,
-Wabaunsee,Chalk,State Senate,17,DEM,Susan Fowler,3,
-Wabaunsee,Chalk,State Senate,17,REP,Jeff Longbine,15,
-Wabaunsee,Chalk,State House,51,REP,Ron Highland,17,
-Wabaunsee,Chalk,State House,51,DEM,Adrienne Olejnik,4,
-Wabaunsee,Farmer,State Senate,17,DEM,Susan Fowler,24,
-Wabaunsee,Farmer,State Senate,17,REP,Jeff Longbine,42,
-Wabaunsee,Farmer,State House,51,REP,Ron Highland,37,
-Wabaunsee,Farmer,State House,51,DEM,Adrienne Olejnik,30,
-Wabaunsee,Alta Vista,State Senate,17,DEM,Susan Fowler,77,
-Wabaunsee,Alta Vista,State Senate,17,REP,Jeff Longbine,186,
-Wabaunsee,Alta Vista,State House,51,REP,Ron Highland,146,
-Wabaunsee,Alta Vista,State House,51,DEM,Adrienne Olejnik,124,
-Wabaunsee,Harveyville,State Senate,20,DEM,Candace Ayars,76,
-Wabaunsee,Harveyville,State Senate,20,REP,Vicki Schmidt,195,
-Wabaunsee,Harveyville,State House,51,REP,Ron Highland,124,
-Wabaunsee,Harveyville,State House,51,DEM,Adrienne Olejnik,150,
-Wabaunsee,Hessdale,State Senate,20,DEM,Candace Ayars,28,
-Wabaunsee,Hessdale,State Senate,20,REP,Vicki Schmidt,114,
-Wabaunsee,Hessdale,State House,51,REP,Ron Highland,65,
-Wabaunsee,Hessdale,State House,51,DEM,Adrienne Olejnik,78,
-Wabaunsee,Kaw,State Senate,18,REP,Dave Jackson,64,
-Wabaunsee,Kaw,State Senate,18,DEM,Laura Kelly,18,
-Wabaunsee,Kaw,State House,51,REP,Ron Highland,61,
-Wabaunsee,Kaw,State House,51,DEM,Adrienne Olejnik,20,
-Wabaunsee,Kaw USD320,State Senate,18,REP,Dave Jackson,37,
-Wabaunsee,Kaw USD320,State Senate,18,DEM,Laura Kelly,5,
-Wabaunsee,Kaw USD320,State House,51,REP,Ron Highland,38,
-Wabaunsee,Kaw USD320,State House,51,DEM,Adrienne Olejnik,4,
-Wabaunsee,Keene,State Senate,20,DEM,Candace Ayars,89,
-Wabaunsee,Keene,State Senate,20,REP,Vicki Schmidt,186,
-Wabaunsee,Keene,State House,51,REP,Ron Highland,139,
-Wabaunsee,Keene,State House,51,DEM,Adrienne Olejnik,132,
-Wabaunsee,Maple Hill,State Senate,18,REP,Dave Jackson,346,
-Wabaunsee,Maple Hill,State Senate,18,DEM,Laura Kelly,183,
-Wabaunsee,Maple Hill,State House,51,REP,Ron Highland,292,
-Wabaunsee,Maple Hill,State House,51,DEM,Adrienne Olejnik,240,
-Wabaunsee,McFarland,State Senate,18,REP,Dave Jackson,88,
-Wabaunsee,McFarland,State Senate,18,DEM,Laura Kelly,65,
-Wabaunsee,McFarland,State House,51,REP,Ron Highland,73,
-Wabaunsee,McFarland,State House,51,DEM,Adrienne Olejnik,79,
-Wabaunsee,Paxico,State Senate,18,REP,Dave Jackson,266,
-Wabaunsee,Paxico,State Senate,18,DEM,Laura Kelly,102,
-Wabaunsee,Paxico,State House,51,REP,Ron Highland,233,
-Wabaunsee,Paxico,State House,51,DEM,Adrienne Olejnik,133,
-Wabaunsee,Paxico USD 320,State Senate,18,REP,Dave Jackson,0,
-Wabaunsee,Paxico USD 320,State Senate,18,DEM,Laura Kelly,2,
-Wabaunsee,Paxico USD 320,State House,51,REP,Ron Highland,0,
-Wabaunsee,Paxico USD 320,State House,51,DEM,Adrienne Olejnik,2,
-Wabaunsee,Wabaunsee 17,State Senate,17,DEM,Susan Fowler,19,
-Wabaunsee,Wabaunsee 17,State Senate,17,REP,Jeff Longbine,64,
-Wabaunsee,Wabaunsee 17,State House,51,REP,Ron Highland,55,
-Wabaunsee,Wabaunsee 17,State House,51,DEM,Adrienne Olejnik,29,
-Wabaunsee,Wabaunsee 17 USD320,State Senate,17,DEM,Susan Fowler,61,
-Wabaunsee,Wabaunsee 17 USD320,State Senate,17,REP,Jeff Longbine,122,
-Wabaunsee,Wabaunsee 17 USD320,State House,51,REP,Ron Highland,100,
-Wabaunsee,Wabaunsee 17 USD320,State House,51,DEM,Adrienne Olejnik,85,
-Wabaunsee,Wabaunsee 18 USD320,State Senate,18,REP,Dave Jackson,9,
-Wabaunsee,Wabaunsee 18 USD320,State Senate,18,DEM,Laura Kelly,5,
-Wabaunsee,Wabaunsee 18 USD320,State House,51,REP,Ron Highland,7,
-Wabaunsee,Wabaunsee 18 USD320,State House,51,DEM,Adrienne Olejnik,7,
-Wabaunsee,Washington,State Senate,17,DEM,Susan Fowler,10,
-Wabaunsee,Washington,State Senate,17,REP,Jeff Longbine,38,
-Wabaunsee,Washington,State House,51,REP,Ron Highland,29,
-Wabaunsee,Washington,State House,51,DEM,Adrienne Olejnik,20,
-Wabaunsee,Eskridge,State Senate,20,DEM,Candace Ayars,68,
-Wabaunsee,Eskridge,State Senate,20,REP,Vicki Schmidt,164,
-Wabaunsee,Eskridge,State House,51,REP,Ron Highland,120,
-Wabaunsee,Eskridge,State House,51,DEM,Adrienne Olejnik,122,
-Wabaunsee,Total,State Senate,17,DEM,Susan Fowler,360,
-Wabaunsee,Total,State Senate,17,REP,Jeff Longbine,865,
-Wabaunsee,Total,State Senate,18,REP,Dave Jackson,810,
-Wabaunsee,Total,State Senate,18,DEM,Laura Kelly,380,
-Wabaunsee,Total,State Senate,20,DEM,Candace Ayars,261,
-Wabaunsee,Total,State Senate,20,REP,Vicki Schmidt,659,
-Wabaunsee,Total,State House,51,REP,Ron Highland,1809,
-Wabaunsee,Total,State House,51,DEM,Adrienne Olejnik,1563,
-WABAUNSEE,Alma Township,President,,,Evan McMullin,8,
-WABAUNSEE,Paxico Township,President,,,Evan McMullin,3,
-WABAUNSEE,Paxico Township,President,,,Darrell Castle,2,
-WABAUNSEE,Wilmington Township,President,,,Evan McMullin,2,
-WABAUNSEE,Alma Township,President,,,Tom Hoefling,1,
-WABAUNSEE,Alma Township,President,,,Mike Maturen,1,
-WABAUNSEE,Harveyville Township,President,,,Evan McMullin,1,
-WABAUNSEE,Maple Hill Township,President,,,Evan McMullin,1,
-WABAUNSEE,Wilmington Township,President,,,Darrell Castle,1,
-WABAUNSEE,Alma Township,U.S. House,1,,Tim Huelskamp,6,
-WABAUNSEE,Paxico Township,U.S. House,1,,Tim Huelskamp,6,
-WABAUNSEE,Maple Hill Township,U.S. House,1,,Tim Huelskamp,5,
-WABAUNSEE,Kaw Township,U.S. House,1,,Tim Huelskamp,4,
-WABAUNSEE,Farmer Township,U.S. House,1,,Tim Huelskamp,3,
-WABAUNSEE,Harveyville Township,U.S. House,1,,Tim Huelskamp,2,
-WABAUNSEE,Hessdale Township,U.S. House,1,,Tim Huelskamp,1,
-WABAUNSEE,McFarland Township,U.S. House,1,,Tim Huelskamp,1,
+county,precinct,office,district,party,candidate,votes,vtd
+WABAUNSEE,Alma Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",304,000010
+WABAUNSEE,Alma Township,Kansas House of Representatives,51,Republican,"Highland, Ron",273,000010
+WABAUNSEE,Chalk Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",4,000020
+WABAUNSEE,Chalk Township,Kansas House of Representatives,51,Republican,"Highland, Ron",17,000020
+WABAUNSEE,Farmer Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",30,000030
+WABAUNSEE,Farmer Township,Kansas House of Representatives,51,Republican,"Highland, Ron",37,000030
+WABAUNSEE,Garfield Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",124,000040
+WABAUNSEE,Garfield Township,Kansas House of Representatives,51,Republican,"Highland, Ron",146,000040
+WABAUNSEE,Harveyville Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",150,000050
+WABAUNSEE,Harveyville Township,Kansas House of Representatives,51,Republican,"Highland, Ron",124,000050
+WABAUNSEE,Hessdale Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",78,000060
+WABAUNSEE,Hessdale Township,Kansas House of Representatives,51,Republican,"Highland, Ron",65,000060
+WABAUNSEE,Kaw Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",24,000070
+WABAUNSEE,Kaw Township,Kansas House of Representatives,51,Republican,"Highland, Ron",99,000070
+WABAUNSEE,Keene Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",132,000080
+WABAUNSEE,Keene Township,Kansas House of Representatives,51,Republican,"Highland, Ron",139,000080
+WABAUNSEE,Maple Hill Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",240,000090
+WABAUNSEE,Maple Hill Township,Kansas House of Representatives,51,Republican,"Highland, Ron",292,000090
+WABAUNSEE,McFarland Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",79,000100
+WABAUNSEE,McFarland Township,Kansas House of Representatives,51,Republican,"Highland, Ron",73,000100
+WABAUNSEE,Paxico Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",135,000110
+WABAUNSEE,Paxico Township,Kansas House of Representatives,51,Republican,"Highland, Ron",233,000110
+WABAUNSEE,Washington Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",20,000130
+WABAUNSEE,Washington Township,Kansas House of Representatives,51,Republican,"Highland, Ron",29,000130
+WABAUNSEE,Wilmington Township,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",122,000140
+WABAUNSEE,Wilmington Township,Kansas House of Representatives,51,Republican,"Highland, Ron",120,000140
+WABAUNSEE,Wabaunsee Township S17,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",114,120020
+WABAUNSEE,Wabaunsee Township S17,Kansas House of Representatives,51,Republican,"Highland, Ron",155,120020
+WABAUNSEE,Wabaunsee Township S18,Kansas House of Representatives,51,Democratic,"Olejnik, Adrienne",7,120030
+WABAUNSEE,Wabaunsee Township S18,Kansas House of Representatives,51,Republican,"Highland, Ron",7,120030
+WABAUNSEE,Alma Township,Kansas Senate,17,Democratic,"Fowler, Susan G",166,000010
+WABAUNSEE,Alma Township,Kansas Senate,17,Republican,"Longbine, Jeff",398,000010
+WABAUNSEE,Chalk Township,Kansas Senate,17,Democratic,"Fowler, Susan G",3,000020
+WABAUNSEE,Chalk Township,Kansas Senate,17,Republican,"Longbine, Jeff",15,000020
+WABAUNSEE,Farmer Township,Kansas Senate,17,Democratic,"Fowler, Susan G",24,000030
+WABAUNSEE,Farmer Township,Kansas Senate,17,Republican,"Longbine, Jeff",42,000030
+WABAUNSEE,Garfield Township,Kansas Senate,17,Democratic,"Fowler, Susan G",77,000040
+WABAUNSEE,Garfield Township,Kansas Senate,17,Republican,"Longbine, Jeff",186,000040
+WABAUNSEE,Harveyville Township,Kansas Senate,20,Democratic,"Ayars, Candace",76,000050
+WABAUNSEE,Harveyville Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",195,000050
+WABAUNSEE,Hessdale Township,Kansas Senate,20,Democratic,"Ayars, Candace",28,000060
+WABAUNSEE,Hessdale Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",114,000060
+WABAUNSEE,Kaw Township,Kansas Senate,18,Democratic,"Kelly, Laura",23,000070
+WABAUNSEE,Kaw Township,Kansas Senate,18,Republican,"Jackson, Dave",101,000070
+WABAUNSEE,Keene Township,Kansas Senate,20,Democratic,"Ayars, Candace",89,000080
+WABAUNSEE,Keene Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",186,000080
+WABAUNSEE,Maple Hill Township,Kansas Senate,18,Democratic,"Kelly, Laura",183,000090
+WABAUNSEE,Maple Hill Township,Kansas Senate,18,Republican,"Jackson, Dave",346,000090
+WABAUNSEE,McFarland Township,Kansas Senate,18,Democratic,"Kelly, Laura",65,000100
+WABAUNSEE,McFarland Township,Kansas Senate,18,Republican,"Jackson, Dave",88,000100
+WABAUNSEE,Paxico Township,Kansas Senate,18,Democratic,"Kelly, Laura",104,000110
+WABAUNSEE,Paxico Township,Kansas Senate,18,Republican,"Jackson, Dave",266,000110
+WABAUNSEE,Washington Township,Kansas Senate,17,Democratic,"Fowler, Susan G",10,000130
+WABAUNSEE,Washington Township,Kansas Senate,17,Republican,"Longbine, Jeff",38,000130
+WABAUNSEE,Wilmington Township,Kansas Senate,20,Democratic,"Ayars, Candace",68,000140
+WABAUNSEE,Wilmington Township,Kansas Senate,20,Republican,"Schmidt, Vicki L.",164,000140
+WABAUNSEE,Wabaunsee Township S17,Kansas Senate,17,Democratic,"Fowler, Susan G",80,120020
+WABAUNSEE,Wabaunsee Township S17,Kansas Senate,17,Republican,"Longbine, Jeff",186,120020
+WABAUNSEE,Wabaunsee Township S18,Kansas Senate,18,Democratic,"Kelly, Laura",5,120030
+WABAUNSEE,Wabaunsee Township S18,Kansas Senate,18,Republican,"Jackson, Dave",9,120030
+WABAUNSEE,Alma Township,President / Vice President,,independent,"Stein, Jill",12,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Hoefling, Tom",1,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Maturen, Michael A",1,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"McMullin, Evan",8,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+WABAUNSEE,Alma Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",139,000010
+WABAUNSEE,Alma Township,President / Vice President,,Libertarian,"Johnson, Gary",24,000010
+WABAUNSEE,Alma Township,President / Vice President,,Republican,"Trump, Donald J.",398,000010
+WABAUNSEE,Chalk Township,President / Vice President,,independent,"Stein, Jill",1,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+WABAUNSEE,Chalk Township,President / Vice President,,Republican,"Trump, Donald J.",18,000020
+WABAUNSEE,Farmer Township,President / Vice President,,independent,"Stein, Jill",1,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+WABAUNSEE,Farmer Township,President / Vice President,,Republican,"Trump, Donald J.",50,000030
+WABAUNSEE,Garfield Township,President / Vice President,,independent,"Stein, Jill",2,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",54,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000040
+WABAUNSEE,Garfield Township,President / Vice President,,Republican,"Trump, Donald J.",197,000040
+WABAUNSEE,Harveyville Township,President / Vice President,,independent,"Stein, Jill",7,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"McMullin, Evan",1,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",67,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Libertarian,"Johnson, Gary",15,000050
+WABAUNSEE,Harveyville Township,President / Vice President,,Republican,"Trump, Donald J.",189,000050
+WABAUNSEE,Hessdale Township,President / Vice President,,independent,"Stein, Jill",1,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",43,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000060
+WABAUNSEE,Hessdale Township,President / Vice President,,Republican,"Trump, Donald J.",89,000060
+WABAUNSEE,Kaw Township,President / Vice President,,independent,"Stein, Jill",1,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",18,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000070
+WABAUNSEE,Kaw Township,President / Vice President,,Republican,"Trump, Donald J.",102,000070
+WABAUNSEE,Keene Township,President / Vice President,,independent,"Stein, Jill",8,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+WABAUNSEE,Keene Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",78,000080
+WABAUNSEE,Keene Township,President / Vice President,,Libertarian,"Johnson, Gary",18,000080
+WABAUNSEE,Keene Township,President / Vice President,,Republican,"Trump, Donald J.",173,000080
+WABAUNSEE,Maple Hill Township,President / Vice President,,independent,"Stein, Jill",12,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"McMullin, Evan",1,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",119,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Libertarian,"Johnson, Gary",14,000090
+WABAUNSEE,Maple Hill Township,President / Vice President,,Republican,"Trump, Donald J.",384,000090
+WABAUNSEE,McFarland Township,President / Vice President,,independent,"Stein, Jill",5,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"McMullin, Evan",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000100
+WABAUNSEE,McFarland Township,President / Vice President,,Republican,"Trump, Donald J.",104,000100
+WABAUNSEE,Paxico Township,President / Vice President,,independent,"Stein, Jill",3,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Castle, Darrell L",2,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"McMullin, Evan",3,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",63,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000110
+WABAUNSEE,Paxico Township,President / Vice President,,Republican,"Trump, Donald J.",286,000110
+WABAUNSEE,Washington Township,President / Vice President,,independent,"Stein, Jill",1,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+WABAUNSEE,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",11,000130
+WABAUNSEE,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000130
+WABAUNSEE,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",34,000130
+WABAUNSEE,Wilmington Township,President / Vice President,,independent,"Stein, Jill",6,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Castle, Darrell L",1,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"McMullin, Evan",2,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",71,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000140
+WABAUNSEE,Wilmington Township,President / Vice President,,Republican,"Trump, Donald J.",159,000140
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,independent,"Stein, Jill",9,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Basiago, Andrew D.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Castle, Darrell L",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Giordani, Rocky",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Hedges, James A",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Hoefling, Tom",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Kahn, Lynn",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"La Riva, Gloria",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Levinson, Michael S.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Maturen, Michael A",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"McMullin, Evan",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Moorehead, Monica G.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Perry, Darryl",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Schriner, Joe C",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Smith, Mike",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Sood, Ajay",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Sterling, Shawna",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Valdivia, Anthony J",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Democratic,"Clinton, Hillary Rodham",64,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Libertarian,"Johnson, Gary",9,120020
+WABAUNSEE,Wabaunsee Township S17,President / Vice President,,Republican,"Trump, Donald J.",181,120020
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,independent,"Stein, Jill",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Basiago, Andrew D.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Castle, Darrell L",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Giordani, Rocky",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Hedges, James A",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Hoefling, Tom",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Kahn, Lynn",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"La Riva, Gloria",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Levinson, Michael S.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Maturen, Michael A",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"McMullin, Evan",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Moorehead, Monica G.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Perry, Darryl",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Schoenke, Marshall R.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Schriner, Joe C",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Smith, Mike",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Sood, Ajay",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Sterling, Shawna",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Valdivia, Anthony J",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Libertarian,"Johnson, Gary",0,120030
+WABAUNSEE,Wabaunsee Township S18,President / Vice President,,Republican,"Trump, Donald J.",8,120030
+WABAUNSEE,Alma Township,United States House of Representatives,1,independent,"LaPolice, Alan",94,000010
+WABAUNSEE,Alma Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,000010
+WABAUNSEE,Alma Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",49,000010
+WABAUNSEE,Alma Township,United States House of Representatives,1,Republican,"Marshall, Roger",407,000010
+WABAUNSEE,Chalk Township,United States House of Representatives,1,independent,"LaPolice, Alan",2,000020
+WABAUNSEE,Chalk Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+WABAUNSEE,Chalk Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000020
+WABAUNSEE,Chalk Township,United States House of Representatives,1,Republican,"Marshall, Roger",15,000020
+WABAUNSEE,Farmer Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000030
+WABAUNSEE,Farmer Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000030
+WABAUNSEE,Farmer Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000030
+WABAUNSEE,Farmer Township,United States House of Representatives,1,Republican,"Marshall, Roger",49,000030
+WABAUNSEE,Garfield Township,United States House of Representatives,1,independent,"LaPolice, Alan",48,000040
+WABAUNSEE,Garfield Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000040
+WABAUNSEE,Garfield Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",18,000040
+WABAUNSEE,Garfield Township,United States House of Representatives,1,Republican,"Marshall, Roger",199,000040
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,independent,"LaPolice, Alan",51,000050
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000050
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",26,000050
+WABAUNSEE,Harveyville Township,United States House of Representatives,1,Republican,"Marshall, Roger",194,000050
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000060
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000060
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",11,000060
+WABAUNSEE,Hessdale Township,United States House of Representatives,1,Republican,"Marshall, Roger",99,000060
+WABAUNSEE,Kaw Township,United States House of Representatives,1,independent,"LaPolice, Alan",13,000070
+WABAUNSEE,Kaw Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",4,000070
+WABAUNSEE,Kaw Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000070
+WABAUNSEE,Kaw Township,United States House of Representatives,1,Republican,"Marshall, Roger",102,000070
+WABAUNSEE,Keene Township,United States House of Representatives,1,independent,"LaPolice, Alan",49,000080
+WABAUNSEE,Keene Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+WABAUNSEE,Keene Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",31,000080
+WABAUNSEE,Keene Township,United States House of Representatives,1,Republican,"Marshall, Roger",191,000080
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,independent,"LaPolice, Alan",84,000090
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",5,000090
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",36,000090
+WABAUNSEE,Maple Hill Township,United States House of Representatives,1,Republican,"Marshall, Roger",381,000090
+WABAUNSEE,McFarland Township,United States House of Representatives,1,independent,"LaPolice, Alan",30,000100
+WABAUNSEE,McFarland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000100
+WABAUNSEE,McFarland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",14,000100
+WABAUNSEE,McFarland Township,United States House of Representatives,1,Republican,"Marshall, Roger",107,000100
+WABAUNSEE,Paxico Township,United States House of Representatives,1,independent,"LaPolice, Alan",67,000110
+WABAUNSEE,Paxico Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",6,000110
+WABAUNSEE,Paxico Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",16,000110
+WABAUNSEE,Paxico Township,United States House of Representatives,1,Republican,"Marshall, Roger",272,000110
+WABAUNSEE,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",8,000130
+WABAUNSEE,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+WABAUNSEE,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000130
+WABAUNSEE,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",35,000130
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,independent,"LaPolice, Alan",48,000140
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",28,000140
+WABAUNSEE,Wilmington Township,United States House of Representatives,1,Republican,"Marshall, Roger",157,000140
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,independent,"LaPolice, Alan",51,120020
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120020
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,Libertarian,"Burt, Kerry",20,120020
+WABAUNSEE,Wabaunsee Township S17,United States House of Representatives,1,Republican,"Marshall, Roger",175,120020
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,independent,"LaPolice, Alan",8,120030
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,120030
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,120030
+WABAUNSEE,Wabaunsee Township S18,United States House of Representatives,1,Republican,"Marshall, Roger",4,120030
+WABAUNSEE,Alma Township,United States Senate,,write - in,"Smith, DJ",0,000010
+WABAUNSEE,Alma Township,United States Senate,,Democratic,"Wiesner, Patrick",102,000010
+WABAUNSEE,Alma Township,United States Senate,,Libertarian,"Garrard, Robert D.",36,000010
+WABAUNSEE,Alma Township,United States Senate,,Republican,"Moran, Jerry",439,000010
+WABAUNSEE,Chalk Township,United States Senate,,write - in,"Smith, DJ",0,000020
+WABAUNSEE,Chalk Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000020
+WABAUNSEE,Chalk Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000020
+WABAUNSEE,Chalk Township,United States Senate,,Republican,"Moran, Jerry",18,000020
+WABAUNSEE,Farmer Township,United States Senate,,write - in,"Smith, DJ",0,000030
+WABAUNSEE,Farmer Township,United States Senate,,Democratic,"Wiesner, Patrick",13,000030
+WABAUNSEE,Farmer Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000030
+WABAUNSEE,Farmer Township,United States Senate,,Republican,"Moran, Jerry",49,000030
+WABAUNSEE,Garfield Township,United States Senate,,write - in,"Smith, DJ",0,000040
+WABAUNSEE,Garfield Township,United States Senate,,Democratic,"Wiesner, Patrick",47,000040
+WABAUNSEE,Garfield Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000040
+WABAUNSEE,Garfield Township,United States Senate,,Republican,"Moran, Jerry",203,000040
+WABAUNSEE,Harveyville Township,United States Senate,,write - in,"Smith, DJ",0,000050
+WABAUNSEE,Harveyville Township,United States Senate,,Democratic,"Wiesner, Patrick",57,000050
+WABAUNSEE,Harveyville Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000050
+WABAUNSEE,Harveyville Township,United States Senate,,Republican,"Moran, Jerry",200,000050
+WABAUNSEE,Hessdale Township,United States Senate,,write - in,"Smith, DJ",0,000060
+WABAUNSEE,Hessdale Township,United States Senate,,Democratic,"Wiesner, Patrick",41,000060
+WABAUNSEE,Hessdale Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000060
+WABAUNSEE,Hessdale Township,United States Senate,,Republican,"Moran, Jerry",100,000060
+WABAUNSEE,Kaw Township,United States Senate,,write - in,"Smith, DJ",0,000070
+WABAUNSEE,Kaw Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000070
+WABAUNSEE,Kaw Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000070
+WABAUNSEE,Kaw Township,United States Senate,,Republican,"Moran, Jerry",111,000070
+WABAUNSEE,Keene Township,United States Senate,,write - in,"Smith, DJ",0,000080
+WABAUNSEE,Keene Township,United States Senate,,Democratic,"Wiesner, Patrick",69,000080
+WABAUNSEE,Keene Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000080
+WABAUNSEE,Keene Township,United States Senate,,Republican,"Moran, Jerry",191,000080
+WABAUNSEE,Maple Hill Township,United States Senate,,write - in,"Smith, DJ",0,000090
+WABAUNSEE,Maple Hill Township,United States Senate,,Democratic,"Wiesner, Patrick",97,000090
+WABAUNSEE,Maple Hill Township,United States Senate,,Libertarian,"Garrard, Robert D.",21,000090
+WABAUNSEE,Maple Hill Township,United States Senate,,Republican,"Moran, Jerry",409,000090
+WABAUNSEE,McFarland Township,United States Senate,,write - in,"Smith, DJ",0,000100
+WABAUNSEE,McFarland Township,United States Senate,,Democratic,"Wiesner, Patrick",24,000100
+WABAUNSEE,McFarland Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000100
+WABAUNSEE,McFarland Township,United States Senate,,Republican,"Moran, Jerry",120,000100
+WABAUNSEE,Paxico Township,United States Senate,,write - in,"Smith, DJ",0,000110
+WABAUNSEE,Paxico Township,United States Senate,,Democratic,"Wiesner, Patrick",44,000110
+WABAUNSEE,Paxico Township,United States Senate,,Libertarian,"Garrard, Robert D.",16,000110
+WABAUNSEE,Paxico Township,United States Senate,,Republican,"Moran, Jerry",312,000110
+WABAUNSEE,Washington Township,United States Senate,,write - in,"Smith, DJ",0,000130
+WABAUNSEE,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000130
+WABAUNSEE,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000130
+WABAUNSEE,Washington Township,United States Senate,,Republican,"Moran, Jerry",41,000130
+WABAUNSEE,Wilmington Township,United States Senate,,write - in,"Smith, DJ",0,000140
+WABAUNSEE,Wilmington Township,United States Senate,,Democratic,"Wiesner, Patrick",53,000140
+WABAUNSEE,Wilmington Township,United States Senate,,Libertarian,"Garrard, Robert D.",22,000140
+WABAUNSEE,Wilmington Township,United States Senate,,Republican,"Moran, Jerry",173,000140
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,write - in,"Smith, DJ",0,120020
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,Democratic,"Wiesner, Patrick",52,120020
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,Libertarian,"Garrard, Robert D.",16,120020
+WABAUNSEE,Wabaunsee Township S17,United States Senate,,Republican,"Moran, Jerry",203,120020
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,write - in,"Smith, DJ",0,120030
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,Democratic,"Wiesner, Patrick",2,120030
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,Libertarian,"Garrard, Robert D.",1,120030
+WABAUNSEE,Wabaunsee Township S18,United States Senate,,Republican,"Moran, Jerry",11,120030

--- a/2016/20161108__ks__general__wallace__precinct.csv
+++ b/2016/20161108__ks__general__wallace__precinct.csv
@@ -1,175 +1,186 @@
-county,precinct,office,district,party,candidate,votes,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,President,,R,Donald Trump / Mike Pence,79,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,President,,D,Hillary Clinton / Tim Kaine,5,,,,,,,,,,,,,,26,,1,,46,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,President,,L,Gary Johnson! Bill Weld,1,,,,,,,,,,,,,,1,,5,,0,,15,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,President,,I,Jill Stein / Ajamu Baraka,1,,,,,,,,,,,,,,,6,,0,,8,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,President,,,John McAfee,1,,,,,,,,,,,,,,,,,,,,,,,,,,0,,0,,1,,,
-Wallace,Sharon Springs #2,President,,R,Donald Trump / Mike Pence,155,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,D,Hillary Clinton / Tim Kaine,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,L,Gary Johnson! Bill Weld,6,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,I,Jill Stein / Ajamu Baraka,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,,Evan McMullin,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,,Jesus Christ,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,,Ted Cruz,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,President,,,Pence,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,President,,R,Donald Trump / Mike Pence,23,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,President,,D,Hillary Clinton / Tim Kaine,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,President,,L,Gary Johnson! Bill Weld,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,President,,I,Jill Stein / Ajamu Baraka,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,President,,R,Donald Trump / Mike Pence,16,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,President,,D,Hillary Clinton / Tim Kaine,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,President,,L,Gary Johnson! Bill Weld,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,President,,I,Jill Stein / Ajamu Baraka,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,President,,R,Donald Trump / Mike Pence,65,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,President,,D,Hillary Clinton / Tim Kaine,4,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,President,,L,Gary Johnson! Bill Weld,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,President,,I,Jill Stein / Ajamu Baraka,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,President,,R,Donald Trump / Mike Pence,45,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,President,,D,Hillary Clinton / Tim Kaine,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,President,,L,Gary Johnson! Bill Weld,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,President,,I,Jill Stein / Ajamu Baraka,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,President,,R,Donald Trump / Mike Pence,124,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,President,,D,Hillary Clinton / Tim Kaine,9,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,President,,L,Gary Johnson! Bill Weld,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,President,,I,Jill Stein / Ajamu Baraka,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,R,Donald Trump / Mike Pence,204,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,D,Hillary Clinton / Tim Kaine,26,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,L,Gary Johnson! Bill Weld,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,I,Jill Stein / Ajamu Baraka,6,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,,Evan McMullin,6,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,,Jesus Christ,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,,Ted Cruz,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,,Pence,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,President,,,John McAfee,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,R,Donald Trump / Mike Pence,10,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,D,Hillary Clinton / Tim Kaine,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,L,Gary Johnson! Bill Weld,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,I,Jill Stein / Ajamu Baraka,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,,Evan McMullin,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,,Jesus Christ,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,,Ted Cruz,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,,Pence,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,President,,,John McAfee,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,R,Donald Trump / Mike Pence,721,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,D,Hillary Clinton / Tim Kaine,46,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,L,Gary Johnson! Bill Weld,15,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,I,Jill Stein / Ajamu Baraka,8,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,,Evan McMullin,8,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,,Jesus Christ,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,,Ted Cruz,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,,Pence,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,President,,,John McAfee,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. Senate,,D,Patrick Wiesner,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. Senate,,L,Robert Garrard,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. Senate,,R,Jerry Moran,81,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. Senate,,D,Patrick Wiesner,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. Senate,,L,Robert Garrard,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. Senate,,R,Jerry Moran,160,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,U.S. Senate,,D,Patrick Wiesner,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,U.S. Senate,,L,Robert Garrard,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,U.S. Senate,,R,Jerry Moran,21,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,U.S. Senate,,D,Patrick Wiesner,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,U.S. Senate,,L,Robert Garrard,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,U.S. Senate,,R,Jerry Moran,15,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,U.S. Senate,,D,Patrick Wiesner,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,U.S. Senate,,L,Robert Garrard,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,U.S. Senate,,R,Jerry Moran,68,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. Senate,,D,Patrick Wiesner,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. Senate,,L,Robert Garrard,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. Senate,,R,Jerry Moran,43,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,U.S. Senate,,D,Patrick Wiesner,4,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,U.S. Senate,,L,Robert Garrard,6,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,U.S. Senate,,R,Jerry Moran,123,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. Senate,,D,Patrick Wiesner,23,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. Senate,,L,Robert Garrard,7,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. Senate,,R,Jerry Moran,212,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. Senate,,D,Patrick Wiesner,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. Senate,,L,Robert Garrard,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. Senate,,R,Jerry Moran,10,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. Senate,,D,Patrick Wiesner,35,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. Senate,,L,Robert Garrard,26,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. Senate,,R,Jerry Moran,733,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. House,1,R,Roger Marshall,68,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. House,1,L,Kerry Burt,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. House,1,D,Alan LaPolice,10,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,U.S. House,1,,Tim Huelskamp,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. House,1,R,Roger Marshall,143,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. House,1,L,Kerry Burt,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. House,1,D,Alan LaPolice,17,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,U.S. House,1,,Tim Huelskamp,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,U.S. House,1,R,Roger Marshall,19,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,U.S. House,1,L,Kerry Burt,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,U.S. House,1,D,Alan LaPolice,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,U.S. House,1,R,Roger Marshall,14,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,U.S. House,1,L,Kerry Burt,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,U.S. House,1,D,Alan LaPolice,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,U.S. House,1,R,Roger Marshall,60,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,U.S. House,1,L,Kerry Burt,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,U.S. House,1,D,Alan LaPolice,7,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. House,1,R,Roger Marshall,37,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. House,1,L,Kerry Burt,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. House,1,D,Alan LaPolice,4,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,U.S. House,1,,Tim Huelskamp,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,U.S. House,1,R,Roger Marshall,121,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,U.S. House,1,L,Kerry Burt,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,U.S. House,1,D,Alan LaPolice,6,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. House,1,R,Roger Marshall,192,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. House,1,L,Kerry Burt,14,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. House,1,D,Alan LaPolice,24,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,U.S. House,1,,Tim Huelskamp,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. House,1,R,Roger Marshall,11,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. House,1,L,Kerry Burt,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. House,1,D,Alan LaPolice,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,U.S. House,1,,Tim Huelskamp,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. House,1,R,Roger Marshall,665,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. House,1,L,Kerry Burt,32,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. House,1,D,Alan LaPolice,71,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,U.S. House,1,,Tim Huelskamp,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,State Senate,40,D,Alex Herman,7,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,State Senate,40,R,Richard Billinger,78,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,State Senate,40,D,Alex Herman,7,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,State Senate,40,R,Richard Billinger,160,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,State Senate,40,D,Alex Herman,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,State Senate,40,R,Richard Billinger,22,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,State Senate,40,D,Alex Herman,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,State Senate,40,R,Richard Billinger,15,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,State Senate,40,D,Alex Herman,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,State Senate,40,R,Richard Billinger,65,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,State Senate,40,D,Alex Herman,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,State Senate,40,R,Richard Billinger,43,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,State Senate,40,D,Alex Herman,4,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,State Senate,40,R,Richard Billinger,129,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,State Senate,40,D,Alex Herman,21,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,State Senate,40,R,Richard Billinger,217,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,State Senate,40,D,Alex Herman,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,State Senate,40,R,Richard Billinger,10,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,State Senate,40,D,Alex Herman,45,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,State Senate,40,R,Richard Billinger,739,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,State House,120,R,Adam Smith,79,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #1 ,State House,120,D,Bonita Peterson,5,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,State House,120,R,Adam Smith,167,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #2,State House,120,D,Bonita Peterson,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,State House,120,R,Adam Smith,18,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Harrison,State House,120,D,Bonita Peterson,3,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,State House,120,R,Adam Smith,16,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #3,State House,120,D,Bonita Peterson,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,State House,120,R,Adam Smith,62,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,State House,120,D,Bonita Peterson,4,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,State House,120,,John Faber,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Sharon Springs #4,State House,120,,John Miller,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,State House,120,R,Adam Smith,44,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Wallace,State House,120,D,Bonita Peterson,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,State House,120,R,Adam Smith,125,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Weskan,State House,120,D,Bonita Peterson,8,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,State House,120,R,Adam Smith,217,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,State House,120,D,Bonita Peterson,21,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,State House,120,,John Faber,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Advance,State House,120,,John Miller,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,State House,120,R,Adam Smith,10,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,State House,120,D,Bonita Peterson,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,State House,120,,John Faber,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Provisional,State House,120,,John Miller,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,State House,120,R,Adam Smith,738,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,State House,120,D,Bonita Peterson,46,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,State House,120,,John Faber,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Wallace,Total,State House,120,,John Miller,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+county,precinct,office,district,party,candidate,votes,vtd
+WALLACE,Harrison Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",4,000010
+WALLACE,Harrison Township,Kansas House of Representatives,120,Republican,"Smith, Adam",31,000010
+WALLACE,Sharon Springs Precinct 1,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",8,000020
+WALLACE,Sharon Springs Precinct 1,Kansas House of Representatives,120,Republican,"Smith, Adam",151,000020
+WALLACE,Sharon Springs Precinct 2,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",17,000030
+WALLACE,Sharon Springs Precinct 2,Kansas House of Representatives,120,Republican,"Smith, Adam",324,000030
+WALLACE,Wallace Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",5,000040
+WALLACE,Wallace Township,Kansas House of Representatives,120,Republican,"Smith, Adam",69,000040
+WALLACE,Weskan Township,Kansas House of Representatives,120,Democratic,"Peterson, Bonita L.",12,000050
+WALLACE,Weskan Township,Kansas House of Representatives,120,Republican,"Smith, Adam",163,000050
+WALLACE,Harrison Township,Kansas Senate,40,Democratic,"Herman, Alex",0,000010
+WALLACE,Harrison Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",35,000010
+WALLACE,Sharon Springs Precinct 1,Kansas Senate,40,Democratic,"Herman, Alex",13,000020
+WALLACE,Sharon Springs Precinct 1,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",147,000020
+WALLACE,Sharon Springs Precinct 2,Kansas Senate,40,Democratic,"Herman, Alex",18,000030
+WALLACE,Sharon Springs Precinct 2,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",321,000030
+WALLACE,Wallace Township,Kansas Senate,40,Democratic,"Herman, Alex",6,000040
+WALLACE,Wallace Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",70,000040
+WALLACE,Weskan Township,Kansas Senate,40,Democratic,"Herman, Alex",8,000050
+WALLACE,Weskan Township,Kansas Senate,40,Republican,"Billinger, Richard (Rick)",166,000050
+WALLACE,Harrison Township,President / Vice President,,independent,"Stein, Jill",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+WALLACE,Harrison Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+WALLACE,Harrison Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000010
+WALLACE,Harrison Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000010
+WALLACE,Harrison Township,President / Vice President,,Republican,"Trump, Donald J.",37,000010
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"McMullin, Evan",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",1,000020
+WALLACE,Sharon Springs Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",151,000020
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,independent,"Stein, Jill",2,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"McMullin, Evan",3,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",12,000030
+WALLACE,Sharon Springs Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",306,000030
+WALLACE,Wallace Township,President / Vice President,,independent,"Stein, Jill",1,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"McMullin, Evan",4,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+WALLACE,Wallace Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+WALLACE,Wallace Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000040
+WALLACE,Wallace Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000040
+WALLACE,Wallace Township,President / Vice President,,Republican,"Trump, Donald J.",69,000040
+WALLACE,Weskan Township,President / Vice President,,independent,"Stein, Jill",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"McMullin, Evan",1,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+WALLACE,Weskan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+WALLACE,Weskan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000050
+WALLACE,Weskan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000050
+WALLACE,Weskan Township,President / Vice President,,Republican,"Trump, Donald J.",158,000050
+WALLACE,Harrison Township,United States House of Representatives,1,independent,"LaPolice, Alan",3,000010
+WALLACE,Harrison Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+WALLACE,Harrison Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000010
+WALLACE,Harrison Township,United States House of Representatives,1,Republican,"Marshall, Roger",32,000010
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",16,000020
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000020
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000020
+WALLACE,Sharon Springs Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",134,000020
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",38,000030
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000030
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",13,000030
+WALLACE,Sharon Springs Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",284,000030
+WALLACE,Wallace Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000040
+WALLACE,Wallace Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000040
+WALLACE,Wallace Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000040
+WALLACE,Wallace Township,United States House of Representatives,1,Republican,"Marshall, Roger",60,000040
+WALLACE,Weskan Township,United States House of Representatives,1,independent,"LaPolice, Alan",7,000050
+WALLACE,Weskan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+WALLACE,Weskan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",9,000050
+WALLACE,Weskan Township,United States House of Representatives,1,Republican,"Marshall, Roger",155,000050
+WALLACE,Harrison Township,United States Senate,,write - in,"Smith, DJ",0,000010
+WALLACE,Harrison Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000010
+WALLACE,Harrison Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+WALLACE,Harrison Township,United States Senate,,Republican,"Moran, Jerry",35,000010
+WALLACE,Sharon Springs Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000020
+WALLACE,Sharon Springs Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",7,000020
+WALLACE,Sharon Springs Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",4,000020
+WALLACE,Sharon Springs Precinct 1,United States Senate,,Republican,"Moran, Jerry",151,000020
+WALLACE,Sharon Springs Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000030
+WALLACE,Sharon Springs Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",16,000030
+WALLACE,Sharon Springs Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",7,000030
+WALLACE,Sharon Springs Precinct 2,United States Senate,,Republican,"Moran, Jerry",323,000030
+WALLACE,Wallace Township,United States Senate,,write - in,"Smith, DJ",0,000040
+WALLACE,Wallace Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000040
+WALLACE,Wallace Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000040
+WALLACE,Wallace Township,United States Senate,,Republican,"Moran, Jerry",67,000040
+WALLACE,Weskan Township,United States Senate,,write - in,"Smith, DJ",0,000050
+WALLACE,Weskan Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000050
+WALLACE,Weskan Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000050
+WALLACE,Weskan Township,United States Senate,,Republican,"Moran, Jerry",157,000050

--- a/2016/20161108__ks__general__washington__precinct.csv
+++ b/2016/20161108__ks__general__washington__precinct.csv
@@ -1,504 +1,1074 @@
-county,precinct,office,district,party,candidate,votes
-Washington,0006 Farmington,President,,,Castle and Bradley,2
-Washington,0001 Barnes,President,,DEM,Clinton and Kaine,13
-Washington,0002 Brantford,President,,DEM,Clinton and Kaine,2
-Washington,0003 Charleston,President,,DEM,Clinton and Kaine,5
-Washington,0004 Clifton,President,,DEM,Clinton and Kaine,32
-Washington,0005 Coleman,President,,DEM,Clinton and Kaine,4
-Washington,0006 Farmington,President,,DEM,Clinton and Kaine,13
-Washington,0007 Franklin,President,,DEM,Clinton and Kaine,6
-Washington,0008 Grant,President,,DEM,Clinton and Kaine,1
-Washington,0009 Greenleaf,President,,DEM,Clinton and Kaine,25
-Washington,0010 Haddam,President,,DEM,Clinton and Kaine,21
-Washington,0011 Hanover,President,,DEM,Clinton and Kaine,50
-Washington,0012 Highland,President,,DEM,Clinton and Kaine,0
-Washington,0013 Independence,President,,DEM,Clinton and Kaine,7
-Washington,0014 Kimeo,President,,DEM,Clinton and Kaine,10
-Washington,0015 Lincoln,President,,DEM,Clinton and Kaine,0
-Washington,0016 Linn,President,,DEM,Clinton and Kaine,26
-Washington,0017 Little Blue,President,,DEM,Clinton and Kaine,9
-Washington,0018 Logan,President,,DEM,Clinton and Kaine,7
-Washington,0019 Lowe,President,,DEM,Clinton and Kaine,4
-Washington,0020 Mill Creek,President,,DEM,Clinton and Kaine,17
-Washington,0021 Sheridan,President,,DEM,Clinton and Kaine,5
-Washington,0022 Sherman,President,,DEM,Clinton and Kaine,9
-Washington,0023 Strawberry,President,,DEM,Clinton and Kaine,4
-Washington,0024 Union,President,,DEM,Clinton and Kaine,4
-Washington,0025 Washington,President,,DEM,Clinton and Kaine,8
-Washington,0026 Washington City,President,,DEM,Clinton and Kaine,105
-Washington,0001 Barnes,President,,LBT,Johnson and Weld,3
-Washington,0002 Brantford,President,,LBT,Johnson and Weld,0
-Washington,0003 Charleston,President,,LBT,Johnson and Weld,1
-Washington,0004 Clifton,President,,LBT,Johnson and Weld,2
-Washington,0005 Coleman,President,,LBT,Johnson and Weld,0
-Washington,0006 Farmington,President,,LBT,Johnson and Weld,6
-Washington,0007 Franklin,President,,LBT,Johnson and Weld,1
-Washington,0008 Grant,President,,LBT,Johnson and Weld,0
-Washington,0009 Greenleaf,President,,LBT,Johnson and Weld,5
-Washington,0010 Haddam,President,,LBT,Johnson and Weld,2
-Washington,0011 Hanover,President,,LBT,Johnson and Weld,11
-Washington,0012 Highland,President,,LBT,Johnson and Weld,0
-Washington,0013 Independence,President,,LBT,Johnson and Weld,4
-Washington,0014 Kimeo,President,,LBT,Johnson and Weld,0
-Washington,0015 Lincoln,President,,LBT,Johnson and Weld,2
-Washington,0016 Linn,President,,LBT,Johnson and Weld,12
-Washington,0017 Little Blue,President,,LBT,Johnson and Weld,3
-Washington,0018 Logan,President,,LBT,Johnson and Weld,6
-Washington,0019 Lowe,President,,LBT,Johnson and Weld,2
-Washington,0020 Mill Creek,President,,LBT,Johnson and Weld,5
-Washington,0021 Sheridan,President,,LBT,Johnson and Weld,1
-Washington,0022 Sherman,President,,LBT,Johnson and Weld,12
-Washington,0023 Strawberry,President,,LBT,Johnson and Weld,6
-Washington,0024 Union,President,,LBT,Johnson and Weld,2
-Washington,0025 Washington,President,,LBT,Johnson and Weld,6
-Washington,0026 Washington City,President,,LBT,Johnson and Weld,32
-Washington,0009 Greenleaf,President,,,McMullin and Johnson,1
-Washington,0020 Mill Creek,President,,,McMullin and Johnson,1
-Washington,0023 Strawberry,President,,,McMullin and Johnson,6
-Washington,0026 Washington City,President,,,McMullin and Johnson,2
-Washington,0004 Clifton,President,,,McMullin and Johnson,1
-Washington,0010 Haddam,President,,,McMullin and Johnson,2
-Washington,0001 Barnes,President,,IND,Stein and Baraka,1
-Washington,0002 Brantford,President,,IND,Stein and Baraka,0
-Washington,0003 Charleston,President,,IND,Stein and Baraka,0
-Washington,0004 Clifton,President,,IND,Stein and Baraka,4
-Washington,0005 Coleman,President,,IND,Stein and Baraka,1
-Washington,0006 Farmington,President,,IND,Stein and Baraka,1
-Washington,0007 Franklin,President,,IND,Stein and Baraka,0
-Washington,0008 Grant,President,,IND,Stein and Baraka,0
-Washington,0009 Greenleaf,President,,IND,Stein and Baraka,3
-Washington,0010 Haddam,President,,IND,Stein and Baraka,4
-Washington,0011 Hanover,President,,IND,Stein and Baraka,7
-Washington,0012 Highland,President,,IND,Stein and Baraka,0
-Washington,0013 Independence,President,,IND,Stein and Baraka,0
-Washington,0014 Kimeo,President,,IND,Stein and Baraka,0
-Washington,0015 Lincoln,President,,IND,Stein and Baraka,0
-Washington,0016 Linn,President,,IND,Stein and Baraka,2
-Washington,0017 Little Blue,President,,IND,Stein and Baraka,0
-Washington,0018 Logan,President,,IND,Stein and Baraka,1
-Washington,0019 Lowe,President,,IND,Stein and Baraka,0
-Washington,0020 Mill Creek,President,,IND,Stein and Baraka,2
-Washington,0021 Sheridan,President,,IND,Stein and Baraka,0
-Washington,0022 Sherman,President,,IND,Stein and Baraka,2
-Washington,0023 Strawberry,President,,IND,Stein and Baraka,2
-Washington,0024 Union,President,,IND,Stein and Baraka,2
-Washington,0025 Washington,President,,IND,Stein and Baraka,2
-Washington,0026 Washington City,President,,IND,Stein and Baraka,11
-Washington,0001 Barnes,President,,REP,Trump and Pence,70
-Washington,0002 Brantford,President,,REP,Trump and Pence,37
-Washington,0003 Charleston,President,,REP,Trump and Pence,28
-Washington,0004 Clifton,President,,REP,Trump and Pence,156
-Washington,0005 Coleman,President,,REP,Trump and Pence,27
-Washington,0006 Farmington,President,,REP,Trump and Pence,60
-Washington,0007 Franklin,President,,REP,Trump and Pence,56
-Washington,0008 Grant,President,,REP,Trump and Pence,17
-Washington,0009 Greenleaf,President,,REP,Trump and Pence,104
-Washington,0010 Haddam,President,,REP,Trump and Pence,56
-Washington,0011 Hanover,President,,REP,Trump and Pence,348
-Washington,0012 Highland,President,,REP,Trump and Pence,13
-Washington,0013 Independence,President,,REP,Trump and Pence,49
-Washington,0014 Kimeo,President,,REP,Trump and Pence,29
-Washington,0015 Lincoln,President,,REP,Trump and Pence,26
-Washington,0016 Linn,President,,REP,Trump and Pence,193
-Washington,0017 Little Blue,President,,REP,Trump and Pence,25
-Washington,0018 Logan,President,,REP,Trump and Pence,50
-Washington,0019 Lowe,President,,REP,Trump and Pence,28
-Washington,0020 Mill Creek,President,,REP,Trump and Pence,87
-Washington,0021 Sheridan,President,,REP,Trump and Pence,42
-Washington,0022 Sherman,President,,REP,Trump and Pence,123
-Washington,0023 Strawberry,President,,REP,Trump and Pence,43
-Washington,0024 Union,President,,REP,Trump and Pence,34
-Washington,0025 Washington,President,,REP,Trump and Pence,103
-Washington,0026 Washington City,President,,REP,Trump and Pence,390
-Washington,0001 Barnes,President,,,Write-ins,0
-Washington,0002 Brantford,President,,,Write-ins,0
-Washington,0003 Charleston,President,,,Write-ins,0
-Washington,0004 Clifton,President,,,Write-ins,1
-Washington,0005 Coleman,President,,,Write-ins,0
-Washington,0006 Farmington,President,,,Write-ins,2
-Washington,0007 Franklin,President,,,Write-ins,0
-Washington,0008 Grant,President,,,Write-ins,0
-Washington,0009 Greenleaf,President,,,Write-ins,4
-Washington,0010 Haddam,President,,,Write-ins,4
-Washington,0011 Hanover,President,,,Write-ins,1
-Washington,0012 Highland,President,,,Write-ins,0
-Washington,0013 Independence,President,,,Write-ins,1
-Washington,0014 Kimeo,President,,,Write-ins,0
-Washington,0015 Lincoln,President,,,Write-ins,0
-Washington,0016 Linn,President,,,Write-ins,2
-Washington,0017 Little Blue,President,,,Write-ins,0
-Washington,0018 Logan,President,,,Write-ins,0
-Washington,0019 Lowe,President,,,Write-ins,0
-Washington,0020 Mill Creek,President,,,Write-ins,1
-Washington,0021 Sheridan,President,,,Write-ins,0
-Washington,0022 Sherman,President,,,Write-ins,1
-Washington,0023 Strawberry,President,,,Write-ins,6
-Washington,0024 Union,President,,,Write-ins,0
-Washington,0025 Washington,President,,,Write-ins,0
-Washington,0026 Washington City,President,,,Write-ins,4
-Washington,0001 Barnes,State House,106,REP,Clay Aurand,43
-Washington,0002 Brantford,State House,106,REP,Clay Aurand,30
-Washington,0003 Charleston,State House,106,REP,Clay Aurand,23
-Washington,0004 Clifton,State House,106,REP,Clay Aurand,134
-Washington,0005 Coleman,State House,106,REP,Clay Aurand,18
-Washington,0006 Farmington,State House,106,REP,Clay Aurand,57
-Washington,0007 Franklin,State House,106,REP,Clay Aurand,37
-Washington,0008 Grant,State House,106,REP,Clay Aurand,17
-Washington,0009 Greenleaf,State House,106,REP,Clay Aurand,89
-Washington,0010 Haddam,State House,106,REP,Clay Aurand,46
-Washington,0011 Hanover,State House,106,REP,Clay Aurand,170
-Washington,0012 Highland,State House,106,REP,Clay Aurand,10
-Washington,0013 Independence,State House,106,REP,Clay Aurand,36
-Washington,0014 Kimeo,State House,106,REP,Clay Aurand,22
-Washington,0015 Lincoln,State House,106,REP,Clay Aurand,17
-Washington,0016 Linn,State House,106,REP,Clay Aurand,154
-Washington,0017 Little Blue,State House,106,REP,Clay Aurand,16
-Washington,0018 Logan,State House,106,REP,Clay Aurand,34
-Washington,0019 Lowe,State House,106,REP,Clay Aurand,20
-Washington,0020 Mill Creek,State House,106,REP,Clay Aurand,62
-Washington,0021 Sheridan,State House,106,REP,Clay Aurand,37
-Washington,0022 Sherman,State House,106,REP,Clay Aurand,107
-Washington,0023 Strawberry,State House,106,REP,Clay Aurand,38
-Washington,0024 Union,State House,106,REP,Clay Aurand,24
-Washington,0025 Washington,State House,106,REP,Clay Aurand,91
-Washington,0026 Washington City,State House,106,REP,Clay Aurand,284
-Washington,0001 Barnes,State House,106,DEM,Todd Frye,45
-Washington,0002 Brantford,State House,106,DEM,Todd Frye,10
-Washington,0003 Charleston,State House,106,DEM,Todd Frye,10
-Washington,0004 Clifton,State House,106,DEM,Todd Frye,59
-Washington,0005 Coleman,State House,106,DEM,Todd Frye,12
-Washington,0006 Farmington,State House,106,DEM,Todd Frye,25
-Washington,0007 Franklin,State House,106,DEM,Todd Frye,24
-Washington,0008 Grant,State House,106,DEM,Todd Frye,1
-Washington,0009 Greenleaf,State House,106,DEM,Todd Frye,50
-Washington,0010 Haddam,State House,106,DEM,Todd Frye,39
-Washington,0011 Hanover,State House,106,DEM,Todd Frye,231
-Washington,0012 Highland,State House,106,DEM,Todd Frye,3
-Washington,0013 Independence,State House,106,DEM,Todd Frye,24
-Washington,0014 Kimeo,State House,106,DEM,Todd Frye,16
-Washington,0015 Lincoln,State House,106,DEM,Todd Frye,10
-Washington,0016 Linn,State House,106,DEM,Todd Frye,75
-Washington,0017 Little Blue,State House,106,DEM,Todd Frye,22
-Washington,0018 Logan,State House,106,DEM,Todd Frye,29
-Washington,0019 Lowe,State House,106,DEM,Todd Frye,12
-Washington,0020 Mill Creek,State House,106,DEM,Todd Frye,50
-Washington,0021 Sheridan,State House,106,DEM,Todd Frye,11
-Washington,0022 Sherman,State House,106,DEM,Todd Frye,38
-Washington,0023 Strawberry,State House,106,DEM,Todd Frye,22
-Washington,0024 Union,State House,106,DEM,Todd Frye,17
-Washington,0025 Washington,State House,106,DEM,Todd Frye,25
-Washington,0026 Washington City,State House,106,DEM,Todd Frye,245
-Washington,0001 Barnes,State House,106,,Write-ins,0
-Washington,0002 Brantford,State House,106,,Write-ins,0
-Washington,0003 Charleston,State House,106,,Write-ins,1
-Washington,0004 Clifton,State House,106,,Write-ins,1
-Washington,0005 Coleman,State House,106,,Write-ins,0
-Washington,0006 Farmington,State House,106,,Write-ins,0
-Washington,0007 Franklin,State House,106,,Write-ins,0
-Washington,0008 Grant,State House,106,,Write-ins,0
-Washington,0009 Greenleaf,State House,106,,Write-ins,0
-Washington,0010 Haddam,State House,106,,Write-ins,0
-Washington,0011 Hanover,State House,106,,Write-ins,0
-Washington,0012 Highland,State House,106,,Write-ins,0
-Washington,0013 Independence,State House,106,,Write-ins,0
-Washington,0014 Kimeo,State House,106,,Write-ins,0
-Washington,0015 Lincoln,State House,106,,Write-ins,0
-Washington,0016 Linn,State House,106,,Write-ins,1
-Washington,0017 Little Blue,State House,106,,Write-ins,0
-Washington,0018 Logan,State House,106,,Write-ins,0
-Washington,0019 Lowe,State House,106,,Write-ins,0
-Washington,0020 Mill Creek,State House,106,,Write-ins,1
-Washington,0021 Sheridan,State House,106,,Write-ins,0
-Washington,0022 Sherman,State House,106,,Write-ins,0
-Washington,0023 Strawberry,State House,106,,Write-ins,0
-Washington,0024 Union,State House,106,,Write-ins,0
-Washington,0025 Washington,State House,106,,Write-ins,2
-Washington,0026 Washington City,State House,106,,Write-ins,0
-Washington,0001 Barnes,State Senate,36,DEM,Brian Angevine,15
-Washington,0002 Brantford,State Senate,36,DEM,Brian Angevine,5
-Washington,0003 Charleston,State Senate,36,DEM,Brian Angevine,4
-Washington,0004 Clifton,State Senate,36,DEM,Brian Angevine,32
-Washington,0005 Coleman,State Senate,36,DEM,Brian Angevine,4
-Washington,0006 Farmington,State Senate,36,DEM,Brian Angevine,10
-Washington,0007 Franklin,State Senate,36,DEM,Brian Angevine,15
-Washington,0008 Grant,State Senate,36,DEM,Brian Angevine,3
-Washington,0009 Greenleaf,State Senate,36,DEM,Brian Angevine,23
-Washington,0010 Haddam,State Senate,36,DEM,Brian Angevine,27
-Washington,0011 Hanover,State Senate,36,DEM,Brian Angevine,64
-Washington,0012 Highland,State Senate,36,DEM,Brian Angevine,0
-Washington,0013 Independence,State Senate,36,DEM,Brian Angevine,7
-Washington,0014 Kimeo,State Senate,36,DEM,Brian Angevine,5
-Washington,0015 Lincoln,State Senate,36,DEM,Brian Angevine,2
-Washington,0016 Linn,State Senate,36,DEM,Brian Angevine,26
-Washington,0017 Little Blue,State Senate,36,DEM,Brian Angevine,10
-Washington,0018 Logan,State Senate,36,DEM,Brian Angevine,10
-Washington,0019 Lowe,State Senate,36,DEM,Brian Angevine,1
-Washington,0020 Mill Creek,State Senate,36,DEM,Brian Angevine,21
-Washington,0021 Sheridan,State Senate,36,DEM,Brian Angevine,6
-Washington,0022 Sherman,State Senate,36,DEM,Brian Angevine,8
-Washington,0023 Strawberry,State Senate,36,DEM,Brian Angevine,6
-Washington,0024 Union,State Senate,36,DEM,Brian Angevine,12
-Washington,0025 Washington,State Senate,36,DEM,Brian Angevine,10
-Washington,0026 Washington City,State Senate,36,DEM,Brian Angevine,104
-Washington,0001 Barnes,State Senate,36,REP,Elaine Bowers,70
-Washington,0002 Brantford,State Senate,36,REP,Elaine Bowers,35
-Washington,0003 Charleston,State Senate,36,REP,Elaine Bowers,29
-Washington,0004 Clifton,State Senate,36,REP,Elaine Bowers,164
-Washington,0005 Coleman,State Senate,36,REP,Elaine Bowers,27
-Washington,0006 Farmington,State Senate,36,REP,Elaine Bowers,68
-Washington,0007 Franklin,State Senate,36,REP,Elaine Bowers,45
-Washington,0008 Grant,State Senate,36,REP,Elaine Bowers,15
-Washington,0009 Greenleaf,State Senate,36,REP,Elaine Bowers,115
-Washington,0010 Haddam,State Senate,36,REP,Elaine Bowers,54
-Washington,0011 Hanover,State Senate,36,REP,Elaine Bowers,337
-Washington,0012 Highland,State Senate,36,REP,Elaine Bowers,13
-Washington,0013 Independence,State Senate,36,REP,Elaine Bowers,52
-Washington,0014 Kimeo,State Senate,36,REP,Elaine Bowers,31
-Washington,0015 Lincoln,State Senate,36,REP,Elaine Bowers,26
-Washington,0016 Linn,State Senate,36,REP,Elaine Bowers,198
-Washington,0017 Little Blue,State Senate,36,REP,Elaine Bowers,25
-Washington,0018 Logan,State Senate,36,REP,Elaine Bowers,51
-Washington,0019 Lowe,State Senate,36,REP,Elaine Bowers,29
-Washington,0020 Mill Creek,State Senate,36,REP,Elaine Bowers,88
-Washington,0021 Sheridan,State Senate,36,REP,Elaine Bowers,41
-Washington,0022 Sherman,State Senate,36,REP,Elaine Bowers,133
-Washington,0023 Strawberry,State Senate,36,REP,Elaine Bowers,54
-Washington,0024 Union,State Senate,36,REP,Elaine Bowers,29
-Washington,0025 Washington,State Senate,36,REP,Elaine Bowers,107
-Washington,0026 Washington City,State Senate,36,REP,Elaine Bowers,418
-Washington,0001 Barnes,State Senate,36,,Write-ins,0
-Washington,0002 Brantford,State Senate,36,,Write-ins,0
-Washington,0003 Charleston,State Senate,36,,Write-ins,0
-Washington,0004 Clifton,State Senate,36,,Write-ins,0
-Washington,0005 Coleman,State Senate,36,,Write-ins,0
-Washington,0006 Farmington,State Senate,36,,Write-ins,0
-Washington,0007 Franklin,State Senate,36,,Write-ins,0
-Washington,0008 Grant,State Senate,36,,Write-ins,0
-Washington,0009 Greenleaf,State Senate,36,,Write-ins,0
-Washington,0010 Haddam,State Senate,36,,Write-ins,0
-Washington,0011 Hanover,State Senate,36,,Write-ins,0
-Washington,0012 Highland,State Senate,36,,Write-ins,0
-Washington,0013 Independence,State Senate,36,,Write-ins,0
-Washington,0014 Kimeo,State Senate,36,,Write-ins,0
-Washington,0015 Lincoln,State Senate,36,,Write-ins,0
-Washington,0016 Linn,State Senate,36,,Write-ins,0
-Washington,0017 Little Blue,State Senate,36,,Write-ins,0
-Washington,0018 Logan,State Senate,36,,Write-ins,0
-Washington,0019 Lowe,State Senate,36,,Write-ins,0
-Washington,0020 Mill Creek,State Senate,36,,Write-ins,0
-Washington,0021 Sheridan,State Senate,36,,Write-ins,1
-Washington,0022 Sherman,State Senate,36,,Write-ins,0
-Washington,0023 Strawberry,State Senate,36,,Write-ins,0
-Washington,0024 Union,State Senate,36,,Write-ins,0
-Washington,0025 Washington,State Senate,36,,Write-ins,0
-Washington,0026 Washington City,State Senate,36,,Write-ins,2
-Washington,0001 Barnes,U.S. House,1,IND,Alan LaPolice,29
-Washington,0002 Brantford,U.S. House,1,IND,Alan LaPolice,21
-Washington,0003 Charleston,U.S. House,1,IND,Alan LaPolice,10
-Washington,0004 Clifton,U.S. House,1,IND,Alan LaPolice,137
-Washington,0005 Coleman,U.S. House,1,IND,Alan LaPolice,10
-Washington,0006 Farmington,U.S. House,1,IND,Alan LaPolice,23
-Washington,0007 Franklin,U.S. House,1,IND,Alan LaPolice,14
-Washington,0008 Grant,U.S. House,1,IND,Alan LaPolice,6
-Washington,0009 Greenleaf,U.S. House,1,IND,Alan LaPolice,51
-Washington,0010 Haddam,U.S. House,1,IND,Alan LaPolice,38
-Washington,0011 Hanover,U.S. House,1,IND,Alan LaPolice,102
-Washington,0012 Highland,U.S. House,1,IND,Alan LaPolice,5
-Washington,0013 Independence,U.S. House,1,IND,Alan LaPolice,11
-Washington,0014 Kimeo,U.S. House,1,IND,Alan LaPolice,15
-Washington,0015 Lincoln,U.S. House,1,IND,Alan LaPolice,4
-Washington,0016 Linn,U.S. House,1,IND,Alan LaPolice,79
-Washington,0017 Little Blue,U.S. House,1,IND,Alan LaPolice,16
-Washington,0018 Logan,U.S. House,1,IND,Alan LaPolice,21
-Washington,0019 Lowe,U.S. House,1,IND,Alan LaPolice,4
-Washington,0020 Mill Creek,U.S. House,1,IND,Alan LaPolice,31
-Washington,0021 Sheridan,U.S. House,1,IND,Alan LaPolice,24
-Washington,0022 Sherman,U.S. House,1,IND,Alan LaPolice,54
-Washington,0023 Strawberry,U.S. House,1,IND,Alan LaPolice,21
-Washington,0024 Union,U.S. House,1,IND,Alan LaPolice,6
-Washington,0025 Washington,U.S. House,1,IND,Alan LaPolice,28
-Washington,0026 Washington City,U.S. House,1,IND,Alan LaPolice,178
-Washington,0001 Barnes,U.S. House,1,LBT,Kerry Burt,1
-Washington,0002 Brantford,U.S. House,1,LBT,Kerry Burt,0
-Washington,0003 Charleston,U.S. House,1,LBT,Kerry Burt,1
-Washington,0004 Clifton,U.S. House,1,LBT,Kerry Burt,0
-Washington,0005 Coleman,U.S. House,1,LBT,Kerry Burt,0
-Washington,0006 Farmington,U.S. House,1,LBT,Kerry Burt,4
-Washington,0007 Franklin,U.S. House,1,LBT,Kerry Burt,3
-Washington,0008 Grant,U.S. House,1,LBT,Kerry Burt,0
-Washington,0009 Greenleaf,U.S. House,1,LBT,Kerry Burt,1
-Washington,0010 Haddam,U.S. House,1,LBT,Kerry Burt,3
-Washington,0011 Hanover,U.S. House,1,LBT,Kerry Burt,12
-Washington,0012 Highland,U.S. House,1,LBT,Kerry Burt,1
-Washington,0013 Independence,U.S. House,1,LBT,Kerry Burt,0
-Washington,0014 Kimeo,U.S. House,1,LBT,Kerry Burt,0
-Washington,0015 Lincoln,U.S. House,1,LBT,Kerry Burt,1
-Washington,0016 Linn,U.S. House,1,LBT,Kerry Burt,5
-Washington,0017 Little Blue,U.S. House,1,LBT,Kerry Burt,3
-Washington,0018 Logan,U.S. House,1,LBT,Kerry Burt,0
-Washington,0019 Lowe,U.S. House,1,LBT,Kerry Burt,2
-Washington,0020 Mill Creek,U.S. House,1,LBT,Kerry Burt,5
-Washington,0021 Sheridan,U.S. House,1,LBT,Kerry Burt,0
-Washington,0022 Sherman,U.S. House,1,LBT,Kerry Burt,1
-Washington,0023 Strawberry,U.S. House,1,LBT,Kerry Burt,1
-Washington,0024 Union,U.S. House,1,LBT,Kerry Burt,2
-Washington,0025 Washington,U.S. House,1,LBT,Kerry Burt,2
-Washington,0026 Washington City,U.S. House,1,LBT,Kerry Burt,23
-Washington,0001 Barnes,U.S. House,1,REP,Roger Marshall,58
-Washington,0002 Brantford,U.S. House,1,REP,Roger Marshall,18
-Washington,0003 Charleston,U.S. House,1,REP,Roger Marshall,21
-Washington,0004 Clifton,U.S. House,1,REP,Roger Marshall,56
-Washington,0005 Coleman,U.S. House,1,REP,Roger Marshall,20
-Washington,0006 Farmington,U.S. House,1,REP,Roger Marshall,51
-Washington,0007 Franklin,U.S. House,1,REP,Roger Marshall,42
-Washington,0008 Grant,U.S. House,1,REP,Roger Marshall,12
-Washington,0009 Greenleaf,U.S. House,1,REP,Roger Marshall,86
-Washington,0010 Haddam,U.S. House,1,REP,Roger Marshall,40
-Washington,0011 Hanover,U.S. House,1,REP,Roger Marshall,282
-Washington,0012 Highland,U.S. House,1,REP,Roger Marshall,7
-Washington,0013 Independence,U.S. House,1,REP,Roger Marshall,50
-Washington,0014 Kimeo,U.S. House,1,REP,Roger Marshall,22
-Washington,0015 Lincoln,U.S. House,1,REP,Roger Marshall,23
-Washington,0016 Linn,U.S. House,1,REP,Roger Marshall,145
-Washington,0017 Little Blue,U.S. House,1,REP,Roger Marshall,18
-Washington,0018 Logan,U.S. House,1,REP,Roger Marshall,42
-Washington,0019 Lowe,U.S. House,1,REP,Roger Marshall,23
-Washington,0020 Mill Creek,U.S. House,1,REP,Roger Marshall,73
-Washington,0021 Sheridan,U.S. House,1,REP,Roger Marshall,25
-Washington,0022 Sherman,U.S. House,1,REP,Roger Marshall,88
-Washington,0023 Strawberry,U.S. House,1,REP,Roger Marshall,40
-Washington,0024 Union,U.S. House,1,REP,Roger Marshall,31
-Washington,0025 Washington,U.S. House,1,REP,Roger Marshall,87
-Washington,0026 Washington City,U.S. House,1,REP,Roger Marshall,325
-Washington,0004 Clifton,U.S. House,1,,Tim Huelskamp,3
-Washington,0011 Hanover,U.S. House,1,,Tim Huelskamp,2
-Washington,0001 Barnes,U.S. House,1,,Write-ins,0
-Washington,0002 Brantford,U.S. House,1,,Write-ins,0
-Washington,0003 Charleston,U.S. House,1,,Write-ins,0
-Washington,0004 Clifton,U.S. House,1,,Write-ins,4
-Washington,0005 Coleman,U.S. House,1,,Write-ins,0
-Washington,0006 Farmington,U.S. House,1,,Write-ins,0
-Washington,0007 Franklin,U.S. House,1,,Write-ins,0
-Washington,0008 Grant,U.S. House,1,,Write-ins,0
-Washington,0009 Greenleaf,U.S. House,1,,Write-ins,1
-Washington,0010 Haddam,U.S. House,1,,Write-ins,0
-Washington,0011 Hanover,U.S. House,1,,Write-ins,4
-Washington,0012 Highland,U.S. House,1,,Write-ins,0
-Washington,0013 Independence,U.S. House,1,,Write-ins,0
-Washington,0014 Kimeo,U.S. House,1,,Write-ins,1
-Washington,0015 Lincoln,U.S. House,1,,Write-ins,0
-Washington,0016 Linn,U.S. House,1,,Write-ins,0
-Washington,0017 Little Blue,U.S. House,1,,Write-ins,0
-Washington,0018 Logan,U.S. House,1,,Write-ins,1
-Washington,0019 Lowe,U.S. House,1,,Write-ins,0
-Washington,0020 Mill Creek,U.S. House,1,,Write-ins,0
-Washington,0021 Sheridan,U.S. House,1,,Write-ins,0
-Washington,0022 Sherman,U.S. House,1,,Write-ins,0
-Washington,0023 Strawberry,U.S. House,1,,Write-ins,0
-Washington,0024 Union,U.S. House,1,,Write-ins,0
-Washington,0025 Washington,U.S. House,1,,Write-ins,0
-Washington,0026 Washington City,U.S. House,1,,Write-ins,2
-Washington,0001 Barnes,U.S. Senate,,REP,Jerry Moran,75
-Washington,0002 Brantford,U.S. Senate,,REP,Jerry Moran,37
-Washington,0003 Charleston,U.S. Senate,,REP,Jerry Moran,30
-Washington,0004 Clifton,U.S. Senate,,REP,Jerry Moran,158
-Washington,0005 Coleman,U.S. Senate,,REP,Jerry Moran,27
-Washington,0006 Farmington,U.S. Senate,,REP,Jerry Moran,64
-Washington,0007 Franklin,U.S. Senate,,REP,Jerry Moran,48
-Washington,0008 Grant,U.S. Senate,,REP,Jerry Moran,15
-Washington,0009 Greenleaf,U.S. Senate,,REP,Jerry Moran,115
-Washington,0010 Haddam,U.S. Senate,,REP,Jerry Moran,69
-Washington,0011 Hanover,U.S. Senate,,REP,Jerry Moran,356
-Washington,0012 Highland,U.S. Senate,,REP,Jerry Moran,12
-Washington,0013 Independence,U.S. Senate,,REP,Jerry Moran,54
-Washington,0014 Kimeo,U.S. Senate,,REP,Jerry Moran,34
-Washington,0015 Lincoln,U.S. Senate,,REP,Jerry Moran,26
-Washington,0016 Linn,U.S. Senate,,REP,Jerry Moran,208
-Washington,0017 Little Blue,U.S. Senate,,REP,Jerry Moran,30
-Washington,0018 Logan,U.S. Senate,,REP,Jerry Moran,54
-Washington,0019 Lowe,U.S. Senate,,REP,Jerry Moran,30
-Washington,0020 Mill Creek,U.S. Senate,,REP,Jerry Moran,101
-Washington,0021 Sheridan,U.S. Senate,,REP,Jerry Moran,44
-Washington,0022 Sherman,U.S. Senate,,REP,Jerry Moran,134
-Washington,0023 Strawberry,U.S. Senate,,REP,Jerry Moran,51
-Washington,0024 Union,U.S. Senate,,REP,Jerry Moran,34
-Washington,0025 Washington,U.S. Senate,,REP,Jerry Moran,111
-Washington,0026 Washington City,U.S. Senate,,REP,Jerry Moran,424
-Washington,0001 Barnes,U.S. Senate,,DEM,Patrick Wiesner,10
-Washington,0002 Brantford,U.S. Senate,,DEM,Patrick Wiesner,3
-Washington,0003 Charleston,U.S. Senate,,DEM,Patrick Wiesner,4
-Washington,0004 Clifton,U.S. Senate,,DEM,Patrick Wiesner,26
-Washington,0005 Coleman,U.S. Senate,,DEM,Patrick Wiesner,2
-Washington,0006 Farmington,U.S. Senate,,DEM,Patrick Wiesner,9
-Washington,0007 Franklin,U.S. Senate,,DEM,Patrick Wiesner,8
-Washington,0008 Grant,U.S. Senate,,DEM,Patrick Wiesner,2
-Washington,0009 Greenleaf,U.S. Senate,,DEM,Patrick Wiesner,18
-Washington,0010 Haddam,U.S. Senate,,DEM,Patrick Wiesner,9
-Washington,0011 Hanover,U.S. Senate,,DEM,Patrick Wiesner,46
-Washington,0012 Highland,U.S. Senate,,DEM,Patrick Wiesner,1
-Washington,0013 Independence,U.S. Senate,,DEM,Patrick Wiesner,5
-Washington,0014 Kimeo,U.S. Senate,,DEM,Patrick Wiesner,2
-Washington,0015 Lincoln,U.S. Senate,,DEM,Patrick Wiesner,0
-Washington,0016 Linn,U.S. Senate,,DEM,Patrick Wiesner,16
-Washington,0017 Little Blue,U.S. Senate,,DEM,Patrick Wiesner,8
-Washington,0018 Logan,U.S. Senate,,DEM,Patrick Wiesner,8
-Washington,0019 Lowe,U.S. Senate,,DEM,Patrick Wiesner,1
-Washington,0020 Mill Creek,U.S. Senate,,DEM,Patrick Wiesner,7
-Washington,0021 Sheridan,U.S. Senate,,DEM,Patrick Wiesner,4
-Washington,0022 Sherman,U.S. Senate,,DEM,Patrick Wiesner,8
-Washington,0023 Strawberry,U.S. Senate,,DEM,Patrick Wiesner,6
-Washington,0024 Union,U.S. Senate,,DEM,Patrick Wiesner,6
-Washington,0025 Washington,U.S. Senate,,DEM,Patrick Wiesner,5
-Washington,0026 Washington City,U.S. Senate,,DEM,Patrick Wiesner,71
-Washington,0001 Barnes,U.S. Senate,,LBT,Robert Garrard,2
-Washington,0002 Brantford,U.S. Senate,,LBT,Robert Garrard,0
-Washington,0003 Charleston,U.S. Senate,,LBT,Robert Garrard,0
-Washington,0004 Clifton,U.S. Senate,,LBT,Robert Garrard,9
-Washington,0005 Coleman,U.S. Senate,,LBT,Robert Garrard,2
-Washington,0006 Farmington,U.S. Senate,,LBT,Robert Garrard,6
-Washington,0007 Franklin,U.S. Senate,,LBT,Robert Garrard,4
-Washington,0008 Grant,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0009 Greenleaf,U.S. Senate,,LBT,Robert Garrard,9
-Washington,0010 Haddam,U.S. Senate,,LBT,Robert Garrard,5
-Washington,0011 Hanover,U.S. Senate,,LBT,Robert Garrard,12
-Washington,0012 Highland,U.S. Senate,,LBT,Robert Garrard,0
-Washington,0013 Independence,U.S. Senate,,LBT,Robert Garrard,3
-Washington,0014 Kimeo,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0015 Lincoln,U.S. Senate,,LBT,Robert Garrard,2
-Washington,0016 Linn,U.S. Senate,,LBT,Robert Garrard,9
-Washington,0017 Little Blue,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0018 Logan,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0019 Lowe,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0020 Mill Creek,U.S. Senate,,LBT,Robert Garrard,4
-Washington,0021 Sheridan,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0022 Sherman,U.S. Senate,,LBT,Robert Garrard,2
-Washington,0023 Strawberry,U.S. Senate,,LBT,Robert Garrard,3
-Washington,0024 Union,U.S. Senate,,LBT,Robert Garrard,3
-Washington,0025 Washington,U.S. Senate,,LBT,Robert Garrard,1
-Washington,0026 Washington City,U.S. Senate,,LBT,Robert Garrard,28
-Washington,0001 Barnes,U.S. Senate,,,Write-ins,0
-Washington,0002 Brantford,U.S. Senate,,,Write-ins,0
-Washington,0003 Charleston,U.S. Senate,,,Write-ins,0
-Washington,0004 Clifton,U.S. Senate,,,Write-ins,0
-Washington,0005 Coleman,U.S. Senate,,,Write-ins,0
-Washington,0006 Farmington,U.S. Senate,,,Write-ins,0
-Washington,0007 Franklin,U.S. Senate,,,Write-ins,0
-Washington,0008 Grant,U.S. Senate,,,Write-ins,0
-Washington,0009 Greenleaf,U.S. Senate,,,Write-ins,0
-Washington,0010 Haddam,U.S. Senate,,,Write-ins,0
-Washington,0011 Hanover,U.S. Senate,,,Write-ins,2
-Washington,0012 Highland,U.S. Senate,,,Write-ins,0
-Washington,0013 Independence,U.S. Senate,,,Write-ins,0
-Washington,0014 Kimeo,U.S. Senate,,,Write-ins,0
-Washington,0015 Lincoln,U.S. Senate,,,Write-ins,0
-Washington,0016 Linn,U.S. Senate,,,Write-ins,3
-Washington,0017 Little Blue,U.S. Senate,,,Write-ins,0
-Washington,0018 Logan,U.S. Senate,,,Write-ins,0
-Washington,0019 Lowe,U.S. Senate,,,Write-ins,0
-Washington,0020 Mill Creek,U.S. Senate,,,Write-ins,1
-Washington,0021 Sheridan,U.S. Senate,,,Write-ins,0
-Washington,0022 Sherman,U.S. Senate,,,Write-ins,1
-Washington,0023 Strawberry,U.S. Senate,,,Write-ins,0
-Washington,0024 Union,U.S. Senate,,,Write-ins,0
-Washington,0025 Washington,U.S. Senate,,,Write-ins,1
-Washington,0026 Washington City,U.S. Senate,,,Write-ins,4
+county,precinct,office,district,party,candidate,votes,vtd
+WASHINGTON,Barnes Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",45,000010
+WASHINGTON,Barnes Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",43,000010
+WASHINGTON,Brantford Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",10,000020
+WASHINGTON,Brantford Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",30,000020
+WASHINGTON,Charleston Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",10,000030
+WASHINGTON,Charleston Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",23,000030
+WASHINGTON,Clifton Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",59,000040
+WASHINGTON,Clifton Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",134,000040
+WASHINGTON,Coleman Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",12,000050
+WASHINGTON,Coleman Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",18,000050
+WASHINGTON,Farmington Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",25,000060
+WASHINGTON,Farmington Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",57,000060
+WASHINGTON,Franklin Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",24,000070
+WASHINGTON,Franklin Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",37,000070
+WASHINGTON,Grant Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",1,000080
+WASHINGTON,Grant Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",17,000080
+WASHINGTON,Greenleaf Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",50,000090
+WASHINGTON,Greenleaf Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",89,000090
+WASHINGTON,Haddam Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",39,000100
+WASHINGTON,Haddam Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",46,000100
+WASHINGTON,Hanover Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",231,000110
+WASHINGTON,Hanover Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",170,000110
+WASHINGTON,Highland Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",3,000120
+WASHINGTON,Highland Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",10,000120
+WASHINGTON,Independence Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",24,000130
+WASHINGTON,Independence Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",36,000130
+WASHINGTON,Kimeo Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",16,000140
+WASHINGTON,Kimeo Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",22,000140
+WASHINGTON,Lincoln Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",10,000150
+WASHINGTON,Lincoln Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",17,000150
+WASHINGTON,Linn Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",75,000160
+WASHINGTON,Linn Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",154,000160
+WASHINGTON,Little Blue Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",22,000170
+WASHINGTON,Little Blue Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",16,000170
+WASHINGTON,Logan Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",29,000180
+WASHINGTON,Logan Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",34,000180
+WASHINGTON,Lowe Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",12,000190
+WASHINGTON,Lowe Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",20,000190
+WASHINGTON,Mill Creek Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",50,000200
+WASHINGTON,Mill Creek Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",62,000200
+WASHINGTON,Sheridan Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",11,000210
+WASHINGTON,Sheridan Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",37,000210
+WASHINGTON,Sherman Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",38,000220
+WASHINGTON,Sherman Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",107,000220
+WASHINGTON,Strawberry Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",22,000230
+WASHINGTON,Strawberry Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",38,000230
+WASHINGTON,Union Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",17,000240
+WASHINGTON,Union Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",24,000240
+WASHINGTON,Washington Township,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",25,00025A
+WASHINGTON,Washington Township,Kansas House of Representatives,106,Republican,"Aurand, Clay",91,00025A
+WASHINGTON,Washington Township Rural Enclave,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00025B
+WASHINGTON,Washington City,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",245,00026A
+WASHINGTON,Washington City,Kansas House of Representatives,106,Republican,"Aurand, Clay",284,00026A
+WASHINGTON,Washington City Exclave,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,00026B
+WASHINGTON,Washington City Exclave,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Kansas House of Representatives,106,Democratic,"Frye, Todd E.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Kansas House of Representatives,106,Republican,"Aurand, Clay",0,900010
+WASHINGTON,Barnes Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,000010
+WASHINGTON,Barnes Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",70,000010
+WASHINGTON,Brantford Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000020
+WASHINGTON,Brantford Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",35,000020
+WASHINGTON,Charleston Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000030
+WASHINGTON,Charleston Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000030
+WASHINGTON,Clifton Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",32,000040
+WASHINGTON,Clifton Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",164,000040
+WASHINGTON,Coleman Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",4,000050
+WASHINGTON,Coleman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",27,000050
+WASHINGTON,Farmington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000060
+WASHINGTON,Farmington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",68,000060
+WASHINGTON,Franklin Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",15,000070
+WASHINGTON,Franklin Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",45,000070
+WASHINGTON,Grant Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",3,000080
+WASHINGTON,Grant Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",15,000080
+WASHINGTON,Greenleaf Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",23,000090
+WASHINGTON,Greenleaf Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",115,000090
+WASHINGTON,Haddam Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",27,000100
+WASHINGTON,Haddam Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000100
+WASHINGTON,Hanover Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",64,000110
+WASHINGTON,Hanover Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",337,000110
+WASHINGTON,Highland Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,000120
+WASHINGTON,Highland Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",13,000120
+WASHINGTON,Independence Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",7,000130
+WASHINGTON,Independence Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",52,000130
+WASHINGTON,Kimeo Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",5,000140
+WASHINGTON,Kimeo Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",31,000140
+WASHINGTON,Lincoln Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",2,000150
+WASHINGTON,Lincoln Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",26,000150
+WASHINGTON,Linn Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",26,000160
+WASHINGTON,Linn Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",198,000160
+WASHINGTON,Little Blue Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000170
+WASHINGTON,Little Blue Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",25,000170
+WASHINGTON,Logan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,000180
+WASHINGTON,Logan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",51,000180
+WASHINGTON,Lowe Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",1,000190
+WASHINGTON,Lowe Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000190
+WASHINGTON,Mill Creek Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",21,000200
+WASHINGTON,Mill Creek Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",88,000200
+WASHINGTON,Sheridan Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000210
+WASHINGTON,Sheridan Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",41,000210
+WASHINGTON,Sherman Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",8,000220
+WASHINGTON,Sherman Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",133,000220
+WASHINGTON,Strawberry Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",6,000230
+WASHINGTON,Strawberry Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",54,000230
+WASHINGTON,Union Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",12,000240
+WASHINGTON,Union Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",29,000240
+WASHINGTON,Washington Township,Kansas Senate,36,Democratic,"Angevine, Brian G.",10,00025A
+WASHINGTON,Washington Township,Kansas Senate,36,Republican,"Bowers, Elaine S.",107,00025A
+WASHINGTON,Washington Township Rural Enclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00025B
+WASHINGTON,Washington City,Kansas Senate,36,Democratic,"Angevine, Brian G.",104,00026A
+WASHINGTON,Washington City,Kansas Senate,36,Republican,"Bowers, Elaine S.",418,00026A
+WASHINGTON,Washington City Exclave,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,00026B
+WASHINGTON,Washington City Exclave,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,Kansas Senate,36,Democratic,"Angevine, Brian G.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,Kansas Senate,36,Republican,"Bowers, Elaine S.",0,900010
+WASHINGTON,Barnes Township,President / Vice President,,independent,"Stein, Jill",1,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+WASHINGTON,Barnes Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000010
+WASHINGTON,Barnes Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000010
+WASHINGTON,Barnes Township,President / Vice President,,Republican,"Trump, Donald J.",70,000010
+WASHINGTON,Brantford Township,President / Vice President,,independent,"Stein, Jill",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000020
+WASHINGTON,Brantford Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000020
+WASHINGTON,Brantford Township,President / Vice President,,Republican,"Trump, Donald J.",37,000020
+WASHINGTON,Charleston Township,President / Vice President,,independent,"Stein, Jill",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+WASHINGTON,Charleston Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+WASHINGTON,Charleston Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000030
+WASHINGTON,Charleston Township,President / Vice President,,Republican,"Trump, Donald J.",28,000030
+WASHINGTON,Clifton Township,President / Vice President,,independent,"Stein, Jill",4,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"McMullin, Evan",1,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+WASHINGTON,Clifton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000040
+WASHINGTON,Clifton Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+WASHINGTON,Clifton Township,President / Vice President,,Republican,"Trump, Donald J.",156,000040
+WASHINGTON,Coleman Township,President / Vice President,,independent,"Stein, Jill",1,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000050
+WASHINGTON,Coleman Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000050
+WASHINGTON,Coleman Township,President / Vice President,,Republican,"Trump, Donald J.",27,000050
+WASHINGTON,Farmington Township,President / Vice President,,independent,"Stein, Jill",1,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Castle, Darrell L",2,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+WASHINGTON,Farmington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,000060
+WASHINGTON,Farmington Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000060
+WASHINGTON,Farmington Township,President / Vice President,,Republican,"Trump, Donald J.",60,000060
+WASHINGTON,Franklin Township,President / Vice President,,independent,"Stein, Jill",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+WASHINGTON,Franklin Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000070
+WASHINGTON,Franklin Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000070
+WASHINGTON,Franklin Township,President / Vice President,,Republican,"Trump, Donald J.",56,000070
+WASHINGTON,Grant Township,President / Vice President,,independent,"Stein, Jill",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Hedges, James A",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"McMullin, Evan",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Perry, Darryl",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Smith, Mike",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Sood, Ajay",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+WASHINGTON,Grant Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+WASHINGTON,Grant Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",1,000080
+WASHINGTON,Grant Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000080
+WASHINGTON,Grant Township,President / Vice President,,Republican,"Trump, Donald J.",17,000080
+WASHINGTON,Greenleaf Township,President / Vice President,,independent,"Stein, Jill",3,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Hedges, James A",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"McMullin, Evan",1,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Perry, Darryl",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Smith, Mike",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Sood, Ajay",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",25,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+WASHINGTON,Greenleaf Township,President / Vice President,,Republican,"Trump, Donald J.",104,000090
+WASHINGTON,Haddam Township,President / Vice President,,independent,"Stein, Jill",4,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Castle, Darrell L",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Giordani, Rocky",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Hedges, James A",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Hoefling, Tom",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Kahn, Lynn",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"La Riva, Gloria",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Maturen, Michael A",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"McMullin, Evan",2,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Perry, Darryl",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Schriner, Joe C",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Smith, Mike",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Sood, Ajay",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Sterling, Shawna",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000100
+WASHINGTON,Haddam Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",21,000100
+WASHINGTON,Haddam Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000100
+WASHINGTON,Haddam Township,President / Vice President,,Republican,"Trump, Donald J.",56,000100
+WASHINGTON,Hanover Township,President / Vice President,,independent,"Stein, Jill",7,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Hedges, James A",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"McMullin, Evan",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Perry, Darryl",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Smith, Mike",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Sood, Ajay",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+WASHINGTON,Hanover Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",50,000110
+WASHINGTON,Hanover Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000110
+WASHINGTON,Hanover Township,President / Vice President,,Republican,"Trump, Donald J.",348,000110
+WASHINGTON,Highland Township,President / Vice President,,independent,"Stein, Jill",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"McMullin, Evan",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+WASHINGTON,Highland Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+WASHINGTON,Highland Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000120
+WASHINGTON,Highland Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000120
+WASHINGTON,Highland Township,President / Vice President,,Republican,"Trump, Donald J.",13,000120
+WASHINGTON,Independence Township,President / Vice President,,independent,"Stein, Jill",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+WASHINGTON,Independence Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+WASHINGTON,Independence Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000130
+WASHINGTON,Independence Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000130
+WASHINGTON,Independence Township,President / Vice President,,Republican,"Trump, Donald J.",49,000130
+WASHINGTON,Kimeo Township,President / Vice President,,independent,"Stein, Jill",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Castle, Darrell L",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Giordani, Rocky",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Hedges, James A",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Hoefling, Tom",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Kahn, Lynn",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"La Riva, Gloria",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Maturen, Michael A",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"McMullin, Evan",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Perry, Darryl",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Schriner, Joe C",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Smith, Mike",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Sood, Ajay",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Sterling, Shawna",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000140
+WASHINGTON,Kimeo Township,President / Vice President,,Republican,"Trump, Donald J.",29,000140
+WASHINGTON,Lincoln Township,President / Vice President,,independent,"Stein, Jill",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Hedges, James A",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"McMullin, Evan",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Perry, Darryl",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Smith, Mike",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Sood, Ajay",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000150
+WASHINGTON,Lincoln Township,President / Vice President,,Republican,"Trump, Donald J.",26,000150
+WASHINGTON,Linn Township,President / Vice President,,independent,"Stein, Jill",2,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Hedges, James A",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"McMullin, Evan",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Perry, Darryl",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Smith, Mike",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Sood, Ajay",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+WASHINGTON,Linn Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+WASHINGTON,Linn Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",26,000160
+WASHINGTON,Linn Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000160
+WASHINGTON,Linn Township,President / Vice President,,Republican,"Trump, Donald J.",193,000160
+WASHINGTON,Little Blue Township,President / Vice President,,independent,"Stein, Jill",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Hedges, James A",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"McMullin, Evan",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Perry, Darryl",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Smith, Mike",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Sood, Ajay",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000170
+WASHINGTON,Little Blue Township,President / Vice President,,Republican,"Trump, Donald J.",25,000170
+WASHINGTON,Logan Township,President / Vice President,,independent,"Stein, Jill",1,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+WASHINGTON,Logan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+WASHINGTON,Logan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000180
+WASHINGTON,Logan Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000180
+WASHINGTON,Logan Township,President / Vice President,,Republican,"Trump, Donald J.",50,000180
+WASHINGTON,Lowe Township,President / Vice President,,independent,"Stein, Jill",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+WASHINGTON,Lowe Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000190
+WASHINGTON,Lowe Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000190
+WASHINGTON,Lowe Township,President / Vice President,,Republican,"Trump, Donald J.",28,000190
+WASHINGTON,Mill Creek Township,President / Vice President,,independent,"Stein, Jill",2,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"McMullin, Evan",1,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",17,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000200
+WASHINGTON,Mill Creek Township,President / Vice President,,Republican,"Trump, Donald J.",87,000200
+WASHINGTON,Sheridan Township,President / Vice President,,independent,"Stein, Jill",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+WASHINGTON,Sheridan Township,President / Vice President,,Republican,"Trump, Donald J.",42,000210
+WASHINGTON,Sherman Township,President / Vice President,,independent,"Stein, Jill",2,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"McMullin, Evan",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+WASHINGTON,Sherman Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",9,000220
+WASHINGTON,Sherman Township,President / Vice President,,Libertarian,"Johnson, Gary",12,000220
+WASHINGTON,Sherman Township,President / Vice President,,Republican,"Trump, Donald J.",123,000220
+WASHINGTON,Strawberry Township,President / Vice President,,independent,"Stein, Jill",2,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"McMullin, Evan",6,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Libertarian,"Johnson, Gary",6,000230
+WASHINGTON,Strawberry Township,President / Vice President,,Republican,"Trump, Donald J.",43,000230
+WASHINGTON,Union Township,President / Vice President,,independent,"Stein, Jill",2,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Castle, Darrell L",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Giordani, Rocky",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Hedges, James A",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Hoefling, Tom",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Kahn, Lynn",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"La Riva, Gloria",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Maturen, Michael A",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"McMullin, Evan",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Perry, Darryl",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Schriner, Joe C",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Smith, Mike",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Sood, Ajay",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Sterling, Shawna",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000240
+WASHINGTON,Union Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000240
+WASHINGTON,Union Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000240
+WASHINGTON,Union Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000240
+WASHINGTON,Union Township,President / Vice President,,Republican,"Trump, Donald J.",34,000240
+WASHINGTON,Washington Township,President / Vice President,,independent,"Stein, Jill",2,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Castle, Darrell L",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Giordani, Rocky",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Hedges, James A",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Hoefling, Tom",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Kahn, Lynn",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"La Riva, Gloria",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Levinson, Michael S.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Maturen, Michael A",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"McMullin, Evan",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Perry, Darryl",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Schriner, Joe C",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Smith, Mike",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Sood, Ajay",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Sterling, Shawna",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00025A
+WASHINGTON,Washington Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",8,00025A
+WASHINGTON,Washington Township,President / Vice President,,Libertarian,"Johnson, Gary",6,00025A
+WASHINGTON,Washington Township,President / Vice President,,Republican,"Trump, Donald J.",103,00025A
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,independent,"Stein, Jill",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Castle, Darrell L",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Giordani, Rocky",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Hedges, James A",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Hoefling, Tom",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Kahn, Lynn",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"La Riva, Gloria",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Maturen, Michael A",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"McMullin, Evan",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Perry, Darryl",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Schriner, Joe C",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Smith, Mike",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Sood, Ajay",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Sterling, Shawna",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00025B
+WASHINGTON,Washington Township Rural Enclave,President / Vice President,,Republican,"Trump, Donald J.",0,00025B
+WASHINGTON,Washington City,President / Vice President,,independent,"Stein, Jill",11,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Basiago, Andrew D.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Castle, Darrell L",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Giordani, Rocky",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Hedges, James A",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Hoefling, Tom",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Kahn, Lynn",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"La Riva, Gloria",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Levinson, Michael S.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Maturen, Michael A",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"McMullin, Evan",2,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Moorehead, Monica G.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Perry, Darryl",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Schriner, Joe C",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Smith, Mike",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Sood, Ajay",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Sterling, Shawna",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Valdivia, Anthony J",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00026A
+WASHINGTON,Washington City,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00026A
+WASHINGTON,Washington City,President / Vice President,,Democratic,"Clinton, Hillary Rodham",105,00026A
+WASHINGTON,Washington City,President / Vice President,,Libertarian,"Johnson, Gary",32,00026A
+WASHINGTON,Washington City,President / Vice President,,Republican,"Trump, Donald J.",390,00026A
+WASHINGTON,Washington City Exclave,President / Vice President,,independent,"Stein, Jill",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Hedges, James A",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Smith, Mike",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00026B
+WASHINGTON,Washington City Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,independent,"Stein, Jill",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Hedges, James A",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"McMullin, Evan",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Perry, Darryl",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Smith, Mike",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Sood, Ajay",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+WASHINGTON,Washington Township Rural Enclave B,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+WASHINGTON,Barnes Township,United States House of Representatives,1,independent,"LaPolice, Alan",29,000010
+WASHINGTON,Barnes Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000010
+WASHINGTON,Barnes Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000010
+WASHINGTON,Barnes Township,United States House of Representatives,1,Republican,"Marshall, Roger",58,000010
+WASHINGTON,Brantford Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000020
+WASHINGTON,Brantford Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+WASHINGTON,Brantford Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000020
+WASHINGTON,Brantford Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000020
+WASHINGTON,Charleston Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000030
+WASHINGTON,Charleston Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000030
+WASHINGTON,Charleston Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000030
+WASHINGTON,Charleston Township,United States House of Representatives,1,Republican,"Marshall, Roger",21,000030
+WASHINGTON,Clifton Township,United States House of Representatives,1,independent,"LaPolice, Alan",137,000040
+WASHINGTON,Clifton Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",3,000040
+WASHINGTON,Clifton Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000040
+WASHINGTON,Clifton Township,United States House of Representatives,1,Republican,"Marshall, Roger",56,000040
+WASHINGTON,Coleman Township,United States House of Representatives,1,independent,"LaPolice, Alan",10,000050
+WASHINGTON,Coleman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000050
+WASHINGTON,Coleman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000050
+WASHINGTON,Coleman Township,United States House of Representatives,1,Republican,"Marshall, Roger",20,000050
+WASHINGTON,Farmington Township,United States House of Representatives,1,independent,"LaPolice, Alan",23,000060
+WASHINGTON,Farmington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000060
+WASHINGTON,Farmington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",4,000060
+WASHINGTON,Farmington Township,United States House of Representatives,1,Republican,"Marshall, Roger",51,000060
+WASHINGTON,Franklin Township,United States House of Representatives,1,independent,"LaPolice, Alan",14,000070
+WASHINGTON,Franklin Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000070
+WASHINGTON,Franklin Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000070
+WASHINGTON,Franklin Township,United States House of Representatives,1,Republican,"Marshall, Roger",42,000070
+WASHINGTON,Grant Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000080
+WASHINGTON,Grant Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000080
+WASHINGTON,Grant Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000080
+WASHINGTON,Grant Township,United States House of Representatives,1,Republican,"Marshall, Roger",12,000080
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,independent,"LaPolice, Alan",51,000090
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000090
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000090
+WASHINGTON,Greenleaf Township,United States House of Representatives,1,Republican,"Marshall, Roger",86,000090
+WASHINGTON,Haddam Township,United States House of Representatives,1,independent,"LaPolice, Alan",38,000100
+WASHINGTON,Haddam Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000100
+WASHINGTON,Haddam Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000100
+WASHINGTON,Haddam Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000100
+WASHINGTON,Hanover Township,United States House of Representatives,1,independent,"LaPolice, Alan",102,000110
+WASHINGTON,Hanover Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000110
+WASHINGTON,Hanover Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",12,000110
+WASHINGTON,Hanover Township,United States House of Representatives,1,Republican,"Marshall, Roger",282,000110
+WASHINGTON,Highland Township,United States House of Representatives,1,independent,"LaPolice, Alan",5,000120
+WASHINGTON,Highland Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000120
+WASHINGTON,Highland Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000120
+WASHINGTON,Highland Township,United States House of Representatives,1,Republican,"Marshall, Roger",7,000120
+WASHINGTON,Independence Township,United States House of Representatives,1,independent,"LaPolice, Alan",11,000130
+WASHINGTON,Independence Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000130
+WASHINGTON,Independence Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000130
+WASHINGTON,Independence Township,United States House of Representatives,1,Republican,"Marshall, Roger",50,000130
+WASHINGTON,Kimeo Township,United States House of Representatives,1,independent,"LaPolice, Alan",15,000140
+WASHINGTON,Kimeo Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000140
+WASHINGTON,Kimeo Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000140
+WASHINGTON,Kimeo Township,United States House of Representatives,1,Republican,"Marshall, Roger",22,000140
+WASHINGTON,Lincoln Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000150
+WASHINGTON,Lincoln Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000150
+WASHINGTON,Lincoln Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000150
+WASHINGTON,Lincoln Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000150
+WASHINGTON,Linn Township,United States House of Representatives,1,independent,"LaPolice, Alan",79,000160
+WASHINGTON,Linn Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000160
+WASHINGTON,Linn Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000160
+WASHINGTON,Linn Township,United States House of Representatives,1,Republican,"Marshall, Roger",145,000160
+WASHINGTON,Little Blue Township,United States House of Representatives,1,independent,"LaPolice, Alan",16,000170
+WASHINGTON,Little Blue Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000170
+WASHINGTON,Little Blue Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",3,000170
+WASHINGTON,Little Blue Township,United States House of Representatives,1,Republican,"Marshall, Roger",18,000170
+WASHINGTON,Logan Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000180
+WASHINGTON,Logan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000180
+WASHINGTON,Logan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000180
+WASHINGTON,Logan Township,United States House of Representatives,1,Republican,"Marshall, Roger",42,000180
+WASHINGTON,Lowe Township,United States House of Representatives,1,independent,"LaPolice, Alan",4,000190
+WASHINGTON,Lowe Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000190
+WASHINGTON,Lowe Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000190
+WASHINGTON,Lowe Township,United States House of Representatives,1,Republican,"Marshall, Roger",23,000190
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,independent,"LaPolice, Alan",31,000200
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000200
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",5,000200
+WASHINGTON,Mill Creek Township,United States House of Representatives,1,Republican,"Marshall, Roger",73,000200
+WASHINGTON,Sheridan Township,United States House of Representatives,1,independent,"LaPolice, Alan",24,000210
+WASHINGTON,Sheridan Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000210
+WASHINGTON,Sheridan Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,000210
+WASHINGTON,Sheridan Township,United States House of Representatives,1,Republican,"Marshall, Roger",25,000210
+WASHINGTON,Sherman Township,United States House of Representatives,1,independent,"LaPolice, Alan",54,000220
+WASHINGTON,Sherman Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000220
+WASHINGTON,Sherman Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000220
+WASHINGTON,Sherman Township,United States House of Representatives,1,Republican,"Marshall, Roger",88,000220
+WASHINGTON,Strawberry Township,United States House of Representatives,1,independent,"LaPolice, Alan",21,000230
+WASHINGTON,Strawberry Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000230
+WASHINGTON,Strawberry Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",1,000230
+WASHINGTON,Strawberry Township,United States House of Representatives,1,Republican,"Marshall, Roger",40,000230
+WASHINGTON,Union Township,United States House of Representatives,1,independent,"LaPolice, Alan",6,000240
+WASHINGTON,Union Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000240
+WASHINGTON,Union Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,000240
+WASHINGTON,Union Township,United States House of Representatives,1,Republican,"Marshall, Roger",31,000240
+WASHINGTON,Washington Township,United States House of Representatives,1,independent,"LaPolice, Alan",28,00025A
+WASHINGTON,Washington Township,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00025A
+WASHINGTON,Washington Township,United States House of Representatives,1,Libertarian,"Burt, Kerry",2,00025A
+WASHINGTON,Washington Township,United States House of Representatives,1,Republican,"Marshall, Roger",87,00025A
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00025B
+WASHINGTON,Washington City,United States House of Representatives,1,independent,"LaPolice, Alan",178,00026A
+WASHINGTON,Washington City,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00026A
+WASHINGTON,Washington City,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,00026A
+WASHINGTON,Washington City,United States House of Representatives,1,Republican,"Marshall, Roger",325,00026A
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,independent,"LaPolice, Alan",0,00026B
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,00026B
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,00026B
+WASHINGTON,Washington City Exclave,United States House of Representatives,1,Republican,"Marshall, Roger",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,independent,"LaPolice, Alan",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,Libertarian,"Burt, Kerry",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States House of Representatives,1,Republican,"Marshall, Roger",0,900010
+WASHINGTON,Barnes Township,United States Senate,,write - in,"Smith, DJ",0,000010
+WASHINGTON,Barnes Township,United States Senate,,Democratic,"Wiesner, Patrick",10,000010
+WASHINGTON,Barnes Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000010
+WASHINGTON,Barnes Township,United States Senate,,Republican,"Moran, Jerry",75,000010
+WASHINGTON,Brantford Township,United States Senate,,write - in,"Smith, DJ",0,000020
+WASHINGTON,Brantford Township,United States Senate,,Democratic,"Wiesner, Patrick",3,000020
+WASHINGTON,Brantford Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000020
+WASHINGTON,Brantford Township,United States Senate,,Republican,"Moran, Jerry",37,000020
+WASHINGTON,Charleston Township,United States Senate,,write - in,"Smith, DJ",0,000030
+WASHINGTON,Charleston Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000030
+WASHINGTON,Charleston Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000030
+WASHINGTON,Charleston Township,United States Senate,,Republican,"Moran, Jerry",30,000030
+WASHINGTON,Clifton Township,United States Senate,,write - in,"Smith, DJ",0,000040
+WASHINGTON,Clifton Township,United States Senate,,Democratic,"Wiesner, Patrick",26,000040
+WASHINGTON,Clifton Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000040
+WASHINGTON,Clifton Township,United States Senate,,Republican,"Moran, Jerry",158,000040
+WASHINGTON,Coleman Township,United States Senate,,write - in,"Smith, DJ",0,000050
+WASHINGTON,Coleman Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000050
+WASHINGTON,Coleman Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000050
+WASHINGTON,Coleman Township,United States Senate,,Republican,"Moran, Jerry",27,000050
+WASHINGTON,Farmington Township,United States Senate,,write - in,"Smith, DJ",0,000060
+WASHINGTON,Farmington Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000060
+WASHINGTON,Farmington Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000060
+WASHINGTON,Farmington Township,United States Senate,,Republican,"Moran, Jerry",64,000060
+WASHINGTON,Franklin Township,United States Senate,,write - in,"Smith, DJ",0,000070
+WASHINGTON,Franklin Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000070
+WASHINGTON,Franklin Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000070
+WASHINGTON,Franklin Township,United States Senate,,Republican,"Moran, Jerry",48,000070
+WASHINGTON,Grant Township,United States Senate,,write - in,"Smith, DJ",0,000080
+WASHINGTON,Grant Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000080
+WASHINGTON,Grant Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000080
+WASHINGTON,Grant Township,United States Senate,,Republican,"Moran, Jerry",15,000080
+WASHINGTON,Greenleaf Township,United States Senate,,write - in,"Smith, DJ",0,000090
+WASHINGTON,Greenleaf Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000090
+WASHINGTON,Greenleaf Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000090
+WASHINGTON,Greenleaf Township,United States Senate,,Republican,"Moran, Jerry",115,000090
+WASHINGTON,Haddam Township,United States Senate,,write - in,"Smith, DJ",0,000100
+WASHINGTON,Haddam Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000100
+WASHINGTON,Haddam Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000100
+WASHINGTON,Haddam Township,United States Senate,,Republican,"Moran, Jerry",69,000100
+WASHINGTON,Hanover Township,United States Senate,,write - in,"Smith, DJ",0,000110
+WASHINGTON,Hanover Township,United States Senate,,Democratic,"Wiesner, Patrick",46,000110
+WASHINGTON,Hanover Township,United States Senate,,Libertarian,"Garrard, Robert D.",12,000110
+WASHINGTON,Hanover Township,United States Senate,,Republican,"Moran, Jerry",356,000110
+WASHINGTON,Highland Township,United States Senate,,write - in,"Smith, DJ",0,000120
+WASHINGTON,Highland Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000120
+WASHINGTON,Highland Township,United States Senate,,Libertarian,"Garrard, Robert D.",0,000120
+WASHINGTON,Highland Township,United States Senate,,Republican,"Moran, Jerry",12,000120
+WASHINGTON,Independence Township,United States Senate,,write - in,"Smith, DJ",0,000130
+WASHINGTON,Independence Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000130
+WASHINGTON,Independence Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000130
+WASHINGTON,Independence Township,United States Senate,,Republican,"Moran, Jerry",54,000130
+WASHINGTON,Kimeo Township,United States Senate,,write - in,"Smith, DJ",0,000140
+WASHINGTON,Kimeo Township,United States Senate,,Democratic,"Wiesner, Patrick",2,000140
+WASHINGTON,Kimeo Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000140
+WASHINGTON,Kimeo Township,United States Senate,,Republican,"Moran, Jerry",34,000140
+WASHINGTON,Lincoln Township,United States Senate,,write - in,"Smith, DJ",0,000150
+WASHINGTON,Lincoln Township,United States Senate,,Democratic,"Wiesner, Patrick",0,000150
+WASHINGTON,Lincoln Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000150
+WASHINGTON,Lincoln Township,United States Senate,,Republican,"Moran, Jerry",26,000150
+WASHINGTON,Linn Township,United States Senate,,write - in,"Smith, DJ",0,000160
+WASHINGTON,Linn Township,United States Senate,,Democratic,"Wiesner, Patrick",16,000160
+WASHINGTON,Linn Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000160
+WASHINGTON,Linn Township,United States Senate,,Republican,"Moran, Jerry",208,000160
+WASHINGTON,Little Blue Township,United States Senate,,write - in,"Smith, DJ",0,000170
+WASHINGTON,Little Blue Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000170
+WASHINGTON,Little Blue Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000170
+WASHINGTON,Little Blue Township,United States Senate,,Republican,"Moran, Jerry",30,000170
+WASHINGTON,Logan Township,United States Senate,,write - in,"Smith, DJ",0,000180
+WASHINGTON,Logan Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000180
+WASHINGTON,Logan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000180
+WASHINGTON,Logan Township,United States Senate,,Republican,"Moran, Jerry",54,000180
+WASHINGTON,Lowe Township,United States Senate,,write - in,"Smith, DJ",0,000190
+WASHINGTON,Lowe Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000190
+WASHINGTON,Lowe Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000190
+WASHINGTON,Lowe Township,United States Senate,,Republican,"Moran, Jerry",30,000190
+WASHINGTON,Mill Creek Township,United States Senate,,write - in,"Smith, DJ",0,000200
+WASHINGTON,Mill Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",7,000200
+WASHINGTON,Mill Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000200
+WASHINGTON,Mill Creek Township,United States Senate,,Republican,"Moran, Jerry",101,000200
+WASHINGTON,Sheridan Township,United States Senate,,write - in,"Smith, DJ",0,000210
+WASHINGTON,Sheridan Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000210
+WASHINGTON,Sheridan Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000210
+WASHINGTON,Sheridan Township,United States Senate,,Republican,"Moran, Jerry",44,000210
+WASHINGTON,Sherman Township,United States Senate,,write - in,"Smith, DJ",0,000220
+WASHINGTON,Sherman Township,United States Senate,,Democratic,"Wiesner, Patrick",8,000220
+WASHINGTON,Sherman Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000220
+WASHINGTON,Sherman Township,United States Senate,,Republican,"Moran, Jerry",134,000220
+WASHINGTON,Strawberry Township,United States Senate,,write - in,"Smith, DJ",0,000230
+WASHINGTON,Strawberry Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000230
+WASHINGTON,Strawberry Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000230
+WASHINGTON,Strawberry Township,United States Senate,,Republican,"Moran, Jerry",51,000230
+WASHINGTON,Union Township,United States Senate,,write - in,"Smith, DJ",0,000240
+WASHINGTON,Union Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000240
+WASHINGTON,Union Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000240
+WASHINGTON,Union Township,United States Senate,,Republican,"Moran, Jerry",34,000240
+WASHINGTON,Washington Township,United States Senate,,write - in,"Smith, DJ",0,00025A
+WASHINGTON,Washington Township,United States Senate,,Democratic,"Wiesner, Patrick",5,00025A
+WASHINGTON,Washington Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,00025A
+WASHINGTON,Washington Township,United States Senate,,Republican,"Moran, Jerry",111,00025A
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,write - in,"Smith, DJ",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00025B
+WASHINGTON,Washington Township Rural Enclave,United States Senate,,Republican,"Moran, Jerry",0,00025B
+WASHINGTON,Washington City,United States Senate,,write - in,"Smith, DJ",0,00026A
+WASHINGTON,Washington City,United States Senate,,Democratic,"Wiesner, Patrick",71,00026A
+WASHINGTON,Washington City,United States Senate,,Libertarian,"Garrard, Robert D.",28,00026A
+WASHINGTON,Washington City,United States Senate,,Republican,"Moran, Jerry",424,00026A
+WASHINGTON,Washington City Exclave,United States Senate,,write - in,"Smith, DJ",0,00026B
+WASHINGTON,Washington City Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00026B
+WASHINGTON,Washington City Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00026B
+WASHINGTON,Washington City Exclave,United States Senate,,Republican,"Moran, Jerry",0,00026B
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,write - in,"Smith, DJ",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+WASHINGTON,Washington Township Rural Enclave B,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/2016/20161108__ks__general__wichita__precinct.csv
+++ b/2016/20161108__ks__general__wichita__precinct.csv
@@ -1,40 +1,109 @@
-county,precinct,office,district,party,candidate,poll_votes,advance_votes,votes
-Wichita,1,President,,REP,Trump and Pence,189,44,233
-Wichita,2,President,,REP,Trump and Pence,245,71,316
-Wichita,3,President,,REP,Trump and Pence,179,37,216
-Wichita,1,President,,DEM,Clinton and Kaine,48,18,66
-Wichita,2,President,,DEM,Clinton and Kaine,38,21,59
-Wichita,3,President,,DEM,Clinton and Kaine,8,6,14
-Wichita,1,President,,LIB,Johnson and Weld,5,0,5
-Wichita,2,President,,LIB,Johnson and Weld,7,3,10
-Wichita,3,President,,LIB,Johnson and Weld,3,0,3
-Wichita,1,President,,IND,Stein and Baraka,4,1,5
-Wichita,2,President,,IND,Stein and Baraka,5,0,5
-Wichita,3,President,,IND,Stein and Baraka,2,0,2
-Wichita,1,U.S. Senate,,DEM,Patrick Wiesner,32,15,47
-Wichita,2,U.S. Senate,,DEM,Patrick Wiesner,33,19,52
-Wichita,3,U.S. Senate,,DEM,Patrick Wiesner,8,7,15
-Wichita,1,U.S. Senate,,LIB,Robert D. Garrard,13,1,14
-Wichita,2,U.S. Senate,,LIB,Robert D. Garrard,12,4,16
-Wichita,3,U.S. Senate,,LIB,Robert D. Garrard,9,1,10
-Wichita,1,U.S. Senate,,REP,Jerry Moran,203,47,250
-Wichita,2,U.S. Senate,,REP,Jerry Moran,256,73,329
-Wichita,3,U.S. Senate,,REP,Jerry Moran,176,33,209
-Wichita,1,U.S. House,1,REP,Roger Marshall,188,40,228
-Wichita,2,U.S. House,1,REP,Roger Marshall,240,73,313
-Wichita,3,U.S. House,1,REP,Roger Marshall,161,33,194
-Wichita,1,U.S. House,1,LIB,Kerry Burt,17,6,23
-Wichita,2,U.S. House,1,LIB,Kerry Burt,11,4,15
-Wichita,3,U.S. House,1,LIB,Kerry Burt,5,1,6
-Wichita,1,U.S. House,1,IND,Alan LaPolice,35,13,48
-Wichita,2,U.S. House,1,IND,Alan LaPolice,41,17,58
-Wichita,3,U.S. House,1,IND,Alan LaPolice,26,5,31
-Wichita,1,State Senate,39,DEM,A. Zacheriah Worf,42,11,53
-Wichita,2,State Senate,39,DEM,A. Zacheriah Worf,33,18,51
-Wichita,3,State Senate,39,DEM,A. Zacheriah Worf,19,2,21
-Wichita,1,State Senate,39,REP,John Doll,198,51,249
-Wichita,2,State Senate,39,REP,John Doll,265,76,341
-Wichita,3,State Senate,39,REP,John Doll,165,39,204
-Wichita,1,State House,118,REP,Don Hineman,230,58,288
-Wichita,2,State House,118,REP,Don Hineman,281,87,368
-Wichita,3,State House,118,REP,Don Hineman,179,40,219
+county,precinct,office,district,party,candidate,votes,vtd
+WICHITA,Leoti Precinct 1,Kansas House of Representatives,118,Republican,"Hineman, Don",290,000010
+WICHITA,Leoti Precinct 2,Kansas House of Representatives,118,Republican,"Hineman, Don",371,000020
+WICHITA,Leoti Precinct 3,Kansas House of Representatives,118,Republican,"Hineman, Don",219,000030
+WICHITA,Leoti Precinct 1,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",53,000010
+WICHITA,Leoti Precinct 1,Kansas Senate,39,Republican,"Doll, John",251,000010
+WICHITA,Leoti Precinct 2,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",51,000020
+WICHITA,Leoti Precinct 2,Kansas Senate,39,Republican,"Doll, John",344,000020
+WICHITA,Leoti Precinct 3,Kansas Senate,39,Democratic,"Worf, A. Zacheriah",21,000030
+WICHITA,Leoti Precinct 3,Kansas Senate,39,Republican,"Doll, John",204,000030
+WICHITA,Leoti Precinct 1,President / Vice President,,independent,"Stein, Jill",5,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Hedges, James A",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"McMullin, Evan",4,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Perry, Darryl",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Smith, Mike",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Sood, Ajay",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",66,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Libertarian,"Johnson, Gary",5,000010
+WICHITA,Leoti Precinct 1,President / Vice President,,Republican,"Trump, Donald J.",235,000010
+WICHITA,Leoti Precinct 2,President / Vice President,,independent,"Stein, Jill",5,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Hedges, James A",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"McMullin, Evan",10,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Perry, Darryl",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Smith, Mike",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Sood, Ajay",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",60,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Libertarian,"Johnson, Gary",10,000020
+WICHITA,Leoti Precinct 2,President / Vice President,,Republican,"Trump, Donald J.",318,000020
+WICHITA,Leoti Precinct 3,President / Vice President,,independent,"Stein, Jill",2,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Hedges, James A",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"McMullin, Evan",3,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Perry, Darryl",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Smith, Mike",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Sood, Ajay",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",14,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Libertarian,"Johnson, Gary",3,000030
+WICHITA,Leoti Precinct 3,President / Vice President,,Republican,"Trump, Donald J.",216,000030
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,independent,"LaPolice, Alan",48,000010
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,write - in,"Huelskamp, Tim",1,000010
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,Libertarian,"Burt, Kerry",23,000010
+WICHITA,Leoti Precinct 1,United States House of Representatives,1,Republican,"Marshall, Roger",230,000010
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,independent,"LaPolice, Alan",58,000020
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,write - in,"Huelskamp, Tim",0,000020
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,Libertarian,"Burt, Kerry",15,000020
+WICHITA,Leoti Precinct 2,United States House of Representatives,1,Republican,"Marshall, Roger",316,000020
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,independent,"LaPolice, Alan",31,000030
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,write - in,"Huelskamp, Tim",2,000030
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,Libertarian,"Burt, Kerry",6,000030
+WICHITA,Leoti Precinct 3,United States House of Representatives,1,Republican,"Marshall, Roger",194,000030
+WICHITA,Leoti Precinct 1,United States Senate,,write - in,"Smith, DJ",0,000010
+WICHITA,Leoti Precinct 1,United States Senate,,Democratic,"Wiesner, Patrick",47,000010
+WICHITA,Leoti Precinct 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000010
+WICHITA,Leoti Precinct 1,United States Senate,,Republican,"Moran, Jerry",252,000010
+WICHITA,Leoti Precinct 2,United States Senate,,write - in,"Smith, DJ",0,000020
+WICHITA,Leoti Precinct 2,United States Senate,,Democratic,"Wiesner, Patrick",52,000020
+WICHITA,Leoti Precinct 2,United States Senate,,Libertarian,"Garrard, Robert D.",16,000020
+WICHITA,Leoti Precinct 2,United States Senate,,Republican,"Moran, Jerry",332,000020
+WICHITA,Leoti Precinct 3,United States Senate,,write - in,"Smith, DJ",0,000030
+WICHITA,Leoti Precinct 3,United States Senate,,Democratic,"Wiesner, Patrick",15,000030
+WICHITA,Leoti Precinct 3,United States Senate,,Libertarian,"Garrard, Robert D.",10,000030
+WICHITA,Leoti Precinct 3,United States Senate,,Republican,"Moran, Jerry",209,000030

--- a/2016/20161108__ks__general__wilson__precinct.csv
+++ b/2016/20161108__ks__general__wilson__precinct.csv
@@ -1,326 +1,1016 @@
-county,precinct,office,district,party,candidate,votes,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,President,,REP,Trump and Pence,774,,,,,,,,,,,,,,,
-Wilson,Cedar,President,,REP,Trump and Pence,139,,,,,,,,,,,,,,,
-Wilson,Center,President,,REP,Trump and Pence,126,,,,,,,,,,,,,,,
-Wilson,Chetopa,President,,REP,Trump and Pence,61,,,,,,,,,,,,,,,
-Wilson,Clifton,President,,REP,Trump and Pence,79,,,,,,,,,,,,,,,
-Wilson,Colfax,President,,REP,Trump and Pence,146,,,,,,,,,,,,,,,
-Wilson,Duck Creek,President,,REP,Trump and Pence,25,,,,,,,,,,,,,,,
-Wilson,Fall River,President,,REP,Trump and Pence,93,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,President,,REP,Trump and Pence,96,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,President,,REP,Trump and Pence,33,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,President,,REP,Trump and Pence,55,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,President,,REP,Trump and Pence,221,,,,,,,,,,,,,,,
-Wilson,Guilford,President,,REP,Trump and Pence,33,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,President,,REP,Trump and Pence,159,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,President,,REP,Trump and Pence,112,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,President,,REP,Trump and Pence,97,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,President,,REP,Trump and Pence,97,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,President,,REP,Trump and Pence,188,,,,,,,,,,,,,,,
-Wilson,Newark,President,,REP,Trump and Pence,74,,,,,,,,,,,,,,,
-Wilson,Pleasant,President,,REP,Trump and Pence,63,,,,,,,,,,,,,,,
-Wilson,Prairie,President,,REP,Trump and Pence,22,,,,,,,,,,,,,,,
-Wilson,Talleyrand,President,,REP,Trump and Pence,48,,,,,,,,,,,,,,,
-Wilson,Verdigris,President,,REP,Trump and Pence,40,,,,,,,,,,,,,,,
-Wilson,Webster,President,,REP,Trump and Pence,7,,,,,,,,,,,,,,,
-Wilson,Total,President,,REP,Trump and Pence,2788,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,President,,DEM,Clinton and Kaine,227,,,,,,,,,,,,,,,
-Wilson,Cedar,President,,DEM,Clinton and Kaine,14,,,,,,,,,,,,,,,
-Wilson,Center,President,,DEM,Clinton and Kaine,23,,,,,,,,,,,,,,,
-Wilson,Chetopa,President,,DEM,Clinton and Kaine,2,,,,,,,,,,,,,,,
-Wilson,Clifton,President,,DEM,Clinton and Kaine,16,,,,,,,,,,,,,,,
-Wilson,Colfax,President,,DEM,Clinton and Kaine,19,,,,,,,,,,,,,,,
-Wilson,Duck Creek,President,,DEM,Clinton and Kaine,1,,,,,,,,,,,,,,,
-Wilson,Fall River,President,,DEM,Clinton and Kaine,1,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,President,,DEM,Clinton and Kaine,23,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,President,,DEM,Clinton and Kaine,5,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,President,,DEM,Clinton and Kaine,3,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,President,,DEM,Clinton and Kaine,47,,,,,,,,,,,,,,,
-Wilson,Guilford,President,,DEM,Clinton and Kaine,1,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,President,,DEM,Clinton and Kaine,28,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,President,,DEM,Clinton and Kaine,24,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,President,,DEM,Clinton and Kaine,38,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,President,,DEM,Clinton and Kaine,30,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,President,,DEM,Clinton and Kaine,55,,,,,,,,,,,,,,,
-Wilson,Newark,President,,DEM,Clinton and Kaine,4,,,,,,,,,,,,,,,
-Wilson,Pleasant,President,,DEM,Clinton and Kaine,10,,,,,,,,,,,,,,,
-Wilson,Prairie,President,,DEM,Clinton and Kaine,2,,,,,,,,,,,,,,,
-Wilson,Talleyrand,President,,DEM,Clinton and Kaine,10,,,,,,,,,,,,,,,
-Wilson,Verdigris,President,,DEM,Clinton and Kaine,9,,,,,,,,,,,,,,,
-Wilson,Webster,President,,DEM,Clinton and Kaine,2,,,,,,,,,,,,,,,
-Wilson,Total,President,,DEM,Clinton and Kaine,594,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,President,,LBT,Johnson and Weld,34,,,,,,,,,,,,,,,
-Wilson,Cedar,President,,LBT,Johnson and Weld,6,,,,,,,,,,,,,,,
-Wilson,Center,President,,LBT,Johnson and Weld,4,,,,,,,,,,,,,,,
-Wilson,Chetopa,President,,LBT,Johnson and Weld,2,,,,,,,,,,,,,,,
-Wilson,Clifton,President,,LBT,Johnson and Weld,3,,,,,,,,,,,,,,,
-Wilson,Colfax,President,,LBT,Johnson and Weld,8,,,,,,,,,,,,,,,
-Wilson,Duck Creek,President,,LBT,Johnson and Weld,0,,,,,,,,,,,,,,,
-Wilson,Fall River,President,,LBT,Johnson and Weld,0,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,President,,LBT,Johnson and Weld,5,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,President,,LBT,Johnson and Weld,2,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,President,,LBT,Johnson and Weld,4,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,President,,LBT,Johnson and Weld,11,,,,,,,,,,,,,,,
-Wilson,Guilford,President,,LBT,Johnson and Weld,0,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,President,,LBT,Johnson and Weld,6,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,President,,LBT,Johnson and Weld,6,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,President,,LBT,Johnson and Weld,6,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,President,,LBT,Johnson and Weld,5,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,President,,LBT,Johnson and Weld,20,,,,,,,,,,,,,,,
-Wilson,Newark,President,,LBT,Johnson and Weld,4,,,,,,,,,,,,,,,
-Wilson,Pleasant,President,,LBT,Johnson and Weld,3,,,,,,,,,,,,,,,
-Wilson,Prairie,President,,LBT,Johnson and Weld,2,,,,,,,,,,,,,,,
-Wilson,Talleyrand,President,,LBT,Johnson and Weld,1,,,,,,,,,,,,,,,
-Wilson,Verdigris,President,,LBT,Johnson and Weld,1,,,,,,,,,,,,,,,
-Wilson,Webster,President,,LBT,Johnson and Weld,2,,,,,,,,,,,,,,,
-Wilson,Total,President,,LBT,Johnson and Weld,135,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,President,,IND,Stein and Baraka,18,,,,,,,,,,,,,,,
-Wilson,Cedar,President,,IND,Stein and Baraka,3,,,,,,,,,,,,,,,
-Wilson,Center,President,,IND,Stein and Baraka,3,,,,,,,,,,,,,,,
-Wilson,Chetopa,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Clifton,President,,IND,Stein and Baraka,1,,,,,,,,,,,,,,,
-Wilson,Colfax,President,,IND,Stein and Baraka,4,,,,,,,,,,,,,,,
-Wilson,Duck Creek,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Fall River,President,,IND,Stein and Baraka,2,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,President,,IND,Stein and Baraka,1,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,President,,IND,Stein and Baraka,1,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,President,,IND,Stein and Baraka,3,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,President,,IND,Stein and Baraka,6,,,,,,,,,,,,,,,
-Wilson,Guilford,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,President,,IND,Stein and Baraka,2,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,President,,IND,Stein and Baraka,2,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,President,,IND,Stein and Baraka,6,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,President,,IND,Stein and Baraka,2,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Newark,President,,IND,Stein and Baraka,4,,,,,,,,,,,,,,,
-Wilson,Pleasant,President,,IND,Stein and Baraka,1,,,,,,,,,,,,,,,
-Wilson,Prairie,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Talleyrand,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Verdigris,President,,IND,Stein and Baraka,1,,,,,,,,,,,,,,,
-Wilson,Webster,President,,IND,Stein and Baraka,0,,,,,,,,,,,,,,,
-Wilson,Total,President,,IND,Stein and Baraka,60,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,U.S. Senate,,DEM,Patrick Wiesner,189,,,,,,,,,,,,,,,
-Wilson,Cedar,U.S. Senate,,DEM,Patrick Wiesner,14,,,,,,,,,,,,,,,
-Wilson,Center,U.S. Senate,,DEM,Patrick Wiesner,21,,,,,,,,,,,,,,,
-Wilson,Chetopa,U.S. Senate,,DEM,Patrick Wiesner,5,,,,,,,,,,,,,,,
-Wilson,Clifton,U.S. Senate,,DEM,Patrick Wiesner,20,,,,,,,,,,,,,,,
-Wilson,Colfax,U.S. Senate,,DEM,Patrick Wiesner,23,,,,,,,,,,,,,,,
-Wilson,Duck Creek,U.S. Senate,,DEM,Patrick Wiesner,0,,,,,,,,,,,,,,,
-Wilson,Fall River,U.S. Senate,,DEM,Patrick Wiesner,3,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,U.S. Senate,,DEM,Patrick Wiesner,20,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,U.S. Senate,,DEM,Patrick Wiesner,9,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,U.S. Senate,,DEM,Patrick Wiesner,6,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,U.S. Senate,,DEM,Patrick Wiesner,37,,,,,,,,,,,,,,,
-Wilson,Guilford,U.S. Senate,,DEM,Patrick Wiesner,2,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,U.S. Senate,,DEM,Patrick Wiesner,24,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,U.S. Senate,,DEM,Patrick Wiesner,24,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,U.S. Senate,,DEM,Patrick Wiesner,41,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,U.S. Senate,,DEM,Patrick Wiesner,21,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,U.S. Senate,,DEM,Patrick Wiesner,53,,,,,,,,,,,,,,,
-Wilson,Newark,U.S. Senate,,DEM,Patrick Wiesner,7,,,,,,,,,,,,,,,
-Wilson,Pleasant,U.S. Senate,,DEM,Patrick Wiesner,8,,,,,,,,,,,,,,,
-Wilson,Prairie,U.S. Senate,,DEM,Patrick Wiesner,1,,,,,,,,,,,,,,,
-Wilson,Talleyrand,U.S. Senate,,DEM,Patrick Wiesner,7,,,,,,,,,,,,,,,
-Wilson,Verdigris,U.S. Senate,,DEM,Patrick Wiesner,6,,,,,,,,,,,,,,,
-Wilson,Webster,U.S. Senate,,DEM,Patrick Wiesner,3,,,,,,,,,,,,,,,
-Wilson,Total,U.S. Senate,,DEM,Patrick Wiesner,189,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,U.S. Senate,,LBT,Robert D. Garrard,71,,,,,,,,,,,,,,,
-Wilson,Cedar,U.S. Senate,,LBT,Robert D. Garrard,6,,,,,,,,,,,,,,,
-Wilson,Center,U.S. Senate,,LBT,Robert D. Garrard,6,,,,,,,,,,,,,,,
-Wilson,Chetopa,U.S. Senate,,LBT,Robert D. Garrard,4,,,,,,,,,,,,,,,
-Wilson,Clifton,U.S. Senate,,LBT,Robert D. Garrard,5,,,,,,,,,,,,,,,
-Wilson,Colfax,U.S. Senate,,LBT,Robert D. Garrard,10,,,,,,,,,,,,,,,
-Wilson,Duck Creek,U.S. Senate,,LBT,Robert D. Garrard,1,,,,,,,,,,,,,,,
-Wilson,Fall River,U.S. Senate,,LBT,Robert D. Garrard,3,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,U.S. Senate,,LBT,Robert D. Garrard,6,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,U.S. Senate,,LBT,Robert D. Garrard,2,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,U.S. Senate,,LBT,Robert D. Garrard,2,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,U.S. Senate,,LBT,Robert D. Garrard,11,,,,,,,,,,,,,,,
-Wilson,Guilford,U.S. Senate,,LBT,Robert D. Garrard,1,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,U.S. Senate,,LBT,Robert D. Garrard,9,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,U.S. Senate,,LBT,Robert D. Garrard,14,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,U.S. Senate,,LBT,Robert D. Garrard,9,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,U.S. Senate,,LBT,Robert D. Garrard,12,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,U.S. Senate,,LBT,Robert D. Garrard,24,,,,,,,,,,,,,,,
-Wilson,Newark,U.S. Senate,,LBT,Robert D. Garrard,1,,,,,,,,,,,,,,,
-Wilson,Pleasant,U.S. Senate,,LBT,Robert D. Garrard,4,,,,,,,,,,,,,,,
-Wilson,Prairie,U.S. Senate,,LBT,Robert D. Garrard,1,,,,,,,,,,,,,,,
-Wilson,Talleyrand,U.S. Senate,,LBT,Robert D. Garrard,4,,,,,,,,,,,,,,,
-Wilson,Verdigris,U.S. Senate,,LBT,Robert D. Garrard,6,,,,,,,,,,,,,,,
-Wilson,Webster,U.S. Senate,,LBT,Robert D. Garrard,0,,,,,,,,,,,,,,,
-Wilson,Total,U.S. Senate,,LBT,Robert D. Garrard,212,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,U.S. Senate,,REP,Jerry Moran,787,,,,,,,,,,,,,,,
-Wilson,Cedar,U.S. Senate,,REP,Jerry Moran,142,,,,,,,,,,,,,,,
-Wilson,Center,U.S. Senate,,REP,Jerry Moran,126,,,,,,,,,,,,,,,
-Wilson,Chetopa,U.S. Senate,,REP,Jerry Moran,56,,,,,,,,,,,,,,,
-Wilson,Clifton,U.S. Senate,,REP,Jerry Moran,70,,,,,,,,,,,,,,,
-Wilson,Colfax,U.S. Senate,,REP,Jerry Moran,141,,,,,,,,,,,,,,,
-Wilson,Duck Creek,U.S. Senate,,REP,Jerry Moran,24,,,,,,,,,,,,,,,
-Wilson,Fall River,U.S. Senate,,REP,Jerry Moran,89,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,U.S. Senate,,REP,Jerry Moran,102,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,U.S. Senate,,REP,Jerry Moran,30,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,U.S. Senate,,REP,Jerry Moran,54,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,U.S. Senate,,REP,Jerry Moran,240,,,,,,,,,,,,,,,
-Wilson,Guilford,U.S. Senate,,REP,Jerry Moran,32,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,U.S. Senate,,REP,Jerry Moran,162,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,U.S. Senate,,REP,Jerry Moran,104,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,U.S. Senate,,REP,Jerry Moran,98,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,U.S. Senate,,REP,Jerry Moran,100,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,U.S. Senate,,REP,Jerry Moran,189,,,,,,,,,,,,,,,
-Wilson,Newark,U.S. Senate,,REP,Jerry Moran,78,,,,,,,,,,,,,,,
-Wilson,Pleasant,U.S. Senate,,REP,Jerry Moran,65,,,,,,,,,,,,,,,
-Wilson,Prairie,U.S. Senate,,REP,Jerry Moran,24,,,,,,,,,,,,,,,
-Wilson,Talleyrand,U.S. Senate,,REP,Jerry Moran,47,,,,,,,,,,,,,,,
-Wilson,Verdigris,U.S. Senate,,REP,Jerry Moran,38,,,,,,,,,,,,,,,
-Wilson,Webster,U.S. Senate,,REP,Jerry Moran,8,,,,,,,,,,,,,,,
-Wilson,Total,U.S. Senate,,REP,Jerry Moran,2806,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,U.S. House,2,DEM,Brittani Potter,175,,,,,,,,,,,,,,,
-Wilson,Cedar,U.S. House,2,DEM,Brittani Potter,16,,,,,,,,,,,,,,,
-Wilson,Center,U.S. House,2,DEM,Brittani Potter,21,,,,,,,,,,,,,,,
-Wilson,Chetopa,U.S. House,2,DEM,Brittani Potter,4,,,,,,,,,,,,,,,
-Wilson,Clifton,U.S. House,2,DEM,Brittani Potter,19,,,,,,,,,,,,,,,
-Wilson,Colfax,U.S. House,2,DEM,Brittani Potter,18,,,,,,,,,,,,,,,
-Wilson,Duck Creek,U.S. House,2,DEM,Brittani Potter,1,,,,,,,,,,,,,,,
-Wilson,Fall River,U.S. House,2,DEM,Brittani Potter,1,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,U.S. House,2,DEM,Brittani Potter,17,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,U.S. House,2,DEM,Brittani Potter,6,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,U.S. House,2,DEM,Brittani Potter,9,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,U.S. House,2,DEM,Brittani Potter,41,,,,,,,,,,,,,,,
-Wilson,Guilford,U.S. House,2,DEM,Brittani Potter,3,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,U.S. House,2,DEM,Brittani Potter,16,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,U.S. House,2,DEM,Brittani Potter,24,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,U.S. House,2,DEM,Brittani Potter,41,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,U.S. House,2,DEM,Brittani Potter,24,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,U.S. House,2,DEM,Brittani Potter,39,,,,,,,,,,,,,,,
-Wilson,Newark,U.S. House,2,DEM,Brittani Potter,8,,,,,,,,,,,,,,,
-Wilson,Pleasant,U.S. House,2,DEM,Brittani Potter,9,,,,,,,,,,,,,,,
-Wilson,Prairie,U.S. House,2,DEM,Brittani Potter,2,,,,,,,,,,,,,,,
-Wilson,Talleyrand,U.S. House,2,DEM,Brittani Potter,8,,,,,,,,,,,,,,,
-Wilson,Verdigris,U.S. House,2,DEM,Brittani Potter,7,,,,,,,,,,,,,,,
-Wilson,Webster,U.S. House,2,DEM,Brittani Potter,4,,,,,,,,,,,,,,,
-Wilson,Total,U.S. House,2,DEM,Brittani Potter,513,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,U.S. House,2,LBT,James Houston Bales,46,,,,,,,,,,,,,,,
-Wilson,Cedar,U.S. House,2,LBT,James Houston Bales,6,,,,,,,,,,,,,,,
-Wilson,Center,U.S. House,2,LBT,James Houston Bales,5,,,,,,,,,,,,,,,
-Wilson,Chetopa,U.S. House,2,LBT,James Houston Bales,6,,,,,,,,,,,,,,,
-Wilson,Clifton,U.S. House,2,LBT,James Houston Bales,7,,,,,,,,,,,,,,,
-Wilson,Colfax,U.S. House,2,LBT,James Houston Bales,7,,,,,,,,,,,,,,,
-Wilson,Duck Creek,U.S. House,2,LBT,James Houston Bales,1,,,,,,,,,,,,,,,
-Wilson,Fall River,U.S. House,2,LBT,James Houston Bales,5,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,U.S. House,2,LBT,James Houston Bales,8,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,U.S. House,2,LBT,James Houston Bales,1,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,U.S. House,2,LBT,James Houston Bales,2,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,U.S. House,2,LBT,James Houston Bales,10,,,,,,,,,,,,,,,
-Wilson,Guilford,U.S. House,2,LBT,James Houston Bales,0,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,U.S. House,2,LBT,James Houston Bales,7,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,U.S. House,2,LBT,James Houston Bales,7,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,U.S. House,2,LBT,James Houston Bales,12,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,U.S. House,2,LBT,James Houston Bales,10,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,U.S. House,2,LBT,James Houston Bales,17,,,,,,,,,,,,,,,
-Wilson,Newark,U.S. House,2,LBT,James Houston Bales,2,,,,,,,,,,,,,,,
-Wilson,Pleasant,U.S. House,2,LBT,James Houston Bales,1,,,,,,,,,,,,,,,
-Wilson,Prairie,U.S. House,2,LBT,James Houston Bales,1,,,,,,,,,,,,,,,
-Wilson,Talleyrand,U.S. House,2,LBT,James Houston Bales,3,,,,,,,,,,,,,,,
-Wilson,Verdigris,U.S. House,2,LBT,James Houston Bales,3,,,,,,,,,,,,,,,
-Wilson,Webster,U.S. House,2,LBT,James Houston Bales,0,,,,,,,,,,,,,,,
-Wilson,Total,U.S. House,2,LBT,James Houston Bales,167,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,U.S. House,2,REP,Lynn Jenkins,840,,,,,,,,,,,,,,,
-Wilson,Cedar,U.S. House,2,REP,Lynn Jenkins,143,,,,,,,,,,,,,,,
-Wilson,Center,U.S. House,2,REP,Lynn Jenkins,129,,,,,,,,,,,,,,,
-Wilson,Chetopa,U.S. House,2,REP,Lynn Jenkins,55,,,,,,,,,,,,,,,
-Wilson,Clifton,U.S. House,2,REP,Lynn Jenkins,71,,,,,,,,,,,,,,,
-Wilson,Colfax,U.S. House,2,REP,Lynn Jenkins,151,,,,,,,,,,,,,,,
-Wilson,Duck Creek,U.S. House,2,REP,Lynn Jenkins,23,,,,,,,,,,,,,,,
-Wilson,Fall River,U.S. House,2,REP,Lynn Jenkins,89,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,U.S. House,2,REP,Lynn Jenkins,99,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,U.S. House,2,REP,Lynn Jenkins,34,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,U.S. House,2,REP,Lynn Jenkins,52,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,U.S. House,2,REP,Lynn Jenkins,234,,,,,,,,,,,,,,,
-Wilson,Guilford,U.S. House,2,REP,Lynn Jenkins,32,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,U.S. House,2,REP,Lynn Jenkins,176,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,U.S. House,2,REP,Lynn Jenkins,113,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,U.S. House,2,REP,Lynn Jenkins,97,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,U.S. House,2,REP,Lynn Jenkins,100,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,U.S. House,2,REP,Lynn Jenkins,211,,,,,,,,,,,,,,,
-Wilson,Newark,U.S. House,2,REP,Lynn Jenkins,76,,,,,,,,,,,,,,,
-Wilson,Pleasant,U.S. House,2,REP,Lynn Jenkins,67,,,,,,,,,,,,,,,
-Wilson,Prairie,U.S. House,2,REP,Lynn Jenkins,23,,,,,,,,,,,,,,,
-Wilson,Talleyrand,U.S. House,2,REP,Lynn Jenkins,48,,,,,,,,,,,,,,,
-Wilson,Verdigris,U.S. House,2,REP,Lynn Jenkins,40,,,,,,,,,,,,,,,
-Wilson,Webster,U.S. House,2,REP,Lynn Jenkins,7,,,,,,,,,,,,,,,
-Wilson,Total,U.S. House,2,REP,Lynn Jenkins,2910,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,State Senate,14,DEM,Mark Pringle,295,,,,,,,,,,,,,,,
-Wilson,Cedar,State Senate,14,DEM,Mark Pringle,38,,,,,,,,,,,,,,,
-Wilson,Center,State Senate,14,DEM,Mark Pringle,34,,,,,,,,,,,,,,,
-Wilson,Chetopa,State Senate,14,DEM,Mark Pringle,17,,,,,,,,,,,,,,,
-Wilson,Clifton,State Senate,14,DEM,Mark Pringle,53,,,,,,,,,,,,,,,
-Wilson,Colfax,State Senate,14,DEM,Mark Pringle,67,,,,,,,,,,,,,,,
-Wilson,Duck Creek,State Senate,14,DEM,Mark Pringle,4,,,,,,,,,,,,,,,
-Wilson,Fall River,State Senate,14,DEM,Mark Pringle,11,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,State Senate,14,DEM,Mark Pringle,33,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,State Senate,14,DEM,Mark Pringle,11,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,State Senate,14,DEM,Mark Pringle,13,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,State Senate,14,DEM,Mark Pringle,65,,,,,,,,,,,,,,,
-Wilson,Guilford,State Senate,14,DEM,Mark Pringle,5,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,State Senate,14,DEM,Mark Pringle,38,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,State Senate,14,DEM,Mark Pringle,31,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,State Senate,14,DEM,Mark Pringle,44,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,State Senate,14,DEM,Mark Pringle,24,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,State Senate,14,DEM,Mark Pringle,44,,,,,,,,,,,,,,,
-Wilson,Newark,State Senate,14,DEM,Mark Pringle,15,,,,,,,,,,,,,,,
-Wilson,Pleasant,State Senate,14,DEM,Mark Pringle,30,,,,,,,,,,,,,,,
-Wilson,Prairie,State Senate,14,DEM,Mark Pringle,2,,,,,,,,,,,,,,,
-Wilson,Talleyrand,State Senate,14,DEM,Mark Pringle,13,,,,,,,,,,,,,,,
-Wilson,Verdigris,State Senate,14,DEM,Mark Pringle,14,,,,,,,,,,,,,,,
-Wilson,Webster,State Senate,14,DEM,Mark Pringle,1,,,,,,,,,,,,,,,
-Wilson,Total,State Senate,14,DEM,Mark Pringle,902,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,State Senate,14,REP,Bruce Givens,745,,,,,,,,,,,,,,,
-Wilson,Cedar,State Senate,14,REP,Bruce Givens,123,,,,,,,,,,,,,,,
-Wilson,Center,State Senate,14,REP,Bruce Givens,120,,,,,,,,,,,,,,,
-Wilson,Chetopa,State Senate,14,REP,Bruce Givens,48,,,,,,,,,,,,,,,
-Wilson,Clifton,State Senate,14,REP,Bruce Givens,45,,,,,,,,,,,,,,,
-Wilson,Colfax,State Senate,14,REP,Bruce Givens,104,,,,,,,,,,,,,,,
-Wilson,Duck Creek,State Senate,14,REP,Bruce Givens,19,,,,,,,,,,,,,,,
-Wilson,Fall River,State Senate,14,REP,Bruce Givens,82,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,State Senate,14,REP,Bruce Givens,96,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,State Senate,14,REP,Bruce Givens,30,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,State Senate,14,REP,Bruce Givens,52,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,State Senate,14,REP,Bruce Givens,218,,,,,,,,,,,,,,,
-Wilson,Guilford,State Senate,14,REP,Bruce Givens,31,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,State Senate,14,REP,Bruce Givens,153,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,State Senate,14,REP,Bruce Givens,109,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,State Senate,14,REP,Bruce Givens,100,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,State Senate,14,REP,Bruce Givens,108,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,State Senate,14,REP,Bruce Givens,220,,,,,,,,,,,,,,,
-Wilson,Newark,State Senate,14,REP,Bruce Givens,69,,,,,,,,,,,,,,,
-Wilson,Pleasant,State Senate,14,REP,Bruce Givens,43,,,,,,,,,,,,,,,
-Wilson,Prairie,State Senate,14,REP,Bruce Givens,24,,,,,,,,,,,,,,,
-Wilson,Talleyrand,State Senate,14,REP,Bruce Givens,43,,,,,,,,,,,,,,,
-Wilson,Verdigris,State Senate,14,REP,Bruce Givens,36,,,,,,,,,,,,,,,
-Wilson,Webster,State Senate,14,REP,Bruce Givens,10,,,,,,,,,,,,,,,
-Wilson,Total,State Senate,14,REP,Bruce Givens,2628,,,,,,,,,,,,,,,
-Wilson,Advance/Provisional,State House,13,REP,Larry P. Hibbard,941,,,,,,,,,,,,,,,
-Wilson,Cedar,State House,13,REP,Larry P. Hibbard,152,,,,,,,,,,,,,,,
-Wilson,Center,State House,13,REP,Larry P. Hibbard,144,,,,,,,,,,,,,,,
-Wilson,Chetopa,State House,13,REP,Larry P. Hibbard,62,,,,,,,,,,,,,,,
-Wilson,Clifton,State House,13,REP,Larry P. Hibbard,87,,,,,,,,,,,,,,,
-Wilson,Colfax,State House,13,REP,Larry P. Hibbard,147,,,,,,,,,,,,,,,
-Wilson,Duck Creek,State House,13,REP,Larry P. Hibbard,25,,,,,,,,,,,,,,,
-Wilson,Fall River,State House,13,REP,Larry P. Hibbard,91,,,,,,,,,,,,,,,
-Wilson,Fredonia 1,State House,13,REP,Larry P. Hibbard,116,,,,,,,,,,,,,,,
-Wilson,Fredonia 2,State House,13,REP,Larry P. Hibbard,37,,,,,,,,,,,,,,,
-Wilson,Fredonia 3,State House,13,REP,Larry P. Hibbard,58,,,,,,,,,,,,,,,
-Wilson,Fredonia 4,State House,13,REP,Larry P. Hibbard,268,,,,,,,,,,,,,,,
-Wilson,Guilford,State House,13,REP,Larry P. Hibbard,32,,,,,,,,,,,,,,,
-Wilson,Neodesha Twp,State House,13,REP,Larry P. Hibbard,179,,,,,,,,,,,,,,,
-Wilson,Neodesha 1,State House,13,REP,Larry P. Hibbard,127,,,,,,,,,,,,,,,
-Wilson,Neodesha 2,State House,13,REP,Larry P. Hibbard,130,,,,,,,,,,,,,,,
-Wilson,Neodesha 3,State House,13,REP,Larry P. Hibbard,116,,,,,,,,,,,,,,,
-Wilson,Neodesha 4,State House,13,REP,Larry P. Hibbard,242,,,,,,,,,,,,,,,
-Wilson,Newark,State House,13,REP,Larry P. Hibbard,80,,,,,,,,,,,,,,,
-Wilson,Pleasant,State House,13,REP,Larry P. Hibbard,64,,,,,,,,,,,,,,,
-Wilson,Prairie,State House,13,REP,Larry P. Hibbard,26,,,,,,,,,,,,,,,
-Wilson,Talleyrand,State House,13,REP,Larry P. Hibbard,52,,,,,,,,,,,,,,,
-Wilson,Verdigris,State House,13,REP,Larry P. Hibbard,44,,,,,,,,,,,,,,,
-Wilson,Webster,State House,13,REP,Larry P. Hibbard,9,,,,,,,,,,,,,,,
-Wilson,Total,State House,13,REP,Larry P. Hibbard,3229,,,,,,,,,,,,,,,
+county,precinct,office,district,party,candidate,votes,vtd
+WILSON,Cedar Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",193,000010
+WILSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",241,000020
+WILSON,Chetopa Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",81,000030
+WILSON,Clifton Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",110,000040
+WILSON,Colfax Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",178,000050
+WILSON,Duck Creek Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",33,000060
+WILSON,Fall River Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",160,000070
+WILSON,Fredonia Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",219,000080
+WILSON,Fredonia Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",78,000090
+WILSON,Fredonia Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",95,00010A
+WILSON,Fredonia Ward 3 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,00010B
+WILSON,Fredonia Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",431,000110
+WILSON,Guilford Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",63,000120
+WILSON,Neodesha Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",210,000130
+WILSON,Neodesha Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",144,00014A
+WILSON,Neodesha Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,00014B
+WILSON,Neodesha Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",157,000150
+WILSON,Neodesha Ward 3,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",139,000160
+WILSON,Neodesha Ward 4,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",287,000170
+WILSON,Newark Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",95,000180
+WILSON,Pleasant Valley Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",76,000190
+WILSON,Prairie Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",54,000200
+WILSON,Talleyrand Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",72,000210
+WILSON,Verdigris Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",90,000220
+WILSON,Webster Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",23,000230
+WILSON,Neodesha Ward 1 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900030
+WILSON,Neodesha Ward 4 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900040
+WILSON,Cedar Township,Kansas Senate,14,Democratic,"Pringle, Mark",46,000010
+WILSON,Cedar Township,Kansas Senate,14,Republican,"Givens, Bruce",156,000010
+WILSON,Center Township,Kansas Senate,14,Democratic,"Pringle, Mark",57,000020
+WILSON,Center Township,Kansas Senate,14,Republican,"Givens, Bruce",195,000020
+WILSON,Chetopa Township,Kansas Senate,14,Democratic,"Pringle, Mark",22,000030
+WILSON,Chetopa Township,Kansas Senate,14,Republican,"Givens, Bruce",62,000030
+WILSON,Clifton Township,Kansas Senate,14,Democratic,"Pringle, Mark",64,000040
+WILSON,Clifton Township,Kansas Senate,14,Republican,"Givens, Bruce",60,000040
+WILSON,Colfax Township,Kansas Senate,14,Democratic,"Pringle, Mark",91,000050
+WILSON,Colfax Township,Kansas Senate,14,Republican,"Givens, Bruce",124,000050
+WILSON,Duck Creek Township,Kansas Senate,14,Democratic,"Pringle, Mark",8,000060
+WILSON,Duck Creek Township,Kansas Senate,14,Republican,"Givens, Bruce",25,000060
+WILSON,Fall River Township,Kansas Senate,14,Democratic,"Pringle, Mark",27,000070
+WILSON,Fall River Township,Kansas Senate,14,Republican,"Givens, Bruce",151,000070
+WILSON,Fredonia Ward 1,Kansas Senate,14,Democratic,"Pringle, Mark",59,000080
+WILSON,Fredonia Ward 1,Kansas Senate,14,Republican,"Givens, Bruce",177,000080
+WILSON,Fredonia Ward 2,Kansas Senate,14,Democratic,"Pringle, Mark",21,000090
+WILSON,Fredonia Ward 2,Kansas Senate,14,Republican,"Givens, Bruce",63,000090
+WILSON,Fredonia Ward 3,Kansas Senate,14,Democratic,"Pringle, Mark",22,00010A
+WILSON,Fredonia Ward 3,Kansas Senate,14,Republican,"Givens, Bruce",83,00010A
+WILSON,Fredonia Ward 3 Exclave,Kansas Senate,14,Democratic,"Pringle, Mark",0,00010B
+WILSON,Fredonia Ward 3 Exclave,Kansas Senate,14,Republican,"Givens, Bruce",0,00010B
+WILSON,Fredonia Ward 4,Kansas Senate,14,Democratic,"Pringle, Mark",108,000110
+WILSON,Fredonia Ward 4,Kansas Senate,14,Republican,"Givens, Bruce",345,000110
+WILSON,Guilford Township,Kansas Senate,14,Democratic,"Pringle, Mark",13,000120
+WILSON,Guilford Township,Kansas Senate,14,Republican,"Givens, Bruce",55,000120
+WILSON,Neodesha Township,Kansas Senate,14,Democratic,"Pringle, Mark",45,000130
+WILSON,Neodesha Township,Kansas Senate,14,Republican,"Givens, Bruce",181,000130
+WILSON,Neodesha Ward 1,Kansas Senate,14,Democratic,"Pringle, Mark",38,00014A
+WILSON,Neodesha Ward 1,Kansas Senate,14,Republican,"Givens, Bruce",122,00014A
+WILSON,Neodesha Ward 1 Exclave,Kansas Senate,14,Democratic,"Pringle, Mark",0,00014B
+WILSON,Neodesha Ward 1 Exclave,Kansas Senate,14,Republican,"Givens, Bruce",0,00014B
+WILSON,Neodesha Ward 2,Kansas Senate,14,Democratic,"Pringle, Mark",57,000150
+WILSON,Neodesha Ward 2,Kansas Senate,14,Republican,"Givens, Bruce",119,000150
+WILSON,Neodesha Ward 3,Kansas Senate,14,Democratic,"Pringle, Mark",35,000160
+WILSON,Neodesha Ward 3,Kansas Senate,14,Republican,"Givens, Bruce",124,000160
+WILSON,Neodesha Ward 4,Kansas Senate,14,Democratic,"Pringle, Mark",61,000170
+WILSON,Neodesha Ward 4,Kansas Senate,14,Republican,"Givens, Bruce",260,000170
+WILSON,Newark Township,Kansas Senate,14,Democratic,"Pringle, Mark",17,000180
+WILSON,Newark Township,Kansas Senate,14,Republican,"Givens, Bruce",82,000180
+WILSON,Pleasant Valley Township,Kansas Senate,14,Democratic,"Pringle, Mark",38,000190
+WILSON,Pleasant Valley Township,Kansas Senate,14,Republican,"Givens, Bruce",57,000190
+WILSON,Prairie Township,Kansas Senate,14,Democratic,"Pringle, Mark",11,000200
+WILSON,Prairie Township,Kansas Senate,14,Republican,"Givens, Bruce",48,000200
+WILSON,Talleyrand Township,Kansas Senate,14,Democratic,"Pringle, Mark",24,000210
+WILSON,Talleyrand Township,Kansas Senate,14,Republican,"Givens, Bruce",55,000210
+WILSON,Verdigris Township,Kansas Senate,14,Democratic,"Pringle, Mark",31,000220
+WILSON,Verdigris Township,Kansas Senate,14,Republican,"Givens, Bruce",67,000220
+WILSON,Webster Township,Kansas Senate,14,Democratic,"Pringle, Mark",7,000230
+WILSON,Webster Township,Kansas Senate,14,Republican,"Givens, Bruce",17,000230
+WILSON,Neodesha Ward 1 Exclave 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,Kansas Senate,14,Republican,"Givens, Bruce",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,Kansas Senate,14,Democratic,"Pringle, Mark",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,Kansas Senate,14,Republican,"Givens, Bruce",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,Kansas Senate,14,Democratic,"Pringle, Mark",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,Kansas Senate,14,Republican,"Givens, Bruce",0,900030
+WILSON,Neodesha Ward 4 Exclave,Kansas Senate,14,Democratic,"Pringle, Mark",0,900040
+WILSON,Neodesha Ward 4 Exclave,Kansas Senate,14,Republican,"Givens, Bruce",0,900040
+WILSON,Cedar Township,President / Vice President,,independent,"Stein, Jill",5,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"McMullin, Evan",3,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+WILSON,Cedar Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+WILSON,Cedar Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000010
+WILSON,Cedar Township,President / Vice President,,Libertarian,"Johnson, Gary",7,000010
+WILSON,Cedar Township,President / Vice President,,Republican,"Trump, Donald J.",175,000010
+WILSON,Center Township,President / Vice President,,independent,"Stein, Jill",5,000020
+WILSON,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+WILSON,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+WILSON,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",42,000020
+WILSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000020
+WILSON,Center Township,President / Vice President,,Republican,"Trump, Donald J.",205,000020
+WILSON,Chetopa Township,President / Vice President,,independent,"Stein, Jill",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"McMullin, Evan",1,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+WILSON,Chetopa Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+WILSON,Chetopa Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",5,000030
+WILSON,Chetopa Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000030
+WILSON,Chetopa Township,President / Vice President,,Republican,"Trump, Donald J.",77,000030
+WILSON,Clifton Township,President / Vice President,,independent,"Stein, Jill",2,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+WILSON,Clifton Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+WILSON,Clifton Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000040
+WILSON,Clifton Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000040
+WILSON,Clifton Township,President / Vice President,,Republican,"Trump, Donald J.",100,000040
+WILSON,Colfax Township,President / Vice President,,independent,"Stein, Jill",4,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+WILSON,Colfax Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+WILSON,Colfax Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",36,000050
+WILSON,Colfax Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000050
+WILSON,Colfax Township,President / Vice President,,Republican,"Trump, Donald J.",174,000050
+WILSON,Duck Creek Township,President / Vice President,,independent,"Stein, Jill",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+WILSON,Duck Creek Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",3,000060
+WILSON,Duck Creek Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000060
+WILSON,Duck Creek Township,President / Vice President,,Republican,"Trump, Donald J.",35,000060
+WILSON,Fall River Township,President / Vice President,,independent,"Stein, Jill",3,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+WILSON,Fall River Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+WILSON,Fall River Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000070
+WILSON,Fall River Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000070
+WILSON,Fall River Township,President / Vice President,,Republican,"Trump, Donald J.",164,000070
+WILSON,Fredonia Ward 1,President / Vice President,,independent,"Stein, Jill",1,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Hedges, James A",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Smith, Mike",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",45,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",13,000080
+WILSON,Fredonia Ward 1,President / Vice President,,Republican,"Trump, Donald J.",171,000080
+WILSON,Fredonia Ward 2,President / Vice President,,independent,"Stein, Jill",1,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",10,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",5,000090
+WILSON,Fredonia Ward 2,President / Vice President,,Republican,"Trump, Donald J.",67,000090
+WILSON,Fredonia Ward 3,President / Vice President,,independent,"Stein, Jill",3,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Hedges, James A",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"McMullin, Evan",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Smith, Mike",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",13,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",6,00010A
+WILSON,Fredonia Ward 3,President / Vice President,,Republican,"Trump, Donald J.",85,00010A
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,independent,"Stein, Jill",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00010B
+WILSON,Fredonia Ward 3 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00010B
+WILSON,Fredonia Ward 4,President / Vice President,,independent,"Stein, Jill",13,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"McMullin, Evan",1,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",88,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",15,000110
+WILSON,Fredonia Ward 4,President / Vice President,,Republican,"Trump, Donald J.",340,000110
+WILSON,Guilford Township,President / Vice President,,independent,"Stein, Jill",1,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Castle, Darrell L",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Giordani, Rocky",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Hedges, James A",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Hoefling, Tom",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Kahn, Lynn",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"La Riva, Gloria",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Maturen, Michael A",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"McMullin, Evan",2,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Perry, Darryl",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Schriner, Joe C",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Smith, Mike",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Sood, Ajay",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Sterling, Shawna",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000120
+WILSON,Guilford Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000120
+WILSON,Guilford Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",2,000120
+WILSON,Guilford Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000120
+WILSON,Guilford Township,President / Vice President,,Republican,"Trump, Donald J.",61,000120
+WILSON,Neodesha Township,President / Vice President,,independent,"Stein, Jill",2,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Castle, Darrell L",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Giordani, Rocky",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Hedges, James A",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Hoefling, Tom",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Kahn, Lynn",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"La Riva, Gloria",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Maturen, Michael A",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"McMullin, Evan",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Perry, Darryl",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Schriner, Joe C",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Smith, Mike",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Sood, Ajay",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Sterling, Shawna",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000130
+WILSON,Neodesha Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000130
+WILSON,Neodesha Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",35,000130
+WILSON,Neodesha Township,President / Vice President,,Libertarian,"Johnson, Gary",8,000130
+WILSON,Neodesha Township,President / Vice President,,Republican,"Trump, Donald J.",186,000130
+WILSON,Neodesha Ward 1,President / Vice President,,independent,"Stein, Jill",2,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",27,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",8,00014A
+WILSON,Neodesha Ward 1,President / Vice President,,Republican,"Trump, Donald J.",127,00014A
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00014B
+WILSON,Neodesha Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00014B
+WILSON,Neodesha Ward 2,President / Vice President,,independent,"Stein, Jill",6,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",52,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",7,000150
+WILSON,Neodesha Ward 2,President / Vice President,,Republican,"Trump, Donald J.",114,000150
+WILSON,Neodesha Ward 3,President / Vice President,,independent,"Stein, Jill",2,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Basiago, Andrew D.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Castle, Darrell L",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Giordani, Rocky",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Hedges, James A",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Hoefling, Tom",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Kahn, Lynn",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"La Riva, Gloria",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Levinson, Michael S.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Maturen, Michael A",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"McMullin, Evan",3,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Moorehead, Monica G.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Perry, Darryl",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Schriner, Joe C",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Smith, Mike",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Sood, Ajay",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Sterling, Shawna",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Valdivia, Anthony J",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Democratic,"Clinton, Hillary Rodham",40,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Libertarian,"Johnson, Gary",7,000160
+WILSON,Neodesha Ward 3,President / Vice President,,Republican,"Trump, Donald J.",110,000160
+WILSON,Neodesha Ward 4,President / Vice President,,independent,"Stein, Jill",3,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Basiago, Andrew D.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Castle, Darrell L",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Giordani, Rocky",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Hedges, James A",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Hoefling, Tom",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Kahn, Lynn",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"La Riva, Gloria",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Levinson, Michael S.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Maturen, Michael A",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"McMullin, Evan",2,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Moorehead, Monica G.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Perry, Darryl",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Schriner, Joe C",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Smith, Mike",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Sood, Ajay",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Sterling, Shawna",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Valdivia, Anthony J",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Democratic,"Clinton, Hillary Rodham",73,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Libertarian,"Johnson, Gary",21,000170
+WILSON,Neodesha Ward 4,President / Vice President,,Republican,"Trump, Donald J.",221,000170
+WILSON,Newark Township,President / Vice President,,independent,"Stein, Jill",4,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Castle, Darrell L",1,000180
+WILSON,Newark Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Giordani, Rocky",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Hedges, James A",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Hoefling, Tom",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Kahn, Lynn",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"La Riva, Gloria",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Maturen, Michael A",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"McMullin, Evan",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Perry, Darryl",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Schriner, Joe C",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Smith, Mike",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Sood, Ajay",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Sterling, Shawna",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000180
+WILSON,Newark Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000180
+WILSON,Newark Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000180
+WILSON,Newark Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000180
+WILSON,Newark Township,President / Vice President,,Republican,"Trump, Donald J.",85,000180
+WILSON,Pleasant Valley Township,President / Vice President,,independent,"Stein, Jill",1,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Castle, Darrell L",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Giordani, Rocky",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Hedges, James A",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Hoefling, Tom",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Kahn, Lynn",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"La Riva, Gloria",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Maturen, Michael A",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"McMullin, Evan",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Perry, Darryl",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Schriner, Joe C",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Smith, Mike",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Sood, Ajay",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Sterling, Shawna",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",15,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000190
+WILSON,Pleasant Valley Township,President / Vice President,,Republican,"Trump, Donald J.",81,000190
+WILSON,Prairie Township,President / Vice President,,independent,"Stein, Jill",1,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Castle, Darrell L",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Giordani, Rocky",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Hedges, James A",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Hoefling, Tom",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Kahn, Lynn",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"La Riva, Gloria",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Maturen, Michael A",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"McMullin, Evan",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Perry, Darryl",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Schriner, Joe C",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Smith, Mike",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Sood, Ajay",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Sterling, Shawna",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000200
+WILSON,Prairie Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000200
+WILSON,Prairie Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",6,000200
+WILSON,Prairie Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000200
+WILSON,Prairie Township,President / Vice President,,Republican,"Trump, Donald J.",52,000200
+WILSON,Talleyrand Township,President / Vice President,,independent,"Stein, Jill",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Castle, Darrell L",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Giordani, Rocky",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Hedges, James A",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Hoefling, Tom",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Kahn, Lynn",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"La Riva, Gloria",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Maturen, Michael A",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"McMullin, Evan",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Perry, Darryl",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Schriner, Joe C",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Smith, Mike",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Sood, Ajay",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Sterling, Shawna",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000210
+WILSON,Talleyrand Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000210
+WILSON,Talleyrand Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",16,000210
+WILSON,Talleyrand Township,President / Vice President,,Libertarian,"Johnson, Gary",1,000210
+WILSON,Talleyrand Township,President / Vice President,,Republican,"Trump, Donald J.",65,000210
+WILSON,Verdigris Township,President / Vice President,,independent,"Stein, Jill",1,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Castle, Darrell L",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Giordani, Rocky",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Hedges, James A",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Hoefling, Tom",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Kahn, Lynn",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"La Riva, Gloria",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Maturen, Michael A",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"McMullin, Evan",1,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Perry, Darryl",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Schriner, Joe C",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Smith, Mike",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Sood, Ajay",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Sterling, Shawna",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000220
+WILSON,Verdigris Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000220
+WILSON,Verdigris Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",22,000220
+WILSON,Verdigris Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000220
+WILSON,Verdigris Township,President / Vice President,,Republican,"Trump, Donald J.",75,000220
+WILSON,Webster Township,President / Vice President,,independent,"Stein, Jill",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Castle, Darrell L",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Giordani, Rocky",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Hedges, James A",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Hoefling, Tom",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Kahn, Lynn",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"La Riva, Gloria",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Maturen, Michael A",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"McMullin, Evan",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Perry, Darryl",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Schriner, Joe C",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Smith, Mike",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Sood, Ajay",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Sterling, Shawna",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000230
+WILSON,Webster Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000230
+WILSON,Webster Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000230
+WILSON,Webster Township,President / Vice President,,Libertarian,"Johnson, Gary",3,000230
+WILSON,Webster Township,President / Vice President,,Republican,"Trump, Donald J.",18,000230
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,independent,"Stein, Jill",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Castle, Darrell L",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Giordani, Rocky",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Hedges, James A",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Hoefling, Tom",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Kahn, Lynn",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"La Riva, Gloria",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Levinson, Michael S.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Maturen, Michael A",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"McMullin, Evan",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Perry, Darryl",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Schriner, Joe C",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Smith, Mike",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Sood, Ajay",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Sterling, Shawna",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Libertarian,"Johnson, Gary",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,President / Vice President,,Republican,"Trump, Donald J.",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,independent,"Stein, Jill",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Castle, Darrell L",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Giordani, Rocky",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Hedges, James A",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Hoefling, Tom",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Kahn, Lynn",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"La Riva, Gloria",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Levinson, Michael S.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Maturen, Michael A",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"McMullin, Evan",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Perry, Darryl",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Schriner, Joe C",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Smith, Mike",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Sood, Ajay",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Sterling, Shawna",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Libertarian,"Johnson, Gary",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,President / Vice President,,Republican,"Trump, Donald J.",0,900030
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,independent,"Stein, Jill",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Hedges, James A",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Smith, Mike",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,900040
+WILSON,Neodesha Ward 4 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,900040
+WILSON,Cedar Township,United States House of Representatives,2,Democratic,"Potter, Britani",20,000010
+WILSON,Cedar Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000010
+WILSON,Cedar Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",179,000010
+WILSON,Center Township,United States House of Representatives,2,Democratic,"Potter, Britani",36,000020
+WILSON,Center Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000020
+WILSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",211,000020
+WILSON,Chetopa Township,United States House of Representatives,2,Democratic,"Potter, Britani",6,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000030
+WILSON,Chetopa Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",73,000030
+WILSON,Clifton Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000040
+WILSON,Clifton Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000040
+WILSON,Clifton Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",91,000040
+WILSON,Colfax Township,United States House of Representatives,2,Democratic,"Potter, Britani",31,000050
+WILSON,Colfax Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000050
+WILSON,Colfax Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,000050
+WILSON,Duck Creek Township,United States House of Representatives,2,Democratic,"Potter, Britani",2,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000060
+WILSON,Duck Creek Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",34,000060
+WILSON,Fall River Township,United States House of Representatives,2,Democratic,"Potter, Britani",13,000070
+WILSON,Fall River Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000070
+WILSON,Fall River Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",162,000070
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",34,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000080
+WILSON,Fredonia Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",183,000080
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",7,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000090
+WILSON,Fredonia Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000090
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",14,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,00010A
+WILSON,Fredonia Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,00010A
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00010B
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",74,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",16,000110
+WILSON,Fredonia Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",369,000110
+WILSON,Guilford Township,United States House of Representatives,2,Democratic,"Potter, Britani",4,000120
+WILSON,Guilford Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000120
+WILSON,Guilford Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",62,000120
+WILSON,Neodesha Township,United States House of Representatives,2,Democratic,"Potter, Britani",24,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000130
+WILSON,Neodesha Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",207,000130
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",27,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",8,00014A
+WILSON,Neodesha Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",129,00014A
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00014B
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",51,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",12,000150
+WILSON,Neodesha Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",120,000150
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Democratic,"Potter, Britani",33,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Libertarian,"Bales, James Houston",11,000160
+WILSON,Neodesha Ward 3,United States House of Representatives,2,Republican,"Jenkins, Lynn",117,000160
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Democratic,"Potter, Britani",51,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,000170
+WILSON,Neodesha Ward 4,United States House of Representatives,2,Republican,"Jenkins, Lynn",254,000170
+WILSON,Newark Township,United States House of Representatives,2,Democratic,"Potter, Britani",9,000180
+WILSON,Newark Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000180
+WILSON,Newark Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",89,000180
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Democratic,"Potter, Britani",13,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000190
+WILSON,Pleasant Valley Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",84,000190
+WILSON,Prairie Township,United States House of Representatives,2,Democratic,"Potter, Britani",5,000200
+WILSON,Prairie Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",5,000200
+WILSON,Prairie Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",48,000200
+WILSON,Talleyrand Township,United States House of Representatives,2,Democratic,"Potter, Britani",11,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000210
+WILSON,Talleyrand Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",68,000210
+WILSON,Verdigris Township,United States House of Representatives,2,Democratic,"Potter, Britani",18,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000220
+WILSON,Verdigris Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",77,000220
+WILSON,Webster Township,United States House of Representatives,2,Democratic,"Potter, Britani",6,000230
+WILSON,Webster Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000230
+WILSON,Webster Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",17,000230
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Democratic,"Potter, Britani",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Democratic,"Potter, Britani",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900030
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900040
+WILSON,Cedar Township,United States Senate,,write - in,"Smith, DJ",0,000010
+WILSON,Cedar Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000010
+WILSON,Cedar Township,United States Senate,,Libertarian,"Garrard, Robert D.",9,000010
+WILSON,Cedar Township,United States Senate,,Republican,"Moran, Jerry",179,000010
+WILSON,Center Township,United States Senate,,write - in,"Smith, DJ",0,000020
+WILSON,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",36,000020
+WILSON,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000020
+WILSON,Center Township,United States Senate,,Republican,"Moran, Jerry",205,000020
+WILSON,Chetopa Township,United States Senate,,write - in,"Smith, DJ",0,000030
+WILSON,Chetopa Township,United States Senate,,Democratic,"Wiesner, Patrick",6,000030
+WILSON,Chetopa Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000030
+WILSON,Chetopa Township,United States Senate,,Republican,"Moran, Jerry",73,000030
+WILSON,Clifton Township,United States Senate,,write - in,"Smith, DJ",0,000040
+WILSON,Clifton Township,United States Senate,,Democratic,"Wiesner, Patrick",25,000040
+WILSON,Clifton Township,United States Senate,,Libertarian,"Garrard, Robert D.",5,000040
+WILSON,Clifton Township,United States Senate,,Republican,"Moran, Jerry",91,000040
+WILSON,Colfax Township,United States Senate,,write - in,"Smith, DJ",0,000050
+WILSON,Colfax Township,United States Senate,,Democratic,"Wiesner, Patrick",39,000050
+WILSON,Colfax Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000050
+WILSON,Colfax Township,United States Senate,,Republican,"Moran, Jerry",167,000050
+WILSON,Duck Creek Township,United States Senate,,write - in,"Smith, DJ",0,000060
+WILSON,Duck Creek Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000060
+WILSON,Duck Creek Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000060
+WILSON,Duck Creek Township,United States Senate,,Republican,"Moran, Jerry",34,000060
+WILSON,Fall River Township,United States Senate,,write - in,"Smith, DJ",0,000070
+WILSON,Fall River Township,United States Senate,,Democratic,"Wiesner, Patrick",14,000070
+WILSON,Fall River Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000070
+WILSON,Fall River Township,United States Senate,,Republican,"Moran, Jerry",159,000070
+WILSON,Fredonia Ward 1,United States Senate,,write - in,"Smith, DJ",0,000080
+WILSON,Fredonia Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",38,000080
+WILSON,Fredonia Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",14,000080
+WILSON,Fredonia Ward 1,United States Senate,,Republican,"Moran, Jerry",180,000080
+WILSON,Fredonia Ward 2,United States Senate,,write - in,"Smith, DJ",0,000090
+WILSON,Fredonia Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",15,000090
+WILSON,Fredonia Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",5,000090
+WILSON,Fredonia Ward 2,United States Senate,,Republican,"Moran, Jerry",64,000090
+WILSON,Fredonia Ward 3,United States Senate,,write - in,"Smith, DJ",0,00010A
+WILSON,Fredonia Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",12,00010A
+WILSON,Fredonia Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",9,00010A
+WILSON,Fredonia Ward 3,United States Senate,,Republican,"Moran, Jerry",80,00010A
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,write - in,"Smith, DJ",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00010B
+WILSON,Fredonia Ward 3 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00010B
+WILSON,Fredonia Ward 4,United States Senate,,write - in,"Smith, DJ",0,000110
+WILSON,Fredonia Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",70,000110
+WILSON,Fredonia Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",22,000110
+WILSON,Fredonia Ward 4,United States Senate,,Republican,"Moran, Jerry",370,000110
+WILSON,Guilford Township,United States Senate,,write - in,"Smith, DJ",0,000120
+WILSON,Guilford Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000120
+WILSON,Guilford Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000120
+WILSON,Guilford Township,United States Senate,,Republican,"Moran, Jerry",58,000120
+WILSON,Neodesha Township,United States Senate,,write - in,"Smith, DJ",0,000130
+WILSON,Neodesha Township,United States Senate,,Democratic,"Wiesner, Patrick",32,000130
+WILSON,Neodesha Township,United States Senate,,Libertarian,"Garrard, Robert D.",11,000130
+WILSON,Neodesha Township,United States Senate,,Republican,"Moran, Jerry",191,000130
+WILSON,Neodesha Ward 1,United States Senate,,write - in,"Smith, DJ",0,00014A
+WILSON,Neodesha Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",29,00014A
+WILSON,Neodesha Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",16,00014A
+WILSON,Neodesha Ward 1,United States Senate,,Republican,"Moran, Jerry",116,00014A
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00014B
+WILSON,Neodesha Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00014B
+WILSON,Neodesha Ward 2,United States Senate,,write - in,"Smith, DJ",0,000150
+WILSON,Neodesha Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",51,000150
+WILSON,Neodesha Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",11,000150
+WILSON,Neodesha Ward 2,United States Senate,,Republican,"Moran, Jerry",119,000150
+WILSON,Neodesha Ward 3,United States Senate,,write - in,"Smith, DJ",0,000160
+WILSON,Neodesha Ward 3,United States Senate,,Democratic,"Wiesner, Patrick",29,000160
+WILSON,Neodesha Ward 3,United States Senate,,Libertarian,"Garrard, Robert D.",15,000160
+WILSON,Neodesha Ward 3,United States Senate,,Republican,"Moran, Jerry",116,000160
+WILSON,Neodesha Ward 4,United States Senate,,write - in,"Smith, DJ",0,000170
+WILSON,Neodesha Ward 4,United States Senate,,Democratic,"Wiesner, Patrick",68,000170
+WILSON,Neodesha Ward 4,United States Senate,,Libertarian,"Garrard, Robert D.",28,000170
+WILSON,Neodesha Ward 4,United States Senate,,Republican,"Moran, Jerry",227,000170
+WILSON,Newark Township,United States Senate,,write - in,"Smith, DJ",0,000180
+WILSON,Newark Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000180
+WILSON,Newark Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000180
+WILSON,Newark Township,United States Senate,,Republican,"Moran, Jerry",91,000180
+WILSON,Pleasant Valley Township,United States Senate,,write - in,"Smith, DJ",0,000190
+WILSON,Pleasant Valley Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000190
+WILSON,Pleasant Valley Township,United States Senate,,Libertarian,"Garrard, Robert D.",4,000190
+WILSON,Pleasant Valley Township,United States Senate,,Republican,"Moran, Jerry",80,000190
+WILSON,Prairie Township,United States Senate,,write - in,"Smith, DJ",0,000200
+WILSON,Prairie Township,United States Senate,,Democratic,"Wiesner, Patrick",4,000200
+WILSON,Prairie Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000200
+WILSON,Prairie Township,United States Senate,,Republican,"Moran, Jerry",52,000200
+WILSON,Talleyrand Township,United States Senate,,write - in,"Smith, DJ",0,000210
+WILSON,Talleyrand Township,United States Senate,,Democratic,"Wiesner, Patrick",11,000210
+WILSON,Talleyrand Township,United States Senate,,Libertarian,"Garrard, Robert D.",6,000210
+WILSON,Talleyrand Township,United States Senate,,Republican,"Moran, Jerry",63,000210
+WILSON,Verdigris Township,United States Senate,,write - in,"Smith, DJ",0,000220
+WILSON,Verdigris Township,United States Senate,,Democratic,"Wiesner, Patrick",15,000220
+WILSON,Verdigris Township,United States Senate,,Libertarian,"Garrard, Robert D.",13,000220
+WILSON,Verdigris Township,United States Senate,,Republican,"Moran, Jerry",72,000220
+WILSON,Webster Township,United States Senate,,write - in,"Smith, DJ",0,000230
+WILSON,Webster Township,United States Senate,,Democratic,"Wiesner, Patrick",5,000230
+WILSON,Webster Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000230
+WILSON,Webster Township,United States Senate,,Republican,"Moran, Jerry",19,000230
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+WILSON,Neodesha Ward 1 Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900010
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,write - in,"Smith, DJ",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,Democratic,"Wiesner, Patrick",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,Libertarian,"Garrard, Robert D.",0,900020
+WILSON,Neodesha Ward 3 Exclave 1,United States Senate,,Republican,"Moran, Jerry",0,900020
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,write - in,"Smith, DJ",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,Democratic,"Wiesner, Patrick",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,Libertarian,"Garrard, Robert D.",0,900030
+WILSON,Neodesha Ward 3 Exclave 2,United States Senate,,Republican,"Moran, Jerry",0,900030
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,write - in,"Smith, DJ",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900040
+WILSON,Neodesha Ward 4 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900040

--- a/2016/20161108__ks__general__woodson__precinct.csv
+++ b/2016/20161108__ks__general__woodson__precinct.csv
@@ -1,144 +1,361 @@
-county,precinct,office,district,party,candidate,votes
-Woodson,Advance,President,,D,Clinton/Kaine,82
-Woodson,NF/NF,President,,D,Clinton/Kaine,9
-Woodson,NF/PIQ,President,,D,Clinton/Kaine,22
-Woodson,PERRY,President,,D,Clinton/Kaine,3
-Woodson,LIBERTY,President,,D,Clinton/Kaine,7
-Woodson,CENTER,President,,D,Clinton/Kaine,23
-Woodson,NORTH,President,,D,Clinton/Kaine,1
-Woodson,TORONTO,President,,D,Clinton/Kaine,36
-Woodson,YC#1,President,,D,Clinton/Kaine,45
-Woodson,YC#2,President,,D,Clinton/Kaine,45
-Woodson,Total,President,,D,Clinton/Kaine,273
-Woodson,Advance,President,,R,Trump/Pence,228
-Woodson,NF/NF,President,,R,Trump/Pence,15
-Woodson,NF/PIQ,President,,R,Trump/Pence,53
-Woodson,PERRY,President,,R,Trump/Pence,29
-Woodson,LIBERTY,President,,R,Trump/Pence,63
-Woodson,CENTER,President,,R,Trump/Pence,194
-Woodson,NORTH,President,,R,Trump/Pence,17
-Woodson,TORONTO,President,,R,Trump/Pence,152
-Woodson,YC#1,President,,R,Trump/Pence,180
-Woodson,YC#2,President,,R,Trump/Pence,151
-Woodson,Total,President,,R,Trump/Pence,1082
-Woodson,Advance,President,,L,Johnson/Weld,13
-Woodson,NF/NF,President,,L,Johnson/Weld,0
-Woodson,NF/PIQ,President,,L,Johnson/Weld,5
-Woodson,PERRY,President,,L,Johnson/Weld,3
-Woodson,LIBERTY,President,,L,Johnson/Weld,1
-Woodson,CENTER,President,,L,Johnson/Weld,8
-Woodson,NORTH,President,,L,Johnson/Weld,2
-Woodson,TORONTO,President,,L,Johnson/Weld,14
-Woodson,YC#1,President,,L,Johnson/Weld,13
-Woodson,YC#2,President,,L,Johnson/Weld,5
-Woodson,Total,President,,L,Johnson/Weld,64
-Woodson,Advance,President,,I,Stein/Baraka,6
-Woodson,NF/NF,President,,I,Stein/Baraka,0
-Woodson,NF/PIQ,President,,I,Stein/Baraka,0
-Woodson,PERRY,President,,I,Stein/Baraka,0
-Woodson,LIBERTY,President,,I,Stein/Baraka,1
-Woodson,CENTER,President,,I,Stein/Baraka,5
-Woodson,NORTH,President,,I,Stein/Baraka,0
-Woodson,TORONTO,President,,I,Stein/Baraka,3
-Woodson,YC#1,President,,I,Stein/Baraka,4
-Woodson,YC#2,President,,I,Stein/Baraka,5
-Woodson,Total,President,,I,Stein/Baraka,24
-Woodson,Advance,U.S. Senate,,R,Jerry Moran,232
-Woodson,NF/NF,U.S. Senate,,R,Jerry Moran,12
-Woodson,NF/PIQ,U.S. Senate,,R,Jerry Moran,57
-Woodson,PERRY,U.S. Senate,,R,Jerry Moran,31
-Woodson,LIBERTY,U.S. Senate,,R,Jerry Moran,58
-Woodson,CENTER,U.S. Senate,,R,Jerry Moran,184
-Woodson,NORTH,U.S. Senate,,R,Jerry Moran,18
-Woodson,TORONTO,U.S. Senate,,R,Jerry Moran,144
-Woodson,YC#1,U.S. Senate,,R,Jerry Moran,173
-Woodson,YC#2,U.S. Senate,,R,Jerry Moran,154
-Woodson,Total,U.S. Senate,,R,Jerry Moran,1063
-Woodson,Advance,U.S. Senate,,D,Patrick Wiesner,75
-Woodson,NF/NF,U.S. Senate,,D,Patrick Wiesner,8
-Woodson,NF/PIQ,U.S. Senate,,D,Patrick Wiesner,20
-Woodson,PERRY,U.S. Senate,,D,Patrick Wiesner,4
-Woodson,LIBERTY,U.S. Senate,,D,Patrick Wiesner,7
-Woodson,CENTER,U.S. Senate,,D,Patrick Wiesner,28
-Woodson,NORTH,U.S. Senate,,D,Patrick Wiesner,1
-Woodson,TORONTO,U.S. Senate,,D,Patrick Wiesner,38
-Woodson,YC#1,U.S. Senate,,D,Patrick Wiesner,38
-Woodson,YC#2,U.S. Senate,,D,Patrick Wiesner,38
-Woodson,Total,U.S. Senate,,D,Patrick Wiesner,257
-Woodson,Advance,U.S. Senate,,L,Robert D. Garrard,19
-Woodson,NF/NF,U.S. Senate,,L,Robert D. Garrard,2
-Woodson,NF/PIQ,U.S. Senate,,L,Robert D. Garrard,2
-Woodson,PERRY,U.S. Senate,,L,Robert D. Garrard,0
-Woodson,LIBERTY,U.S. Senate,,L,Robert D. Garrard,6
-Woodson,CENTER,U.S. Senate,,L,Robert D. Garrard,17
-Woodson,NORTH,U.S. Senate,,L,Robert D. Garrard,1
-Woodson,TORONTO,U.S. Senate,,L,Robert D. Garrard,22
-Woodson,YC#1,U.S. Senate,,L,Robert D. Garrard,16
-Woodson,YC#2,U.S. Senate,,L,Robert D. Garrard,7
-Woodson,Total,U.S. Senate,,L,Robert D. Garrard,92
-Woodson,Advance,U.S. House,2,D,Britani Potter,76
-Woodson,NF/NF,U.S. House,2,D,Britani Potter,6
-Woodson,NF/PIQ,U.S. House,2,D,Britani Potter,19
-Woodson,PERRY,U.S. House,2,D,Britani Potter,3
-Woodson,LIBERTY,U.S. House,2,D,Britani Potter,10
-Woodson,CENTER,U.S. House,2,D,Britani Potter,26
-Woodson,NORTH,U.S. House,2,D,Britani Potter,1
-Woodson,TORONTO,U.S. House,2,D,Britani Potter,39
-Woodson,YC#1,U.S. House,2,D,Britani Potter,35
-Woodson,YC#2,U.S. House,2,D,Britani Potter,30
-Woodson,Total,U.S. House,2,D,Britani Potter,245
-Woodson,Advance,U.S. House,2,R,Lynn Jenkins,237
-Woodson,NF/NF,U.S. House,2,R,Lynn Jenkins,13
-Woodson,NF/PIQ,U.S. House,2,R,Lynn Jenkins,54
-Woodson,PERRY,U.S. House,2,R,Lynn Jenkins,32
-Woodson,LIBERTY,U.S. House,2,R,Lynn Jenkins,59
-Woodson,CENTER,U.S. House,2,R,Lynn Jenkins,191
-Woodson,NORTH,U.S. House,2,R,Lynn Jenkins,17
-Woodson,TORONTO,U.S. House,2,R,Lynn Jenkins,146
-Woodson,YC#1,U.S. House,2,R,Lynn Jenkins,186
-Woodson,YC#2,U.S. House,2,R,Lynn Jenkins,170
-Woodson,Total,U.S. House,2,R,Lynn Jenkins,1105
-Woodson,Advance,U.S. House,2,L,James Houston Bales,12
-Woodson,NF/NF,U.S. House,2,L,James Houston Bales,3
-Woodson,NF/PIQ,U.S. House,2,L,James Houston Bales,5
-Woodson,PERRY,U.S. House,2,L,James Houston Bales,0
-Woodson,LIBERTY,U.S. House,2,L,James Houston Bales,3
-Woodson,CENTER,U.S. House,2,L,James Houston Bales,13
-Woodson,NORTH,U.S. House,2,L,James Houston Bales,2
-Woodson,TORONTO,U.S. House,2,L,James Houston Bales,16
-Woodson,YC#1,U.S. House,2,L,James Houston Bales,13
-Woodson,YC#2,U.S. House,2,L,James Houston Bales,5
-Woodson,Total,U.S. House,2,L,James Houston Bales,72
-Woodson,Advance,State Senate,14,D,Mark Pringle,196
-Woodson,NF/NF,State Senate,14,D,Mark Pringle,13
-Woodson,NF/PIQ,State Senate,14,D,Mark Pringle,53
-Woodson,PERRY,State Senate,14,D,Mark Pringle,21
-Woodson,LIBERTY,State Senate,14,D,Mark Pringle,47
-Woodson,CENTER,State Senate,14,D,Mark Pringle,125
-Woodson,NORTH,State Senate,14,D,Mark Pringle,12
-Woodson,TORONTO,State Senate,14,D,Mark Pringle,109
-Woodson,YC#1,State Senate,14,D,Mark Pringle,146
-Woodson,YC#2,State Senate,14,D,Mark Pringle,134
-Woodson,Total,State Senate,14,D,Mark Pringle,856
-Woodson,Advance,State Senate,14,R,Bruce Givens,131
-Woodson,NF/NF,State Senate,14,R,Bruce Givens,9
-Woodson,NF/PIQ,State Senate,14,R,Bruce Givens,26
-Woodson,PERRY,State Senate,14,R,Bruce Givens,12
-Woodson,LIBERTY,State Senate,14,R,Bruce Givens,24
-Woodson,CENTER,State Senate,14,R,Bruce Givens,101
-Woodson,NORTH,State Senate,14,R,Bruce Givens,8
-Woodson,TORONTO,State Senate,14,R,Bruce Givens,90
-Woodson,YC#1,State Senate,14,R,Bruce Givens,92
-Woodson,YC#2,State Senate,14,R,Bruce Givens,73
-Woodson,Total,State Senate,14,R,Bruce Givens,566
-Woodson,Advance,State House,13,R,Larry P. Hibbard,293
-Woodson,NF/NF,State House,13,R,Larry P. Hibbard,14
-Woodson,NF/PIQ,State House,13,R,Larry P. Hibbard,69
-Woodson,PERRY,State House,13,R,Larry P. Hibbard,29
-Woodson,LIBERTY,State House,13,R,Larry P. Hibbard,63
-Woodson,CENTER,State House,13,R,Larry P. Hibbard,209
-Woodson,NORTH,State House,13,R,Larry P. Hibbard,18
-Woodson,TORONTO,State House,13,R,Larry P. Hibbard,190
-Woodson,YC#1,State House,13,R,Larry P. Hibbard,220
-Woodson,YC#2,State House,13,R,Larry P. Hibbard,183
-Woodson,Total,State House,13,R,Larry P. Hibbard,1288
+county,precinct,office,district,party,candidate,votes,vtd
+WOODSON,Center Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",254,000010
+WOODSON,Liberty Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",82,000020
+WOODSON,Neosho Falls Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",31,000030
+WOODSON,North Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",31,000040
+WOODSON,Perry Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",41,000050
+WOODSON,Piqua Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",96,000060
+WOODSON,Toronto Township,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",232,000070
+WOODSON,Yates Center Ward 1,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",282,00008A
+WOODSON,Yates Center Ward 1 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,00008B
+WOODSON,Yates Center Ward 2,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",239,000090
+WOODSON,Yates Center Ward 2 Exclave,Kansas House of Representatives,13,Republican,"Hibbard, Larry P.",0,900010
+WOODSON,Center Township,Kansas Senate,14,Democratic,"Pringle, Mark",156,000010
+WOODSON,Center Township,Kansas Senate,14,Republican,"Givens, Bruce",101,000010
+WOODSON,Liberty Township,Kansas Senate,14,Democratic,"Pringle, Mark",60,000020
+WOODSON,Liberty Township,Kansas Senate,14,Republican,"Givens, Bruce",24,000020
+WOODSON,Neosho Falls Township,Kansas Senate,14,Democratic,"Pringle, Mark",26,000030
+WOODSON,Neosho Falls Township,Kansas Senate,14,Republican,"Givens, Bruce",9,000030
+WOODSON,North Township,Kansas Senate,14,Democratic,"Pringle, Mark",19,000040
+WOODSON,North Township,Kansas Senate,14,Republican,"Givens, Bruce",8,000040
+WOODSON,Perry Township,Kansas Senate,14,Democratic,"Pringle, Mark",31,000050
+WOODSON,Perry Township,Kansas Senate,14,Republican,"Givens, Bruce",12,000050
+WOODSON,Piqua Township,Kansas Senate,14,Democratic,"Pringle, Mark",71,000060
+WOODSON,Piqua Township,Kansas Senate,14,Republican,"Givens, Bruce",26,000060
+WOODSON,Toronto Township,Kansas Senate,14,Democratic,"Pringle, Mark",129,000070
+WOODSON,Toronto Township,Kansas Senate,14,Republican,"Givens, Bruce",90,000070
+WOODSON,Yates Center Ward 1,Kansas Senate,14,Democratic,"Pringle, Mark",197,00008A
+WOODSON,Yates Center Ward 1,Kansas Senate,14,Republican,"Givens, Bruce",92,00008A
+WOODSON,Yates Center Ward 1 Exclave,Kansas Senate,14,Democratic,"Pringle, Mark",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,Kansas Senate,14,Republican,"Givens, Bruce",0,00008B
+WOODSON,Yates Center Ward 2,Kansas Senate,14,Democratic,"Pringle, Mark",167,000090
+WOODSON,Yates Center Ward 2,Kansas Senate,14,Republican,"Givens, Bruce",73,000090
+WOODSON,Yates Center Ward 2 Exclave,Kansas Senate,14,Democratic,"Pringle, Mark",0,900010
+WOODSON,Yates Center Ward 2 Exclave,Kansas Senate,14,Republican,"Givens, Bruce",0,900010
+WOODSON,Center Township,President / Vice President,,independent,"Stein, Jill",5,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Castle, Darrell L",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Giordani, Rocky",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Hedges, James A",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Hoefling, Tom",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Kahn, Lynn",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"La Riva, Gloria",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Maturen, Michael A",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"McMullin, Evan",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Perry, Darryl",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Schriner, Joe C",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Smith, Mike",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Sood, Ajay",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Sterling, Shawna",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000010
+WOODSON,Center Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000010
+WOODSON,Center Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",32,000010
+WOODSON,Center Township,President / Vice President,,Libertarian,"Johnson, Gary",11,000010
+WOODSON,Center Township,President / Vice President,,Republican,"Trump, Donald J.",235,000010
+WOODSON,Liberty Township,President / Vice President,,independent,"Stein, Jill",1,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Castle, Darrell L",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Giordani, Rocky",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Hedges, James A",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Hoefling, Tom",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Kahn, Lynn",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"La Riva, Gloria",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Maturen, Michael A",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"McMullin, Evan",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Perry, Darryl",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Schriner, Joe C",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Smith, Mike",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Sood, Ajay",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Sterling, Shawna",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000020
+WOODSON,Liberty Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000020
+WOODSON,Liberty Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",12,000020
+WOODSON,Liberty Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000020
+WOODSON,Liberty Township,President / Vice President,,Republican,"Trump, Donald J.",75,000020
+WOODSON,Neosho Falls Township,President / Vice President,,independent,"Stein, Jill",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Castle, Darrell L",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Giordani, Rocky",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Hedges, James A",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Hoefling, Tom",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Kahn, Lynn",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"La Riva, Gloria",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Maturen, Michael A",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"McMullin, Evan",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Perry, Darryl",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Schriner, Joe C",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Smith, Mike",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Sood, Ajay",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Sterling, Shawna",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",19,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Libertarian,"Johnson, Gary",0,000030
+WOODSON,Neosho Falls Township,President / Vice President,,Republican,"Trump, Donald J.",27,000030
+WOODSON,North Township,President / Vice President,,independent,"Stein, Jill",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Castle, Darrell L",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Giordani, Rocky",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Hedges, James A",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Hoefling, Tom",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Kahn, Lynn",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"La Riva, Gloria",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Maturen, Michael A",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"McMullin, Evan",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Perry, Darryl",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Schriner, Joe C",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Smith, Mike",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Sood, Ajay",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Sterling, Shawna",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000040
+WOODSON,North Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000040
+WOODSON,North Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",4,000040
+WOODSON,North Township,President / Vice President,,Libertarian,"Johnson, Gary",2,000040
+WOODSON,North Township,President / Vice President,,Republican,"Trump, Donald J.",28,000040
+WOODSON,Perry Township,President / Vice President,,independent,"Stein, Jill",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Castle, Darrell L",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Giordani, Rocky",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Hedges, James A",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Hoefling, Tom",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Kahn, Lynn",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"La Riva, Gloria",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Maturen, Michael A",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"McMullin, Evan",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Perry, Darryl",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Schriner, Joe C",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Smith, Mike",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Sood, Ajay",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Sterling, Shawna",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000050
+WOODSON,Perry Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000050
+WOODSON,Perry Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",7,000050
+WOODSON,Perry Township,President / Vice President,,Libertarian,"Johnson, Gary",4,000050
+WOODSON,Perry Township,President / Vice President,,Republican,"Trump, Donald J.",38,000050
+WOODSON,Piqua Township,President / Vice President,,independent,"Stein, Jill",2,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Castle, Darrell L",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Giordani, Rocky",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Hedges, James A",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Hoefling, Tom",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Kahn, Lynn",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"La Riva, Gloria",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Maturen, Michael A",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"McMullin, Evan",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Perry, Darryl",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Schriner, Joe C",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Smith, Mike",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Sood, Ajay",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Sterling, Shawna",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000060
+WOODSON,Piqua Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000060
+WOODSON,Piqua Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",28,000060
+WOODSON,Piqua Township,President / Vice President,,Libertarian,"Johnson, Gary",5,000060
+WOODSON,Piqua Township,President / Vice President,,Republican,"Trump, Donald J.",70,000060
+WOODSON,Toronto Township,President / Vice President,,independent,"Stein, Jill",3,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Basiago, Andrew D.",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Castle, Darrell L",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Giordani, Rocky",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Hedges, James A",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Hoefling, Tom",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Kahn, Lynn",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"La Riva, Gloria",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Levinson, Michael S.",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Maturen, Michael A",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"McMullin, Evan",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Moorehead, Monica G.",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Perry, Darryl",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Schriner, Joe C",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Smith, Mike",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Sood, Ajay",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Sterling, Shawna",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Valdivia, Anthony J",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000070
+WOODSON,Toronto Township,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000070
+WOODSON,Toronto Township,President / Vice President,,Democratic,"Clinton, Hillary Rodham",41,000070
+WOODSON,Toronto Township,President / Vice President,,Libertarian,"Johnson, Gary",16,000070
+WOODSON,Toronto Township,President / Vice President,,Republican,"Trump, Donald J.",190,000070
+WOODSON,Yates Center Ward 1,President / Vice President,,independent,"Stein, Jill",7,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Castle, Darrell L",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Giordani, Rocky",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Hedges, James A",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Hoefling, Tom",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Kahn, Lynn",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"La Riva, Gloria",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Levinson, Michael S.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Maturen, Michael A",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"McMullin, Evan",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Perry, Darryl",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Schriner, Joe C",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Smith, Mike",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Sood, Ajay",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Sterling, Shawna",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Democratic,"Clinton, Hillary Rodham",69,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Libertarian,"Johnson, Gary",15,00008A
+WOODSON,Yates Center Ward 1,President / Vice President,,Republican,"Trump, Donald J.",225,00008A
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,independent,"Stein, Jill",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Basiago, Andrew D.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Castle, Darrell L",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Giordani, Rocky",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Hedges, James A",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Hoefling, Tom",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Kahn, Lynn",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"La Riva, Gloria",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Levinson, Michael S.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Maturen, Michael A",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"McMullin, Evan",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Moorehead, Monica G.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Perry, Darryl",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Schoenke, Marshall R.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Schriner, Joe C",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Smith, Mike",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Sood, Ajay",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Sterling, Shawna",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Valdivia, Anthony J",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,Democratic,"Clinton, Hillary Rodham",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,Libertarian,"Johnson, Gary",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,President / Vice President,,Republican,"Trump, Donald J.",0,00008B
+WOODSON,Yates Center Ward 2,President / Vice President,,independent,"Stein, Jill",6,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Basiago, Andrew D.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Castle, Darrell L",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"De La Fuente, ""Rocky"" Roque",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Giordani, Rocky",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Hedges, James A",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Hoefling, Tom",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Kahn, Lynn",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"La Riva, Gloria",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Levinson, Michael S.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Maturen, Michael A",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"McMullin, Evan",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Moorehead, Monica G.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Perry, Darryl",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Schoenke, Marshall R.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Schriner, Joe C",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Smith, Mike",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Sood, Ajay",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Sterling, Shawna",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Valdivia, Anthony J",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Vogel-Walcutt, J.J.",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,write - in,"Wysinger, Demetra Jefferson",0,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Democratic,"Clinton, Hillary Rodham",61,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Libertarian,"Johnson, Gary",9,000090
+WOODSON,Yates Center Ward 2,President / Vice President,,Republican,"Trump, Donald J.",194,000090
+WOODSON,Center Township,United States House of Representatives,2,Democratic,"Potter, Britani",34,000010
+WOODSON,Center Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",13,000010
+WOODSON,Center Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,000010
+WOODSON,Liberty Township,United States House of Representatives,2,Democratic,"Potter, Britani",15,000020
+WOODSON,Liberty Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",4,000020
+WOODSON,Liberty Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",70,000020
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Democratic,"Potter, Britani",16,000030
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",3,000030
+WOODSON,Neosho Falls Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",25,000030
+WOODSON,North Township,United States House of Representatives,2,Democratic,"Potter, Britani",2,000040
+WOODSON,North Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",2,000040
+WOODSON,North Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",30,000040
+WOODSON,Perry Township,United States House of Representatives,2,Democratic,"Potter, Britani",9,000050
+WOODSON,Perry Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",1,000050
+WOODSON,Perry Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",40,000050
+WOODSON,Piqua Township,United States House of Representatives,2,Democratic,"Potter, Britani",27,000060
+WOODSON,Piqua Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",6,000060
+WOODSON,Piqua Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",72,000060
+WOODSON,Toronto Township,United States House of Representatives,2,Democratic,"Potter, Britani",47,000070
+WOODSON,Toronto Township,United States House of Representatives,2,Libertarian,"Bales, James Houston",17,000070
+WOODSON,Toronto Township,United States House of Representatives,2,Republican,"Jenkins, Lynn",182,000070
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Democratic,"Potter, Britani",54,00008A
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Libertarian,"Bales, James Houston",19,00008A
+WOODSON,Yates Center Ward 1,United States House of Representatives,2,Republican,"Jenkins, Lynn",233,00008A
+WOODSON,Yates Center Ward 1 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,00008B
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Democratic,"Potter, Britani",41,000090
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Libertarian,"Bales, James Houston",7,000090
+WOODSON,Yates Center Ward 2,United States House of Representatives,2,Republican,"Jenkins, Lynn",220,000090
+WOODSON,Yates Center Ward 2 Exclave,United States House of Representatives,2,Democratic,"Potter, Britani",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States House of Representatives,2,Libertarian,"Bales, James Houston",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States House of Representatives,2,Republican,"Jenkins, Lynn",0,900010
+WOODSON,Center Township,United States Senate,,write - in,"Smith, DJ",0,000010
+WOODSON,Center Township,United States Senate,,Democratic,"Wiesner, Patrick",34,000010
+WOODSON,Center Township,United States Senate,,Libertarian,"Garrard, Robert D.",20,000010
+WOODSON,Center Township,United States Senate,,Republican,"Moran, Jerry",226,000010
+WOODSON,Liberty Township,United States Senate,,write - in,"Smith, DJ",0,000020
+WOODSON,Liberty Township,United States Senate,,Democratic,"Wiesner, Patrick",12,000020
+WOODSON,Liberty Township,United States Senate,,Libertarian,"Garrard, Robert D.",8,000020
+WOODSON,Liberty Township,United States Senate,,Republican,"Moran, Jerry",70,000020
+WOODSON,Neosho Falls Township,United States Senate,,write - in,"Smith, DJ",0,000030
+WOODSON,Neosho Falls Township,United States Senate,,Democratic,"Wiesner, Patrick",18,000030
+WOODSON,Neosho Falls Township,United States Senate,,Libertarian,"Garrard, Robert D.",2,000030
+WOODSON,Neosho Falls Township,United States Senate,,Republican,"Moran, Jerry",23,000030
+WOODSON,North Township,United States Senate,,write - in,"Smith, DJ",0,000040
+WOODSON,North Township,United States Senate,,Democratic,"Wiesner, Patrick",1,000040
+WOODSON,North Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000040
+WOODSON,North Township,United States Senate,,Republican,"Moran, Jerry",32,000040
+WOODSON,Perry Township,United States Senate,,write - in,"Smith, DJ",0,000050
+WOODSON,Perry Township,United States Senate,,Democratic,"Wiesner, Patrick",9,000050
+WOODSON,Perry Township,United States Senate,,Libertarian,"Garrard, Robert D.",1,000050
+WOODSON,Perry Township,United States Senate,,Republican,"Moran, Jerry",40,000050
+WOODSON,Piqua Township,United States Senate,,write - in,"Smith, DJ",0,000060
+WOODSON,Piqua Township,United States Senate,,Democratic,"Wiesner, Patrick",29,000060
+WOODSON,Piqua Township,United States Senate,,Libertarian,"Garrard, Robert D.",3,000060
+WOODSON,Piqua Township,United States Senate,,Republican,"Moran, Jerry",74,000060
+WOODSON,Toronto Township,United States Senate,,write - in,"Smith, DJ",0,000070
+WOODSON,Toronto Township,United States Senate,,Democratic,"Wiesner, Patrick",45,000070
+WOODSON,Toronto Township,United States Senate,,Libertarian,"Garrard, Robert D.",25,000070
+WOODSON,Toronto Township,United States Senate,,Republican,"Moran, Jerry",178,000070
+WOODSON,Yates Center Ward 1,United States Senate,,write - in,"Smith, DJ",0,00008A
+WOODSON,Yates Center Ward 1,United States Senate,,Democratic,"Wiesner, Patrick",58,00008A
+WOODSON,Yates Center Ward 1,United States Senate,,Libertarian,"Garrard, Robert D.",23,00008A
+WOODSON,Yates Center Ward 1,United States Senate,,Republican,"Moran, Jerry",218,00008A
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,write - in,"Smith, DJ",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,00008B
+WOODSON,Yates Center Ward 1 Exclave,United States Senate,,Republican,"Moran, Jerry",0,00008B
+WOODSON,Yates Center Ward 2,United States Senate,,write - in,"Smith, DJ",0,000090
+WOODSON,Yates Center Ward 2,United States Senate,,Democratic,"Wiesner, Patrick",51,000090
+WOODSON,Yates Center Ward 2,United States Senate,,Libertarian,"Garrard, Robert D.",9,000090
+WOODSON,Yates Center Ward 2,United States Senate,,Republican,"Moran, Jerry",202,000090
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,write - in,"Smith, DJ",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,Democratic,"Wiesner, Patrick",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,Libertarian,"Garrard, Robert D.",0,900010
+WOODSON,Yates Center Ward 2 Exclave,United States Senate,,Republican,"Moran, Jerry",0,900010

--- a/src/parse-csv.rb
+++ b/src/parse-csv.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+
+# The MIT License (MIT)
+# Copyright (c) 2017 Peter Karman
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all 
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+# SOFTWARE.
+
+require 'csv'
+
+# filename template
+# date__state__{party}__{special}__election_type__{jurisdiction}{office}__{office_district}__{reporting_level}.format
+#
+# header template
+# county,precinct,office,district,party,candidate,votes
+#
+
+require 'optparse'
+
+@options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{$0} [options]"
+
+  opts.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+    @options[:verbose] = v
+  end
+  opts.on("-d=YMD", "--date=YMD", String, "Election date") do |d|
+    @options[:date] = d
+  end
+  opts.on("-o=DIR", "--outdir=DIR", String, "Output directory") do |d|
+    @options[:out] = d
+  end
+  opts.on('-t=TYPE', "--type=TYPE", String, "Election type") do |t|
+    @options[:type] = t
+  end
+end.parse!
+
+def csv_out_file(county)
+  @options[:out] ||= '.'
+  @options[:out] + '/' + sprintf("%s__ks__%s__%s__precinct.csv",
+                          (@options[:date] || 'yyyymmdd'),
+                          (@options[:type] || 'general'),
+                          county.downcase,
+                        )
+end
+
+def write_to_csv(filepath, row)
+  fh = fh_for(filepath)
+  new_row = format_csv_row(row)
+  fh.write(new_row)
+end
+
+def fh_for(filepath)
+  @_filehandles ||= {}
+  @_filehandles[filepath] ||= begin
+    fh = File.new(filepath, 'w')
+    fh.write("county,precinct,office,district,party,candidate,votes,vtd\n")
+    fh
+  end
+end
+
+def format_csv_row(row)
+  cells = [
+    row['county'],
+    row['precinct'],
+    (row['office'] || row['race']),
+    (row['district'] || nil),
+    (row['party']),
+    (row['candidate']).strip,
+    (row['votes']),
+    (row['vtd']),
+  ].to_csv
+end
+  
+ARGV.each do |filename|
+  puts filename
+  CSV.foreach(filename, headers: true, header_converters: [:downcase], encoding: 'bom|utf-8') do |row|
+    write_to_csv(csv_out_file(row['county']), row)
+  end
+end


### PR DESCRIPTION
The parse-csv.rb script might be repurposed for other years, depending
on the format of the input files.

Not sure where the original .csv file data originated. These changes
all derive from
https://github.com/openelections/openelections-sources-ks/tree/master/2016%20general%20precinct